### PR TITLE
Add info alert for empty deadline overrides; fix toggle alignment

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/FieldWrapper.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/FieldWrapper.tsx
@@ -41,10 +41,7 @@ export function FieldWrapper({
         ) : (
           <>
             <div className="d-flex justify-content-between align-items-center gap-3 mb-2 flex-wrap">
-              <div className="d-flex align-items-center gap-2">
-                {headerToggle}
-                <strong>{label}</strong>
-              </div>
+              {headerToggle ?? <strong>{label}</strong>}
               <div className="d-flex align-items-center gap-2 flex-shrink-0 ms-auto">
                 {headerAction}
                 {onRemoveOverride && (

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/ToggleTitle.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/ToggleTitle.tsx
@@ -5,7 +5,6 @@ export function ToggleTitle({
   checked,
   onChange,
   label,
-  showLabel = true,
   disabled,
   title,
 }: {
@@ -13,7 +12,6 @@ export function ToggleTitle({
   checked: boolean;
   onChange: (checked: boolean) => void;
   label: string;
-  showLabel?: boolean;
   disabled?: boolean;
   title?: string;
 }) {
@@ -21,9 +19,7 @@ export function ToggleTitle({
     <Form.Check
       type="checkbox"
       id={id}
-      label={
-        showLabel ? <strong>{label}</strong> : <span className="visually-hidden">{label}</span>
-      }
+      label={<strong>{label}</strong>}
       checked={checked}
       disabled={disabled}
       title={title}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -578,8 +578,8 @@ export function OverrideDeadlineArrayField({
     >
       {fields.length === 0 && (
         <Alert variant="info" className="py-2 mb-0">
-          With no {type} deadlines set, this override clears any {type} deadlines inherited from
-          the defaults or earlier overrides. Click "Remove override" to inherit them instead.
+          With no {type} deadlines set, this override clears any {type} deadlines inherited from the
+          defaults or earlier overrides. Click "Remove override" to inherit them instead.
         </Alert>
       )}
       <DeadlineArrayInput

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -553,7 +553,6 @@ export function OverrideDeadlineArrayField({
           id={`${idPrefix}-${type}-deadlines-enabled`}
           label={label}
           checked={fields.length > 0}
-          showLabel={false}
           disabled={addEarlyDisabled && fields.length === 0}
           title={addEarlyDisabled && fields.length === 0 ? addEarlyDisabledTitle : undefined}
           onChange={(checked) => (checked ? append(nextDeadline()) : remove())}
@@ -577,6 +576,12 @@ export function OverrideDeadlineArrayField({
       }}
       onRemoveOverride={removeOverride}
     >
+      {fields.length === 0 && (
+        <Alert variant="info" className="py-2 mb-0">
+          With no {type} deadlines set, this override clears any {type} deadlines inherited from
+          the defaults or earlier overrides. Click "Remove override" to inherit them instead.
+        </Alert>
+      )}
       <DeadlineArrayInput
         type={type}
         fieldArrayName={fieldArrayName}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DurationField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DurationField.tsx
@@ -72,19 +72,16 @@ function DurationToggle({
   value,
   onChange,
   idPrefix,
-  showLabel,
 }: {
   value: number | null;
   onChange: (value: number | null) => void;
   idPrefix: string;
-  showLabel?: boolean;
 }) {
   return (
     <ToggleTitle
       id={`${idPrefix}-time-limit-enabled`}
       label="Time limit"
       checked={value !== null}
-      showLabel={showLabel}
       onChange={(checked) => onChange(checked ? 60 : null)}
     />
   );
@@ -135,7 +132,6 @@ export function OverrideDurationField({ index }: { index: number }) {
         <DurationToggle
           value={field.value}
           idPrefix={`overrides-${index}`}
-          showLabel={false}
           onChange={field.onChange}
         />
       }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/PasswordField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/PasswordField.tsx
@@ -11,19 +11,16 @@ function PasswordToggle({
   value,
   onChange,
   idPrefix,
-  showLabel,
 }: {
   value: string | null;
   onChange: (value: string | null) => void;
   idPrefix: string;
-  showLabel?: boolean;
 }) {
   return (
     <ToggleTitle
       id={`${idPrefix}-password-enabled`}
       label="Password"
       checked={value !== null}
-      showLabel={showLabel}
       onChange={(checked) => onChange(checked ? '' : null)}
     />
   );
@@ -119,7 +116,6 @@ export function OverridePasswordField({ index }: { index: number }) {
         <PasswordToggle
           value={field.value}
           idPrefix={`overrides-${index}`}
-          showLabel={false}
           onChange={field.onChange}
         />
       }


### PR DESCRIPTION
# Description

Addresses an item from #14469: when overriding early/late deadlines to clear them, the empty array silently wipes the deadlines that would otherwise be inherited from the defaults (or earlier overrides). Adds an info alert inside the override panel that fires whenever the field is overridden but has no deadlines, explaining the behavior and pointing the user to "Remove override" if they actually wanted to inherit.

While in there, fixed a small alignment issue with the override card header. The header was rendering the toggle's label twice (visually-hidden inside `Form.Check` *and* as a separate `<strong>` next to it), which produced extra horizontal padding from Bootstrap's `.form-check` left-padding. `FieldWrapper` now lets `ToggleTitle` own the label rendering, and the now-dead `showLabel` prop is removed from `ToggleTitle`, `DurationToggle`, and `PasswordToggle`. Same fix benefits the Time limit and Password override cards too.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation with Claude Code.

# Testing

Verified manually in the dev server:

- Override early deadlines on a rule whose defaults have early deadlines, uncheck the toggle → alert appears with "early" wording.
- Re-check the toggle → alert disappears.
- Same flow with late deadlines (after setting a due date) → alert appears with "late" wording.
- Override early deadlines on a rule whose defaults have *no* early deadlines → alert still appears (since the override semantically still removes any inherited deadlines).
- Visually compared the override toggle header against the Defaults toggle header for early deadlines — checkbox and label alignment now match.