### PR TITLE
Make course repository optional in admin courses page

### DIFF
--- a/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
+++ b/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
@@ -70,6 +70,7 @@ export function AdministratorCourseFormFields({
   emailDomain,
   aiSecretsConfigured,
   autoFilledInstitutionId,
+  repositoryRequired,
 }: {
   institutions: AdminInstitution[];
   availableTimezones: Timezone[];
@@ -78,6 +79,7 @@ export function AdministratorCourseFormFields({
   emailDomain?: string;
   aiSecretsConfigured: boolean;
   autoFilledInstitutionId?: string | null;
+  repositoryRequired: boolean;
 }) {
   const trpc = useTRPC();
   const {
@@ -311,7 +313,9 @@ export function AdministratorCourseFormFields({
             aria-errormessage={
               errors.repository_short_name ? 'courseFormRepositoryName-error' : undefined
             }
-            {...register('repository_short_name')}
+            {...register('repository_short_name', {
+              required: repositoryRequired && 'Enter a repository name',
+            })}
           />
           {prefixState.status === 'resolved' && !prefixState.prefix && aiSecretsConfigured && (
             <OverlayTrigger

--- a/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
+++ b/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
@@ -311,7 +311,7 @@ export function AdministratorCourseFormFields({
             aria-errormessage={
               errors.repository_short_name ? 'courseFormRepositoryName-error' : undefined
             }
-            {...register('repository_short_name', { required: 'Enter a repository name' })}
+            {...register('repository_short_name')}
           />
           {prefixState.status === 'resolved' && !prefixState.prefix && aiSecretsConfigured && (
             <OverlayTrigger

--- a/apps/prairielearn/src/models/course.sql
+++ b/apps/prairielearn/src/models/course.sql
@@ -237,7 +237,7 @@ VALUES
     $title,
     $display_timezone,
     $path,
-    $repository,
+    NULLIF($repository, ''),
     $branch,
     $institution_id,
     TRUE

--- a/apps/prairielearn/src/models/course.sql
+++ b/apps/prairielearn/src/models/course.sql
@@ -302,7 +302,7 @@ RETURNING
 -- BLOCK update_course_column_repository
 UPDATE courses
 SET
-  repository = $value
+  repository = NULLIF($value, '')
 WHERE
   id = $course_id
   AND deleted_at IS NULL

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -542,6 +542,7 @@ function CourseRequestApproveModalContent({
             emailDomain={request.work_email?.split('@')[1] ?? ''}
             aiSecretsConfigured={aiSecretsConfigured}
             autoFilledInstitutionId={autoFilledInstitutionId}
+            repositoryRequired={true}
           />
           <div className="mb-3">
             <label className="form-label" htmlFor="courseRequestAddInputGithubUser">

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
@@ -352,6 +352,7 @@ function CourseInsertModal({
               coursesRoot={coursesRoot}
               prefixState={prefixState}
               aiSecretsConfigured={aiSecretsConfigured}
+              repositoryRequired={false}
             />
             <div className="mb-3">
               <label className="form-label" htmlFor="courseAddInputBranch">

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
@@ -175,7 +175,7 @@ const CourseRow = memo(({ row }: { row: CourseWithInstitution }) => {
       <CourseUpdateColumn row={row} columnName="title" label="title" />
       <CourseUpdateColumn row={row} columnName="display_timezone" label="timezone" />
       <CourseUpdateColumn row={row} columnName="path" label="path" />
-      <CourseUpdateColumn row={row} columnName="repository" label="repository" />
+      <CourseUpdateColumn row={row} columnName="repository" label="repository" required={false} />
       <CourseUpdateColumn row={row} columnName="branch" label="branch" />
       <td className="align-middle">
         <OverlayTrigger
@@ -398,11 +398,13 @@ function CourseUpdateColumn({
   columnName,
   label,
   href,
+  required = true,
 }: {
   row: CourseWithInstitution;
   columnName: CourseColumnName;
   label: string;
   href?: string;
+  required?: boolean;
 }) {
   const [showPopover, setShowPopover] = useState(false);
 
@@ -419,6 +421,7 @@ function CourseUpdateColumn({
               row={row}
               columnName={columnName}
               label={label}
+              required={required}
               onCancel={() => setShowPopover(false)}
             />
           ),
@@ -443,11 +446,13 @@ function CourseUpdateColumnForm({
   row,
   columnName,
   label,
+  required,
   onCancel,
 }: {
   row: CourseWithInstitution;
   columnName: CourseColumnName;
   label: string;
+  required: boolean;
   onCancel: () => void;
 }) {
   const trpc = useTRPC();
@@ -485,7 +490,7 @@ function CourseUpdateColumnForm({
           className={clsx('form-control', errors.value && 'is-invalid')}
           aria-label={label}
           {...register('value', {
-            required: `Enter a ${label}`,
+            required: required && `Enter a ${label}`,
             pattern:
               columnName === 'short_name'
                 ? {

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
@@ -324,7 +324,9 @@ function CourseInsertModal({
         shortName: data.short_name,
         institutionId: data.institution_id,
         displayTimezone: data.display_timezone,
-        repository: `git@github.com:PrairieLearn/${data.repository_short_name}.git`,
+        repository: data.repository_short_name
+          ? `git@github.com:PrairieLearn/${data.repository_short_name}.git`
+          : null,
       },
       { onSuccess: () => window.location.reload() },
     );

--- a/apps/prairielearn/src/trpc/administrator/courses.ts
+++ b/apps/prairielearn/src/trpc/administrator/courses.ts
@@ -92,18 +92,18 @@ const deleteCourseProcedure = t.procedure
 const updateColumn = t.procedure
   .use(requireAdministrator)
   .input(
-    z.discriminatedUnion('columnName', [
-      z.object({
-        courseId: IdSchema,
-        columnName: z.enum(['short_name', 'title', 'display_timezone', 'path', 'branch']),
-        value: z.string().min(1, 'Value is required'),
-      }),
-      z.object({
-        courseId: IdSchema,
-        columnName: z.enum(['repository']),
-        value: z.string(), // Optional
-      }),
-    ]),
+    z.object({ courseId: IdSchema }).and(
+      z.discriminatedUnion('columnName', [
+        z.object({
+          columnName: z.enum(['short_name', 'title', 'display_timezone', 'path', 'branch']),
+          value: z.string().min(1, 'Value is required'),
+        }),
+        z.object({
+          columnName: z.enum(['repository']),
+          value: z.string(), // Optional
+        }),
+      ]),
+    ),
   )
   .mutation(async ({ input, ctx }) => {
     let value = input.value;

--- a/apps/prairielearn/src/trpc/administrator/courses.ts
+++ b/apps/prairielearn/src/trpc/administrator/courses.ts
@@ -31,7 +31,7 @@ const insert = t.procedure
       title: z.string().min(1, 'Title is required').max(75, 'Title must be at most 75 characters'),
       displayTimezone: z.string().min(1, 'Timezone is required'),
       path: z.string().min(1, 'Path is required'),
-      repository: z.string().min(1, 'Repository is required'),
+      repository: z.string(), // Optional
       branch: z.string().min(1, 'Branch is required'),
     }),
   )
@@ -92,23 +92,23 @@ const deleteCourseProcedure = t.procedure
 const updateColumn = t.procedure
   .use(requireAdministrator)
   .input(
-    z.object({
-      courseId: IdSchema,
-      columnName: z.enum([
-        'short_name',
-        'title',
-        'display_timezone',
-        'path',
-        'repository',
-        'branch',
-      ]),
-      value: z.string().min(1, 'Value is required'),
-    }),
+    z.discriminatedUnion('columnName', [
+      z.object({
+        courseId: IdSchema,
+        columnName: z.enum(['short_name', 'title', 'display_timezone', 'path', 'branch']),
+        value: z.string().min(1, 'Value is required'),
+      }),
+      z.object({
+        courseId: IdSchema,
+        columnName: z.enum(['repository']),
+        value: z.string(), // Optional
+      }),
+    ]),
   )
   .mutation(async ({ input, ctx }) => {
     let value = input.value;
 
-    if (input.columnName === 'repository') {
+    if (input.columnName === 'repository' && value) {
       const repoExists = await checkCourseRepositoryUrlExists(value, input.courseId);
       if (repoExists) {
         throw new TRPCError({

--- a/apps/prairielearn/src/trpc/administrator/courses.ts
+++ b/apps/prairielearn/src/trpc/administrator/courses.ts
@@ -31,19 +31,21 @@ const insert = t.procedure
       title: z.string().min(1, 'Title is required').max(75, 'Title must be at most 75 characters'),
       displayTimezone: z.string().min(1, 'Timezone is required'),
       path: z.string().min(1, 'Path is required'),
-      repository: z.string(), // Optional
+      repository: z.string().nullable(),
       branch: z.string().min(1, 'Branch is required'),
     }),
   )
   .mutation(async ({ input, ctx }) => {
     const normalizedPath = normalizeCoursePathInput(input.path);
 
-    const repoExists = await checkCourseRepositoryUrlExists(input.repository);
-    if (repoExists) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'A course with this repository already exists.',
-      });
+    if (input.repository) {
+      const repoExists = await checkCourseRepositoryUrlExists(input.repository);
+      if (repoExists) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'A course with this repository already exists.',
+        });
+      }
     }
 
     const pathExists = await checkCoursePathExists(normalizedPath);
@@ -99,7 +101,7 @@ const updateColumn = t.procedure
           value: z.string().min(1, 'Value is required'),
         }),
         z.object({
-          columnName: z.enum(['repository']),
+          columnName: z.literal('repository'),
           value: z.string(), // Optional
         }),
       ]),


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Course repositories are optional, and typically blank in local dev environments. The current implementation forces the input of a repository. The new PR makes the repository optional.

This came about after, in a test, changing the repository of a local course to a repository, then trying to change it back to blank.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Tested updating the repository of a course to blank and back. Tested updating other columns, they still require a value.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
