### PR TITLE
Allow `dateControl.due` to be omitted on main access control rules

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -90,7 +90,7 @@ describe('migrateAllowAccess', () => {
       ],
       expected: {
         result: {
-          dateControl: { release: { date: '2024-01-01' }, due: { date: null } },
+          dateControl: { release: { date: '2024-01-01' } },
           integrations: { prairieTest: { exams: [{ examUuid: 'exam-uuid-1' }] } },
         },
         errors: [],
@@ -102,7 +102,7 @@ describe('migrateAllowAccess', () => {
       name: 'view-only',
       rules: [{ startDate: '2024-01-01', active: false }],
       expected: {
-        result: { dateControl: { release: { date: '2024-01-01' }, due: { date: null } } },
+        result: { dateControl: { release: { date: '2024-01-01' } } },
         errors: [],
         notes: [],
         hasUidRules: false,
@@ -148,7 +148,7 @@ describe('migrateAllowAccess', () => {
       name: 'always-open',
       rules: [{ credit: 100 }],
       expected: {
-        result: { dateControl: { due: { date: null } } },
+        result: { dateControl: {} },
         errors: [],
         notes: [],
         hasUidRules: false,
@@ -226,7 +226,7 @@ describe('migrateAllowAccess', () => {
       name: 'open-ended full credit (startDate, no endDate)',
       rules: [{ credit: 100, startDate: '2024-01-01' }],
       expected: {
-        result: { dateControl: { release: { date: '2024-01-01' }, due: { date: null } } },
+        result: { dateControl: { release: { date: '2024-01-01' } } },
         errors: [],
         notes: [],
         hasUidRules: false,
@@ -307,7 +307,6 @@ describe('migrateAllowAccess', () => {
         result: {
           dateControl: {
             release: { date: '2024-01-01' },
-            due: { date: null },
           },
         },
         errors: [],
@@ -809,7 +808,7 @@ describe('migrateAllowAccess', () => {
       name: 'password-gated without dates',
       rules: [{ password: 'secret', credit: 100 }],
       expected: {
-        result: { dateControl: { password: 'secret', due: { date: null } } },
+        result: { dateControl: { password: 'secret' } },
         errors: [],
         notes: [],
         hasUidRules: false,
@@ -937,7 +936,6 @@ describe('migrateAllowAccess', () => {
         result: {
           dateControl: {
             release: { date: '2024-02-01' },
-            due: { date: null },
           },
         },
         errors: [],

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -325,8 +325,9 @@ function normalizeCreditDeadlines(
  * If afterLastDeadline grants credit >= dueDateCredit and there are no
  * early/late deadlines describing intermediate credit windows, the dueDate
  * is meaningless — credit continues at the same or higher level forever.
- * Collapse to `due: { date: null }` (always open from release), preserving
- * the open-ended credit so we don't silently upgrade a non-100% rule to 100%.
+ * Collapse to "always open from release": omit `due` entirely when the
+ * collapsed credit is 100%, or use `due: { date: null, credit: X }` to
+ * preserve a non-100% open-ended credit.
  *
  * When early or late deadlines exist, skip the collapse so we don't drop
  * those windows on the floor (the dueDate carries them; collapsing erases
@@ -343,8 +344,11 @@ function simplifyTimeline(
     (dateControl.afterLastDeadline.credit ?? 0) >= dueDateCredit
   ) {
     const collapseCredit = dateControl.afterLastDeadline.credit ?? 0;
-    dateControl.due =
-      collapseCredit === 100 ? { date: null } : { date: null, credit: collapseCredit };
+    if (collapseCredit === 100) {
+      delete dateControl.due;
+    } else {
+      dateControl.due = { date: null, credit: collapseCredit };
+    }
     delete dateControl.afterLastDeadline;
   }
 }
@@ -406,9 +410,7 @@ function buildCreditTimeline(rules: AssessmentAccessRuleJson[]): BuilderResult {
       return { dateControl: undefined, errors, notes };
     }
     const releaseDate = findReleaseDate(rules);
-    const dateControl: NonNullable<AccessControlJsonInput['dateControl']> = {
-      due: { date: null },
-    };
+    const dateControl: NonNullable<AccessControlJsonInput['dateControl']> = {};
     if (releaseDate) dateControl.release = { date: releaseDate };
     return { dateControl, errors, notes };
   }
@@ -736,7 +738,7 @@ export function migrateAllowAccess(
     const viewOnlyRules = getVisibilityRules(schedulingRules).filter((r) => r.startDate);
     if (viewOnlyRules.length > 0) {
       const releaseDate = viewOnlyRules.map((r) => r.startDate!).sort()[0];
-      result.dateControl = { release: { date: releaseDate }, due: { date: null } };
+      result.dateControl = { release: { date: releaseDate } };
     }
   }
 

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1434,21 +1434,6 @@ describe('Structural field dependency validation', () => {
     assert.isTrue(issues.some((i) => i.message === 'Late deadlines require a due date.'));
   });
 
-  it('should reject main-rule dateControl without due configuration', () => {
-    const rule = AccessControlJsonSchema.parse({
-      dateControl: {
-        release: { date: '2024-03-14T00:01:00' },
-        earlyDeadlines: [{ date: '2024-03-17T23:59:00', credit: 120 }],
-      },
-    });
-    const errors = validateRule(rule, 'none');
-    assert.isTrue(
-      errors.includes(
-        'Due date configuration is required on the defaults when dateControl is specified.',
-      ),
-    );
-  });
-
   it('should reject after-complete dates without any deadline', () => {
     const rule = AccessControlJsonSchema.parse({
       afterComplete: {

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -650,11 +650,6 @@ export function validateRule(
     if (rule.dateControl && !rule.dateControl.release) {
       errors.push('Release date is required on the defaults when dateControl is specified.');
     }
-    if (rule.dateControl && !rule.dateControl.due) {
-      errors.push(
-        'Due date configuration is required on the defaults when dateControl is specified.',
-      );
-    }
   } else {
     if (rule.beforeRelease !== undefined) {
       errors.push('beforeRelease can only be specified on the defaults.');

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
@@ -104,7 +104,7 @@ describe('formDataToJson', () => {
     });
   });
 
-  it('emits an explicit null due date for main rules when date control is enabled', () => {
+  it('omits `due` on main rules when there is no due date and no custom credit', () => {
     const result = formDataToJson({
       mainRule: {
         ...defaultMainRule,
@@ -113,7 +113,19 @@ describe('formDataToJson', () => {
       overrides: [],
     });
 
-    expect(result[0].dateControl?.due).toEqual({ date: null });
+    expect(result[0].dateControl?.due).toBeUndefined();
+  });
+
+  it('emits an explicit null due date on main rules with custom credit', () => {
+    const result = formDataToJson({
+      mainRule: {
+        ...defaultMainRule,
+        due: { date: null, credit: 80, customCredit: true },
+      },
+      overrides: [],
+    });
+
+    expect(result[0].dateControl?.due).toEqual({ date: null, credit: 80 });
   });
 
   it('omits dateControl when no date fields are overridden', () => {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -356,7 +356,12 @@ function mainRuleToJson(rule: MainRuleData): AccessControlJsonWithId {
   if (rule.dateControlEnabled) {
     output.dateControl = {};
     if (rule.release.date) output.dateControl.release = { date: rule.release.date };
-    output.dateControl.due = buildDueJson(rule.due);
+    // Omit `due` on the main rule when no date is set and no custom credit is
+    // applied — it would just emit `{ date: null }`, which is semantically
+    // equivalent to "no due configured".
+    if (rule.due.date !== null || rule.due.customCredit) {
+      output.dateControl.due = buildDueJson(rule.due);
+    }
     if (rule.earlyDeadlines.length > 0) {
       output.dateControl.earlyDeadlines = rule.earlyDeadlines;
     }


### PR DESCRIPTION
# Description

Previously, modern assessment access control required `due: { date: null }` on main rules whenever `dateControl` was set, even when the assessment had no deadline at all. This change makes `due` truly optional on the main rule:

- The validation rule that required `due` is removed.
- The legacy-rule migration no longer emits redundant `due: { date: null }` (in `simplifyTimeline` when collapseCredit=100, the open-ended-100% case, and the view-only release-only fallback).
- The form serializer omits `due` when no date is set and no custom credit is applied.

`due: { date: null, credit: X }` is still meaningful (indefinite due with reduced credit), and on overrides `due: { date: null }` is still the explicit "override main rule's due to nothing" signal — only the truly redundant emission goes away.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

- All existing access-control unit tests (migration, validation, resolver, timeline, form serializer) pass with the relevant test cases updated to expect omission instead of `{ date: null }`.
- A new test asserts that custom credit on an indefinite due (`{ date: null, credit: 80 }`) still round-trips through the form serializer.