### PR TITLE
Hide date-control timeline popover under PT grants and when empty

### DIFF
--- a/apps/prairielearn/src/components/StudentAccessPopovers.tsx
+++ b/apps/prairielearn/src/components/StudentAccessPopovers.tsx
@@ -60,6 +60,12 @@ export function StudentAccessTimelinePopover({
   accessTimeline: AccessTimelineEntry[];
   displayTimezone: string;
 }) {
+  // Hide segments where submissions aren't allowed. Rendering a 0%-credit
+  // after-last-deadline row reads as "keep submitting for 0 credit" when
+  // submissions are actually forbidden. The resolver still emits these entries
+  // so other consumers (e.g. instructor views) can show the full picture.
+  const visibleEntries = accessTimeline.filter((entry) => entry.submittable);
+  if (visibleEntries.length === 0) return '';
   return html`
     <button
       type="button"
@@ -69,7 +75,7 @@ export function StudentAccessTimelinePopover({
       data-bs-html="true"
       data-bs-title="Access details"
       data-bs-content="${escapeHtml(
-        StudentAccessTimelinePopoverContent({ accessTimeline, displayTimezone }),
+        StudentAccessTimelinePopoverContent({ visibleEntries, displayTimezone }),
       )}"
     >
       <i class="fa fa-question-circle"></i>
@@ -78,17 +84,12 @@ export function StudentAccessTimelinePopover({
 }
 
 function StudentAccessTimelinePopoverContent({
-  accessTimeline,
+  visibleEntries,
   displayTimezone,
 }: {
-  accessTimeline: AccessTimelineEntry[];
+  visibleEntries: AccessTimelineEntry[];
   displayTimezone: string;
 }) {
-  // Hide segments where submissions aren't allowed. Rendering a 0%-credit
-  // after-last-deadline row reads as "keep submitting for 0 credit" when
-  // submissions are actually forbidden. The resolver still emits these entries
-  // so other consumers (e.g. instructor views) can show the full picture.
-  const visibleEntries = accessTimeline.filter((entry) => entry.submittable);
   return html`
     <table class="table" aria-label="Access details">
       <tr>

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -922,6 +922,27 @@ describe('resolveAccessControl', () => {
         reservations: [validReservation],
         expect: { authorized: true, credit: 100, submittable: false, creditDateString: 'None' },
       },
+      {
+        // The date-control timeline is irrelevant under a PT grant: the PT
+        // reservation governs access, so the student popover shouldn't show
+        // a date-control timeline at all.
+        name: 'PT grant clears the date-control access timeline',
+        rules: [
+          makeMainRule(
+            {
+              dateControl: {
+                release: { date: '2025-01-01T00:00:00Z' },
+                due: { date: '2025-02-01T00:00:00Z' },
+                afterLastDeadline: { credit: 50, allowSubmissions: true },
+              },
+            },
+            { prairieTestExams: [ptExam('exam-uuid-1')] },
+          ),
+        ],
+        authzMode: 'Exam',
+        reservations: [validReservation],
+        expect: { authorized: true, submittable: true, accessTimeline: [] },
+      },
     ])('$name', (c) => {
       expect(runCase(c)).toMatchObject(c.expect);
     });

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -419,7 +419,9 @@ export function resolveAccessControl(
       ...examVisibility,
       examAccessEnd: reservation.accessEnd,
       showBeforeRelease: false,
-      accessTimeline,
+      // The PT reservation governs access; the date-control timeline is
+      // irrelevant under a PT grant, so omit it from the student popover.
+      accessTimeline: [],
       nextActiveDate: null,
     };
   }


### PR DESCRIPTION
# Description

Follow-up from #14469: avoids showing date-control timelines for PrairieTest grants in the student access control popover, and avoids rendering an empty popover button.

- In `resolveAccessControl`, when a PT reservation grants access in Exam mode, return `accessTimeline: []` instead of the date-control timeline — the reservation governs access in this branch, so the timeline is not relevant to the student.
- In `StudentAccessTimelinePopover`, return nothing when there are no submittable entries, preventing the empty popover button from rendering.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation with Claude.

# Testing

Added a resolver test verifying the access timeline is cleared when a PT reservation grants access alongside a configured `dateControl`. All resolver unit tests pass.