### PR TITLE
Bump `ruff` target version to `py313`

### DIFF
--- a/.agents/skills/element-backwards-compat/SKILL.md
+++ b/.agents/skills/element-backwards-compat/SKILL.md
@@ -12,6 +12,6 @@ The persisted dict-shaped fields are:
 
 ## Rules
 
-1. **Adding a new key to a persisted dict?** Every reader in every element function must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to top-level keys and to keys inside any nested per-block / per-answer dict stored inside a persisted field. If the element uses a `TypedDict` for the nested shape, mark the new field `NotRequired[...]` from `typing_extensions` so pyright catches unguarded reads.
+1. **Adding a new key to a persisted dict?** Every reader in every element function must use `dict.get(key, default)` with a sensible default, never `dict[key]`. This applies to top-level keys and to keys inside any nested per-block / per-answer dict stored inside a persisted field. If the element uses a `TypedDict` for the nested shape, mark the new field `NotRequired[...]` from `typing` so pyright catches unguarded reads.
 
 2. **Renaming, removing, or changing the semantics of a persisted key?** Don't. Keep the old key alongside the new one and have readers fall back to it when the new one is missing. Old rows still hold the old shape forever.

--- a/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.py
+++ b/apps/prairielearn/elements/pl-big-o-input/pl-big-o-input.py
@@ -1,6 +1,7 @@
 import random
 from enum import Enum
 from sys import get_int_max_str_digits
+from typing import assert_never
 
 import big_o_utils as bou
 import chevron
@@ -8,7 +9,6 @@ import lxml.html
 import prairielearn as pl
 import prairielearn.sympy_utils as psu
 import sympy
-from typing_extensions import assert_never
 
 
 class BigOType(Enum):

--- a/apps/prairielearn/elements/pl-checkbox/pl-checkbox.py
+++ b/apps/prairielearn/elements/pl-checkbox/pl-checkbox.py
@@ -2,12 +2,11 @@ import html
 import random
 from enum import Enum
 from itertools import count
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, assert_never, cast
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class PartialCreditType(Enum):

