### PR TITLE
Allow editing release date when state is "Released"

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -92,7 +92,7 @@ export function AccessControlForm({
   // so we re-sync when child `trigger()` calls clear a manual error we set.
   useEffect(() => {
     const nextManualErrors = new Map<AccessControlFormFieldPath, string>();
-    for (const error of getGlobalDateValidationErrors(watchedData)) {
+    for (const error of getGlobalDateValidationErrors(watchedData, displayTimezone)) {
       nextManualErrors.set(error.path, error.message);
     }
 
@@ -117,7 +117,7 @@ export function AccessControlForm({
     }
 
     manualErrorPathsRef.current = new Set(nextManualErrors.keys());
-  }, [clearErrors, getFieldState, setError, watchedData, errors]);
+  }, [clearErrors, getFieldState, setError, watchedData, errors, displayTimezone]);
 
   const handleFormSubmit = (data: AccessControlFormData) => {
     onSubmit(formDataToJson(data));
@@ -184,7 +184,7 @@ export function AccessControlForm({
     }
   };
 
-  const hasManualErrors = getGlobalDateValidationErrors(watchedData).length > 0;
+  const hasManualErrors = getGlobalDateValidationErrors(watchedData, displayTimezone).length > 0;
 
   const saveDisabledReason = isSaving
     ? 'Saving...'

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DateControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DateControlForm.tsx
@@ -46,6 +46,10 @@ export function MainDateControlForm({
                   shouldDirty: true,
                   shouldValidate: true,
                 });
+                setValue('mainRule.release.released', true, {
+                  shouldDirty: true,
+                  shouldValidate: true,
+                });
               }
             },
           })}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -54,19 +54,23 @@ export function generateMainRuleDateTableRows(
 
   // Build rows in logical order: release, early deadlines, due date, late deadlines.
   const afterLastDeadline = rule.afterLastDeadline;
+  const releaseDateError = formErrors?.release?.date?.message;
 
-  if (releaseDate) {
+  if (releaseDate || releaseDateError) {
     rows.push({
-      date: (
+      date: releaseDate ? (
         <FriendlyDate
           date={Temporal.PlainDateTime.from(releaseDate)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
           tooltip
         />
+      ) : (
+        'No date set'
       ),
       label: 'Release',
       credit: '—',
+      error: releaseDateError,
     });
   }
 
@@ -415,6 +419,7 @@ function generateOverrideFieldItems(
       ) : (
         'Not released'
       ),
+      error: formErrors?.release?.date?.message,
     });
   }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
@@ -1,10 +1,10 @@
-import { Temporal } from '@js-temporal/polyfill';
+import { useRef } from 'react';
 import { Form } from 'react-bootstrap';
 import { useController, useWatch } from 'react-hook-form';
 
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
-import type { AccessControlFormData } from '../types.js';
+import { type AccessControlFormData, isReleasedNow } from '../types.js';
 import { startOfDayDatetime, todayDate, tomorrowDate } from '../utils/dateUtils.js';
 
 function todayLocalDatetime(displayTimezone: string): string {
@@ -15,28 +15,25 @@ function tomorrowLocalDatetime(displayTimezone: string): string {
   return startOfDayDatetime(tomorrowDate(displayTimezone));
 }
 
-function isReleasedNow(value: string | null, displayTimezone: string): boolean {
-  if (!value) return true;
-  const release = Temporal.PlainDateTime.from(value);
-  const now = Temporal.Now.plainDateTimeISO(displayTimezone);
-  return Temporal.PlainDateTime.compare(release, now) <= 0;
-}
-
 function ReleaseDateInput({
-  value,
-  onChange,
+  date,
+  released,
+  onChangeDate,
+  onChangeReleased,
   error,
   idPrefix,
   displayTimezone,
+  inputRef,
 }: {
-  value: string | null;
-  onChange: (value: string | null) => void;
+  date: string | null;
+  released: boolean;
+  onChangeDate: (value: string | null) => void;
+  onChangeReleased: (value: boolean) => void;
   error?: string;
   idPrefix: string;
   displayTimezone: string;
+  inputRef?: React.Ref<HTMLInputElement>;
 }) {
-  const released = isReleasedNow(value, displayTimezone);
-
   return (
     <Form.Group>
       <div className="mb-2">
@@ -48,7 +45,13 @@ function ReleaseDateInput({
           checked={released}
           onChange={({ currentTarget }) => {
             if (currentTarget.checked) {
-              onChange(todayLocalDatetime(displayTimezone));
+              onChangeReleased(true);
+              // Snap the date into the past only when the current value
+              // doesn't already fit "Released" (null or in the future), so
+              // existing past dates are preserved.
+              if (!date || !isReleasedNow(date, displayTimezone)) {
+                onChangeDate(todayLocalDatetime(displayTimezone));
+              }
             }
           }}
         />
@@ -60,28 +63,31 @@ function ReleaseDateInput({
           checked={!released}
           onChange={({ currentTarget }) => {
             if (currentTarget.checked) {
-              onChange(tomorrowLocalDatetime(displayTimezone));
+              onChangeReleased(false);
+              // Snap the date into the future only when the current value
+              // doesn't already fit "Scheduled" (null or in the past), so
+              // existing future dates are preserved.
+              if (!date || isReleasedNow(date, displayTimezone)) {
+                onChangeDate(tomorrowLocalDatetime(displayTimezone));
+              }
             }
           }}
         />
       </div>
-      {!released && (
-        <>
-          <Form.Control
-            type="datetime-local"
-            step={1}
-            aria-label="Release date"
-            aria-invalid={!!error}
-            aria-errormessage={error ? `${idPrefix}-release-date-error` : undefined}
-            value={value ?? ''}
-            onChange={({ currentTarget }) => onChange(currentTarget.value)}
-          />
-          {error && (
-            <Form.Text id={`${idPrefix}-release-date-error`} className="text-danger" role="alert">
-              {error}
-            </Form.Text>
-          )}
-        </>
+      <Form.Control
+        ref={inputRef}
+        type="datetime-local"
+        step={1}
+        aria-label="Release date"
+        aria-invalid={!!error}
+        aria-errormessage={error ? `${idPrefix}-release-date-error` : undefined}
+        value={date ?? ''}
+        onChange={({ currentTarget }) => onChangeDate(currentTarget.value)}
+      />
+      {error && (
+        <Form.Text id={`${idPrefix}-release-date-error`} className="text-danger" role="alert">
+          {error}
+        </Form.Text>
       )}
     </Form.Group>
   );
@@ -92,29 +98,47 @@ export function MainReleaseDateField({ displayTimezone }: { displayTimezone: str
     name: 'mainRule.dateControlEnabled',
   });
 
+  // The browser zeroes a datetime-local input's value when the user types an
+  // invalid date (e.g. "04/31/2026"), so an empty `value` can mean either
+  // "blank" or "malformed input". Read the input's `validity.badInput` via a
+  // ref to distinguish the two and surface a more useful message.
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const {
-    field,
+    field: dateField,
     fieldState: { error },
   } = useController<AccessControlFormData, 'mainRule.release.date'>({
     name: 'mainRule.release.date',
     rules: {
       validate: (value) => {
         if (!dateControlEnabled) return true;
-        if (!value) return 'Release date is required';
+        if (!value) {
+          return inputRef.current?.validity.badInput
+            ? 'Enter a valid release date.'
+            : 'A release date is required.';
+        }
         return true;
       },
     },
   });
 
+  const { field: releasedField } = useController<
+    AccessControlFormData,
+    'mainRule.release.released'
+  >({ name: 'mainRule.release.released' });
+
   return (
     <div>
       <strong className="d-block mb-2">Release</strong>
       <ReleaseDateInput
-        value={field.value}
+        date={dateField.value}
+        released={releasedField.value}
         error={error?.message}
         idPrefix="mainRule"
         displayTimezone={displayTimezone}
-        onChange={field.onChange}
+        inputRef={inputRef}
+        onChangeDate={dateField.onChange}
+        onChangeReleased={releasedField.onChange}
       />
     </div>
   );
@@ -131,8 +155,18 @@ export function OverrideReleaseDateField({
     name: 'mainRule.release.date',
   });
 
-  const { field } = useController<AccessControlFormData, `overrides.${number}.release.date`>({
+  const {
+    field: dateField,
+    fieldState: { error },
+  } = useController<AccessControlFormData, `overrides.${number}.release.date`>({
     name: `overrides.${index}.release.date`,
+  });
+
+  const { field: releasedField } = useController<
+    AccessControlFormData,
+    `overrides.${number}.release.released`
+  >({
+    name: `overrides.${index}.release.released`,
   });
 
   const { isOverridden, addOverride, removeOverride } = useOverrideField(index, 'release');
@@ -142,16 +176,21 @@ export function OverrideReleaseDateField({
       isOverridden={isOverridden}
       label="Release"
       onOverride={() => {
-        field.onChange(mainValue || todayLocalDatetime(displayTimezone));
+        const date = mainValue || todayLocalDatetime(displayTimezone);
+        dateField.onChange(date);
+        releasedField.onChange(isReleasedNow(date, displayTimezone));
         addOverride();
       }}
       onRemoveOverride={removeOverride}
     >
       <ReleaseDateInput
-        value={field.value}
+        date={dateField.value}
+        released={releasedField.value}
+        error={error?.message}
         idPrefix={`overrides-${index}`}
         displayTimezone={displayTimezone}
-        onChange={field.onChange}
+        onChangeDate={dateField.onChange}
+        onChangeReleased={releasedField.onChange}
       />
     </FieldWrapper>
   );

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { Form } from 'react-bootstrap';
 import { useController, useWatch } from 'react-hook-form';
 
@@ -23,7 +22,6 @@ function ReleaseDateInput({
   error,
   idPrefix,
   displayTimezone,
-  inputRef,
 }: {
   date: string | null;
   released: boolean;
@@ -32,7 +30,6 @@ function ReleaseDateInput({
   error?: string;
   idPrefix: string;
   displayTimezone: string;
-  inputRef?: React.Ref<HTMLInputElement>;
 }) {
   return (
     <Form.Group>
@@ -75,7 +72,6 @@ function ReleaseDateInput({
         />
       </div>
       <Form.Control
-        ref={inputRef}
         type="datetime-local"
         step={1}
         aria-label="Release date"
@@ -98,12 +94,6 @@ export function DefaultReleaseDateField({ displayTimezone }: { displayTimezone: 
     name: 'defaultRule.dateControlEnabled',
   });
 
-  // The browser zeroes a datetime-local input's value when the user types an
-  // invalid date (e.g. "04/31/2026"), so an empty `value` can mean either
-  // "blank" or "malformed input". Read the input's `validity.badInput` via a
-  // ref to distinguish the two and surface a more useful message.
-  const inputRef = useRef<HTMLInputElement>(null);
-
   const {
     field: dateField,
     fieldState: { error },
@@ -112,11 +102,7 @@ export function DefaultReleaseDateField({ displayTimezone }: { displayTimezone: 
     rules: {
       validate: (value) => {
         if (!dateControlEnabled) return true;
-        if (!value) {
-          return inputRef.current?.validity.badInput
-            ? 'Enter a valid release date.'
-            : 'A release date is required.';
-        }
+        if (!value) return 'Release date is required';
         return true;
       },
     },
@@ -136,7 +122,6 @@ export function DefaultReleaseDateField({ displayTimezone }: { displayTimezone: 
         error={error?.message}
         idPrefix="defaultRule"
         displayTimezone={displayTimezone}
-        inputRef={inputRef}
         onChangeDate={dateField.onChange}
         onChangeReleased={releasedField.onChange}
       />

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
@@ -14,7 +14,7 @@ const defaultMainRule: MainRuleData = {
   trackingId: 'main-1',
   beforeReleaseListed: true,
   dateControlEnabled: true,
-  release: { date: '2025-03-01T00:00:00Z' },
+  release: { date: '2025-03-01T00:00:00Z', released: true },
   due: { date: '2025-04-01T00:00:00Z', credit: null, customCredit: false },
   earlyDeadlines: [{ date: '2025-03-15T00:00:00Z', credit: 110 }],
   lateDeadlines: [{ date: '2025-04-15T00:00:00Z', credit: 50 }],
@@ -34,7 +34,7 @@ const baseOverride: OverrideData = {
     studentLabels: [],
   },
   overriddenFields: [],
-  release: { date: null },
+  release: { date: null, released: true },
   due: { date: null, credit: null, customCredit: false },
   earlyDeadlines: [],
   lateDeadlines: [],
@@ -53,6 +53,27 @@ describe('jsonToMainRuleFormData', () => {
   it('defaults release.date to null when dateControl is not configured', () => {
     const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
     expect(mainRule.release.date).toBeNull();
+  });
+
+  it('defaults release.released to true for unconfigured release', () => {
+    const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
+    expect(mainRule.release.released).toBe(true);
+  });
+
+  it('initializes release.released = true when stored date is in the past', () => {
+    const mainRule = jsonToMainRuleFormData(
+      { dateControl: { release: { date: '2000-01-01T00:00:00Z' }, due: { date: null } } },
+      TEST_TIMEZONE,
+    );
+    expect(mainRule.release.released).toBe(true);
+  });
+
+  it('initializes release.released = false when stored date is far in the future', () => {
+    const mainRule = jsonToMainRuleFormData(
+      { dateControl: { release: { date: '2099-01-01T00:00:00Z' }, due: { date: null } } },
+      TEST_TIMEZONE,
+    );
+    expect(mainRule.release.released).toBe(false);
   });
 
   it('defaults hidden to true for questions when afterComplete is not configured', () => {
@@ -87,6 +108,15 @@ describe('formDataToJson', () => {
     const mainRule = jsonToMainRuleFormData({}, TEST_TIMEZONE);
 
     expect(mainRule.beforeReleaseListed).toBe(false);
+  });
+
+  it('does not emit the UI-only release.released flag to JSON', () => {
+    const result = formDataToJson({
+      mainRule: { ...defaultMainRule, release: { date: '2099-01-01T00:00:00Z', released: true } },
+      overrides: [],
+    });
+
+    expect(result[0].dateControl?.release).toEqual({ date: '2099-01-01T00:00:00Z' });
   });
 
   it('omits default score visibility when only main-rule question visibility is non-default', () => {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -88,13 +88,27 @@ export interface AppliesTo {
   studentLabels: StudentLabelTarget[];
 }
 
+/**
+ * Form-state representation of the release configuration. `date` is the
+ * release date itself; `released` is a UI-only flag that backs the
+ * "Released" / "Scheduled for release" radio choice. We track it separately
+ * from `date` so the user can express a state that is inconsistent with the
+ * date (e.g., "Released" with a future date) and see a validation error,
+ * which would not otherwise be possible if `released` were derived from
+ * `date <= now`. The flag is dropped on JSON serialization.
+ */
+export interface ReleaseValue {
+  date: string | null;
+  released: boolean;
+}
+
 // Main rule: flat fields, null = feature off
 export interface MainRuleData {
   id?: string;
   trackingId: string;
   beforeReleaseListed: boolean;
   dateControlEnabled: boolean;
-  release: { date: string | null };
+  release: ReleaseValue;
   due: DueValue;
   earlyDeadlines: DeadlineEntry[];
   lateDeadlines: DeadlineEntry[];
@@ -115,7 +129,7 @@ export interface OverrideData {
   trackingId: string;
   appliesTo: AppliesTo;
   overriddenFields: OverridableFieldName[];
-  release: { date: string | null };
+  release: ReleaseValue;
   due: DueValue;
   earlyDeadlines: DeadlineEntry[];
   lateDeadlines: DeadlineEntry[];
@@ -129,6 +143,17 @@ export interface OverrideData {
 export interface AccessControlFormData {
   mainRule: MainRuleData;
   overrides: OverrideData[];
+}
+
+/**
+ * Whether a (timezone-naive) datetime string is at or before "now" in the
+ * given display timezone. A null/empty value is treated as released.
+ */
+export function isReleasedNow(value: string | null, displayTimezone: string): boolean {
+  if (!value) return true;
+  const release = Temporal.PlainDateTime.from(value);
+  const now = Temporal.Now.plainDateTimeISO(displayTimezone);
+  return Temporal.PlainDateTime.compare(release, now) <= 0;
 }
 
 /**
@@ -158,6 +183,8 @@ export function jsonToMainRuleFormData(
   const dc = json.dateControl;
   const ac = json.afterComplete;
 
+  const releaseDate = toLocalDatetimeValue(dc?.release?.date, displayTimezone) ?? null;
+
   return {
     id: json.id,
     trackingId: json.id ?? crypto.randomUUID(),
@@ -170,7 +197,7 @@ export function jsonToMainRuleFormData(
       dc?.afterLastDeadline != null ||
       dc?.durationMinutes != null ||
       dc?.password != null,
-    release: { date: toLocalDatetimeValue(dc?.release?.date, displayTimezone) ?? null },
+    release: { date: releaseDate, released: isReleasedNow(releaseDate, displayTimezone) },
     due: {
       date: toLocalDatetimeValue(dc?.due?.date ?? null, displayTimezone),
       credit: dc?.due?.credit ?? null,
@@ -233,9 +260,10 @@ export function jsonToOverrideFormData(
 
   const overriddenFields: OverridableFieldName[] = [];
 
-  let release: { date: string | null } = { date: null };
+  let release: ReleaseValue = { date: null, released: true };
   if (dc?.release !== undefined) {
-    release = { date: toLocalDatetimeValue(dc.release.date, displayTimezone) };
+    const date = toLocalDatetimeValue(dc.release.date, displayTimezone);
+    release = { date, released: isReleasedNow(date, displayTimezone) };
     overriddenFields.push('release');
   }
 
@@ -493,7 +521,10 @@ export function createDefaultOverrideFormData(mainRule?: MainRuleData): Override
       studentLabels: [],
     },
     overriddenFields: [],
-    release: { date: mainRule?.release.date ?? null },
+    release: {
+      date: mainRule?.release.date ?? null,
+      released: mainRule?.release.released ?? true,
+    },
     due: mainRule?.due ? { ...mainRule.due } : { date: null, credit: null, customCredit: false },
     earlyDeadlines: (mainRule?.earlyDeadlines ?? []).map((d) => ({ ...d })),
     lateDeadlines: (mainRule?.lateDeadlines ?? []).map((d) => ({ ...d })),

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -1,9 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AccessControlFormData } from './types.js';
+import type { AccessControlFormData, OverrideData } from './types.js';
 import { getGlobalDateValidationErrors } from './validation.js';
 
 const TEST_TIMEZONE = 'America/Chicago';
+
+function makeOverride(partial: Partial<OverrideData> = {}): OverrideData {
+  return {
+    trackingId: 'override',
+    appliesTo: {
+      targetType: 'student_label',
+      enrollments: [],
+      studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
+    },
+    overriddenFields: [],
+    release: { date: null, released: true },
+    due: { date: null, credit: null, customCredit: false },
+    earlyDeadlines: [],
+    lateDeadlines: [],
+    afterLastDeadline: { allowSubmissions: false },
+    durationMinutes: null,
+    password: null,
+    questionVisibility: { hidden: true },
+    scoreVisibility: { hidden: false },
+    ...partial,
+  };
+}
 
 function makeFormData(
   overrides: AccessControlFormData['overrides'],
@@ -34,42 +56,19 @@ describe('getGlobalDateValidationErrors', () => {
   it('maps an impossible early deadline to the matching override field path', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData([
-        {
-          trackingId: 'override-1',
-          appliesTo: {
-            targetType: 'student_label',
-            enrollments: [],
-            studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
-          },
+        makeOverride({
           overriddenFields: ['release'],
           release: { date: '2024-04-06T00:00:00', released: true },
-          due: { date: null, credit: null, customCredit: false },
-          earlyDeadlines: [],
-          lateDeadlines: [],
-          afterLastDeadline: { allowSubmissions: false },
-          durationMinutes: null,
-          password: null,
-          questionVisibility: { hidden: true },
-          scoreVisibility: { hidden: false },
-        },
-        {
-          trackingId: 'override-2',
+        }),
+        makeOverride({
           appliesTo: {
             targetType: 'enrollment',
             enrollments: [{ enrollmentId: 'e1', uid: 'student1', name: 'Student 1' }],
             studentLabels: [],
           },
           overriddenFields: ['earlyDeadlines'],
-          release: { date: null, released: true },
-          due: { date: null, credit: null, customCredit: false },
           earlyDeadlines: [{ date: '2024-04-05T00:00:00', credit: 120 }],
-          lateDeadlines: [],
-          afterLastDeadline: { allowSubmissions: false },
-          durationMinutes: null,
-          password: null,
-          questionVisibility: { hidden: true },
-          scoreVisibility: { hidden: false },
-        },
+        }),
       ]),
       TEST_TIMEZONE,
     );
@@ -83,42 +82,16 @@ describe('getGlobalDateValidationErrors', () => {
   it('skips due-based global errors when any rule can unset the due date', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData([
-        {
-          trackingId: 'override-1',
-          appliesTo: {
-            targetType: 'student_label',
-            enrollments: [],
-            studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
-          },
-          overriddenFields: ['due'],
-          release: { date: null, released: true },
-          due: { date: null, credit: null, customCredit: false },
-          earlyDeadlines: [],
-          lateDeadlines: [],
-          afterLastDeadline: { allowSubmissions: false },
-          durationMinutes: null,
-          password: null,
-          questionVisibility: { hidden: true },
-          scoreVisibility: { hidden: false },
-        },
-        {
-          trackingId: 'override-2',
+        makeOverride({ overriddenFields: ['due'] }),
+        makeOverride({
           appliesTo: {
             targetType: 'student_label',
             enrollments: [],
             studentLabels: [{ studentLabelId: '2', name: 'Section B' }],
           },
           overriddenFields: ['lateDeadlines'],
-          release: { date: null, released: true },
-          due: { date: null, credit: null, customCredit: false },
-          earlyDeadlines: [],
           lateDeadlines: [{ date: '2024-04-07T12:00:00', credit: 50 }],
-          afterLastDeadline: { allowSubmissions: false },
-          durationMinutes: null,
-          password: null,
-          questionVisibility: { hidden: true },
-          scoreVisibility: { hidden: false },
-        },
+        }),
       ]),
       TEST_TIMEZONE,
     );
@@ -159,24 +132,10 @@ describe('getGlobalDateValidationErrors', () => {
   it('flags a future override release date when override radio is "Released"', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData([
-        {
-          trackingId: 'override-1',
-          appliesTo: {
-            targetType: 'student_label',
-            enrollments: [],
-            studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
-          },
+        makeOverride({
           overriddenFields: ['release'],
           release: { date: '2099-01-01T00:00:00', released: true },
-          due: { date: null, credit: null, customCredit: false },
-          earlyDeadlines: [],
-          lateDeadlines: [],
-          afterLastDeadline: { allowSubmissions: false },
-          durationMinutes: null,
-          password: null,
-          questionVisibility: { hidden: true },
-          scoreVisibility: { hidden: false },
-        },
+        }),
       ]),
       TEST_TIMEZONE,
     );
@@ -190,24 +149,11 @@ describe('getGlobalDateValidationErrors', () => {
   it('does not flag override release inconsistency when release is not overridden', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData([
-        {
-          trackingId: 'override-1',
-          appliesTo: {
-            targetType: 'student_label',
-            enrollments: [],
-            studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
-          },
+        makeOverride({
           overriddenFields: ['due'],
           release: { date: '2099-01-01T00:00:00', released: true },
           due: { date: '2099-06-01T00:00:00', credit: null, customCredit: false },
-          earlyDeadlines: [],
-          lateDeadlines: [],
-          afterLastDeadline: { allowSubmissions: false },
-          durationMinutes: null,
-          password: null,
-          questionVisibility: { hidden: true },
-          scoreVisibility: { hidden: false },
-        },
+        }),
       ]),
       TEST_TIMEZONE,
     );

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -3,13 +3,18 @@ import { describe, expect, it } from 'vitest';
 import type { AccessControlFormData } from './types.js';
 import { getGlobalDateValidationErrors } from './validation.js';
 
-function makeFormData(overrides: AccessControlFormData['overrides']): AccessControlFormData {
+const TEST_TIMEZONE = 'America/Chicago';
+
+function makeFormData(
+  overrides: AccessControlFormData['overrides'],
+  mainRuleOverrides: Partial<AccessControlFormData['mainRule']> = {},
+): AccessControlFormData {
   return {
     mainRule: {
       trackingId: 'main',
       beforeReleaseListed: false,
       dateControlEnabled: true,
-      release: { date: '2024-04-07T00:00:00' },
+      release: { date: '2024-04-07T00:00:00', released: true },
       due: { date: '2024-04-10T00:00:00', credit: null, customCredit: false },
       earlyDeadlines: [],
       lateDeadlines: [],
@@ -19,6 +24,7 @@ function makeFormData(overrides: AccessControlFormData['overrides']): AccessCont
       prairieTestExams: [],
       questionVisibility: { hidden: true },
       scoreVisibility: { hidden: false },
+      ...mainRuleOverrides,
     },
     overrides,
   };
@@ -36,7 +42,7 @@ describe('getGlobalDateValidationErrors', () => {
             studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
           },
           overriddenFields: ['release'],
-          release: { date: '2024-04-06T00:00:00' },
+          release: { date: '2024-04-06T00:00:00', released: true },
           due: { date: null, credit: null, customCredit: false },
           earlyDeadlines: [],
           lateDeadlines: [],
@@ -54,7 +60,7 @@ describe('getGlobalDateValidationErrors', () => {
             studentLabels: [],
           },
           overriddenFields: ['earlyDeadlines'],
-          release: { date: null },
+          release: { date: null, released: true },
           due: { date: null, credit: null, customCredit: false },
           earlyDeadlines: [{ date: '2024-04-05T00:00:00', credit: 120 }],
           lateDeadlines: [],
@@ -65,6 +71,7 @@ describe('getGlobalDateValidationErrors', () => {
           scoreVisibility: { hidden: false },
         },
       ]),
+      TEST_TIMEZONE,
     );
 
     expect(errors).toContainEqual({
@@ -84,7 +91,7 @@ describe('getGlobalDateValidationErrors', () => {
             studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
           },
           overriddenFields: ['due'],
-          release: { date: null },
+          release: { date: null, released: true },
           due: { date: null, credit: null, customCredit: false },
           earlyDeadlines: [],
           lateDeadlines: [],
@@ -102,7 +109,7 @@ describe('getGlobalDateValidationErrors', () => {
             studentLabels: [{ studentLabelId: '2', name: 'Section B' }],
           },
           overriddenFields: ['lateDeadlines'],
-          release: { date: null },
+          release: { date: null, released: true },
           due: { date: null, credit: null, customCredit: false },
           earlyDeadlines: [],
           lateDeadlines: [{ date: '2024-04-07T12:00:00', credit: 50 }],
@@ -113,8 +120,98 @@ describe('getGlobalDateValidationErrors', () => {
           scoreVisibility: { hidden: false },
         },
       ]),
+      TEST_TIMEZONE,
     );
 
     expect(errors).toEqual([]);
+  });
+
+  it('flags a future release date when the radio choice is "Released"', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([], {
+        release: { date: '2099-01-01T00:00:00', released: true },
+        due: { date: '2099-02-01T00:00:00', credit: null, customCredit: false },
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'mainRule.release.date',
+      message: 'Release date must not be in the future when state is Released.',
+    });
+  });
+
+  it('flags a past release date when the radio choice is "Scheduled for release"', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([], {
+        release: { date: '2000-01-01T00:00:00', released: false },
+        due: { date: '2000-02-01T00:00:00', credit: null, customCredit: false },
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'mainRule.release.date',
+      message: 'Release date must be in the future when scheduled for release.',
+    });
+  });
+
+  it('flags a future override release date when override radio is "Released"', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([
+        {
+          trackingId: 'override-1',
+          appliesTo: {
+            targetType: 'student_label',
+            enrollments: [],
+            studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
+          },
+          overriddenFields: ['release'],
+          release: { date: '2099-01-01T00:00:00', released: true },
+          due: { date: null, credit: null, customCredit: false },
+          earlyDeadlines: [],
+          lateDeadlines: [],
+          afterLastDeadline: { allowSubmissions: false },
+          durationMinutes: null,
+          password: null,
+          questionVisibility: { hidden: true },
+          scoreVisibility: { hidden: false },
+        },
+      ]),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'overrides.0.release.date',
+      message: 'Release date must not be in the future when state is Released.',
+    });
+  });
+
+  it('does not flag override release inconsistency when release is not overridden', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([
+        {
+          trackingId: 'override-1',
+          appliesTo: {
+            targetType: 'student_label',
+            enrollments: [],
+            studentLabels: [{ studentLabelId: '1', name: 'Section A' }],
+          },
+          overriddenFields: ['due'],
+          release: { date: '2099-01-01T00:00:00', released: true },
+          due: { date: '2099-06-01T00:00:00', credit: null, customCredit: false },
+          earlyDeadlines: [],
+          lateDeadlines: [],
+          afterLastDeadline: { allowSubmissions: false },
+          durationMinutes: null,
+          password: null,
+          questionVisibility: { hidden: true },
+          scoreVisibility: { hidden: false },
+        },
+      ]),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors.find((e) => e.path === 'overrides.0.release.date')).toBeUndefined();
   });
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -7,7 +7,7 @@ import {
   validateRuleStructuralDependencyIssues,
 } from '../../../lib/assessment-access-control/validation.js';
 
-import { type AccessControlFormData, formDataToJson } from './types.js';
+import { type AccessControlFormData, formDataToJson, isReleasedNow } from './types.js';
 
 export type AccessControlFormFieldPath =
   | 'mainRule.release.date'
@@ -91,7 +91,54 @@ function mapIssueToFormFieldPath(
   }
 }
 
-export function getGlobalDateValidationErrors(formData: AccessControlFormData): {
+/**
+ * Surface inconsistencies between the "Released" / "Scheduled for release"
+ * radio choice and the chosen date. The radio reflects the user's intent;
+ * if the date contradicts that intent we want a form error rather than
+ * silently flipping the radio.
+ */
+function getReleaseStateValidationErrors(
+  formData: AccessControlFormData,
+  displayTimezone: string,
+): { path: AccessControlFormFieldPath; message: string }[] {
+  const results: { path: AccessControlFormFieldPath; message: string }[] = [];
+
+  const checkRule = (
+    release: AccessControlFormData['mainRule']['release'],
+    path: AccessControlFormFieldPath,
+  ) => {
+    if (!release.date) return;
+    const dateIsPast = isReleasedNow(release.date, displayTimezone);
+    if (release.released && !dateIsPast) {
+      results.push({
+        path,
+        message: 'Release date must not be in the future when state is Released.',
+      });
+    } else if (!release.released && dateIsPast) {
+      results.push({
+        path,
+        message: 'Release date must be in the future when scheduled for release.',
+      });
+    }
+  };
+
+  if (formData.mainRule.dateControlEnabled) {
+    checkRule(formData.mainRule.release, 'mainRule.release.date');
+  }
+
+  formData.overrides.forEach((override, index) => {
+    if (override.overriddenFields.includes('release')) {
+      checkRule(override.release, `overrides.${index}.release.date`);
+    }
+  });
+
+  return results;
+}
+
+export function getGlobalDateValidationErrors(
+  formData: AccessControlFormData,
+  displayTimezone: string,
+): {
   path: AccessControlFormFieldPath;
   message: string;
 }[] {
@@ -124,6 +171,12 @@ export function getGlobalDateValidationErrors(formData: AccessControlFormData): 
         results.push({ path, message: issue.message });
       }
     }
+  }
+
+  for (const error of getReleaseStateValidationErrors(formData, displayTimezone)) {
+    if (seenPaths.has(error.path)) continue;
+    seenPaths.add(error.path);
+    results.push(error);
   }
 
   return results;


### PR DESCRIPTION
# Description

Addresses the release-date item from #14469: "We need to be able to change the release date even if the release state is released; the release date may matter. If state is released, form error if in the future. Scheduled for release radio option should be a form error if in the past."

The datetime input is now always visible. The "Released" / "Scheduled for release" radio is tracked as a UI-only form field (`released: boolean`) so the user's intent can be expressed independently of the date and surfaced as a validation error when the two disagree (released + future date, or scheduled + past date). Toggling the radio uses a smart default — the date only snaps to today/tomorrow when the existing value doesn't already fit the new mode, so user-typed dates that already work are preserved (per the team consensus in Slack: "alter other inputs to give non-error states", "don't try to remember previous state"). Empty vs. browser-rejected input (e.g. `04/31/2026`) are now distinguished — the latter shows "Enter a valid release date." (detected via `inputRef.current.validity.badInput`) instead of the misleading "is required."

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation by Claude (Opus 4.7), guided by my UX review and the Slack discussion linked above.

# Testing

- New unit tests in `validation.test.ts` cover the released-vs-date inconsistency cases for both main rule and overrides, plus a guard that override release inconsistencies don't fire when `release` isn't overridden.
- New unit tests in `types.test.ts` cover initial `released` derivation from the date and that the UI-only flag is dropped on JSON serialization.
- Manually exercised in the dev browser (instructor → assessment → Access page): toggling between modes with various existing dates (past/future/null), typing custom dates that mismatch the radio, and reproducing the `04/31/2026` browser-rejected input case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)