### PR TITLE
Improve assessment access indicators

### DIFF
--- a/apps/prairielearn/assets/stylesheets/instructorAssessmentAccess.css
+++ b/apps/prairielearn/assets/stylesheets/instructorAssessmentAccess.css
@@ -12,10 +12,6 @@
   }
 }
 
-.table > :not(caption) > * > .assessment-access-date-cell {
-  padding-left: 1rem;
-}
-
 .assessment-access-date-cell-current::before {
   content: '';
   position: absolute;

--- a/apps/prairielearn/assets/stylesheets/instructorAssessmentAccess.css
+++ b/apps/prairielearn/assets/stylesheets/instructorAssessmentAccess.css
@@ -11,3 +11,20 @@
     display: none;
   }
 }
+
+.table > :not(caption) > * > .assessment-access-date-cell {
+  padding-left: 1rem;
+}
+
+.assessment-access-date-cell-current::before {
+  content: '';
+  position: absolute;
+  inset: 0.25rem auto 0.25rem 0.25rem;
+  width: 4px;
+  border-radius: 999px;
+  background-color: var(--bs-primary);
+}
+
+.assessment-access-date-cell-current-success::before {
+  background-color: var(--bs-success);
+}

--- a/apps/prairielearn/assets/stylesheets/instructorAssessmentQuestions.css
+++ b/apps/prairielearn/assets/stylesheets/instructorAssessmentQuestions.css
@@ -98,3 +98,12 @@
   outline: 2px solid var(--bs-primary);
   outline-offset: -2px;
 }