--- a/apps/prairielearn/elements/pl-code/pl-code.py
+++ b/apps/prairielearn/elements/pl-code/pl-code.py
@@ -110,7 +110,7 @@ class HighlightingHtmlFormatter(pygments.formatters.HtmlFormatter[str]):
 
     def _highlight_lines(
         self, tokensource: Iterable[tuple[int, str]]
-    ) -> Generator[tuple[int, str], None, None]:
+    ) -> Generator[tuple[int, str]]:
         """
         Highlighted the lines specified in the `hl_lines` option by post-processing the token stream.
         Based on the code at "https://github.com/pygments/pygments/blob/master/pygments/formatters/html.py#L816"

--- a/apps/prairielearn/elements/pl-dataframe/pl-dataframe.py
+++ b/apps/prairielearn/elements/pl-dataframe/pl-dataframe.py
@@ -1,11 +1,11 @@
 import pprint
 from enum import Enum
+from typing import assert_never
 
 import chevron
 import lxml.html
 import pandas as pd
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class DisplayLanguage(Enum):

--- a/apps/prairielearn/elements/pl-dropdown/pl-dropdown.py
+++ b/apps/prairielearn/elements/pl-dropdown/pl-dropdown.py
@@ -1,10 +1,10 @@
 import random
 from enum import Enum
+from typing import assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 WEIGHT_DEFAULT = 1
 BLANK_ANSWER = " "

--- a/apps/prairielearn/elements/pl-figure/pl-figure.py
+++ b/apps/prairielearn/elements/pl-figure/pl-figure.py
@@ -1,10 +1,10 @@
 import os
 from enum import Enum
+from typing import assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class FileType(Enum):

--- a/apps/prairielearn/elements/pl-file-download/pl-file-download.py
+++ b/apps/prairielearn/elements/pl-file-download/pl-file-download.py
@@ -1,9 +1,9 @@
 import os
 from enum import Enum
+from typing import assert_never
 
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class FileType(Enum):

--- a/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
+++ b/apps/prairielearn/elements/pl-integer-input/pl-integer-input.py
@@ -1,12 +1,11 @@
 import random
 from enum import Enum
-from typing import Any
+from typing import Any, assert_never
 
 import chevron
 import lxml.html
 import numpy as np
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class DisplayType(Enum):

--- a/apps/prairielearn/elements/pl-matrix-component-input/pl-matrix-component-input.py
+++ b/apps/prairielearn/elements/pl-matrix-component-input/pl-matrix-component-input.py
@@ -2,14 +2,13 @@ import math
 import random
 from enum import Enum
 from html import escape
-from typing import Literal
+from typing import Literal, assert_never
 
 import chevron
 import lxml.html
 import numpy as np
 import prairielearn as pl
 from sympy import Expr
-from typing_extensions import assert_never
 
 
 class ComparisonMode(Enum):

--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -4,13 +4,12 @@ import pathlib
 import random
 from collections import Counter
 from enum import Enum
-from typing import NamedTuple
+from typing import NamedTuple, assert_never
 
 import chevron
 import lxml.etree
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class DisplayType(Enum):

--- a/apps/prairielearn/elements/pl-number-input/pl-number-input.py
+++ b/apps/prairielearn/elements/pl-number-input/pl-number-input.py
@@ -1,13 +1,12 @@
 import random
 from decimal import Decimal, InvalidOperation
 from enum import Enum
-from typing import Any
+from typing import Any, assert_never
 
 import chevron
 import lxml.html
 import numpy as np
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class DisplayType(Enum):

--- a/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
+++ b/apps/prairielearn/elements/pl-order-blocks/dag_checker.py
@@ -2,9 +2,9 @@ import itertools
 from collections import Counter
 from collections.abc import Generator, Iterable, Mapping, Sequence
 from copy import deepcopy
+from typing import TypeIs
 
 import networkx as nx
-from typing_extensions import TypeIs
 
 ColoredEdges = list[list[str]]
 Edges = list[str]

--- a/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
+++ b/apps/prairielearn/elements/pl-order-blocks/pl-order-blocks.py
@@ -5,7 +5,7 @@ import os
 import random
 from collections import defaultdict
 from copy import deepcopy
-from typing import TypedDict
+from typing import NotRequired, TypedDict, assert_never
 
 import chevron
 import lxml.html
@@ -34,7 +34,6 @@ from order_blocks_options_parsing import (
     SolutionPlacementType,
     SourceBlocksOrderType,
 )
-from typing_extensions import NotRequired, assert_never
 
 
 class OrderBlocksAnswerData(TypedDict):

--- a/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
+++ b/apps/prairielearn/elements/pl-rich-text-editor/pl-rich-text-editor.py
@@ -5,11 +5,11 @@ import json
 import os
 import re
 from enum import Enum
+from typing import assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class Counter(Enum):

--- a/apps/prairielearn/elements/pl-string-input/pl-string-input.py
+++ b/apps/prairielearn/elements/pl-string-input/pl-string-input.py
@@ -1,12 +1,11 @@
 import html
 import random
 from enum import Enum
-from typing import Any
+from typing import Any, assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 class DisplayType(Enum):

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.py
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.py
@@ -2,13 +2,13 @@ import random
 import re
 from enum import Enum
 from sys import get_int_max_str_digits
+from typing import assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
 import prairielearn.sympy_utils as psu
 import sympy
-from typing_extensions import assert_never
 
 
 class DisplayType(Enum):

--- a/apps/prairielearn/elements/pl-units-input/pl-units-input.py
+++ b/apps/prairielearn/elements/pl-units-input/pl-units-input.py
@@ -1,13 +1,12 @@
 from enum import Enum
 from random import choice
-from typing import Any
+from typing import Any, assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
 import unit_utils as uu
 from pint import UnitRegistry, errors
-from typing_extensions import assert_never
 
 
 class DisplayType(Enum):

--- a/apps/prairielearn/elements/pl-units-input/unit_utils.py
+++ b/apps/prairielearn/elements/pl-units-input/unit_utils.py
@@ -1,11 +1,10 @@
 from collections.abc import Callable
 from enum import Enum
-from typing import Any
+from typing import Any, assert_never
 
 import numpy as np
 import prairielearn as pl
 from pint import UnitRegistry
-from typing_extensions import assert_never
 
 CORRECT_UNITS_INCORRECT_MAGNITUDE_FEEDBACK = (
     "Your answer has correct units, but incorrect magnitude."

--- a/apps/prairielearn/python/prairielearn/conversion_utils.py
+++ b/apps/prairielearn/python/prairielearn/conversion_utils.py
@@ -9,14 +9,13 @@ import json
 import numbers
 import re
 from io import StringIO
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, assert_never, cast, overload
 
 import networkx as nx
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import sympy
-from typing_extensions import assert_never
 
 from prairielearn.html_utils import escape_invalid_string
 from prairielearn.misc_utils import full_unidecode

--- a/apps/prairielearn/python/prairielearn/grading_utils.py
+++ b/apps/prairielearn/python/prairielearn/grading_utils.py
@@ -7,12 +7,11 @@ from prairielearn import ...
 
 import math
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Any, Literal, assert_never
 
 import numpy as np
 import numpy.typing as npt
 from numpy.typing import ArrayLike
-from typing_extensions import assert_never
 
 from prairielearn.question_utils import QuestionData
 from prairielearn.timeout_utils import SignalTimeout, TimeoutState

--- a/apps/prairielearn/python/prairielearn/html_utils.py
+++ b/apps/prairielearn/python/prairielearn/html_utils.py
@@ -8,14 +8,12 @@ from prairielearn import ...
 import html
 import re
 from enum import Enum
-from typing import Any, TypeVar, overload
+from typing import Any, overload
 
 import lxml.html
 
 from prairielearn.colors import PLColor
 from prairielearn.misc_utils import escape_unicode_string
-
-EnumT = TypeVar("EnumT", bound=Enum)
 
 # From https://gitlab.gnome.org/GNOME/libxml2/-/blob/4aa08c80b711ab296f6e6ecab24df8cf6d0be5fc/HTMLtree.c#L305-309
 LIBXML_BOOLEAN_ATTRIBUTES = frozenset({
@@ -35,7 +33,7 @@ LIBXML_BOOLEAN_ATTRIBUTES = frozenset({
 })
 
 
-def get_enum_attrib(
+def get_enum_attrib[EnumT: Enum](
     element: lxml.html.HtmlElement,
     name: str,
     enum_type: type[EnumT],

--- a/apps/prairielearn/python/prairielearn/internal/question_phases.py
+++ b/apps/prairielearn/python/prairielearn/internal/question_phases.py
@@ -5,10 +5,9 @@ import os
 import pathlib
 import sys
 from inspect import signature
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypedDict, assert_never
 
 import lxml.html
-from typing_extensions import assert_never
 
 from prairielearn.internal.check_data import Phase, check_data
 from prairielearn.internal.traverse import (

--- a/apps/prairielearn/python/prairielearn/misc_utils.py
+++ b/apps/prairielearn/python/prairielearn/misc_utils.py
@@ -12,13 +12,12 @@ import string
 import unicodedata
 import uuid
 from collections.abc import Callable, Generator, Iterable
-from typing import TypeVar
 
 from pint import UnitRegistry
 from text_unidecode import unidecode
 
 
-def iter_keys() -> Generator[str, None, None]:
+def iter_keys() -> Generator[str]:
     """A continuous alphabetic list of the form `['a', 'b', ..., 'z', 'aa', 'ab', ..., 'zz', 'aaa', 'aab', ...]`.
 
     <https://stackoverflow.com/questions/29351492/how-to-make-a-continuous-alphabetic-list-python-from-a-z-then-from-aa-ab-ac-e/29351603#29351603>
