### PR TITLE
Fix scrolling on the assessment access control page when there are sync error warnings

### DIFF
--- a/apps/prairielearn/assets/stylesheets/splitPane.css
+++ b/apps/prairielearn/assets/stylesheets/splitPane.css
@@ -2,10 +2,15 @@
    from @prairielearn/ui. The generic split-pane styles live in the library. */
 
 /* Full-height layout: make the split pane fill remaining space in the
-   app-main-container flex column instead of using a hardcoded viewport offset. */
+   app-main-container flex column instead of using a hardcoded viewport offset.
+   #content is a flex column so siblings of the hydrated component (e.g. the
+   SyncErrorsAndWarnings banner) take their natural height rather than pushing
+   the hydrated component below the clipped region. */
 #content:has([data-split-pane-page]) {
   flex: 1;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 /* On wider viewports, prevent overflowing #content so that only the
@@ -19,7 +24,8 @@
 }
 
 #content:has([data-split-pane-page]) > .js-hydrated-component {
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 /* ── Section headers (banded) ─────────────────────────────────────────── */


### PR DESCRIPTION


<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

The assessement access control page had a bug in which whenever a sync error warning banner was rendered, the contents of the page got pushed down beyond the viewport, and scrolling was not possible. This PR fixes that issue.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Cause a sync error and access the access control page on the assessment.