### PR TITLE
Change NaN messaging on assessment access control

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -248,7 +248,7 @@ export function generateDefaultRuleDateTableRows(
         />
       ),
       label: 'Due',
-      credit: `${dueCredit}%`,
+      credit: formatCreditPercent(dueCredit),
       error: dueError,
       current: isDeadlineCurrent(dueDate),
       currentVariant,
@@ -257,7 +257,7 @@ export function generateDefaultRuleDateTableRows(
     rows.push({
       date: 'No due date',
       label: 'Due',
-      credit: `${dueCredit}%`,
+      credit: formatCreditPercent(dueCredit),
       error: dueError,
       current: isNoDeadlineSegment,
       currentVariant,
@@ -267,7 +267,7 @@ export function generateDefaultRuleDateTableRows(
     rows.push({
       date: 'No date set',
       label: 'Due',
-      credit: `${dueCredit}%`,
+      credit: formatCreditPercent(dueCredit),
       error: dueError,
     });
   }
@@ -579,7 +579,7 @@ function generateOverrideFieldItems(
   }
 
   if (overriddenFields.has('due')) {
-    const creditLabel = rule.due.credit != null ? ` (${rule.due.credit}%)` : '';
+    const creditLabel = rule.due.credit != null ? ` (${formatCreditPercent(rule.due.credit)})` : '';
     const dueDateErr = formErrors?.due?.date?.message;
     const dueCreditErr = formErrors?.due?.credit?.message;
     items.push({
@@ -944,7 +944,7 @@ function buildDefaultRuleCurrentIndicator(
       icon: 'bi-unlock',
       text: (
         <>
-          Open · {segment.credit}% credit until {friendlyDate(segment.endDate)}
+          Open · {formatCreditPercent(segment.credit)} credit until {friendlyDate(segment.endDate)}
         </>
       ),
     };
@@ -952,7 +952,7 @@ function buildDefaultRuleCurrentIndicator(
   return {
     variant: 'success',
     icon: 'bi-unlock',
-    text: `Open · ${segment.credit}% credit`,
+    text: `Open · ${formatCreditPercent(segment.credit)} credit`,
   };
 }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -28,6 +28,10 @@ import {
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+function formatCreditPercent(credit: number): string {
+  return Number.isFinite(credit) ? `${credit}%` : '—';
+}
+
 type RuleData = DefaultRuleData | OverrideData;
 
 /** react-hook-form error subtree for a single access control rule. */
@@ -222,7 +226,7 @@ export function generateDefaultRuleDateTableRows(
         'No date set'
       ),
       label: `Early ${index + 1}`,
-      credit: `${deadline.credit}%`,
+      credit: formatCreditPercent(deadline.credit),
       error: [dateErr, creditErr].filter(Boolean).join('; ') || undefined,
       current: deadline.date ? isDeadlineCurrent(deadline.date) : false,
       currentVariant,
@@ -283,7 +287,7 @@ export function generateDefaultRuleDateTableRows(
         'No date set'
       ),
       label: `Late ${index + 1}`,
-      credit: `${deadline.credit}%`,
+      credit: formatCreditPercent(deadline.credit),
       error: [dateErr, creditErr].filter(Boolean).join('; ') || undefined,
       current: deadline.date ? isDeadlineCurrent(deadline.date) : false,
       currentVariant,
@@ -299,7 +303,7 @@ export function generateDefaultRuleDateTableRows(
       label: 'After last deadline',
       credit: afterLastDeadline?.allowSubmissions
         ? afterLastDeadline.credit != null
-          ? `${afterLastDeadline.credit}%`
+          ? formatCreditPercent(afterLastDeadline.credit)
           : 'Practice'
         : 'Closed',
       error: formErrors?.afterLastDeadline?.credit?.message,
@@ -504,10 +508,10 @@ function formatDeadlineEntries(
           options={{ includeTz: false }}
           tooltip
         />{' '}
-        ({entry.credit}% credit)
+        ({formatCreditPercent(entry.credit)} credit)
       </>
     ) : (
-      `No date set (${entry.credit}% credit)`
+      `No date set (${formatCreditPercent(entry.credit)} credit)`
     ),
     error: deadlineErrors?.[i],
   }));
@@ -515,7 +519,11 @@ function formatDeadlineEntries(
 
 function formatAfterLastDeadline(afterLastDeadline: AfterLastDeadlineValue): string {
   const parts: string[] = [];
-  if (afterLastDeadline.allowSubmissions && afterLastDeadline.credit != null) {
+  if (
+    afterLastDeadline.allowSubmissions &&
+    afterLastDeadline.credit != null &&
+    Number.isFinite(afterLastDeadline.credit)
+  ) {
     parts.push(`${afterLastDeadline.credit}% credit`);
   }
   if (afterLastDeadline.allowSubmissions) {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -180,7 +180,7 @@ function AfterLastDeadlineInput({
               <Form.Control
                 id={`${idPrefix}-after-deadline-credit`}
                 type="number"
-                style={{ width: '5rem' }}
+                style={{ width: '6rem' }}
                 aria-label="Credit percentage after last deadline"
                 aria-invalid={!!creditError}
                 aria-errormessage={
@@ -197,6 +197,7 @@ function AfterLastDeadlineInput({
                   deps: creditDeps,
                   validate: (v, formValues) => {
                     if (v == null || Number.isNaN(v)) return 'Credit is required';
+                    if (!Number.isFinite(v)) return 'Credit must be a finite number';
                     if (v < 0 || v > 200) return 'Must be 0\u2013200%';
                     const { dueDate, dueCredit, lateDeadlines } = resolveConstraints(
                       formValues,

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -264,7 +264,8 @@ function DeadlineArrayInput({
   };
 
   const validateCredit = (value: number, index: number) => {
-    if (!Number.isFinite(value)) return 'Credit is required';
+    if (Number.isNaN(value)) return 'Credit is required';
+    if (!Number.isFinite(value)) return 'Credit must be a finite number';
     if (isEarly) {
       if (value < 101 || value > 200) return 'Credit must be 101-200%';
     } else if (dueCreditRef.current !== 0) {
@@ -363,7 +364,7 @@ function DeadlineArrayInput({
                   id={`${idPrefix}-${type}-deadline-${index}-credit`}
                   type="number"
                   defaultValue={deadlineField.credit}
-                  style={{ width: '5rem' }}
+                  style={{ width: '6rem' }}
                   aria-label={`${isEarly ? 'Early' : 'Late'} deadline ${index + 1} credit percentage`}
                   aria-invalid={!!getCreditError(index)}
                   aria-errormessage={

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DueDateField.tsx
@@ -162,7 +162,7 @@ function DueDateInput({
                 min={0}
                 max={200}
                 step={1}
-                style={{ width: '5rem' }}
+                style={{ width: '6rem' }}
                 aria-label="Due date credit percentage"
                 aria-invalid={!!creditError}
                 aria-errormessage={creditError ? `${idPrefix}-due-credit-error` : undefined}
@@ -230,7 +230,7 @@ function validateDueCredit(credit: number | null, customCredit: boolean): string
     if (customCredit) return 'Credit is required';
     return undefined;
   }
-  if (!Number.isFinite(credit)) return 'Credit must be a number';
+  if (!Number.isFinite(credit)) return 'Credit must be a finite number';
   if (!Number.isInteger(credit)) return 'Credit must be an integer';
   if (credit < 0 || credit > 200) return 'Credit must be between 0% and 200%';
   return undefined;

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -364,16 +364,13 @@ export function jsonToOverrideFormData(
  * distinct from default because cross-rule validation (e.g. forbidding early
  * deadlines) treats any set credit as customized.
  *
- * `customCredit: true` with `credit: null` is a transient editing state that
- * the form's per-field validator blocks at submit time; assert here so any
- * future caller that bypasses the form fails loudly instead of silently
- * coercing to "default credit".
+ * `customCredit: true` with `credit: null` is a transient editing state (the
+ * user has cleared the input). The field-level validator surfaces "Credit is
+ * required" and blocks submit; here we just omit `credit` so that live
+ * cross-field validation can keep running without throwing.
  */
 function buildDueJson(due: DueValue): { date: string | null; credit?: number } {
-  if (due.customCredit) {
-    if (due.credit === null) {
-      throw new Error('customCredit is true but credit is null');
-    }
+  if (due.customCredit && due.credit !== null) {
     return { date: due.date, credit: due.credit };
   }
   return { date: due.date };


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Some "Credit" fields on assessment access control error message text using the credit value of the field. That causes "NaN% Credit..." to be shown to the user, which is undesirable. This PR fixes this by changing the wording to "Credit is required":

<img width="1253" height="396" alt="image" src="https://github.com/user-attachments/assets/0c055ca6-0181-4f25-8223-135732e7204b" />

<br>
Also, during the developing of this change, a bug caused by the runtime validation of the values for cross-field error handling was found, where if the user clears the "Credit" override field in the default rule's "Due date", an error was thrown before submit:

https://github.com/user-attachments/assets/3d4032e2-a48c-45c3-9113-74a0fcd515f4

Which was fixed:

<img width="1271" height="459" alt="image" src="https://github.com/user-attachments/assets/8cb2abd9-5073-4a41-8c9f-940c46045ff5" />

<br>

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Manually tested.
