### PR TITLE
Use random ports for dev asset server

### DIFF
--- a/.changeset/fix-esbuild-dev-port.md
+++ b/.changeset/fix-esbuild-dev-port.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/compiled-assets': patch
+---
+
+Use random non-8000 ports for esbuild development asset servers.

--- a/.changeset/fix-esbuild-dev-port.md
+++ b/.changeset/fix-esbuild-dev-port.md
@@ -2,4 +2,4 @@
 '@prairielearn/compiled-assets': patch
 ---
 
-Use random non-8000 ports for esbuild development asset servers.
+Use OS-assigned ports for esbuild development asset servers.

--- a/packages/compiled-assets/package.json
+++ b/packages/compiled-assets/package.json
@@ -23,6 +23,7 @@
     "esbuild": "^0.28.0",
     "express-static-gzip": "^2.2.0 <3",
     "fs-extra": "^11.3.4",
+    "get-port": "^7.2.0",
     "globby": "^16.2.0",
     "pretty-bytes": "^7.1.0",
     "tmp-promise": "^3.0.3"
@@ -35,7 +36,6 @@
     "@typescript/native-preview": "^7.0.0-dev.20260305.1",
     "@vitest/coverage-v8": "^4.1.2",
     "express": "^4.22.1",
-    "get-port": "^7.2.0",
     "node-fetch": "^3.3.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/packages/compiled-assets/package.json
+++ b/packages/compiled-assets/package.json
@@ -23,7 +23,6 @@
     "esbuild": "^0.28.0",
     "express-static-gzip": "^2.2.0 <3",
     "fs-extra": "^11.3.4",
-    "get-port": "^7.2.0",
     "globby": "^16.2.0",
     "pretty-bytes": "^7.1.0",
     "tmp-promise": "^3.0.3"
@@ -36,6 +35,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20260305.1",
     "@vitest/coverage-v8": "^4.1.2",
     "express": "^4.22.1",
+    "get-port": "^7.2.0",
     "node-fetch": "^3.3.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import esbuild, { type Metafile } from 'esbuild';
 import expressStaticGzip from 'express-static-gzip';
 import fs from 'fs-extra';
-import getPort from 'get-port';
 import { globby } from 'globby';
 
 import { type HtmlSafeString, html } from '@prairielearn/html';
@@ -55,14 +54,16 @@ let relativeSourcePaths: string[] | null = null;
  * See https://github.com/tree-sitter/tree-sitter/pull/5546.
  */
 const NODE_ONLY_EXTERNALS = ['fs/promises', 'module'];
-// Avoid mkdocs' default development port, which is used by `make dev-docs`.
-const ESBUILD_EXCLUDED_PORTS = [8000];
 
 async function serveEsbuildContext(context: esbuild.BuildContext): Promise<esbuild.ServeResult> {
-  const port = await getPort({ exclude: ESBUILD_EXCLUDED_PORTS });
   // This must stay in sync with the Host header workaround in `handler()`.
   // esbuild 0.25+ validates proxied requests against the server's listening host.
-  return context.serve({ host: '0.0.0.0', port });
+  return context.serve({
+    host: '0.0.0.0',
+    // Use an OS-assigned port to avoid esbuild's default port 8000, which
+    // conflicts with mkdocs when running `make dev-docs`.
+    port: 0,
+  });
 }
 
 export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<void> {

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import esbuild, { type Metafile } from 'esbuild';
 import expressStaticGzip from 'express-static-gzip';
 import fs from 'fs-extra';
+import getPort from 'get-port';
 import { globby } from 'globby';
 
 import { type HtmlSafeString, html } from '@prairielearn/html';
@@ -54,6 +55,15 @@ let relativeSourcePaths: string[] | null = null;
  * See https://github.com/tree-sitter/tree-sitter/pull/5546.
  */
 const NODE_ONLY_EXTERNALS = ['fs/promises', 'module'];
+// Avoid mkdocs' default development port, which is used by `make dev-docs`.
+const ESBUILD_EXCLUDED_PORTS = [8000];
+
+async function serveEsbuildContext(context: esbuild.BuildContext): Promise<esbuild.ServeResult> {
+  const port = await getPort({ exclude: ESBUILD_EXCLUDED_PORTS });
+  // This must stay in sync with the Host header workaround in `handler()`.
+  // esbuild 0.25+ validates proxied requests against the server's listening host.
+  return context.serve({ host: '0.0.0.0', port });
+}
 
 export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<void> {
   options = {
@@ -96,7 +106,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
       },
       external: NODE_ONLY_EXTERNALS,
     });
-    esbuildServer = await esbuildContext.serve({ host: '0.0.0.0' });
+    esbuildServer = await serveEsbuildContext(esbuildContext);
 
     const splitSourceGlob = path.join(
       options.sourceDirectory,
@@ -127,7 +137,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
       },
       external: NODE_ONLY_EXTERNALS,
     });
-    splitEsbuildServer = await splitEsbuildContext.serve({ host: '0.0.0.0' });
+    splitEsbuildServer = await serveEsbuildContext(splitEsbuildContext);
   }
 }
 


### PR DESCRIPTION
# Description

Use a free non-8000 port for the compiled-assets esbuild development servers so `make dev-docs` can keep mkdocs on its default port without breaking PrairieLearn asset requests. This also moves `get-port` into runtime dependencies for `@prairielearn/compiled-assets` and adds a patch changeset.

To reproduce the original issue here, run `make dev-docs` and `make dev` at the same time, then try loading an instructor page. Before this fix, `mkdocs` would end up trying to serve the assets for PL, which it obviously knows nothing about. 

AI assistance: majority of implementation.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Tested with the docs preview running; PL still works!
