### PR TITLE
Handle dates with fractional seconds and timezone specifiers in access migration

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -605,6 +605,34 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
+      name: 'dates with fractional seconds and UTC suffix match input_date handling',
+      rules: [
+        {
+          credit: 100,
+          startDate: '2019-09-03T08:00:00.179Z',
+          endDate: '2019-12-20T23:59:59.999Z',
+          showClosedAssessment: false,
+          showClosedAssessmentScore: false,
+        },
+        { active: false, startDate: '2020-01-01 12:34:56.789Z' },
+      ],
+      expected: {
+        accessControl: {
+          dateControl: {
+            release: { date: '2019-09-03T08:00:00' },
+            due: { date: '2019-12-20T23:59:59' },
+          },
+          afterComplete: {
+            questions: { hidden: true, visibleFromDate: '2020-01-01T12:34:56' },
+            score: { hidden: true, visibleFromDate: '2020-01-01T12:34:56' },
+          },
+        },
+        errors: [],
+        notes: [],
+        hasUidRules: false,
+      },
+    },
+    {
       name: 'pre-release listing and later reveal',
       rules: [
         { endDate: '2030-01-01T00:00:00', active: false },

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -85,6 +85,22 @@ function findLastCreditEndDate(rules: AssessmentAccessRuleJson[]): string | unde
   return endDates[endDates.length - 1];
 }
 
+function normalizeDateForInputDate(date: string): string {
+  // Match the `input_date` sproc behavior: only the date and whole-second time
+  // are used, so fractional seconds and trailing timezone markers are ignored.
+  const dateParts = /([0-9]{4}-[0-9]{2}-[0-9]{2})[ T]([0-9]{2}:[0-9]{2}:[0-9]{2})/.exec(date);
+  if (!dateParts) return date;
+  return `${dateParts[1]}T${dateParts[2]}`;
+}
+
+function normalizeRuleDates(rule: AssessmentAccessRuleJson): AssessmentAccessRuleJson {
+  return {
+    ...rule,
+    ...(rule.startDate ? { startDate: normalizeDateForInputDate(rule.startDate) } : {}),
+    ...(rule.endDate ? { endDate: normalizeDateForInputDate(rule.endDate) } : {}),
+  };
+}
+
 /**
  * Returns true when `outer`'s [start, end] window fully covers `inner`'s.
  * Both rules must be closed (have an endDate). A missing startDate on `outer`
@@ -138,7 +154,8 @@ export function normalizeRules(rules: AssessmentAccessRuleJson[]): AssessmentAcc
         return rest;
       }
       return r;
-    });
+    })
+    .map(normalizeRuleDates);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Normalize legacy `allowAccess` `startDate` and `endDate` values during modern access-control migration using the same whole-second parsing shape as the `input_date` sproc, so ISO strings with fractional seconds and trailing `Z` migrate to schema-compatible `datetime-local` strings.
This addresses the Z-date migration followup in #14469.
Added regression coverage for UTC-suffixed fractional dates and a space-separated legacy date.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation and PR preparation used AI assistance.

# Testing

- `yarn test apps/prairielearn/src/lib/assessment-access-control/migration.test.ts`
- `./scripts/typecheck-file.sh apps/prairielearn/src/lib/assessment-access-control/migration.ts apps/prairielearn/src/lib/assessment-access-control/migration.test.ts`
- `make format-changed`
- `git diff --check`