@@ -105,10 +104,7 @@ def get_uuid() -> str:
     return random_char + uuid_string[1:]
 
 
-ListItem = TypeVar("ListItem")
-
-
-def partition(
+def partition[ListItem](
     data: Iterable[ListItem], pred: Callable[[ListItem], bool]
 ) -> tuple[list[ListItem], list[ListItem]]:
     """Implement a partition function, splitting the data into two lists based on the predicate.

--- a/apps/prairielearn/python/prairielearn/question_utils.py
+++ b/apps/prairielearn/python/prairielearn/question_utils.py
@@ -7,9 +7,7 @@ from prairielearn import ...
 
 import base64
 import math
-from typing import Any, Literal, TypedDict
-
-from typing_extensions import NotRequired
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class PartialScore(TypedDict):

--- a/apps/prairielearn/python/prairielearn/sympy_utils.py
+++ b/apps/prairielearn/python/prairielearn/sympy_utils.py
@@ -196,7 +196,7 @@ class _SympyJsonStrPrinter(StrPrinter):
     Callers must deserialize with `allow_sets=True` or the literal forms will be rejected.
     """
 
-    def _print_EmptySet(self, expr: sympy.Set) -> str:  # noqa: ARG002, N802
+    def _print_EmptySet(self, expr: sympy.Set) -> str:  # pyright: ignore[reportIncompatibleMethodOverride] # noqa: ARG002, N802
         return "{}"
 
     def _print_Interval(self, i: sympy.Interval) -> str:  # noqa: N802

--- a/apps/prairielearn/python/prairielearn/sympy_utils.py
+++ b/apps/prairielearn/python/prairielearn/sympy_utils.py
@@ -19,13 +19,20 @@ from functools import wraps
 from tokenize import NAME, NUMBER, OP, TokenError
 from types import CodeType
 from types import MappingProxyType as FrozenDict
-from typing import Any, Final, Literal, TypeAlias, TypedDict, TypeGuard, cast
+from typing import (
+    Any,
+    Final,
+    Literal,
+    NotRequired,
+    TypedDict,
+    TypeGuard,
+    cast,
+)
 
 import sympy
 from sympy.parsing import sympy_parser
 from sympy.parsing.sympy_parser import DICT, TOKEN, TRANS
 from sympy.printing.str import StrPrinter
-from typing_extensions import NotRequired
 
 from prairielearn.misc_utils import full_unidecode
 
@@ -67,7 +74,7 @@ class SympyParseFailure:
     error: str
 
 
-SympyParseResult: TypeAlias = SympyParseSuccess | SympyParseFailure
+type SympyParseResult = SympyParseSuccess | SympyParseFailure
 
 
 def is_sympy_json(json: Any) -> TypeGuard[SympyJson]:
@@ -189,7 +196,7 @@ class _SympyJsonStrPrinter(StrPrinter):
     Callers must deserialize with `allow_sets=True` or the literal forms will be rejected.
     """
 
-    def _print_EmptySet(self, expr: sympy.Set) -> str:  # type: ignore[reportIncompatibleMethodOverride] # noqa: ARG002, N802
+    def _print_EmptySet(self, expr: sympy.Set) -> str:  # noqa: ARG002, N802
         return "{}"
 
     def _print_Interval(self, i: sympy.Interval) -> str:  # noqa: N802

--- a/apps/prairielearn/python/prairielearn/timeout_utils.py
+++ b/apps/prairielearn/python/prairielearn/timeout_utils.py
@@ -16,8 +16,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from types import FrameType, TracebackType
-
-    from typing_extensions import Self
+    from typing import Self
 
 
 class TimeoutState(IntEnum):

--- a/apps/prairielearn/python/prairielearn/to_precision.py
+++ b/apps/prairielearn/python/prairielearn/to_precision.py
@@ -8,9 +8,7 @@ from prairielearn.to_precision import ...
 __author__ = "William Rusnack github.com/BebeSparkelSparkel linkedin.com/in/williamrusnack williamrusnack@gmail.com"
 
 import math
-from typing import Any, Literal
-
-from typing_extensions import assert_never
+from typing import Any, Literal, assert_never
 
 Notation = Literal["auto", "sci", "std", "standard", "eng", "engineering", "scientific"]
 

--- a/contrib/api_download.py
+++ b/contrib/api_download.py
@@ -194,7 +194,7 @@ def log(logfile: typing.TextIO, message: str):
 
 
 def local_iso_time():
-    utc_dt = datetime.datetime.now(datetime.timezone.utc)
+    utc_dt = datetime.datetime.now(datetime.UTC)
     dt = utc_dt.astimezone()
     return dt.isoformat()
 

--- a/exampleCourse/elements/clickable-image/clickable-image.py
+++ b/exampleCourse/elements/clickable-image/clickable-image.py
@@ -1,9 +1,9 @@
 import random
+from typing import assert_never
 
 import chevron
 import lxml.html
 import prairielearn as pl
-from typing_extensions import assert_never
 
 FEEDBACK_INCORRECT = "You didn't click on the image the correct number of times"
 FEEDBACK_TOOSMALL = "Your number was one too small."

--- a/exampleCourse/questions/demo/custom/gradeFunction/server.py
+++ b/exampleCourse/questions/demo/custom/gradeFunction/server.py
@@ -1,5 +1,6 @@
+from typing import assert_never
+
 import prairielearn as pl
-from typing_extensions import assert_never
 
 
 def generate(data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ extend-exclude = [
   "exampleCourse/questions/**/tests/initial_code.py",
   "exampleCourse/questions/**/tests/trailing_code.py",
 ]
-target-version = "py310"
+target-version = "py313"
 preview = true
 [tool.ruff.lint]
 select = ["ALL"]

--- a/scripts/build_images/utils.py
+++ b/scripts/build_images/utils.py
@@ -49,7 +49,7 @@ def get_current_platform() -> str:
 
 
 @contextmanager
-def local_registry(name: str) -> Generator[None, None, None]:
+def local_registry(name: str) -> Generator[None]:
     """Create a local Docker registry."""
     # Stop any existing registry container.
     with contextlib.suppress(subprocess.CalledProcessError):
@@ -82,7 +82,7 @@ def local_registry(name: str) -> Generator[None, None, None]:
 
 
 @contextmanager
-def buildx_builder(name: str) -> Generator[None, None, None]:
+def buildx_builder(name: str) -> Generator[None]:
     """Create a Docker buildx builder."""
     # Remove any existing builder with the same name.
     with contextlib.suppress(subprocess.CalledProcessError):


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Bumped `ruff` target version to py313 and fixed various ruff errors following the change

- [x] I have disclosed the level of AI assistance used: none

# Testing

`make lint-python`