### PR TITLE
Rename access control's main rule to default rule

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/data.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.ts
@@ -56,7 +56,7 @@ function buildDateControl(
   lateDeadlines: z.infer<typeof DeadlineJsonSchema>,
 ): RuntimeDateControl | undefined {
   // Only include fields that were explicitly configured (overridden flag is true).
-  // This applies uniformly to main rules and overrides.
+  // This applies uniformly to default rules and overrides.
   const dateControl: RuntimeDateControl = {};
 
   if (rule.date_control_release_date != null) {
@@ -150,7 +150,7 @@ function rowToAccessControlRuleInput(row: AccessControlRuleRow): AccessControlRu
   const afterComplete = buildAfterComplete(rule);
   if (afterComplete !== undefined) runtimeRule.afterComplete = afterComplete;
 
-  // Integrations are only on main rules (number 0)
+  // Integrations are only on default rules (number 0)
   const prairietestExamsRaw = (!isOverride(rule) && row.prairietest_exams) || [];
   const prairietestExams = prairietestExamsRaw.map((e) => ({
     uuid: e.uuid,

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -621,10 +621,6 @@ function extractPrairieTest(rules: AssessmentAccessRuleJson[]): {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Main migration pipeline
-// ---------------------------------------------------------------------------
-
 export function migrateAllowAccess(
   rules: AssessmentAccessRuleJson[],
   fallbackReleaseDate?: string,

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -780,7 +780,7 @@ describe('resolveAccessControl', () => {
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
-              password: 'main-pass',
+              password: 'default-pass',
             },
           }),
           makeOverrideRule(

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -76,7 +76,7 @@ function ptExam(
   };
 }
 
-function makeMainRule(rule: AccessControlJson = {}): AccessControlRuleInput {
+function makeDefaultRule(rule: AccessControlJson = {}): AccessControlRuleInput {
   return {
     rule: toRuntime(rule),
     number: 0,
@@ -108,7 +108,7 @@ const defaultEnrollment: EnrollmentContext = {
 };
 
 const baseInput: AccessControlResolverInput = {
-  rules: [makeMainRule()],
+  rules: [makeDefaultRule()],
   enrollment: defaultEnrollment,
   date: new Date('2025-03-15T12:00:00Z'),
   displayTimezone: 'America/Chicago',
@@ -158,7 +158,7 @@ describe('resolveAccessControl', () => {
     });
   });
 
-  describe('main rule only, no date control', () => {
+  describe('default rule only, no date control', () => {
     it('returns unauthorized when no dateControl configured', () => {
       const result = resolveAccessControl(baseInput);
       expect(result.authorized).toBe(false);
@@ -166,7 +166,7 @@ describe('resolveAccessControl', () => {
       expect(result.active).toBe(false);
     });
 
-    it('returns unauthorized when no main rule exists', () => {
+    it('returns unauthorized when no default rule exists', () => {
       const result = resolveAccessControl({ ...baseInput, rules: [] });
       expect(result.authorized).toBe(false);
       expect(result.credit).toBe(0);
@@ -174,12 +174,12 @@ describe('resolveAccessControl', () => {
     });
   });
 
-  describe('main rule with date control', () => {
+  describe('default rule with date control', () => {
     it('denies access before release date when beforeRelease.listed is false', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-04-01T00:00:00Z' },
               due: { date: '2025-05-01T00:00:00Z' },
@@ -197,7 +197,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-05-01T00:00:00Z' },
@@ -218,7 +218,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-03-10T00:00:00Z' },
@@ -240,7 +240,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-03-10T00:00:00Z' },
@@ -254,7 +254,7 @@ describe('resolveAccessControl', () => {
     });
 
     it('handles late deadline with 0% credit', () => {
-      const rule = makeMainRule({
+      const rule = makeDefaultRule({
         dateControl: {
           release: { date: '2025-03-01T00:00:00Z' },
           due: { date: '2025-03-10T00:00:00Z' },
@@ -286,7 +286,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-03-10T00:00:00Z' },
@@ -304,7 +304,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-03-10T00:00:00Z' },
@@ -322,7 +322,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-03-10T00:00:00Z' },
@@ -345,7 +345,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             beforeRelease: { listed: true },
             dateControl: {
               release: { date: '2025-04-01T00:00:00Z' },
@@ -367,7 +367,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             beforeRelease: { listed: true },
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
@@ -384,7 +384,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               due: { date: '2025-01-01T00:00:00Z' },
             },
@@ -401,7 +401,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: { release: { date: '2025-03-01T00:00:00Z' } },
           }),
         ],
@@ -415,7 +415,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               password: 'secret',
@@ -454,7 +454,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               earlyDeadlines: [{ date: earlyDate, credit: 110 }],
@@ -473,7 +473,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -497,7 +497,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: { due: { date: '2025-03-10T00:00:00Z' } },
           }),
           makeOverrideRule(
@@ -509,7 +509,7 @@ describe('resolveAccessControl', () => {
         enrollment: { enrollmentId: 'enroll-1', studentLabelIds: [] },
         date: new Date('2025-03-15T00:00:00Z'),
       });
-      // No override match, so main rule's due date (March 10) applies, we're past it
+      // No override match, so default rule's due date (March 10) applies, we're past it
       expect(result.credit).toBe(0);
       expect(result.active).toBe(false);
     });
@@ -518,7 +518,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: { due: { date: '2025-03-10T00:00:00Z' } },
           }),
           makeOverrideRule(
@@ -539,7 +539,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -560,7 +560,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: { due: { date: '2025-03-10T00:00:00Z' } },
           }),
           makeOverrideRule(
@@ -581,7 +581,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -608,7 +608,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -635,7 +635,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -662,7 +662,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -691,7 +691,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -722,7 +722,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -746,7 +746,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -766,7 +766,7 @@ describe('resolveAccessControl', () => {
   });
 
   describe('PrairieTest integration', () => {
-    const prairieTestMainRule: AccessControlRuleInput = {
+    const prairieTestDefaultRule: AccessControlRuleInput = {
       rule: {},
       number: 0,
       targetType: 'none',
@@ -783,7 +783,7 @@ describe('resolveAccessControl', () => {
     it('grants access with valid exam reservation and full credit', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [prairieTestMainRule],
+        rules: [prairieTestDefaultRule],
         authzMode: 'Exam',
         prairieTestReservations: [validReservation],
       });
@@ -799,7 +799,7 @@ describe('resolveAccessControl', () => {
       // denied.
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [prairieTestMainRule],
+        rules: [prairieTestDefaultRule],
         authzMode: 'Public',
         prairieTestReservations: [validReservation],
       });
@@ -812,7 +812,7 @@ describe('resolveAccessControl', () => {
     it('denies access when reservation UUID does not match', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [prairieTestMainRule],
+        rules: [prairieTestDefaultRule],
         authzMode: 'Exam',
         prairieTestReservations: [
           {
@@ -827,7 +827,7 @@ describe('resolveAccessControl', () => {
     it('denies access when no reservation exists', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [prairieTestMainRule],
+        rules: [prairieTestDefaultRule],
         authzMode: 'Exam',
         prairieTestReservations: [],
       });
@@ -841,7 +841,7 @@ describe('resolveAccessControl', () => {
       };
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [prairieTestMainRule],
+        rules: [prairieTestDefaultRule],
         authzMode: 'Exam',
         prairieTestReservations: [wrongReservation, validReservation],
       });
@@ -851,7 +851,7 @@ describe('resolveAccessControl', () => {
 
     it('sets active to false for readOnly exam', () => {
       const readOnlyRule: AccessControlRuleInput = {
-        ...prairieTestMainRule,
+        ...prairieTestDefaultRule,
         prairietestExams: [ptExam('exam-uuid-1', { readOnly: true })],
       };
       const result = resolveAccessControl({
@@ -868,7 +868,7 @@ describe('resolveAccessControl', () => {
     it('denies access for non-exam rule when in PrairieTest exam mode', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [makeMainRule()],
+        rules: [makeDefaultRule()],
         authzMode: 'Exam',
       });
       expect(result.authorized).toBe(false);
@@ -876,7 +876,7 @@ describe('resolveAccessControl', () => {
 
     it('uses readOnly flag from matched exam when multiple exams are configured', () => {
       const multiExamRule: AccessControlRuleInput = {
-        ...prairieTestMainRule,
+        ...prairieTestDefaultRule,
         prairietestExams: [ptExam('exam-uuid-1'), ptExam('exam-uuid-3', { readOnly: true })],
       };
       const reservation: PrairieTestReservation = {
@@ -896,7 +896,7 @@ describe('resolveAccessControl', () => {
 
     it('overrides date-control credit with 100% when PT reservation matches', () => {
       const ruleWithDateControl: AccessControlRuleInput = {
-        ...prairieTestMainRule,
+        ...prairieTestDefaultRule,
         rule: toRuntime({
           dateControl: {
             release: { date: '2025-01-01T00:00:00Z' },
@@ -922,7 +922,7 @@ describe('resolveAccessControl', () => {
     // during a PT reservation via a readOnly exam config.
     describe('cheat sheet hack workflow', () => {
       const cheatSheetRule: AccessControlRuleInput = {
-        ...prairieTestMainRule,
+        ...prairieTestDefaultRule,
         rule: toRuntime({
           dateControl: {
             release: { date: '2025-02-01T00:00:00Z' },
@@ -1000,7 +1000,7 @@ describe('resolveAccessControl', () => {
           const result = resolveAccessControl({
             ...baseInput,
             authzMode: 'Exam',
-            rules: [{ ...makeMainRule(), prairietestExams: [ptExam('pt-exam-1')] }],
+            rules: [{ ...makeDefaultRule(), prairietestExams: [ptExam('pt-exam-1')] }],
             prairieTestReservations: [validReservation],
           });
           expect(result.authorized).toBe(true);
@@ -1015,7 +1015,7 @@ describe('resolveAccessControl', () => {
             authzMode: 'Exam',
             rules: [
               {
-                ...makeMainRule(),
+                ...makeDefaultRule(),
                 prairietestExams: [ptExam('pt-exam-1', { questionsHidden: true })],
               },
             ],
@@ -1031,7 +1031,7 @@ describe('resolveAccessControl', () => {
             authzMode: 'Exam',
             rules: [
               {
-                ...makeMainRule(),
+                ...makeDefaultRule(),
                 prairietestExams: [
                   ptExam('pt-exam-1', { questionsHidden: true, scoreHidden: true }),
                 ],
@@ -1050,7 +1050,7 @@ describe('resolveAccessControl', () => {
             ...baseInput,
             authzMode: 'Exam',
             rules: [
-              { ...makeMainRule(), prairietestExams: [ptExam('pt-exam-1', { readOnly: true })] },
+              { ...makeDefaultRule(), prairietestExams: [ptExam('pt-exam-1', { readOnly: true })] },
             ],
             prairieTestReservations: [validReservation],
           });
@@ -1071,7 +1071,7 @@ describe('resolveAccessControl', () => {
             authzMode: 'Exam',
             rules: [
               {
-                ...makeMainRule({
+                ...makeDefaultRule({
                   afterComplete: {
                     questions: { hidden: true },
                     score: { hidden: true },
@@ -1092,7 +1092,7 @@ describe('resolveAccessControl', () => {
             authzMode: 'Exam',
             rules: [
               {
-                ...makeMainRule({
+                ...makeDefaultRule({
                   afterComplete: { questions: { hidden: true }, score: { hidden: true } },
                 }),
                 prairietestExams: [ptExam('pt-exam-1', { readOnly: true })],
@@ -1113,7 +1113,7 @@ describe('resolveAccessControl', () => {
       describe('deferred at-home release (grading disabled during exam)', () => {
         const atHomeVisibleDate = '2025-04-01T00:00:00Z';
         const ruleWithDeferredRelease = {
-          ...makeMainRule({
+          ...makeDefaultRule({
             afterComplete: {
               questions: { hidden: true, visibleFromDate: atHomeVisibleDate },
               score: { hidden: true, visibleFromDate: atHomeVisibleDate },
@@ -1203,7 +1203,7 @@ describe('resolveAccessControl', () => {
       // and they can never see their work again.
       describe('real-time grading during exam, hidden after', () => {
         const ruleWithBothVisibleInExamMode = {
-          ...makeMainRule({
+          ...makeDefaultRule({
             afterComplete: { questions: { hidden: true }, score: { hidden: true } },
           }),
           prairietestExams: [ptExam('pt-exam-1')],
@@ -1250,7 +1250,7 @@ describe('resolveAccessControl', () => {
             authzMode: 'Exam',
             rules: [
               {
-                ...makeMainRule(),
+                ...makeDefaultRule(),
                 prairietestExams: [ptExam('pt-exam-1', { readOnly: true })],
               },
             ],
@@ -1268,7 +1268,7 @@ describe('resolveAccessControl', () => {
             authzMode: 'Public',
             rules: [
               {
-                ...makeMainRule({
+                ...makeDefaultRule({
                   afterComplete: { questions: { hidden: true }, score: { hidden: true } },
                 }),
                 prairietestExams: [ptExam('pt-exam-1', { readOnly: true })],
@@ -1295,7 +1295,10 @@ describe('resolveAccessControl', () => {
         const result = resolveAccessControl({
           ...baseInput,
           rules: [
-            { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam1] },
+            {
+              ...makeDefaultRule({ beforeRelease: { listed: true } }),
+              prairietestExams: [ptExam1],
+            },
           ],
         });
         expect(result.authorized).toBe(false);
@@ -1309,7 +1312,10 @@ describe('resolveAccessControl', () => {
           ...baseInput,
           authzMode: 'Exam',
           rules: [
-            { ...makeMainRule({ beforeRelease: { listed: true } }), prairietestExams: [ptExam1] },
+            {
+              ...makeDefaultRule({ beforeRelease: { listed: true } }),
+              prairietestExams: [ptExam1],
+            },
           ],
           prairieTestReservations: [
             { examUuid: 'other-exam', accessEnd: new Date('2025-04-01T00:00:00Z') },
@@ -1328,7 +1334,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Public',
           rules: [
             {
-              ...makeMainRule({
+              ...makeDefaultRule({
                 beforeRelease: { listed: true },
                 dateControl: {
                   release: { date: '2025-01-01T00:00:00Z' },
@@ -1348,7 +1354,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Exam',
           rules: [
             {
-              ...makeMainRule({
+              ...makeDefaultRule({
                 beforeRelease: { listed: true },
                 dateControl: {
                   release: { date: '2025-01-01T00:00:00Z' },
@@ -1373,7 +1379,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Exam',
           rules: [
             {
-              ...makeMainRule({
+              ...makeDefaultRule({
                 dateControl: {
                   release: { date: '2025-01-01T00:00:00Z' },
                   due: { date: '2025-02-01T00:00:00Z' },
@@ -1398,7 +1404,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Exam',
           rules: [
             {
-              ...makeMainRule({
+              ...makeDefaultRule({
                 dateControl: {
                   release: { date: '2025-06-01T00:00:00Z' },
                   due: { date: '2025-07-01T00:00:00Z' },
@@ -1428,7 +1434,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Public',
           rules: [
             {
-              ...makeMainRule({
+              ...makeDefaultRule({
                 beforeRelease: { listed: true },
                 dateControl: { release: { date: '2025-04-01T00:00:00Z' } },
               }),
@@ -1453,7 +1459,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Exam',
           rules: [
             {
-              ...makeMainRule({ beforeRelease: { listed: true } }),
+              ...makeDefaultRule({ beforeRelease: { listed: true } }),
               prairietestExams: [ptExam1],
             },
           ],
@@ -1475,7 +1481,7 @@ describe('resolveAccessControl', () => {
           authzMode: 'Exam',
           rules: [
             {
-              ...makeMainRule({
+              ...makeDefaultRule({
                 beforeRelease: { listed: true },
                 dateControl: {
                   release: { date: '2025-01-01T00:00:00Z' },
@@ -1498,7 +1504,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -1515,7 +1521,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-03-15T12:30:00Z' },
@@ -1559,7 +1565,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               due: { date: '2025-03-15T12:00:20Z' },
@@ -1577,7 +1583,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: { due: { date: '2025-04-01T00:00:00Z' } },
           }),
         ],
@@ -1590,7 +1596,7 @@ describe('resolveAccessControl', () => {
     it('hides questions by default when questions.hidden is not set', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [makeMainRule({})],
+        rules: [makeDefaultRule({})],
       });
       expect(result.showClosedAssessment).toBe(false);
     });
@@ -1599,7 +1605,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: { questions: { hidden: false } },
           }),
         ],
@@ -1610,7 +1616,7 @@ describe('resolveAccessControl', () => {
     it('still shows score by default when afterComplete is undefined', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [makeMainRule({})],
+        rules: [makeDefaultRule({})],
       });
       expect(result.showClosedAssessmentScore).toBe(true);
     });
@@ -1619,7 +1625,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: { questions: { hidden: true } },
           }),
         ],
@@ -1631,7 +1637,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: {
               questions: {
                 hidden: true,
@@ -1649,7 +1655,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: {
               questions: {
                 hidden: true,
@@ -1668,7 +1674,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: { score: { hidden: true } },
           }),
         ],
@@ -1680,7 +1686,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: {
               score: {
                 hidden: true,
@@ -1697,14 +1703,14 @@ describe('resolveAccessControl', () => {
     it('hides questions when a merged main + override produces visible-questions + hidden-score', () => {
       // Per-rule validation forbids `score.hidden: true` alongside
       // `questions.hidden: false` on a single rule, but merging is independent
-      // per sub-object: a main rule that only sets `questions` combined with
+      // per sub-object: a default rule that only sets `questions` combined with
       // an override that only sets `score` can yield the forbidden pair.
       // The resolver must clamp to "hide questions" rather than show answers
       // without a score.
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             afterComplete: { questions: { hidden: false } },
           }),
           makeOverrideRule(
@@ -1724,7 +1730,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -1740,7 +1746,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               due: { date: '2025-03-10T00:00:00Z' },
             },
@@ -1762,7 +1768,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-15T00:00:00Z' },
               due: { date: '2025-04-01T00:00:00Z' },
@@ -1784,7 +1790,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-03T00:00:00Z' },
               earlyDeadlines: [
@@ -1804,7 +1810,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-15T00:00:00Z' },
               due: { date: '2025-03-20T00:00:00Z' },
@@ -1824,7 +1830,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
               earlyDeadlines: [
@@ -1850,7 +1856,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               due: { date: '2025-03-20T00:00:00Z' },
@@ -1873,7 +1879,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               afterLastDeadline: { credit: 50, allowSubmissions: true },
@@ -1894,7 +1900,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               lateDeadlines: [{ date: '2025-04-01T00:00:00Z', credit: 50 }],
@@ -1911,7 +1917,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               lateDeadlines: [{ date: '2025-04-01T00:00:00Z', credit: 50 }],
@@ -1929,7 +1935,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               earlyDeadlines: [{ date: '2025-04-01T00:00:00Z', credit: 120 }],
@@ -1946,7 +1952,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             dateControl: {
               release: { date: '2025-03-01T00:00:00Z' },
               earlyDeadlines: [{ date: '2025-04-01T00:00:00Z', credit: 120 }],
@@ -1961,7 +1967,7 @@ describe('resolveAccessControl', () => {
 
     it('resolves bonus+reduced declining credit without dueDate', () => {
       // Migrated from: [{ credit: 120, endDate: '2025-03-10' }, { credit: 50, endDate: '2025-04-01' }]
-      const rule = makeMainRule({
+      const rule = makeDefaultRule({
         dateControl: {
           release: { date: '2025-03-01T00:00:00Z' },
           earlyDeadlines: [{ date: '2025-03-10T00:00:00Z', credit: 120 }],
@@ -1996,7 +2002,7 @@ describe('resolveAccessControl', () => {
     it('shows before release when beforeRelease.listed set without dateControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [makeMainRule({ beforeRelease: { listed: true } })],
+        rules: [makeDefaultRule({ beforeRelease: { listed: true } })],
       });
       // Supported use case: instructor lists every assessment a student will
       // take over the term, perpetually "coming soon" until dates are added.
@@ -2012,7 +2018,7 @@ describe('resolveAccessControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
         rules: [
-          makeMainRule({
+          makeDefaultRule({
             beforeRelease: { listed: true },
             dateControl: {
               due: { date: '2025-04-01T00:00:00Z' },
@@ -2029,7 +2035,7 @@ describe('resolveAccessControl', () => {
     it('does not show before release without beforeRelease.listed and no dateControl', () => {
       const result = resolveAccessControl({
         ...baseInput,
-        rules: [makeMainRule({})],
+        rules: [makeDefaultRule({})],
       });
       expect(result.authorized).toBe(false);
       expect(result.showBeforeRelease).toBe(false);
@@ -2038,7 +2044,7 @@ describe('resolveAccessControl', () => {
 });
 
 describe('mergeRules', () => {
-  it('returns main rule when override is null', () => {
+  it('returns default rule when override is null', () => {
     const main = toRuntime({ beforeRelease: { listed: true } });
     expect(mergeRules(main, null)).toEqual(main);
   });
@@ -2052,7 +2058,7 @@ describe('mergeRules', () => {
     expect(result.dateControl?.password).toBe('secret');
   });
 
-  it('does not mutate main rule', () => {
+  it('does not mutate default rule', () => {
     const main = toRuntime({
       dateControl: { due: { date: '2025-04-01T00:00:00Z' } },
     });
@@ -2087,7 +2093,7 @@ describe('mergeRules', () => {
     expect(result.afterComplete?.score?.hidden).toBe(true);
   });
 
-  it('allows override to clear main rule after-complete dates', () => {
+  it('allows override to clear default rule after-complete dates', () => {
     const result = mergeRules(
       toRuntime({
         afterComplete: {
@@ -2321,7 +2327,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: '2025-04-01T00:00:00Z', credit: 80 },
@@ -2339,7 +2345,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: '2025-04-01T00:00:00Z', credit: 80 },
@@ -2360,7 +2366,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: '2025-04-01T00:00:00Z', credit: 80 },
@@ -2382,7 +2388,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-01-01T00:00:00Z' },
             due: { date: '2025-04-01T00:00:00Z', credit: 120 },
@@ -2403,7 +2409,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: '2025-04-01T00:00:00Z', credit: 80 },
@@ -2421,7 +2427,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: '2025-04-01T00:00:00Z' },
@@ -2437,7 +2443,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: null, credit: 50 },
@@ -2457,7 +2463,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-03-01T00:00:00Z' },
             due: { date: null, credit: 0 },
@@ -2474,7 +2480,7 @@ describe('custom due credit', () => {
 
   it('applies afterLastDeadline after early deadlines when no due date is set', () => {
     const rules = [
-      makeMainRule({
+      makeDefaultRule({
         dateControl: {
           release: { date: '2025-01-01T00:00:00Z' },
           earlyDeadlines: [{ date: '2025-02-01T00:00:00Z', credit: 120 }],
@@ -2504,7 +2510,7 @@ describe('custom due credit', () => {
     const result = resolveAccessControl({
       ...baseInput,
       rules: [
-        makeMainRule({
+        makeDefaultRule({
           dateControl: {
             release: { date: '2025-01-01T00:00:00Z' },
             due: { date: null },
@@ -2521,7 +2527,7 @@ describe('custom due credit', () => {
 
   it('honors early deadlines with null due date, then applies default credit indefinitely', () => {
     const rules = [
-      makeMainRule({
+      makeDefaultRule({
         dateControl: {
           release: { date: '2025-01-01T00:00:00Z' },
           due: { date: null },

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -930,7 +930,7 @@ describe('resolveAccessControl', () => {
         // a date-control timeline at all.
         name: 'PT grant clears the date-control access timeline',
         rules: [
-          makeMainRule(
+          makeDefaultRule(
             {
               dateControl: {
                 release: { date: '2025-01-01T00:00:00Z' },

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -187,18 +187,18 @@ function mergeAfterComplete(
 }
 
 export function mergeRules(
-  main: RuntimeAccessControl,
+  defaultRule: RuntimeAccessControl,
   override: RuntimeAccessControl | null,
 ): RuntimeAccessControl {
-  if (!override) return main;
+  if (!override) return defaultRule;
 
   const merged: RuntimeAccessControl = {};
 
-  // beforeRelease is only configurable on the main rule.
-  if (main.beforeRelease !== undefined) merged.beforeRelease = main.beforeRelease;
+  // beforeRelease is only configurable on the default rule.
+  if (defaultRule.beforeRelease !== undefined) merged.beforeRelease = defaultRule.beforeRelease;
 
-  merged.dateControl = mergeDateControl(main.dateControl, override.dateControl);
-  merged.afterComplete = mergeAfterComplete(main.afterComplete, override.afterComplete);
+  merged.dateControl = mergeDateControl(defaultRule.dateControl, override.dateControl);
+  merged.afterComplete = mergeAfterComplete(defaultRule.afterComplete, override.afterComplete);
 
   return merged;
 }
@@ -535,8 +535,8 @@ export function resolveAccessControl(
     };
   }
 
-  const mainRuleInput = rules.find((r) => r.number === 0 && r.targetType === 'none');
-  if (!mainRuleInput) {
+  const defaultRuleInput = rules.find((r) => r.number === 0 && r.targetType === 'none');
+  if (!defaultRuleInput) {
     return { ...UNAUTHORIZED_RESULT };
   }
 
@@ -567,14 +567,14 @@ export function resolveAccessControl(
     }
   }
 
-  // Cascade all matched overrides, then merge with main rule.
+  // Cascade all matched overrides, then merge with default rule.
   let cascadedOverride: RuntimeAccessControl | null = null;
   for (const override of matchedOverrides) {
     cascadedOverride = cascadedOverride
       ? cascadeOverrides(cascadedOverride, override.rule)
       : override.rule;
   }
-  const effectiveRule = mergeRules(mainRuleInput.rule, cascadedOverride);
+  const effectiveRule = mergeRules(defaultRuleInput.rule, cascadedOverride);
 
   let creditResult = computeCredit(effectiveRule.dateControl, date, authzMode);
 
@@ -605,7 +605,7 @@ export function resolveAccessControl(
   // showing questions (with their submitted answers) while hiding the
   // score. Per-rule validation catches this within a single rule, but
   // `mergeAfterComplete` picks `questions` and `score` sub-objects
-  // independently, so a main rule with `questions.hidden: false` merged
+  // independently, so a default rule with `questions.hidden: false` merged
   // with an override that sets `score.hidden: true` can produce the
   // invalid combination. Clamp here so every downstream return carries a
   // consistent state.
@@ -617,7 +617,7 @@ export function resolveAccessControl(
   // the resolver linear: it either denies early, grants PT credit overrides,
   // or continues with the normal date-control-based result.
   const ptOutcome = resolvePrairieTestAccess({
-    prairieTestExams: mainRuleInput.prairietestExams,
+    prairieTestExams: defaultRuleInput.prairietestExams,
     prairieTestReservations,
     authzMode,
   });
@@ -684,7 +684,7 @@ export function resolveAccessControl(
   // review-only page. Otherwise deny outright.
   if (
     ptOutcome.action === 'continue' &&
-    mainRuleInput.prairietestExams.length > 0 &&
+    defaultRuleInput.prairietestExams.length > 0 &&
     !effectiveRule.dateControl?.release
   ) {
     if (!showClosedAssessment) {
@@ -714,7 +714,7 @@ export function resolveAccessControl(
   // listed-only and PT review-only paths above have already returned for the
   // cases where they apply, so reaching here means the rule has no way to
   // grant access.
-  if (!effectiveRule.dateControl?.release && mainRuleInput.prairietestExams.length === 0) {
+  if (!effectiveRule.dateControl?.release && defaultRuleInput.prairietestExams.length === 0) {
     return { ...UNAUTHORIZED_RESULT, showClosedAssessment, showClosedAssessmentScore };
   }
 

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1072,7 +1072,7 @@ describe('Global credit validation', () => {
         ruleIndex: 1,
       },
       {
-        // Override inherits due credit (90 from main) but sets a late credit
+        // Override inherits due credit (90 from default) but sets a late credit
         // above it — no possible timeline can make this monotonic.
         rule: AccessControlJsonSchema.parse({
           labels: ['Section B'],

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -94,7 +94,7 @@ describe('Valid configs', () => {
     // Example 5: Extended time override
     [
       {
-        // Main rule (no targets)
+        // Default rule (no targets)
         dateControl: {
           release: { date: '2024-03-14T00:01:00' },
           due: { date: '2024-03-21T23:59:00' },
@@ -182,9 +182,9 @@ describe('Valid configs', () => {
   });
 });
 
-describe('Main rule requirement', () => {
-  it('should fail validation when no main rule exists', () => {
-    const rulesWithoutMain: AccessControlJsonInput[] = [
+describe('Default rule requirement', () => {
+  it('should fail validation when no default rule exists', () => {
+    const rulesWithoutDefault: AccessControlJsonInput[] = [
       {
         labels: ['student1'],
         dateControl: {
@@ -199,12 +199,12 @@ describe('Main rule requirement', () => {
       },
     ];
 
-    const parsedRules = rulesWithoutMain.map((rule) => AccessControlJsonSchema.parse(rule));
+    const parsedRules = rulesWithoutDefault.map((rule) => AccessControlJsonSchema.parse(rule));
     const result = validateAccessControlRules({
       rules: parsedRules,
     });
 
-    assert.isTrue(result.errors.length > 0, 'Expected error when no main rule exists');
+    assert.isTrue(result.errors.length > 0, 'Expected error when no default rule exists');
     assert.isTrue(
       result.errors.includes(
         'No defaults found. The first element of accessControl must apply to everyone.',
@@ -213,8 +213,8 @@ describe('Main rule requirement', () => {
     );
   });
 
-  it('should fail validation when multiple main rules exist', () => {
-    const rulesWithMultipleMain: AccessControlJsonInput[] = [
+  it('should fail validation when multiple default rules exist', () => {
+    const rulesWithMultipleDefault: AccessControlJsonInput[] = [
       {
         dateControl: {
           release: { date: '2024-03-14T00:01:00' },
@@ -229,12 +229,12 @@ describe('Main rule requirement', () => {
       },
     ];
 
-    const parsedRules = rulesWithMultipleMain.map((rule) => AccessControlJsonSchema.parse(rule));
+    const parsedRules = rulesWithMultipleDefault.map((rule) => AccessControlJsonSchema.parse(rule));
     const result = validateAccessControlRules({
       rules: parsedRules,
     });
 
-    assert.isTrue(result.errors.length > 0, 'Expected error when multiple main rules exist');
+    assert.isTrue(result.errors.length > 0, 'Expected error when multiple default rules exist');
     assert.isTrue(
       result.errors.includes(
         'Found 2 defaults entries. Only one element of accessControl should apply to everyone.',
@@ -243,8 +243,8 @@ describe('Main rule requirement', () => {
     );
   });
 
-  it('should pass validation with exactly one main rule', () => {
-    const rulesWithOneMain: AccessControlJsonInput[] = [
+  it('should pass validation with exactly one default rule', () => {
+    const rulesWithOneDefault: AccessControlJsonInput[] = [
       {
         dateControl: {
           release: { date: '2024-03-14T00:01:00' },
@@ -253,12 +253,12 @@ describe('Main rule requirement', () => {
       },
     ];
 
-    const parsedRules = rulesWithOneMain.map((rule) => AccessControlJsonSchema.parse(rule));
+    const parsedRules = rulesWithOneDefault.map((rule) => AccessControlJsonSchema.parse(rule));
     const result = validateAccessControlRules({
       rules: parsedRules,
     });
 
-    assert.equal(result.errors.length, 0, 'Should have no errors with one main rule');
+    assert.equal(result.errors.length, 0, 'Should have no errors with one default rule');
   });
 
   it('should fail validation when an override specifies beforeRelease', () => {
@@ -1434,7 +1434,7 @@ describe('Structural field dependency validation', () => {
     assert.isTrue(issues.some((i) => i.message === 'Late deadlines require a due date.'));
   });
 
-  it('should reject main-rule dateControl without due configuration', () => {
+  it('should reject default-rule dateControl without due configuration', () => {
     const rule = AccessControlJsonSchema.parse({
       dateControl: {
         release: { date: '2024-03-14T00:01:00' },
@@ -1547,7 +1547,7 @@ describe('Structural field dependency validation', () => {
     assert.isTrue(result.errors.includes('Late deadlines require a due date.'));
   });
 
-  it('should allow overrides to inherit due date from main rule', () => {
+  it('should allow overrides to inherit due date from default rule', () => {
     const rule = AccessControlJsonSchema.parse({
       labels: ['Section A'],
       dateControl: {

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -1,7 +1,7 @@
 import type { AccessControlJson } from '../../schemas/accessControl.js';
 
 /**
- * Maximum number of access control rules (main + overrides) per assessment.
+ * Maximum number of access control rules (default + overrides) per assessment.
  * Enforced during both JSON sync and tRPC input validation.
  */
 export const MAX_ACCESS_CONTROL_RULES = 50;
@@ -760,7 +760,7 @@ function formatValues(values: Set<string> | string[]) {
  *
  * @param params
  * @param params.rules The full ordered list of access control rules: index 0 is the
- * main (defaults) rule that applies to everyone (no labels), and all
+ * default rule that applies to everyone (no labels), and all
  * subsequent entries are student-label rules that target specific labels.
  * @param params.enrollmentRules Optional separate list of enrollment-based rules.
  * @param params.validStudentLabelNames Optional set of known student label names for

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -113,7 +113,7 @@ export function validateRuleStructuralDependencyIssues(
   // Constraint 1: Late deadlines require a due date.
   // Late deadlines define credit after the due date, so they need one as an anchor.
   // Early deadlines are standalone bonus-credit windows and don't need a due date.
-  // On overrides, due === undefined means "inherit from main rule" (valid),
+  // On overrides, due === undefined means "inherit from default rule" (valid),
   // while due.date === null means "explicitly no due date" (invalid with late deadlines).
   if (dc) {
     const dueDateMissing =
@@ -159,7 +159,7 @@ export function validateRuleStructuralDependencyIssues(
   // to the last deadline. Boolean fields (hidden) are fine without deadlines.
   // PrairieTest and timed assessments manage completion independently,
   // so after-complete dates are valid without deadlines in those cases.
-  // Only enforced on the main rule — overrides may inherit deadlines.
+  // Only enforced on the default rule — overrides may inherit deadlines.
   const hasPrairieTest = (rule.integrations?.prairieTest?.exams ?? []).length > 0;
   const hasDuration = dc?.durationMinutes != null;
   const ac = rule.afterComplete;
@@ -455,8 +455,8 @@ export function validateGlobalCreditConsistencyIssues(
   const issues: AccessControlValidationIssue[] = [];
   if (validationRules.length === 0) return issues;
 
-  const mainRule = validationRules.find((vr) => vr.targetType === 'none');
-  const baseHasCustomCredit = mainRule?.rule.dateControl?.due?.credit !== undefined;
+  const defaultRule = validationRules.find((vr) => vr.targetType === 'none');
+  const baseHasCustomCredit = defaultRule?.rule.dateControl?.due?.credit !== undefined;
 
   // "Clears custom credit" = an override supplies its own `due` with no credit
   // field (explicit default 100%). A non-overridden `due` inherits instead.
@@ -635,10 +635,10 @@ export function validateRuleCreditMonotonicity(rule: AccessControlJson): string[
 /**
  * Validates a single access control rule. Checks duplicates, date ordering,
  * credit monotonicity, and target-type constraints (e.g. integrations and
- * beforeRelease are only valid on the main rule).
+ * beforeRelease are only valid on the default rule).
  *
  * @param rule The access control rule to validate.
- * @param targetType 'none' for the main rule, 'student_label' or 'enrollment' for overrides.
+ * @param targetType 'none' for the default rule, 'student_label' or 'enrollment' for overrides.
  */
 export function validateRule(
   rule: AccessControlJson,
@@ -796,24 +796,24 @@ export function validateAccessControlRules({
     );
   }
 
-  // A main rule is identified by the absence of a `labels` key.
-  const mainRules = rules.filter((rule) => rule.labels == null);
+  // A default rule is identified by the absence of a `labels` key.
+  const defaultRules = rules.filter((rule) => rule.labels == null);
 
-  if (mainRules.length === 0) {
+  if (defaultRules.length === 0) {
     errors.push('No defaults found. The first element of accessControl must apply to everyone.');
-  } else if (mainRules.length > 1) {
+  } else if (defaultRules.length > 1) {
     errors.push(
-      `Found ${mainRules.length} defaults entries. Only one element of accessControl should apply to everyone.`,
+      `Found ${defaultRules.length} defaults entries. Only one element of accessControl should apply to everyone.`,
     );
   } else {
-    // The DB constraint `check_first_rule_is_none` requires the main rule at index 0
+    // The DB constraint `check_first_rule_is_none` requires the default rule at index 0
     const firstRule = rules[0];
     if (firstRule.labels != null) {
       errors.push('The defaults must be the first element in the array.');
     }
   }
 
-  // Index 0 is the main rule; everything else is a student-label rule.
+  // Index 0 is the default rule; everything else is a student-label rule.
   rules.forEach((rule, index) => {
     const targetType: AccessControlRuleTargetType = index === 0 ? 'none' : 'student_label';
 

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -251,7 +251,7 @@ export const AssessmentAccessControlRuleSchema = z.object({
   id: IdSchema,
   number: z.number(),
 
-  // Target type: 'none' for main rule (applies to all), 'student_label' for labels, 'enrollment' for individual students
+  // Target type: 'none' for default rule (applies to all), 'student_label' for labels, 'enrollment' for individual students
   target_type: z.enum(['none', 'student_label', 'enrollment']),
 });
 export type AssessmentAccessControlRule = z.infer<typeof AssessmentAccessControlRuleSchema>;

--- a/apps/prairielearn/src/migrations/20260112202741_assessment_access_control__add.sql
+++ b/apps/prairielearn/src/migrations/20260112202741_assessment_access_control__add.sql
@@ -1,16 +1,16 @@
 -- Enum for access control target types
 CREATE TYPE enum_assessment_access_control_target_type AS ENUM('none', 'enrollment', 'student_label');
 
--- Main access control rules table
+-- Primary access control rules table
 CREATE TABLE assessment_access_control_rules (
   id BIGSERIAL PRIMARY KEY,
   assessment_id BIGINT NOT NULL REFERENCES assessments (id) ON DELETE CASCADE ON UPDATE CASCADE,
   list_before_release boolean,
   -- `number` is unique per (assessment_id, target_type), not per assessment.
-  -- number=0 is always the main rule (target_type='none'), while override rules
+  -- number=0 is always the default rule (target_type='none'), while non-default rules
   -- (target_type='enrollment' or 'student_label') start numbering from 1 independently.
   number INTEGER NOT NULL,
-  -- Target type: 'none' for main rule (applies to all), 'enrollment' for individual students, 'student_label' for student labels
+  -- Target type: 'none' for default rule (applies to all), 'enrollment' for individual students, 'student_label' for student labels
   target_type enum_assessment_access_control_target_type NOT NULL,
   date_control_release_date_overridden boolean NOT NULL DEFAULT false,
   date_control_release_date TIMESTAMP WITH TIME ZONE,

--- a/apps/prairielearn/src/models/assessment-access-control-rules.test.ts
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.test.ts
@@ -113,7 +113,7 @@ describe('dbRowToAccessControlJson', () => {
     expect(result.afterComplete?.score).toBeUndefined();
   });
 
-  it('omits credit for main rule afterLastDeadline when not set', () => {
+  it('omits credit for default rule afterLastDeadline when not set', () => {
     const result = dbRowToAccessControlJson(
       makeRow({
         rule: {

--- a/apps/prairielearn/src/models/assessment-access-control-rules.ts
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.ts
@@ -179,8 +179,8 @@ function dbBaseRowToAccessControlJson(
     afterComplete.score = score;
   }
 
-  const isMainRule = rule.number === 0 && rule.target_type === 'none';
-  const beforeReleaseListed = isMainRule
+  const isDefaultRule = rule.number === 0 && rule.target_type === 'none';
+  const beforeReleaseListed = isDefaultRule
     ? (rule.before_release_listed ?? false)
     : rule.before_release_listed;
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -9,14 +9,14 @@ import type { PageContext } from '../../../lib/client/page-context.js';
 import type { AccessControlJsonWithId } from '../../../models/assessment-access-control-rules.js';
 
 import { AccessControlSummary } from './AccessControlSummary.js';
-import { MainRuleForm } from './MainRuleForm.js';
+import { DefaultRuleForm } from './DefaultRuleForm.js';
 import { OverrideRuleContent } from './OverrideRuleContent.js';
 import { AppliesToField } from './fields/AppliesToField.js';
 import {
   type AccessControlFormData,
   createDefaultOverrideFormData,
   formDataToJson,
-  jsonToMainRuleFormData,
+  jsonToDefaultRuleFormData,
   jsonToOverrideFormData,
 } from './types.js';
 import { type AccessControlFormFieldPath, getGlobalDateValidationErrors } from './validation.js';
@@ -29,7 +29,7 @@ const defaultInitialData: AccessControlJsonWithId[] = [];
  */
 const accessControlFormInitialRightWidth = 560;
 
-type SelectedRule = { type: 'main' } | { type: 'override'; index: number } | null;
+type SelectedRule = { type: 'default' } | { type: 'override'; index: number } | null;
 
 export function AccessControlForm({
   initialData = defaultInitialData,
@@ -50,15 +50,15 @@ export function AccessControlForm({
   const deleteModal = useModalState<{ index: number; name: string }>();
 
   const displayTimezone = courseInstance.display_timezone;
-  const mainRule = initialData[0]
-    ? jsonToMainRuleFormData(initialData[0], displayTimezone)
-    : jsonToMainRuleFormData({}, displayTimezone);
+  const defaultRule = initialData[0]
+    ? jsonToDefaultRuleFormData(initialData[0], displayTimezone)
+    : jsonToDefaultRuleFormData({}, displayTimezone);
   const overrides = initialData.slice(1).map((o) => jsonToOverrideFormData(o, displayTimezone));
 
   const methods = useForm<AccessControlFormData>({
     mode: 'onChange',
     defaultValues: {
-      mainRule,
+      defaultRule,
       overrides,
     },
   });
@@ -124,7 +124,7 @@ export function AccessControlForm({
   };
 
   const addOverride = () => {
-    const newOverride = createDefaultOverrideFormData(watchedData.mainRule);
+    const newOverride = createDefaultOverrideFormData(watchedData.defaultRule);
     // Enrollment overrides are inserted before student-label overrides
     const firstLabelIndex = watchedData.overrides.findIndex(
       (o) => o.appliesTo.targetType === 'student_label',
@@ -205,7 +205,7 @@ export function AccessControlForm({
   );
 
   const rightTitle =
-    selectedRule?.type === 'main'
+    selectedRule?.type === 'default'
       ? 'Defaults'
       : selectedRule?.type === 'override'
         ? getOverrideName(selectedRule.index)
@@ -223,9 +223,9 @@ export function AccessControlForm({
   ) : undefined;
 
   const rightPanel =
-    selectedRule?.type === 'main' ? (
+    selectedRule?.type === 'default' ? (
       <div className="px-3 pb-3">
-        <MainRuleForm
+        <DefaultRuleForm
           displayTimezone={displayTimezone}
           assessmentId={assessmentId}
           courseInstanceId={courseInstance.id}
@@ -280,16 +280,16 @@ export function AccessControlForm({
                   <AccessControlSummary
                     displayTimezone={courseInstance.display_timezone}
                     getOverrideName={getOverrideName}
-                    mainRule={watchedData.mainRule}
+                    defaultRule={watchedData.defaultRule}
                     overrides={watchedData.overrides}
                     onAddOverride={addOverride}
                     onRemoveOverride={handleDeleteClick}
                     onMoveOverride={moveOverride}
-                    onEditMainRule={() => setSelectedRule({ type: 'main' })}
-                    onClearMainRule={() =>
+                    onEditDefaultRule={() => setSelectedRule({ type: 'default' })}
+                    onClearDefaultRule={() =>
                       reset(
                         {
-                          mainRule: jsonToMainRuleFormData({}, displayTimezone),
+                          defaultRule: jsonToDefaultRuleFormData({}, displayTimezone),
                           overrides: watch('overrides'),
                         },
                         {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
@@ -17,10 +17,10 @@ import {
   DateTableView,
   OverrideRuleSummaryCard,
   type RuleFormErrors,
-  generateMainRuleDateTableRows,
+  generateDefaultRuleDateTableRows,
   generateRuleSummary,
 } from './RuleSummary.js';
-import type { AccessControlFormData, MainRuleData, OverrideData } from './types.js';
+import type { AccessControlFormData, DefaultRuleData, OverrideData } from './types.js';
 
 /**
  * Count leaf errors in a react-hook-form errors object. Leaf nodes have a
@@ -105,17 +105,17 @@ function SummaryItemChips({
   );
 }
 
-function MainRuleSummaryContent({
+function DefaultRuleSummaryContent({
   rule,
   formErrors,
   displayTimezone,
 }: {
-  rule: MainRuleData;
+  rule: DefaultRuleData;
   formErrors: RuleFormErrors | undefined;
   displayTimezone: string;
 }) {
   const summaryItems = generateRuleSummary(rule, displayTimezone, formErrors);
-  const dateTableRows = generateMainRuleDateTableRows(rule, displayTimezone, formErrors);
+  const dateTableRows = generateDefaultRuleDateTableRows(rule, displayTimezone, formErrors);
 
   return (
     <div>
@@ -140,28 +140,28 @@ function MainRuleSummaryContent({
 }
 
 export function AccessControlSummary({
-  mainRule,
+  defaultRule,
   overrides,
   getOverrideName,
   onAddOverride,
   onRemoveOverride,
   onMoveOverride,
-  onEditMainRule,
-  onClearMainRule,
+  onEditDefaultRule,
+  onClearDefaultRule,
   onEditOverride,
   displayTimezone,
 }: {
-  mainRule: MainRuleData;
+  defaultRule: DefaultRuleData;
   overrides: OverrideData[];
   /** Get the display name for an override by index */
   getOverrideName: (index: number) => string;
   onAddOverride: () => void;
   onRemoveOverride: (index: number) => void;
   onMoveOverride: (fromIndex: number, toIndex: number) => void;
-  /** Callback when main rule edit is requested */
-  onEditMainRule: () => void;
-  /** Callback when main rule reset is requested */
-  onClearMainRule: () => void;
+  /** Callback when default rule edit is requested */
+  onEditDefaultRule: () => void;
+  /** Callback when default rule reset is requested */
+  onClearDefaultRule: () => void;
   /** Callback when an override edit is requested */
   onEditOverride: (index: number) => void;
   displayTimezone: string;
@@ -189,7 +189,7 @@ export function AccessControlSummary({
   };
 
   const { errors } = useFormState<AccessControlFormData>();
-  const mainRuleErrorCount = countErrors(errors.mainRule);
+  const defaultRuleErrorCount = countErrors(errors.defaultRule);
   const overridesErrorCount = countErrors(errors.overrides);
 
   return (
@@ -198,18 +198,28 @@ export function AccessControlSummary({
         <div className="d-flex justify-content-between align-items-center gap-2 mb-1">
           <h5 className="mb-0 d-flex align-items-center">
             Defaults
-            {mainRuleErrorCount > 0 && (
+            {defaultRuleErrorCount > 0 && (
               <Badge bg="danger" className="ms-2" style={{ fontSize: '0.7rem' }}>
-                {mainRuleErrorCount} {mainRuleErrorCount === 1 ? 'error' : 'errors'}
+                {defaultRuleErrorCount} {defaultRuleErrorCount === 1 ? 'error' : 'errors'}
               </Badge>
             )}
           </h5>
           <div className="d-flex gap-2">
-            <Button variant="outline-primary" size="sm" aria-label="Edit" onClick={onEditMainRule}>
+            <Button
+              variant="outline-primary"
+              size="sm"
+              aria-label="Edit"
+              onClick={onEditDefaultRule}
+            >
               <i className="bi bi-pencil" aria-hidden="true" />
               <span className="toolbar-btn-label ms-1">Edit</span>
             </Button>
-            <Button variant="outline-danger" size="sm" aria-label="Clear" onClick={onClearMainRule}>
+            <Button
+              variant="outline-danger"
+              size="sm"
+              aria-label="Clear"
+              onClick={onClearDefaultRule}
+            >
               <i className="bi bi-trash" aria-hidden="true" />
               <span className="toolbar-btn-label ms-1">Clear</span>
             </Button>
@@ -219,9 +229,9 @@ export function AccessControlSummary({
           Access settings that apply to all students by default.
         </small>
 
-        <MainRuleSummaryContent
-          rule={mainRule}
-          formErrors={errors.mainRule}
+        <DefaultRuleSummaryContent
+          rule={defaultRule}
+          formErrors={errors.defaultRule}
           displayTimezone={displayTimezone}
         />
       </section>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -396,51 +396,53 @@ function AfterCompleteCard({
   );
 }
 
-export function MainAfterCompleteForm({
+export function DefaultAfterCompleteForm({
   title,
   displayTimezone,
 }: {
   title?: string;
   displayTimezone: string;
 }) {
-  const { field: qvField } = useController<AccessControlFormData, 'mainRule.questionVisibility'>({
-    name: 'mainRule.questionVisibility',
-    rules: { validate: validateQuestionVisibility },
-  });
+  const { field: qvField } = useController<AccessControlFormData, 'defaultRule.questionVisibility'>(
+    {
+      name: 'defaultRule.questionVisibility',
+      rules: { validate: validateQuestionVisibility },
+    },
+  );
 
-  const { field: svField } = useController<AccessControlFormData, 'mainRule.scoreVisibility'>({
-    name: 'mainRule.scoreVisibility',
+  const { field: svField } = useController<AccessControlFormData, 'defaultRule.scoreVisibility'>({
+    name: 'defaultRule.scoreVisibility',
     rules: { validate: validateScoreVisibility },
   });
 
   const { errors } = useFormState<AccessControlFormData>();
   const qvVisibleFromError: string | undefined = get(
     errors,
-    'mainRule.questionVisibility.visibleFromDate',
+    'defaultRule.questionVisibility.visibleFromDate',
   )?.message;
   const visibleUntilDateError: string | undefined = get(
     errors,
-    'mainRule.questionVisibility.visibleUntilDate',
+    'defaultRule.questionVisibility.visibleUntilDate',
   )?.message;
   const svVisibleFromError: string | undefined = get(
     errors,
-    'mainRule.scoreVisibility.visibleFromDate',
+    'defaultRule.scoreVisibility.visibleFromDate',
   )?.message;
 
-  const prairieTestExams = useWatch<AccessControlFormData, 'mainRule.prairieTestExams'>({
-    name: 'mainRule.prairieTestExams',
+  const prairieTestExams = useWatch<AccessControlFormData, 'defaultRule.prairieTestExams'>({
+    name: 'defaultRule.prairieTestExams',
   });
   const hasPrairieTest = prairieTestExams.length > 0;
 
-  const due = useWatch<AccessControlFormData, 'mainRule.due'>({
-    name: 'mainRule.due',
+  const due = useWatch<AccessControlFormData, 'defaultRule.due'>({
+    name: 'defaultRule.due',
   });
   const dueDate = due.date;
-  const lateDeadlines = useWatch<AccessControlFormData, 'mainRule.lateDeadlines'>({
-    name: 'mainRule.lateDeadlines',
+  const lateDeadlines = useWatch<AccessControlFormData, 'defaultRule.lateDeadlines'>({
+    name: 'defaultRule.lateDeadlines',
   });
-  const durationMinutes = useWatch<AccessControlFormData, 'mainRule.durationMinutes'>({
-    name: 'mainRule.durationMinutes',
+  const durationMinutes = useWatch<AccessControlFormData, 'defaultRule.durationMinutes'>({
+    name: 'defaultRule.durationMinutes',
   });
   const hasCompletionMechanism =
     hasPrairieTest || dueDate != null || lateDeadlines.length > 0 || durationMinutes != null;
@@ -460,12 +462,12 @@ export function MainAfterCompleteForm({
         </Col>
       )}
       <Col md={6}>
-        <Form.Label className="fw-bold" htmlFor="mainRule-question-visibility-mode">
+        <Form.Label className="fw-bold" htmlFor="defaultRule-question-visibility-mode">
           Question visibility
         </Form.Label>
         <QuestionVisibilityInput
           value={qvField.value}
-          idPrefix="mainRule"
+          idPrefix="defaultRule"
           hasPrairieTest={hasPrairieTest}
           hasCompletionMechanism={hasCompletionMechanism}
           visibleFromDateError={qvVisibleFromError}
@@ -475,12 +477,12 @@ export function MainAfterCompleteForm({
         />
       </Col>
       <Col md={6}>
-        <Form.Label className="fw-bold" htmlFor="mainRule-score-visibility-mode">
+        <Form.Label className="fw-bold" htmlFor="defaultRule-score-visibility-mode">
           Score visibility
         </Form.Label>
         <ScoreVisibilityInput
           value={svField.value}
-          idPrefix="mainRule"
+          idPrefix="defaultRule"
           visibleFromDateError={svVisibleFromError}
           displayTimezone={displayTimezone}
           onChange={svField.onChange}
@@ -499,14 +501,14 @@ export function OverrideAfterCompleteForm({
   title?: string;
   displayTimezone: string;
 }) {
-  const mainQV = useWatch<AccessControlFormData, 'mainRule.questionVisibility'>({
-    name: 'mainRule.questionVisibility',
+  const defaultRuleQV = useWatch<AccessControlFormData, 'defaultRule.questionVisibility'>({
+    name: 'defaultRule.questionVisibility',
   });
-  const mainSV = useWatch<AccessControlFormData, 'mainRule.scoreVisibility'>({
-    name: 'mainRule.scoreVisibility',
+  const defaultRuleSV = useWatch<AccessControlFormData, 'defaultRule.scoreVisibility'>({
+    name: 'defaultRule.scoreVisibility',
   });
-  const prairieTestExams = useWatch<AccessControlFormData, 'mainRule.prairieTestExams'>({
-    name: 'mainRule.prairieTestExams',
+  const prairieTestExams = useWatch<AccessControlFormData, 'defaultRule.prairieTestExams'>({
+    name: 'defaultRule.prairieTestExams',
   });
   const hasPrairieTest = prairieTestExams.length > 0;
 
@@ -557,7 +559,7 @@ export function OverrideAfterCompleteForm({
           isOverridden={qvOverridden}
           label="Question visibility"
           onOverride={() => {
-            qvField.onChange({ ...mainQV });
+            qvField.onChange({ ...defaultRuleQV });
             addQvOverride();
           }}
           onRemoveOverride={removeQvOverride}
@@ -578,7 +580,7 @@ export function OverrideAfterCompleteForm({
           isOverridden={svOverridden}
           label="Score visibility"
           onOverride={() => {
-            svField.onChange({ ...mainSV });
+            svField.onChange({ ...defaultRuleSV });
             addSvOverride();
           }}
           onRemoveOverride={removeSvOverride}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DateControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DateControlForm.tsx
@@ -2,18 +2,21 @@ import { Col, Form, Row } from 'react-bootstrap';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import {
-  MainAfterLastDeadlineField,
+  DefaultAfterLastDeadlineField,
   OverrideAfterLastDeadlineField,
 } from './fields/AfterLastDeadlineField.js';
-import { MainDeadlineArrayField, OverrideDeadlineArrayField } from './fields/DeadlineArrayField.js';
-import { MainDueDateField, OverrideDueDateField } from './fields/DueDateField.js';
-import { MainDurationField, OverrideDurationField } from './fields/DurationField.js';
-import { MainPasswordField, OverridePasswordField } from './fields/PasswordField.js';
-import { MainReleaseDateField, OverrideReleaseDateField } from './fields/ReleaseDateField.js';
+import {
+  DefaultDeadlineArrayField,
+  OverrideDeadlineArrayField,
+} from './fields/DeadlineArrayField.js';
+import { DefaultDueDateField, OverrideDueDateField } from './fields/DueDateField.js';
+import { DefaultDurationField, OverrideDurationField } from './fields/DurationField.js';
+import { DefaultPasswordField, OverridePasswordField } from './fields/PasswordField.js';
+import { DefaultReleaseDateField, OverrideReleaseDateField } from './fields/ReleaseDateField.js';
 import type { AccessControlFormData } from './types.js';
 import { startOfDayDatetime, todayDate } from './utils/dateUtils.js';
 
-export function MainDateControlForm({
+export function DefaultDateControlForm({
   title = 'Date control',
   description = 'Control access and credit to your assessment based on a schedule',
   displayTimezone,
@@ -28,8 +31,8 @@ export function MainDateControlForm({
 }) {
   const { register, setValue, getValues } = useFormContext<AccessControlFormData>();
 
-  const dateControlEnabled = useWatch<AccessControlFormData, 'mainRule.dateControlEnabled'>({
-    name: 'mainRule.dateControlEnabled',
+  const dateControlEnabled = useWatch<AccessControlFormData, 'defaultRule.dateControlEnabled'>({
+    name: 'defaultRule.dateControlEnabled',
   });
 
   return (
@@ -37,41 +40,45 @@ export function MainDateControlForm({
       <div className="section-header mb-3">
         <Form.Check
           type="checkbox"
-          id="mainRule-date-control-enabled"
+          id="defaultRule-date-control-enabled"
           label={<strong>{title}</strong>}
-          {...register('mainRule.dateControlEnabled', {
+          {...register('defaultRule.dateControlEnabled', {
             onChange: (e) => {
-              if (e.target.checked && !getValues('mainRule.release.date')) {
-                setValue('mainRule.release.date', startOfDayDatetime(todayDate(displayTimezone)), {
-                  shouldDirty: true,
-                  shouldValidate: true,
-                });
+              if (e.target.checked && !getValues('defaultRule.release.date')) {
+                setValue(
+                  'defaultRule.release.date',
+                  startOfDayDatetime(todayDate(displayTimezone)),
+                  {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  },
+                );
               }
             },
           })}
-          aria-describedby="mainRule-date-control-help"
+          aria-describedby="defaultRule-date-control-help"
         />
-        <Form.Text id="mainRule-date-control-help" className="text-muted">
+        <Form.Text id="defaultRule-date-control-help" className="text-muted">
           {description}
         </Form.Text>
       </div>
       {dateControlEnabled ? (
         <div className="d-flex flex-column gap-3">
-          <MainReleaseDateField displayTimezone={displayTimezone} />
-          <MainDeadlineArrayField type="early" displayTimezone={displayTimezone} />
-          <MainDueDateField
+          <DefaultReleaseDateField displayTimezone={displayTimezone} />
+          <DefaultDeadlineArrayField type="early" displayTimezone={displayTimezone} />
+          <DefaultDueDateField
             displayTimezone={displayTimezone}
             assessmentId={assessmentId}
             courseInstanceId={courseInstanceId}
           />
-          <MainDeadlineArrayField type="late" displayTimezone={displayTimezone} />
-          <MainAfterLastDeadlineField displayTimezone={displayTimezone} />
+          <DefaultDeadlineArrayField type="late" displayTimezone={displayTimezone} />
+          <DefaultAfterLastDeadlineField displayTimezone={displayTimezone} />
           <Row className="gy-3">
             <Col md={6}>
-              <MainDurationField />
+              <DefaultDurationField />
             </Col>
             <Col md={6}>
-              <MainPasswordField />
+              <DefaultPasswordField />
             </Col>
           </Row>
         </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DefaultRuleForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DefaultRuleForm.tsx
@@ -3,8 +3,8 @@ import { useFormContext } from 'react-hook-form';
 
 import { OverlayTrigger } from '@prairielearn/ui';
 
-import { MainAfterCompleteForm } from './AfterCompleteForm.js';
-import { MainDateControlForm } from './DateControlForm.js';
+import { DefaultAfterCompleteForm } from './AfterCompleteForm.js';
+import { DefaultDateControlForm } from './DateControlForm.js';
 import { IntegrationsSection } from './IntegrationsSection.js';
 import type { AccessControlFormData } from './types.js';
 
@@ -20,7 +20,7 @@ const beforeReleasePopoverConfig = {
   props: { id: 'before-release-info-popover' },
 };
 
-export function MainRuleForm({
+export function DefaultRuleForm({
   displayTimezone,
   assessmentId,
   courseInstanceId,
@@ -33,7 +33,7 @@ export function MainRuleForm({
 
   return (
     <div className="d-flex flex-column gap-3">
-      <MainDateControlForm
+      <DefaultDateControlForm
         displayTimezone={displayTimezone}
         assessmentId={assessmentId}
         courseInstanceId={courseInstanceId}
@@ -55,16 +55,16 @@ export function MainRuleForm({
         </div>
         <Form.Check
           type="checkbox"
-          id="mainRule-before-release-listed"
+          id="defaultRule-before-release-listed"
           label={<strong>List before release</strong>}
-          {...register('mainRule.beforeReleaseListed')}
-          aria-describedby="mainRule-before-release-listed-help"
+          {...register('defaultRule.beforeReleaseListed')}
+          aria-describedby="defaultRule-before-release-listed-help"
         />
-        <Form.Text id="mainRule-before-release-listed-help" className="text-muted">
+        <Form.Text id="defaultRule-before-release-listed-help" className="text-muted">
           Students can see the assessment title before release
         </Form.Text>
       </div>
-      <MainAfterCompleteForm displayTimezone={displayTimezone} />
+      <DefaultAfterCompleteForm displayTimezone={displayTimezone} />
     </div>
   );
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/IntegrationsSection.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/IntegrationsSection.tsx
@@ -7,8 +7,8 @@ import type { AccessControlFormData } from './types.js';
 export function IntegrationsSection() {
   const { setValue } = useFormContext<AccessControlFormData>();
 
-  const prairieTestExams = useWatch<AccessControlFormData, 'mainRule.prairieTestExams'>({
-    name: 'mainRule.prairieTestExams',
+  const prairieTestExams = useWatch<AccessControlFormData, 'defaultRule.prairieTestExams'>({
+    name: 'defaultRule.prairieTestExams',
   });
 
   const prairieTestEnabled = prairieTestExams.length > 0;
@@ -20,24 +20,27 @@ export function IntegrationsSection() {
       </div>
       <Form.Check
         type="checkbox"
-        id="mainRule-prairietest-enabled"
+        id="defaultRule-prairietest-enabled"
         label={<strong>PrairieTest</strong>}
         checked={prairieTestEnabled}
-        aria-describedby="mainRule-prairietest-help"
+        aria-describedby="defaultRule-prairietest-help"
         onChange={(e) => {
           if (!e.target.checked) {
-            setValue('mainRule.prairieTestExams', [], { shouldDirty: true, shouldValidate: true });
+            setValue('defaultRule.prairieTestExams', [], {
+              shouldDirty: true,
+              shouldValidate: true,
+            });
           } else {
             // Add an initial entry when toggling it on so that the user can immediately
             // start configuring it without needing to click "Add Exam" first.
-            setValue('mainRule.prairieTestExams', [{ examUuid: '', readOnly: false }], {
+            setValue('defaultRule.prairieTestExams', [{ examUuid: '', readOnly: false }], {
               shouldDirty: true,
               shouldValidate: true,
             });
           }
         }}
       />
-      <Form.Text id="mainRule-prairietest-help" className="text-muted">
+      <Form.Text id="defaultRule-prairietest-help" className="text-muted">
         Control access to your assessment through PrairieTest exams
       </Form.Text>
       {prairieTestEnabled && <PrairieTestControlForm />}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
@@ -11,14 +11,14 @@ export function PrairieTestControlForm() {
     fields: examFields,
     append: appendExam,
     remove: removeExam,
-  } = useFieldArray<AccessControlFormData, 'mainRule.prairieTestExams'>({
-    name: 'mainRule.prairieTestExams',
+  } = useFieldArray<AccessControlFormData, 'defaultRule.prairieTestExams'>({
+    name: 'defaultRule.prairieTestExams',
   });
 
   const { errors } = useFormState();
 
-  const watchedExams = useWatch<AccessControlFormData, 'mainRule.prairieTestExams'>({
-    name: 'mainRule.prairieTestExams',
+  const watchedExams = useWatch<AccessControlFormData, 'defaultRule.prairieTestExams'>({
+    name: 'defaultRule.prairieTestExams',
   });
   const examsRef = useRef(watchedExams);
   examsRef.current = watchedExams;
@@ -30,11 +30,11 @@ export function PrairieTestControlForm() {
   // IntegrationsSection) show errors immediately and duplicate detection
   // re-runs after add/remove/edit.
   useEffect(() => {
-    void trigger('mainRule.prairieTestExams');
+    void trigger('defaultRule.prairieTestExams');
   }, [examFields.length, watchedExamUuids, trigger]);
 
   const getExamUuidError = (index: number): string | undefined => {
-    return get(errors, `mainRule.prairieTestExams.${index}.examUuid`)?.message;
+    return get(errors, `defaultRule.prairieTestExams.${index}.examUuid`)?.message;
   };
 
   return (
@@ -45,19 +45,19 @@ export function PrairieTestControlForm() {
           className="mb-3 border rounded p-3"
           style={{ borderColor: 'var(--bs-border-color)' }}
         >
-          <Form.Group className="mb-3" controlId={`mainRule-exam-uuid-${index}`}>
+          <Form.Group className="mb-3" controlId={`defaultRule-exam-uuid-${index}`}>
             <Form.Label>Exam UUID</Form.Label>
             <Form.Control
               type="text"
               isInvalid={!!getExamUuidError(index)}
               aria-invalid={!!getExamUuidError(index)}
               aria-errormessage={
-                getExamUuidError(index) ? `mainRule-exam-uuid-${index}-error` : undefined
+                getExamUuidError(index) ? `defaultRule-exam-uuid-${index}-error` : undefined
               }
-              aria-describedby={`mainRule-exam-uuid-${index}-help`}
+              aria-describedby={`defaultRule-exam-uuid-${index}-help`}
               defaultValue=""
               placeholder="e.g., 11e89892-3eff-4d7f-90a2-221372f14e5c"
-              {...register(`mainRule.prairieTestExams.${index}.examUuid`, {
+              {...register(`defaultRule.prairieTestExams.${index}.examUuid`, {
                 required: 'Exam UUID is required',
                 pattern: {
                   value: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
@@ -76,14 +76,14 @@ export function PrairieTestControlForm() {
             />
             {getExamUuidError(index) && (
               <Form.Text
-                id={`mainRule-exam-uuid-${index}-error`}
+                id={`defaultRule-exam-uuid-${index}-error`}
                 className="text-danger d-block"
                 role="alert"
               >
                 {getExamUuidError(index)}
               </Form.Text>
             )}
-            <Form.Text id={`mainRule-exam-uuid-${index}-help`} className="text-muted">
+            <Form.Text id={`defaultRule-exam-uuid-${index}-help`} className="text-muted">
               You can find this UUID in the PrairieTest exam settings
             </Form.Text>
           </Form.Group>
@@ -91,13 +91,13 @@ export function PrairieTestControlForm() {
             <Form.Group>
               <Form.Check
                 type="checkbox"
-                id={`mainRule-exam-readonly-${index}`}
+                id={`defaultRule-exam-readonly-${index}`}
                 label="Read-only mode"
                 defaultChecked={false}
-                {...register(`mainRule.prairieTestExams.${index}.readOnly`)}
-                aria-describedby={`mainRule-exam-readonly-${index}-help`}
+                {...register(`defaultRule.prairieTestExams.${index}.readOnly`)}
+                aria-describedby={`defaultRule-exam-readonly-${index}-help`}
               />
-              <Form.Text id={`mainRule-exam-readonly-${index}-help`} className="text-muted">
+              <Form.Text id={`defaultRule-exam-readonly-${index}-help`} className="text-muted">
                 Students can view but not submit answers
               </Form.Text>
             </Form.Group>
@@ -119,7 +119,7 @@ export function PrairieTestControlForm() {
         onClick={() => {
           appendExam({ examUuid: '', readOnly: false });
           // Trigger validation so the empty UUID error shows immediately.
-          void trigger('mainRule.prairieTestExams');
+          void trigger('defaultRule.prairieTestExams');
         }}
       >
         <i className="bi bi-plus-circle me-1" aria-hidden="true" />

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -219,10 +219,10 @@ export function generateRuleSummary(
   }
 
   if (isDefaultRuleData(rule) && rule.prairieTestExams.length > 0) {
-    const mainErrors = formErrors as FieldErrors<DefaultRuleData> | undefined;
+    const defaultRuleErrors = formErrors as FieldErrors<DefaultRuleData> | undefined;
     const examErrors: string[] = [];
     for (let i = 0; i < rule.prairieTestExams.length; i++) {
-      const msg = mainErrors?.prairieTestExams?.[i]?.examUuid?.message;
+      const msg = defaultRuleErrors?.prairieTestExams?.[i]?.examUuid?.message;
       if (msg) examErrors.push(`Exam ${i + 1}: ${msg}`);
     }
     const error = examErrors.length > 0 ? examErrors.join('; ') : undefined;

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -9,24 +9,24 @@ import { StudentLabelBadge } from '../../../components/StudentLabelBadge.js';
 import {
   type AfterLastDeadlineValue,
   type DeadlineEntry,
-  type MainRuleData,
+  type DefaultRuleData,
   type OverridableFieldName,
   type OverrideData,
   isNonDefaultQuestionVisibility,
   isNonDefaultScoreVisibility,
 } from './types.js';
 
-type RuleData = MainRuleData | OverrideData;
+type RuleData = DefaultRuleData | OverrideData;
 
 /** react-hook-form error subtree for a single access control rule. */
-export type RuleFormErrors = FieldErrors<MainRuleData> | FieldErrors<OverrideData>;
+export type RuleFormErrors = FieldErrors<DefaultRuleData> | FieldErrors<OverrideData>;
 
-function isMainRuleData(rule: RuleData): rule is MainRuleData {
+function isDefaultRuleData(rule: RuleData): rule is DefaultRuleData {
   return 'dateControlEnabled' in rule;
 }
 
 function isOverrideFieldActive(rule: RuleData, fieldName: OverridableFieldName): boolean {
-  if (isMainRuleData(rule)) return true;
+  if (isDefaultRuleData(rule)) return true;
   return rule.overriddenFields.includes(fieldName);
 }
 
@@ -37,8 +37,8 @@ interface DateTableRow {
   error?: string;
 }
 
-export function generateMainRuleDateTableRows(
-  rule: MainRuleData,
+export function generateDefaultRuleDateTableRows(
+  rule: DefaultRuleData,
   displayTimezone: string,
   formErrors?: RuleFormErrors,
 ): DateTableRow[] {
@@ -179,7 +179,7 @@ export function generateRuleSummary(
   const items: SummaryItem[] = [];
 
   // Show "before release" chip when release date is in the future.
-  if (isMainRuleData(rule) && rule.dateControlEnabled && rule.release.date) {
+  if (isDefaultRuleData(rule) && rule.dateControlEnabled && rule.release.date) {
     const releasePlainDateTime = Temporal.PlainDateTime.from(rule.release.date);
     const nowInTimezone = Temporal.Now.plainDateTimeISO(displayTimezone);
 
@@ -218,8 +218,8 @@ export function generateRuleSummary(
     }
   }
 
-  if (isMainRuleData(rule) && rule.prairieTestExams.length > 0) {
-    const mainErrors = formErrors as FieldErrors<MainRuleData> | undefined;
+  if (isDefaultRuleData(rule) && rule.prairieTestExams.length > 0) {
+    const mainErrors = formErrors as FieldErrors<DefaultRuleData> | undefined;
     const examErrors: string[] = [];
     for (let i = 0; i < rule.prairieTestExams.length; i++) {
       const msg = mainErrors?.prairieTestExams?.[i]?.examUuid?.message;
@@ -236,9 +236,9 @@ export function generateRuleSummary(
     });
   }
 
-  const isMain = isMainRuleData(rule);
-  const hasDateControl = isMain ? rule.dateControlEnabled : false;
-  const hasPrairieTest = isMain ? rule.prairieTestExams.length > 0 : false;
+  const isDefault = isDefaultRuleData(rule);
+  const hasDateControl = isDefault ? rule.dateControlEnabled : false;
+  const hasPrairieTest = isDefault ? rule.prairieTestExams.length > 0 : false;
   const showAfterComplete = hasDateControl || hasPrairieTest;
 
   const qvNonDefault = isNonDefaultQuestionVisibility(rule.questionVisibility);

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -53,22 +53,22 @@ function resolveConstraints(
   overrideIndex?: number,
 ): { dueDate: string | null; dueCredit: number; lateDeadlines: DeadlineEntry[] } {
   if (overrideIndex == null) {
-    const due = formValues.mainRule.due;
+    const due = formValues.defaultRule.due;
     return {
       dueDate: due.date,
       dueCredit: due.credit ?? 100,
-      lateDeadlines: formValues.mainRule.lateDeadlines,
+      lateDeadlines: formValues.defaultRule.lateDeadlines,
     };
   }
   const override = formValues.overrides[overrideIndex];
   const overriddenFields = override.overriddenFields;
-  const effectiveDue = overriddenFields.includes('due') ? override.due : formValues.mainRule.due;
+  const effectiveDue = overriddenFields.includes('due') ? override.due : formValues.defaultRule.due;
   return {
     dueDate: effectiveDue.date,
     dueCredit: effectiveDue.credit ?? 100,
     lateDeadlines: overriddenFields.includes('lateDeadlines')
       ? override.lateDeadlines
-      : formValues.mainRule.lateDeadlines,
+      : formValues.defaultRule.lateDeadlines,
   };
 }
 
@@ -88,20 +88,20 @@ function AfterLastDeadlineInput({
   const isOverride = overrideIndex != null;
   const creditFieldPath = isOverride
     ? (`overrides.${overrideIndex}.afterLastDeadline.credit` as const)
-    : ('mainRule.afterLastDeadline.credit' as const);
-  const idPrefix = isOverride ? `overrides-${overrideIndex}` : 'mainRule';
+    : ('defaultRule.afterLastDeadline.credit' as const);
+  const idPrefix = isOverride ? `overrides-${overrideIndex}` : 'defaultRule';
 
   // Field paths that affect credit validation — used for both display
   // reactivity (useWatch) and validation re-triggering (deps).
   const creditDeps: FieldPath<AccessControlFormData>[] = isOverride
     ? [
-        'mainRule.due',
-        'mainRule.lateDeadlines',
+        'defaultRule.due',
+        'defaultRule.lateDeadlines',
         `overrides.${overrideIndex}.overriddenFields`,
         `overrides.${overrideIndex}.due`,
         `overrides.${overrideIndex}.lateDeadlines`,
       ]
-    : ['mainRule.due', 'mainRule.lateDeadlines'];
+    : ['defaultRule.due', 'defaultRule.lateDeadlines'];
 
   const { register, getValues, trigger } = useFormContext<AccessControlFormData>();
   const { errors } = useFormState();
@@ -232,9 +232,9 @@ function AfterLastDeadlineInput({
   );
 }
 
-export function MainAfterLastDeadlineField({ displayTimezone }: { displayTimezone: string }) {
-  const { field } = useController<AccessControlFormData, 'mainRule.afterLastDeadline'>({
-    name: 'mainRule.afterLastDeadline',
+export function DefaultAfterLastDeadlineField({ displayTimezone }: { displayTimezone: string }) {
+  const { field } = useController<AccessControlFormData, 'defaultRule.afterLastDeadline'>({
+    name: 'defaultRule.afterLastDeadline',
   });
 
   return (
@@ -256,8 +256,8 @@ export function OverrideAfterLastDeadlineField({
   index: number;
   displayTimezone: string;
 }) {
-  const mainValue = useWatch<AccessControlFormData, 'mainRule.afterLastDeadline'>({
-    name: 'mainRule.afterLastDeadline',
+  const defaultRuleValue = useWatch<AccessControlFormData, 'defaultRule.afterLastDeadline'>({
+    name: 'defaultRule.afterLastDeadline',
   });
 
   const { field } = useController<AccessControlFormData, `overrides.${number}.afterLastDeadline`>({
@@ -274,7 +274,7 @@ export function OverrideAfterLastDeadlineField({
       isOverridden={isOverridden}
       label="After last deadline"
       onOverride={() => {
-        field.onChange(mainValue ?? { allowSubmissions: false });
+        field.onChange(defaultRuleValue ?? { allowSubmissions: false });
         addOverride();
       }}
       onRemoveOverride={removeOverride}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -21,8 +21,8 @@ import type { AccessControlFormData, DeadlineEntry } from '../types.js';
 import { endOfDayDatetime } from '../utils/dateUtils.js';
 
 type DeadlineArrayFieldName =
-  | 'mainRule.earlyDeadlines'
-  | 'mainRule.lateDeadlines'
+  | 'defaultRule.earlyDeadlines'
+  | 'defaultRule.lateDeadlines'
   | `overrides.${number}.earlyDeadlines`
   | `overrides.${number}.lateDeadlines`;
 
@@ -417,7 +417,7 @@ function DeadlineArrayInput({
   );
 }
 
-export function MainDeadlineArrayField({
+export function DefaultDeadlineArrayField({
   type,
   displayTimezone,
 }: {
@@ -425,14 +425,14 @@ export function MainDeadlineArrayField({
   displayTimezone: string;
 }) {
   const isEarly = type === 'early';
-  const fieldName = isEarly ? 'mainRule.earlyDeadlines' : 'mainRule.lateDeadlines';
+  const fieldName = isEarly ? 'defaultRule.earlyDeadlines' : 'defaultRule.lateDeadlines';
 
-  const releaseDate = useWatch<AccessControlFormData, 'mainRule.release.date'>({
-    name: 'mainRule.release.date',
+  const releaseDate = useWatch<AccessControlFormData, 'defaultRule.release.date'>({
+    name: 'defaultRule.release.date',
   });
 
-  const due = useWatch<AccessControlFormData, 'mainRule.due'>({
-    name: 'mainRule.due',
+  const due = useWatch<AccessControlFormData, 'defaultRule.due'>({
+    name: 'defaultRule.due',
   });
 
   const deadlines = useWatch<AccessControlFormData, typeof fieldName>({
@@ -455,7 +455,7 @@ export function MainDeadlineArrayField({
     <DeadlineArrayInput
       type={type}
       fieldArrayName={fieldName}
-      idPrefix="mainRule"
+      idPrefix="defaultRule"
       releaseDate={releaseDate}
       dueDate={dueDate}
       dueCredit={dueCredit}
@@ -488,19 +488,19 @@ export function OverrideDeadlineArrayField({
 
   const { isOverridden, addOverride, removeOverride } = useOverrideField(index, fieldPath);
 
-  const mainDeadlines = useWatch<AccessControlFormData, `mainRule.${typeof fieldPath}`>({
-    name: `mainRule.${fieldPath}`,
+  const defaultRuleDeadlines = useWatch<AccessControlFormData, `defaultRule.${typeof fieldPath}`>({
+    name: `defaultRule.${fieldPath}`,
   });
 
   const deadlines = useWatch<AccessControlFormData, typeof fieldArrayName>({
     name: fieldArrayName,
   });
 
-  const mainReleaseDate = useWatch<AccessControlFormData, 'mainRule.release.date'>({
-    name: 'mainRule.release.date',
+  const defaultRuleReleaseDate = useWatch<AccessControlFormData, 'defaultRule.release.date'>({
+    name: 'defaultRule.release.date',
   });
-  const mainDue = useWatch<AccessControlFormData, 'mainRule.due'>({
-    name: 'mainRule.due',
+  const defaultRuleDue = useWatch<AccessControlFormData, 'defaultRule.due'>({
+    name: 'defaultRule.due',
   });
 
   const { isOverridden: releaseDateOverridden } = useOverrideField(index, 'release');
@@ -512,8 +512,8 @@ export function OverrideDeadlineArrayField({
     name: `overrides.${index}.due`,
   });
 
-  const effectiveReleaseDate = releaseDateOverridden ? overrideReleaseDate : mainReleaseDate;
-  const effectiveDue = dueOverridden ? overrideDue : mainDue;
+  const effectiveReleaseDate = releaseDateOverridden ? overrideReleaseDate : defaultRuleReleaseDate;
+  const effectiveDue = dueOverridden ? overrideDue : defaultRuleDue;
   const effectiveDueDate = effectiveDue.date;
   const effectiveDueCredit = effectiveDue.credit ?? 100;
   const validationReleaseDate = releaseDateOverridden ? overrideReleaseDate : undefined;
@@ -526,7 +526,7 @@ export function OverrideDeadlineArrayField({
     name: fieldArrayName,
   });
 
-  // See MainDeadlineArrayField: late deadlines need a due date to anchor.
+  // See DefaultDeadlineArrayField: late deadlines need a due date to anchor.
   if (!isEarly && !isOverridden && deadlines.length === 0 && !effectiveDueDate) return null;
 
   const nextDeadline = () =>
@@ -571,7 +571,7 @@ export function OverrideDeadlineArrayField({
         </Button>
       }
       onOverride={() => {
-        const copied = mainDeadlines.map((d) => ({ ...d }));
+        const copied = defaultRuleDeadlines.map((d) => ({ ...d }));
         replace(copied);
         addOverride();
       }}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
@@ -270,7 +270,7 @@ function validateDueCredit(credit: number | null, customCredit: boolean): string
   return undefined;
 }
 
-export function MainDueDateField({
+export function DefaultDueDateField({
   displayTimezone,
   assessmentId,
   courseInstanceId,
@@ -279,29 +279,29 @@ export function MainDueDateField({
   assessmentId: string;
   courseInstanceId: string;
 }) {
-  const releaseDate = useWatch<AccessControlFormData, 'mainRule.release.date'>({
-    name: 'mainRule.release.date',
+  const releaseDate = useWatch<AccessControlFormData, 'defaultRule.release.date'>({
+    name: 'defaultRule.release.date',
   });
 
-  const earlyDeadlines = useWatch<AccessControlFormData, 'mainRule.earlyDeadlines'>({
-    name: 'mainRule.earlyDeadlines',
+  const earlyDeadlines = useWatch<AccessControlFormData, 'defaultRule.earlyDeadlines'>({
+    name: 'defaultRule.earlyDeadlines',
   });
 
-  const customCreditCtrl = useController<AccessControlFormData, 'mainRule.due.customCredit'>({
-    name: 'mainRule.due.customCredit',
+  const customCreditCtrl = useController<AccessControlFormData, 'defaultRule.due.customCredit'>({
+    name: 'defaultRule.due.customCredit',
   });
 
-  const dateCtrl = useController<AccessControlFormData, 'mainRule.due.date'>({
-    name: 'mainRule.due.date',
+  const dateCtrl = useController<AccessControlFormData, 'defaultRule.due.date'>({
+    name: 'defaultRule.due.date',
     rules: {
       validate: (value) => validateDueDate(value, releaseDate, displayTimezone) ?? true,
     },
   });
-  const creditCtrl = useController<AccessControlFormData, 'mainRule.due.credit'>({
-    name: 'mainRule.due.credit',
+  const creditCtrl = useController<AccessControlFormData, 'defaultRule.due.credit'>({
+    name: 'defaultRule.due.credit',
     rules: {
       validate: (value, formValues) =>
-        validateDueCredit(value, formValues.mainRule.due.customCredit) ?? true,
+        validateDueCredit(value, formValues.defaultRule.due.customCredit) ?? true,
     },
   });
 
@@ -323,7 +323,7 @@ export function MainDueDateField({
       <Form.Label className="fw-bold">Due date</Form.Label>
       <DueDateInput
         value={value}
-        idPrefix="mainRule"
+        idPrefix="defaultRule"
         releaseDate={releaseDate}
         earlyDeadlines={earlyDeadlines}
         dateError={dateCtrl.fieldState.error?.message}
@@ -348,8 +348,8 @@ export function OverrideDueDateField({
   assessmentId: string;
   courseInstanceId: string;
 }) {
-  const mainValue = useWatch<AccessControlFormData, 'mainRule.due'>({
-    name: 'mainRule.due',
+  const defaultRuleValue = useWatch<AccessControlFormData, 'defaultRule.due'>({
+    name: 'defaultRule.due',
   });
 
   const { isOverridden, addOverride, removeOverride } = useOverrideField(index, 'due');
@@ -358,19 +358,19 @@ export function OverrideDueDateField({
   const releaseDate = useWatch<AccessControlFormData, `overrides.${number}.release.date`>({
     name: `overrides.${index}.release.date`,
   });
-  const mainReleaseDate = useWatch<AccessControlFormData, 'mainRule.release.date'>({
-    name: 'mainRule.release.date',
+  const defaultRuleReleaseDate = useWatch<AccessControlFormData, 'defaultRule.release.date'>({
+    name: 'defaultRule.release.date',
   });
 
   const { isOverridden: earlyDeadlinesOverridden } = useOverrideField(index, 'earlyDeadlines');
   const earlyDeadlines = useWatch<AccessControlFormData, `overrides.${number}.earlyDeadlines`>({
     name: `overrides.${index}.earlyDeadlines`,
   });
-  const mainEarlyDeadlines = useWatch<AccessControlFormData, 'mainRule.earlyDeadlines'>({
-    name: 'mainRule.earlyDeadlines',
+  const defaultRuleEarlyDeadlines = useWatch<AccessControlFormData, 'defaultRule.earlyDeadlines'>({
+    name: 'defaultRule.earlyDeadlines',
   });
 
-  const effectiveReleaseDate = releaseDateOverridden ? releaseDate : mainReleaseDate;
+  const effectiveReleaseDate = releaseDateOverridden ? releaseDate : defaultRuleReleaseDate;
   const validationReleaseDate = releaseDateOverridden ? releaseDate : undefined;
 
   const customCreditCtrl = useController<
@@ -412,9 +412,9 @@ export function OverrideDueDateField({
       isOverridden={isOverridden}
       label="Due date"
       onOverride={() => {
-        dateCtrl.field.onChange(mainValue.date);
-        creditCtrl.field.onChange(mainValue.credit);
-        customCreditCtrl.field.onChange(mainValue.customCredit);
+        dateCtrl.field.onChange(defaultRuleValue.date);
+        creditCtrl.field.onChange(defaultRuleValue.credit);
+        customCreditCtrl.field.onChange(defaultRuleValue.customCredit);
         addOverride();
       }}
       onRemoveOverride={removeOverride}
@@ -423,7 +423,7 @@ export function OverrideDueDateField({
         value={value}
         idPrefix={`overrides-${index}`}
         releaseDate={effectiveReleaseDate}
-        earlyDeadlines={earlyDeadlinesOverridden ? earlyDeadlines : mainEarlyDeadlines}
+        earlyDeadlines={earlyDeadlinesOverridden ? earlyDeadlines : defaultRuleEarlyDeadlines}
         dateError={dateCtrl.fieldState.error?.message}
         creditError={creditCtrl.fieldState.error?.message}
         displayTimezone={displayTimezone}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DurationField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DurationField.tsx
@@ -90,21 +90,21 @@ function DurationToggle({
   );
 }
 
-export function MainDurationField() {
+export function DefaultDurationField() {
   const {
     field,
     fieldState: { error },
-  } = useController<AccessControlFormData, 'mainRule.durationMinutes'>({
-    name: 'mainRule.durationMinutes',
+  } = useController<AccessControlFormData, 'defaultRule.durationMinutes'>({
+    name: 'defaultRule.durationMinutes',
     rules: { validate: validateDuration },
   });
 
   return (
     <Form.Group>
-      <DurationToggle value={field.value} idPrefix="mainRule" onChange={field.onChange} />
+      <DurationToggle value={field.value} idPrefix="defaultRule" onChange={field.onChange} />
       <DurationDetails
         value={field.value}
-        idPrefix="mainRule"
+        idPrefix="defaultRule"
         error={error?.message}
         onChange={field.onChange}
       />
@@ -113,8 +113,8 @@ export function MainDurationField() {
 }
 
 export function OverrideDurationField({ index }: { index: number }) {
-  const mainValue = useWatch<AccessControlFormData, 'mainRule.durationMinutes'>({
-    name: 'mainRule.durationMinutes',
+  const defaultRuleValue = useWatch<AccessControlFormData, 'defaultRule.durationMinutes'>({
+    name: 'defaultRule.durationMinutes',
   });
 
   const {
@@ -140,7 +140,7 @@ export function OverrideDurationField({ index }: { index: number }) {
         />
       }
       onOverride={() => {
-        field.onChange(mainValue);
+        field.onChange(defaultRuleValue);
         addOverride();
       }}
       onRemoveOverride={removeOverride}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/PasswordField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/PasswordField.tsx
@@ -85,23 +85,23 @@ function PasswordDetails({
   );
 }
 
-export function MainPasswordField() {
-  const { field } = useController<AccessControlFormData, 'mainRule.password'>({
-    name: 'mainRule.password',
+export function DefaultPasswordField() {
+  const { field } = useController<AccessControlFormData, 'defaultRule.password'>({
+    name: 'defaultRule.password',
     rules: { validate: (v) => v !== '' || 'Password is required' },
   });
 
   return (
     <Form.Group>
-      <PasswordToggle value={field.value} idPrefix="mainRule" onChange={field.onChange} />
-      <PasswordDetails value={field.value} idPrefix="mainRule" onChange={field.onChange} />
+      <PasswordToggle value={field.value} idPrefix="defaultRule" onChange={field.onChange} />
+      <PasswordDetails value={field.value} idPrefix="defaultRule" onChange={field.onChange} />
     </Form.Group>
   );
 }
 
 export function OverridePasswordField({ index }: { index: number }) {
-  const mainValue = useWatch<AccessControlFormData, 'mainRule.password'>({
-    name: 'mainRule.password',
+  const defaultRuleValue = useWatch<AccessControlFormData, 'defaultRule.password'>({
+    name: 'defaultRule.password',
   });
 
   const { field } = useController<AccessControlFormData, `overrides.${number}.password`>({
@@ -124,7 +124,7 @@ export function OverridePasswordField({ index }: { index: number }) {
         />
       }
       onOverride={() => {
-        field.onChange(mainValue);
+        field.onChange(defaultRuleValue);
         addOverride();
       }}
       onRemoveOverride={removeOverride}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
@@ -87,16 +87,16 @@ function ReleaseDateInput({
   );
 }
 
-export function MainReleaseDateField({ displayTimezone }: { displayTimezone: string }) {
-  const dateControlEnabled = useWatch<AccessControlFormData, 'mainRule.dateControlEnabled'>({
-    name: 'mainRule.dateControlEnabled',
+export function DefaultReleaseDateField({ displayTimezone }: { displayTimezone: string }) {
+  const dateControlEnabled = useWatch<AccessControlFormData, 'defaultRule.dateControlEnabled'>({
+    name: 'defaultRule.dateControlEnabled',
   });
 
   const {
     field,
     fieldState: { error },
-  } = useController<AccessControlFormData, 'mainRule.release.date'>({
-    name: 'mainRule.release.date',
+  } = useController<AccessControlFormData, 'defaultRule.release.date'>({
+    name: 'defaultRule.release.date',
     rules: {
       validate: (value) => {
         if (!dateControlEnabled) return true;
@@ -112,7 +112,7 @@ export function MainReleaseDateField({ displayTimezone }: { displayTimezone: str
       <ReleaseDateInput
         value={field.value}
         error={error?.message}
-        idPrefix="mainRule"
+        idPrefix="defaultRule"
         displayTimezone={displayTimezone}
         onChange={field.onChange}
       />
@@ -127,8 +127,8 @@ export function OverrideReleaseDateField({
   index: number;
   displayTimezone: string;
 }) {
-  const mainValue = useWatch<AccessControlFormData, 'mainRule.release.date'>({
-    name: 'mainRule.release.date',
+  const defaultRuleValue = useWatch<AccessControlFormData, 'defaultRule.release.date'>({
+    name: 'defaultRule.release.date',
   });
 
   const { field } = useController<AccessControlFormData, `overrides.${number}.release.date`>({
@@ -142,7 +142,7 @@ export function OverrideReleaseDateField({
       isOverridden={isOverridden}
       label="Release"
       onOverride={() => {
-        field.onChange(mainValue || todayLocalDatetime(displayTimezone));
+        field.onChange(defaultRuleValue || todayLocalDatetime(displayTimezone));
         addOverride();
       }}
       onRemoveOverride={removeOverride}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/hooks/useOverrideField.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/hooks/useOverrideField.ts
@@ -5,7 +5,7 @@ import type { AccessControlFormData, OverridableFieldName } from '../types.js';
 
 /**
  * Hook that manages whether a single override field is active (overridden) or
- * inherited from the main rule.  The overridden state is tracked via the
+ * inherited from the default rule.  The overridden state is tracked via the
  * `overriddenFields` string array on the override – not by setting the value
  * to `undefined`, which react-hook-form does not support.
  */

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type AccessControlFormData,
-  type MainRuleData,
+  type DefaultRuleData,
   type OverrideData,
   formDataToJson,
-  jsonToMainRuleFormData,
+  jsonToDefaultRuleFormData,
 } from './types.js';
 
 const TEST_TIMEZONE = 'America/Chicago';
 
-const defaultMainRule: MainRuleData = {
-  trackingId: 'main-1',
+const defaultRuleFixture: DefaultRuleData = {
+  trackingId: 'default-1',
   beforeReleaseListed: true,
   dateControlEnabled: true,
   release: { date: '2025-03-01T00:00:00Z' },
@@ -46,53 +46,53 @@ const baseOverride: OverrideData = {
 };
 
 function buildFormData(override: OverrideData): AccessControlFormData {
-  return { mainRule: defaultMainRule, overrides: [override] };
+  return { defaultRule: defaultRuleFixture, overrides: [override] };
 }
 
-describe('jsonToMainRuleFormData', () => {
+describe('jsonToDefaultRuleFormData', () => {
   it('defaults release.date to null when dateControl is not configured', () => {
-    const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
-    expect(mainRule.release.date).toBeNull();
+    const defaultRule = jsonToDefaultRuleFormData({}, TEST_TIMEZONE);
+    expect(defaultRule.release.date).toBeNull();
   });
 
   it('defaults hidden to true for questions when afterComplete is not configured', () => {
-    const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
-    expect(mainRule.questionVisibility.hidden).toBe(true);
+    const defaultRule = jsonToDefaultRuleFormData({}, TEST_TIMEZONE);
+    expect(defaultRule.questionVisibility.hidden).toBe(true);
   });
 
   it('defaults hidden to false for score when afterComplete is not configured', () => {
-    const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
-    expect(mainRule.scoreVisibility.hidden).toBe(false);
+    const defaultRule = jsonToDefaultRuleFormData({}, TEST_TIMEZONE);
+    expect(defaultRule.scoreVisibility.hidden).toBe(false);
   });
 
   it('preserves hidden: false for questions when explicitly set in JSON', () => {
-    const mainRule = jsonToMainRuleFormData(
+    const defaultRule = jsonToDefaultRuleFormData(
       { afterComplete: { questions: { hidden: false } } },
       TEST_TIMEZONE,
     );
-    expect(mainRule.questionVisibility.hidden).toBe(false);
+    expect(defaultRule.questionVisibility.hidden).toBe(false);
   });
 
   it('preserves hidden: true for questions when explicitly set in JSON', () => {
-    const mainRule = jsonToMainRuleFormData(
+    const defaultRule = jsonToDefaultRuleFormData(
       { afterComplete: { questions: { hidden: true } } },
       TEST_TIMEZONE,
     );
-    expect(mainRule.questionVisibility.hidden).toBe(true);
+    expect(defaultRule.questionVisibility.hidden).toBe(true);
   });
 });
 
 describe('formDataToJson', () => {
-  it('defaults beforeReleaseListed to false when omitted from the main rule JSON', () => {
-    const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
+  it('defaults beforeReleaseListed to false when omitted from the default rule JSON', () => {
+    const defaultRule = jsonToDefaultRuleFormData({}, TEST_TIMEZONE);
 
-    expect(mainRule.beforeReleaseListed).toBe(false);
+    expect(defaultRule.beforeReleaseListed).toBe(false);
   });
 
-  it('omits default score visibility when only main-rule question visibility is non-default', () => {
+  it('omits default score visibility when only default-rule question visibility is non-default', () => {
     const result = formDataToJson({
-      mainRule: {
-        ...defaultMainRule,
+      defaultRule: {
+        ...defaultRuleFixture,
         questionVisibility: { hidden: false },
         scoreVisibility: { hidden: false },
       },
@@ -104,10 +104,10 @@ describe('formDataToJson', () => {
     });
   });
 
-  it('emits an explicit null due date for main rules when date control is enabled', () => {
+  it('emits an explicit null due date for default rules when date control is enabled', () => {
     const result = formDataToJson({
-      mainRule: {
-        ...defaultMainRule,
+      defaultRule: {
+        ...defaultRuleFixture,
         due: { date: null, credit: null, customCredit: false },
       },
       overrides: [],
@@ -214,7 +214,7 @@ describe('formDataToJson', () => {
 
   it('preserves explicit null/empty override removals in dateControl', () => {
     const formData: AccessControlFormData = {
-      mainRule: defaultMainRule,
+      defaultRule: defaultRuleFixture,
       overrides: [
         {
           ...baseOverride,

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -88,8 +88,8 @@ export interface AppliesTo {
   studentLabels: StudentLabelTarget[];
 }
 
-// Main rule: flat fields, null = feature off
-export interface MainRuleData {
+// Default rule: flat fields, null = feature off
+export interface DefaultRuleData {
   id?: string;
   trackingId: string;
   beforeReleaseListed: boolean;
@@ -107,7 +107,7 @@ export interface MainRuleData {
 }
 
 // Override: flat fields. The `overriddenFields` array tracks which fields
-// are overridden vs inherited from the main rule.  We avoid using `undefined`
+// are overridden vs inherited from the default rule.  We avoid using `undefined`
 // as a sentinel because react-hook-form does not support setting field values
 // to `undefined` (the value silently reverts).
 export interface OverrideData {
@@ -127,7 +127,7 @@ export interface OverrideData {
 }
 
 export interface AccessControlFormData {
-  mainRule: MainRuleData;
+  defaultRule: DefaultRuleData;
   overrides: OverrideData[];
 }
 
@@ -151,10 +151,10 @@ function toLocalDatetimeValue<T extends string | null | undefined>(
   return value;
 }
 
-export function jsonToMainRuleFormData(
+export function jsonToDefaultRuleFormData(
   json: AccessControlJsonWithId,
   displayTimezone: string,
-): MainRuleData {
+): DefaultRuleData {
   const dc = json.dateControl;
   const ac = json.afterComplete;
 
@@ -344,7 +344,7 @@ function buildDueJson(due: DueValue): { date: string | null; credit?: number } {
   return { date: due.date };
 }
 
-function mainRuleToJson(rule: MainRuleData): AccessControlJsonWithId {
+function defaultRuleToJson(rule: DefaultRuleData): AccessControlJsonWithId {
   const output: AccessControlJsonWithId = {
     id: rule.id,
   };
@@ -410,7 +410,7 @@ function mainRuleToJson(rule: MainRuleData): AccessControlJsonWithId {
 }
 
 function overrideToJson(rule: OverrideData): AccessControlJsonWithId {
-  // Override rules always emit a `labels` array (possibly empty); only main
+  // Override rules always emit a `labels` array (possibly empty); only default
   // rules omit the key. An empty array means the rule targets zero students
   // (e.g. every label it used to reference was deleted) and is still a
   // student-label rule, not a second default.
@@ -481,10 +481,13 @@ function overrideToJson(rule: OverrideData): AccessControlJsonWithId {
 }
 
 export function formDataToJson(formData: AccessControlFormData): AccessControlJsonWithId[] {
-  return [mainRuleToJson(formData.mainRule), ...formData.overrides.map((o) => overrideToJson(o))];
+  return [
+    defaultRuleToJson(formData.defaultRule),
+    ...formData.overrides.map((o) => overrideToJson(o)),
+  ];
 }
 
-export function createDefaultOverrideFormData(mainRule?: MainRuleData): OverrideData {
+export function createDefaultOverrideFormData(defaultRule?: DefaultRuleData): OverrideData {
   return {
     trackingId: crypto.randomUUID(),
     appliesTo: {
@@ -493,16 +496,18 @@ export function createDefaultOverrideFormData(mainRule?: MainRuleData): Override
       studentLabels: [],
     },
     overriddenFields: [],
-    release: { date: mainRule?.release.date ?? null },
-    due: mainRule?.due ? { ...mainRule.due } : { date: null, credit: null, customCredit: false },
-    earlyDeadlines: (mainRule?.earlyDeadlines ?? []).map((d) => ({ ...d })),
-    lateDeadlines: (mainRule?.lateDeadlines ?? []).map((d) => ({ ...d })),
-    afterLastDeadline: mainRule?.afterLastDeadline
-      ? { ...mainRule.afterLastDeadline }
+    release: { date: defaultRule?.release.date ?? null },
+    due: defaultRule?.due
+      ? { ...defaultRule.due }
+      : { date: null, credit: null, customCredit: false },
+    earlyDeadlines: (defaultRule?.earlyDeadlines ?? []).map((d) => ({ ...d })),
+    lateDeadlines: (defaultRule?.lateDeadlines ?? []).map((d) => ({ ...d })),
+    afterLastDeadline: defaultRule?.afterLastDeadline
+      ? { ...defaultRule.afterLastDeadline }
       : { allowSubmissions: false },
-    durationMinutes: mainRule?.durationMinutes ?? null,
-    password: mainRule?.password ?? null,
-    questionVisibility: mainRule ? { ...mainRule.questionVisibility } : { hidden: true },
-    scoreVisibility: mainRule ? { ...mainRule.scoreVisibility } : { hidden: false },
+    durationMinutes: defaultRule?.durationMinutes ?? null,
+    password: defaultRule?.password ?? null,
+    questionVisibility: defaultRule ? { ...defaultRule.questionVisibility } : { hidden: true },
+    scoreVisibility: defaultRule ? { ...defaultRule.scoreVisibility } : { hidden: false },
   };
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -356,7 +356,7 @@ function defaultRuleToJson(rule: DefaultRuleData): AccessControlJsonWithId {
   if (rule.dateControlEnabled) {
     output.dateControl = {};
     if (rule.release.date) output.dateControl.release = { date: rule.release.date };
-    // Omit `due` on the main rule when no date is set and no custom credit is
+    // Omit `due` on the default rule when no date is set and no custom credit is
     // applied — it would just emit `{ date: null }`, which is semantically
     // equivalent to "no due configured".
     if (rule.due.date !== null || rule.due.customCredit) {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -5,8 +5,8 @@ import { getGlobalDateValidationErrors } from './validation.js';
 
 function makeFormData(overrides: AccessControlFormData['overrides']): AccessControlFormData {
   return {
-    mainRule: {
-      trackingId: 'main',
+    defaultRule: {
+      trackingId: 'default',
       beforeReleaseListed: false,
       dateControlEnabled: true,
       release: { date: '2024-04-07T00:00:00' },

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -10,16 +10,16 @@ import {
 import { type AccessControlFormData, formDataToJson } from './types.js';
 
 export type AccessControlFormFieldPath =
-  | 'mainRule.release.date'
-  | 'mainRule.due.date'
-  | 'mainRule.due.credit'
-  | `mainRule.earlyDeadlines.${number}.date`
-  | `mainRule.lateDeadlines.${number}.date`
-  | `mainRule.lateDeadlines.${number}.credit`
-  | 'mainRule.afterLastDeadline.credit'
-  | 'mainRule.questionVisibility.visibleFromDate'
-  | 'mainRule.questionVisibility.visibleUntilDate'
-  | 'mainRule.scoreVisibility.visibleFromDate'
+  | 'defaultRule.release.date'
+  | 'defaultRule.due.date'
+  | 'defaultRule.due.credit'
+  | `defaultRule.earlyDeadlines.${number}.date`
+  | `defaultRule.lateDeadlines.${number}.date`
+  | `defaultRule.lateDeadlines.${number}.credit`
+  | 'defaultRule.afterLastDeadline.credit'
+  | 'defaultRule.questionVisibility.visibleFromDate'
+  | 'defaultRule.questionVisibility.visibleUntilDate'
+  | 'defaultRule.scoreVisibility.visibleFromDate'
   | `overrides.${number}.release.date`
   | `overrides.${number}.due.date`
   | `overrides.${number}.due.credit`
@@ -42,8 +42,8 @@ function buildValidationRules(formData: AccessControlFormData): AccessControlVal
 function mapIssueToFormFieldPath(
   issue: AccessControlValidationIssue,
 ): AccessControlFormFieldPath | null {
-  const prefix: 'mainRule' | `overrides.${number}` =
-    issue.ruleIndex === 0 ? 'mainRule' : `overrides.${issue.ruleIndex - 1}`;
+  const prefix: 'defaultRule' | `overrides.${number}` =
+    issue.ruleIndex === 0 ? 'defaultRule' : `overrides.${issue.ruleIndex - 1}`;
 
   switch (issue.path[0]) {
     case 'dateControl':

--- a/apps/prairielearn/src/sprocs/sync_access_control.sql
+++ b/apps/prairielearn/src/sprocs/sync_access_control.sql
@@ -149,7 +149,7 @@ BEGIN
     ON CONFLICT (assessment_access_control_rule_id, date) DO UPDATE SET
         credit = EXCLUDED.credit;
 
-    -- Upsert PrairieTest exams (main rules only).
+    -- Upsert PrairieTest exams (default rules only).
     INSERT INTO assessment_access_control_prairietest_exams (
         assessment_access_control_rule_id,
         uuid,

--- a/apps/prairielearn/src/sync/fromDisk/accessControl.ts
+++ b/apps/prairielearn/src/sync/fromDisk/accessControl.ts
@@ -40,7 +40,7 @@ function validateAssessmentRules(
   // When the course instance config is invalid, student label syncing is
   // skipped, so labels that appear valid in JSON may not exist in the DB.
   // Reject them here to prevent label-targeted rules from being silently
-  // treated as main rules.
+  // treated as default rules.
   for (const rule of rules) {
     const ruleLabels = rule.labels ?? [];
     const invalidLabels = ruleLabels.filter((label) => !studentLabelIdByName.has(label));
@@ -82,7 +82,7 @@ function prepareRuleRow(
   const dateControl = rule.dateControl ?? {};
   const afterComplete = rule.afterComplete ?? {};
   const afterLastDeadline = dateControl.afterLastDeadline;
-  const isMainRule = ruleNumber === JSON_RULE_START;
+  const isDefaultRule = ruleNumber === JSON_RULE_START;
 
   const beforeReleaseListed = mapField(rule.beforeRelease?.listed);
   const dueField = mapField(dateControl.due);
@@ -99,13 +99,13 @@ function prepareRuleRow(
     .map((label) => studentLabelIdByName.get(label))
     .filter((id): id is string => id !== undefined);
 
-  const targetType: 'none' | 'student_label' = isMainRule ? 'none' : 'student_label';
+  const targetType: 'none' | 'student_label' = isDefaultRule ? 'none' : 'student_label';
 
   const ruleRow = JSON.stringify({
     assessment_id: assessmentId,
     number: ruleNumber,
-    // beforeRelease.listed is only configurable on the main rule.
-    before_release_listed: isMainRule ? (beforeReleaseListed.value ?? false) : null,
+    // beforeRelease.listed is only configurable on the default rule.
+    before_release_listed: isDefaultRule ? (beforeReleaseListed.value ?? false) : null,
     target_type: targetType,
     date_control_release_date: dateControl.release?.date ?? null,
     date_control_due_overridden: dueField.overridden,

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -192,11 +192,11 @@ describe('Access control syncing', () => {
   //   JSON field null      → overridden=true,  value=NULL  ("explicitly cleared")
   //   JSON field has value → overridden=true,  value=<val> ("explicitly set")
   //
-  // For main rules (number=0), "not configured" simply means the field was
+  // For default rules (number=0), "not configured" simply means the field was
   // absent from the JSON — there is no parent to inherit from.
   // For overrides (number>0), "not configured" means "inherit from the main
   // rule"; the resolver's merge step skips undefined fields.
-  describe('_overridden flag behavior on main rules', () => {
+  describe('_overridden flag behavior on default rules', () => {
     it('fields present in JSON get overridden=true', () =>
       runInTransactionAndRollback(async () => {
         const rule = makeAccessControlRule({
@@ -295,7 +295,7 @@ describe('Access control syncing', () => {
     it('override with one field: only that field gets overridden=true', () =>
       runInTransactionAndRollback(async () => {
         const labelName = 'Test Label';
-        const mainRule = makeAccessControlRule({
+        const defaultRule = makeAccessControlRule({
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -309,7 +309,7 @@ describe('Access control syncing', () => {
             due: { date: '2024-04-01T23:59:00' },
           },
         };
-        const { syncedRules } = await syncRulesAndRead([mainRule, overrideRule], {
+        const { syncedRules } = await syncRulesAndRead([defaultRule, overrideRule], {
           studentLabels: [labelName],
         });
         const override = syncedRules.find((r) => r.target_type === 'student_label');
@@ -330,12 +330,12 @@ describe('Access control syncing', () => {
     it('override with no dateControl: all flags are overridden=false', () =>
       runInTransactionAndRollback(async () => {
         const labelName = 'Test Label';
-        const mainRule = makeAccessControlRule();
+        const defaultRule = makeAccessControlRule();
         const overrideRule: AccessControlJsonInput = {
           labels: [labelName],
           // no dateControl at all — inherit everything
         };
-        const { syncedRules } = await syncRulesAndRead([mainRule, overrideRule], {
+        const { syncedRules } = await syncRulesAndRead([defaultRule, overrideRule], {
           studentLabels: [labelName],
         });
         const override = syncedRules.find((r) => r.target_type === 'student_label');
@@ -368,7 +368,7 @@ describe('Access control syncing', () => {
     it('defaults to false in round-trip when omitted from JSON', () =>
       runInTransactionAndRollback(async () => {
         const courseData = util.getCourseData();
-        const mainRule: AccessControlJsonInput = {
+        const defaultRule: AccessControlJsonInput = {
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -377,7 +377,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule];
+        ].accessControl = [defaultRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1295,7 +1295,7 @@ describe('Access control syncing', () => {
         assert.equal(syncedRules.length, 0);
       }));
 
-    it('rejects sync when non-main rule specifies integrations', () =>
+    it('rejects sync when non-default rule specifies integrations', () =>
       runInTransactionAndRollback(async () => {
         const labelName = 'Test Label';
         const { syncedRules, errors } = await syncRulesAndRead(
@@ -1317,7 +1317,7 @@ describe('Access control syncing', () => {
         assert.equal(syncedRules.length, 0);
       }));
 
-    it('allows main rule to specify integrations', () =>
+    it('allows default rule to specify integrations', () =>
       runInTransactionAndRollback(async () => {
         const labelName = 'Test Label';
         const { syncedRules } = await syncRulesAndRead(
@@ -1526,7 +1526,7 @@ describe('Access control syncing', () => {
         const labelName = 'Test Label';
         addStudentLabelToConfig(courseData, util.COURSE_INSTANCE_ID, labelName);
 
-        const mainRule = makeAccessControlRule({
+        const defaultRule = makeAccessControlRule({
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -1542,7 +1542,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule, overrideRule];
+        ].accessControl = [defaultRule, overrideRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1559,7 +1559,7 @@ describe('Access control syncing', () => {
         const labelName = 'Test Label';
         addStudentLabelToConfig(courseData, util.COURSE_INSTANCE_ID, labelName);
 
-        const mainRule = makeAccessControlRule();
+        const defaultRule = makeAccessControlRule();
         const overrideRule: AccessControlJsonInput = {
           labels: [labelName],
           afterComplete: {
@@ -1569,7 +1569,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule, overrideRule];
+        ].accessControl = [defaultRule, overrideRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1590,7 +1590,7 @@ describe('Access control syncing', () => {
         const labelName = 'Test Label';
         addStudentLabelToConfig(courseData, util.COURSE_INSTANCE_ID, labelName);
 
-        const mainRule = makeAccessControlRule();
+        const defaultRule = makeAccessControlRule();
         const overrideRule: AccessControlJsonInput = {
           labels: [labelName],
           dateControl: {
@@ -1600,7 +1600,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule, overrideRule];
+        ].accessControl = [defaultRule, overrideRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1619,7 +1619,7 @@ describe('Access control syncing', () => {
         const labelName = 'Test Label';
         addStudentLabelToConfig(courseData, util.COURSE_INSTANCE_ID, labelName);
 
-        const mainRule: AccessControlJsonInput = {
+        const defaultRule: AccessControlJsonInput = {
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -1639,7 +1639,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule, overrideRule];
+        ].accessControl = [defaultRule, overrideRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1656,7 +1656,7 @@ describe('Access control syncing', () => {
       runInTransactionAndRollback(async () => {
         const courseData = util.getCourseData();
         courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.timezone = timezone;
-        const mainRule: AccessControlJsonInput = {
+        const defaultRule: AccessControlJsonInput = {
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -1665,7 +1665,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule];
+        ].accessControl = [defaultRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1690,11 +1690,11 @@ describe('Access control syncing', () => {
     it('no dateControl in JSON produces no dateControl in round-trip', () =>
       runInTransactionAndRollback(async () => {
         const courseData = util.getCourseData();
-        const mainRule: AccessControlJsonInput = {};
+        const defaultRule: AccessControlJsonInput = {};
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule];
+        ].accessControl = [defaultRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1708,7 +1708,7 @@ describe('Access control syncing', () => {
       runInTransactionAndRollback(async () => {
         const courseData = util.getCourseData();
         courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.timezone = timezone;
-        const mainRule: AccessControlJsonInput = {
+        const defaultRule: AccessControlJsonInput = {
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -1732,7 +1732,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule];
+        ].accessControl = [defaultRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1776,7 +1776,7 @@ describe('Access control syncing', () => {
         const labelName = 'Override Label';
         addStudentLabelToConfig(courseData, util.COURSE_INSTANCE_ID, labelName);
 
-        const mainRule: AccessControlJsonInput = {
+        const defaultRule: AccessControlJsonInput = {
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
@@ -1793,7 +1793,7 @@ describe('Access control syncing', () => {
 
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule, overrideRule];
+        ].accessControl = [defaultRule, overrideRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1804,15 +1804,15 @@ describe('Access control syncing', () => {
         assert.isOk(dc);
         // Only due was configured on the override
         assert.deepEqual(dc.due?.date, plainDateTimeStringToDate('2024-04-01T23:59:00', timezone));
-        // Fields from the main rule should NOT appear on the override's own JSON
+        // Fields from the default rule should NOT appear on the override's own JSON
         assert.isUndefined(dc.release);
         assert.isUndefined(dc.durationMinutes);
         assert.isUndefined(dc.password);
       }));
 
-    it('PrairieTest exam UUIDs round-trip on main rule', () =>
+    it('PrairieTest exam UUIDs round-trip on default rule', () =>
       runInTransactionAndRollback(async () => {
-        const mainRule = makeAccessControlRule({
+        const defaultRule = makeAccessControlRule({
           dateControl: undefined,
           integrations: {
             prairieTest: {
@@ -1824,7 +1824,7 @@ describe('Access control syncing', () => {
         const courseData = util.getCourseData();
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule];
+        ].accessControl = [defaultRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1843,7 +1843,7 @@ describe('Access control syncing', () => {
 
     it('PrairieTest readOnly flag round-trips correctly', () =>
       runInTransactionAndRollback(async () => {
-        const mainRule = makeAccessControlRule({
+        const defaultRule = makeAccessControlRule({
           dateControl: undefined,
           integrations: {
             prairieTest: {
@@ -1855,7 +1855,7 @@ describe('Access control syncing', () => {
         const courseData = util.getCourseData();
         courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
           util.ASSESSMENT_ID
-        ].accessControl = [mainRule];
+        ].accessControl = [defaultRule];
         await util.writeAndSyncCourseData(courseData);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
@@ -1914,7 +1914,7 @@ describe('cleanAccessControlRulesForDisk', () => {
     assert.notProperty(cleaned[0], 'afterComplete');
   });
 
-  it('preserves beforeRelease.listed: true on the main rule only', () => {
+  it('preserves beforeRelease.listed: true on the default rule only', () => {
     const rules: AccessControlJsonInput[] = [
       makeAccessControlRule({ beforeRelease: { listed: true } }),
       makeAccessControlRule({ beforeRelease: { listed: true } }),

--- a/apps/prairielearn/src/trpc/assessment/access-control.ts
+++ b/apps/prairielearn/src/trpc/assessment/access-control.ts
@@ -145,7 +145,7 @@ function isNonEmptyObject(value: unknown): boolean {
 
 /**
  * Cleans access control rules for writing to infoAssessment.json on disk.
- * Removes empty objects/arrays and omits beforeRelease: { listed: false } on the main rule.
+ * Removes empty objects/arrays and omits beforeRelease: { listed: false } on the default rule.
  */
 export function cleanAccessControlRulesForDisk(rules: AccessControlJson[]): AccessControlJson[] {
   return rules.map((rule, index) => {
@@ -277,7 +277,7 @@ const saveAllRules = t.procedure
         await deleteEnrollmentAccessControlsByIds(idsToDelete, opts.ctx.assessment);
 
         if (enrollmentRules.length > 0) {
-          // TODO: Add audit logging for enrollment rule changes. Label/main rules
+          // TODO: Add audit logging for enrollment rule changes. Label/default rules
           // are tracked in git; only enrollment rules need separate audit logs.
           for (const enrollmentRule of enrollmentRules) {
             const ruleData = formJsonToEnrollmentRuleData(enrollmentRule.ruleJson);


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Assessment access control's main rule has been officially renamed to default rule. This PR renames it to default rule across the database. 

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): Completely done by Claude.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Navigate to pages that mention the default rule. The reviewer should do a sanity check for mentions of mainRule|MainRule.