+
+.tree-row-warning-indicator::before {
+  content: '';
+  position: absolute;
+  inset: 0.25rem auto 0.25rem 0.25rem;
+  width: 4px;
+  border-radius: 999px;
+  background-color: var(--bs-warning);
+}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -164,6 +164,20 @@ export function AccessControlForm({
     deleteModal.hide();
   };
 
+  const handleMoveOverride = (fromIndex: number, toIndex: number) => {
+    moveOverride(fromIndex, toIndex);
+
+    if (selectedRule?.type !== 'override') return;
+
+    if (selectedRule.index === fromIndex) {
+      setSelectedRule({ type: 'override', index: toIndex });
+    } else if (fromIndex < selectedRule.index && selectedRule.index <= toIndex) {
+      setSelectedRule({ type: 'override', index: selectedRule.index - 1 });
+    } else if (toIndex <= selectedRule.index && selectedRule.index < fromIndex) {
+      setSelectedRule({ type: 'override', index: selectedRule.index + 1 });
+    }
+  };
+
   const getOverrideName = (index: number): string => {
     if (index >= watchedData.overrides.length) return `Override ${index + 1}`;
     const override = watchedData.overrides[index];
@@ -289,11 +303,14 @@ export function AccessControlForm({
                     getOverrideName={getOverrideName}
                     defaultRule={watchedData.defaultRule}
                     overrides={watchedData.overrides}
+                    selectedOverrideIndex={
+                      selectedRule?.type === 'override' ? selectedRule.index : null
+                    }
                     prairieTestExamMetadata={prairieTestExamMetadata}
                     ptHost={ptHost}
                     onAddOverride={addOverride}
                     onRemoveOverride={handleDeleteClick}
-                    onMoveOverride={moveOverride}
+                    onMoveOverride={handleMoveOverride}
                     onEditDefaultRule={() => setSelectedRule({ type: 'default' })}
                     onClearDefaultRule={() =>
                       reset(

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
@@ -44,12 +44,14 @@ function SortableOverrideCard({
   displayTimezone,
   onEdit,
   onRemove,
+  isActive,
 }: {
   id: string;
   override: OverrideData;
   formErrors: RuleFormErrors | undefined;
   title: string;
   displayTimezone: string;
+  isActive: boolean;
   onEdit: () => void;
   onRemove: () => void;
 }) {
@@ -70,6 +72,7 @@ function SortableOverrideCard({
         title={title}
         displayTimezone={displayTimezone}
         formErrors={formErrors}
+        isActive={isActive}
         dragHandleProps={{ ...attributes, ...listeners }}
         onEdit={onEdit}
         onRemove={onRemove}
@@ -164,6 +167,7 @@ function DefaultRuleSummaryContent({
 export function AccessControlSummary({
   defaultRule,
   overrides,
+  selectedOverrideIndex,
   getOverrideName,
   onAddOverride,
   onRemoveOverride,
@@ -177,6 +181,7 @@ export function AccessControlSummary({
 }: {
   defaultRule: DefaultRuleData;
   overrides: OverrideData[];
+  selectedOverrideIndex: number | null;
   /** Get the display name for an override by index */
   getOverrideName: (index: number) => string;
   onAddOverride: () => void;
@@ -323,6 +328,7 @@ export function AccessControlSummary({
                       formErrors={errors.overrides?.[index]}
                       title={getOverrideName(index)}
                       displayTimezone={displayTimezone}
+                      isActive={selectedOverrideIndex === index}
                       onEdit={() => onEditOverride(index)}
                       onRemove={() => onRemoveOverride(index)}
                     />

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -845,7 +845,7 @@ export function DateTableView({ rows }: { rows: DateTableRow[] }) {
             <tr key={index}>
               <td
                 className={clsx(
-                  'border-0 position-relative ps-3 assessment-access-date-cell',
+                  'border-0 position-relative ps-3',
                   row.current &&
                     `assessment-access-date-cell-current assessment-access-date-cell-current-${row.currentVariant ?? 'primary'}`,
                 )}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -1,5 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
 import { type ReactNode } from 'react';
 import { Button, Card } from 'react-bootstrap';
 import type { FieldErrors } from 'react-hook-form';
@@ -843,16 +844,12 @@ export function DateTableView({ rows }: { rows: DateTableRow[] }) {
             // eslint-disable-next-line @eslint-react/no-array-index-key
             <tr key={index}>
               <td
-                style={{
-                  ...tdStyle,
-                  paddingLeft: '1rem',
-                  borderTop: 0,
-                  borderRight: 0,
-                  borderBottom: 0,
-                  borderLeft: `6px solid ${
-                    row.current ? `var(--bs-${row.currentVariant ?? 'primary'})` : 'transparent'
-                  }`,
-                }}
+                className={clsx(
+                  'border-0 position-relative assessment-access-date-cell',
+                  row.current &&
+                    `assessment-access-date-cell-current assessment-access-date-cell-current-${row.currentVariant ?? 'primary'}`,
+                )}
+                style={tdStyle}
               >
                 <div className="text-nowrap">
                   {row.label && (
@@ -1119,6 +1116,7 @@ export function OverrideRuleSummaryCard({
   displayTimezone,
   formErrors,
   dragHandleProps,
+  isActive = false,
 }: {
   rule: OverrideData;
   title: string;
@@ -1127,6 +1125,7 @@ export function OverrideRuleSummaryCard({
   formErrors?: RuleFormErrors;
   onRemove?: () => void;
   dragHandleProps?: Record<string, unknown>;
+  isActive?: boolean;
 }) {
   const overrideFieldItems = generateOverrideFieldItems(rule, displayTimezone, formErrors);
 
@@ -1134,7 +1133,11 @@ export function OverrideRuleSummaryCard({
     rule.appliesTo.targetType === 'student_label' ? rule.appliesTo.studentLabels : [];
 
   return (
-    <Card className="mb-3" data-testid="override-card">
+    <Card
+      className={clsx('mb-3', isActive && 'border-primary border-2')}
+      data-testid="override-card"
+      aria-current={isActive ? 'true' : undefined}
+    >
       <Card.Header className="d-flex flex-column flex-sm-row justify-content-between align-items-sm-center gap-2">
         <div className="d-flex align-items-center gap-2 flex-wrap">
           {dragHandleProps && (

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -845,7 +845,7 @@ export function DateTableView({ rows }: { rows: DateTableRow[] }) {
             <tr key={index}>
               <td
                 className={clsx(
-                  'border-0 position-relative assessment-access-date-cell',
+                  'border-0 position-relative ps-3 assessment-access-date-cell',
                   row.current &&
                     `assessment-access-date-cell-current assessment-access-date-cell-current-${row.currentVariant ?? 'primary'}`,
                 )}

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
@@ -167,8 +167,9 @@ export function TreeQuestionBlockNode({
         role="button"
         tabIndex={0}
         className={clsx(
-          'tree-row d-flex align-items-center py-1 border-bottom user-select-none',
+          'tree-row d-flex align-items-center py-1 border-bottom user-select-none position-relative',
           isAltPoolSelected ? 'tree-row-selected' : 'list-group-item-action',
+          (chooseExceeds || pointsMismatch) && 'tree-row-warning-indicator',
         )}
         style={{
           paddingLeft: '2.5rem',
@@ -177,7 +178,6 @@ export function TreeQuestionBlockNode({
           // https://bugzilla.mozilla.org/show_bug.cgi?id=636564
           paddingRight: '1.5rem',
           cursor: 'pointer',
-          ...(chooseExceeds || pointsMismatch ? { borderLeft: '6px solid var(--bs-warning)' } : {}),
         }}
         onClick={(e) => {
           e.stopPropagation();

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx
@@ -238,8 +238,9 @@ export function TreeQuestionRow({
       role="button"
       tabIndex={0}
       className={clsx(
-        'tree-row d-flex align-items-center py-1 border-bottom',
+        'tree-row d-flex align-items-center py-1 border-bottom position-relative',
         isSelected ? 'tree-row-selected' : 'list-group-item-action',
+        hasManualGradingAutoPointsWarning && 'tree-row-warning-indicator',
       )}
       style={{
         paddingLeft: indent,
@@ -248,9 +249,6 @@ export function TreeQuestionRow({
         // https://bugzilla.mozilla.org/show_bug.cgi?id=636564
         paddingRight: '1.5rem',
         cursor: 'pointer',
-        ...(hasManualGradingAutoPointsWarning && {
-          borderLeft: '6px solid var(--bs-warning)',
-        }),
       }}
       onClick={(e) => {
         e.stopPropagation();

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeZoneNode.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeZoneNode.tsx
@@ -99,6 +99,7 @@ export function TreeZoneNode({
             isSelected
               ? 'tree-row-selected bg-body-secondary'
               : 'bg-body-secondary list-group-item-action',
+            (zoneChooseExceeds || zonePointsMismatch != null) && 'tree-row-warning-indicator',
           )}
           style={{
             // Extra right padding prevents macOS overlay scrollbars
@@ -109,9 +110,6 @@ export function TreeZoneNode({
             position: 'sticky',
             top: 0,
             zIndex: 10,
-            ...(zoneChooseExceeds || zonePointsMismatch != null
-              ? { borderLeft: '6px solid var(--bs-warning)' }
-              : {}),
           }}
           onClick={(e) => {
             e.stopPropagation();


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

This improves the modern assessment access control page by highlighting the override currently open in the editor and refining the current-rule marker in the defaults summary table. The active override now uses Bootstrap border utilities, and the current table marker is rendered as an inset rounded pseudo-element so it no longer creates a gap in the table header border. It also carries the same inset rounded indicator treatment over to warning rows in the modern assessment question editor.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

- Ran `make format-changed`.
- Ran `./scripts/typecheck-file.sh apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx`.
- Ran `./scripts/typecheck-file.sh apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeZoneNode.tsx`.
- Checked the local access-control page with Playwright to confirm the active override border and current-row marker styling.
