### PR TITLE
Fix manual grading rubric E2E flake

### DIFF
--- a/apps/prairielearn/src/tests/e2e/manualGradingRubric.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/manualGradingRubric.spec.ts
@@ -1,3 +1,5 @@
+import type { Locator, Page } from '@playwright/test';
+
 import * as sqldb from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
@@ -14,7 +16,25 @@ const STUDENT = { uid: 'e2e_rubric_student@test.com', name: 'E2E Rubric Student'
 
 let assessmentId: string;
 
+async function addRubricItem(page: Page, rubricTable: Locator): Promise<Locator> {
+  const rubricRows = rubricTable
+    .locator('tr')
+    .filter({ has: page.getByRole('spinbutton', { name: 'Points' }) });
+  const previousRowCount = await rubricRows.count();
+
+  await expect(async () => {
+    if ((await rubricRows.count()) === previousRowCount + 1) return;
+
+    await page.getByRole('button', { name: 'Add item' }).click();
+    await expect(rubricRows).toHaveCount(previousRowCount + 1, { timeout: 2000 });
+  }).toPass({ timeout: 10000 });
+
+  return rubricRows.nth(previousRowCount);
+}
+
 test.describe('Manual grading rubric submission panel update', () => {
+  test.setTimeout(60000);
+
   test.beforeAll(async ({ courseInstance }) => {
     const student = await getOrCreateUser(STUDENT);
 
@@ -91,12 +111,13 @@ test.describe('Manual grading rubric submission panel update', () => {
     // Set up a rubric and grade the submission.
     await page.locator('[aria-label="Toggle rubric settings"]').click();
     await expect(page.locator('#rubric-setting')).toBeVisible();
-    await page.getByRole('button', { name: 'Add item' }).click();
 
-    const rubricTable = page.locator('#rubric-editor table tbody');
-    const firstRow = rubricTable.locator('tr').first();
-    await firstRow.locator('input[type="number"]').fill('6');
-    await firstRow.locator('input[type="text"]').first().fill('Full credit for correct solution');
+    const rubricTable = page.locator('#rubric-editor table[aria-label="Rubric items"] tbody');
+    const firstRow = await addRubricItem(page, rubricTable);
+    await firstRow.getByRole('spinbutton', { name: 'Points' }).fill('6');
+    await firstRow
+      .getByRole('textbox', { name: 'Description' })
+      .fill('Full credit for correct solution');
 
     await page.locator('#rubric-setting').getByRole('button', { name: 'Save' }).click();
     await expect(
@@ -120,11 +141,10 @@ test.describe('Manual grading rubric submission panel update', () => {
 
     await page.locator('[aria-label="Toggle rubric settings"]').click();
     await expect(page.locator('#rubric-setting')).toBeVisible();
-    await page.getByRole('button', { name: 'Add item' }).click();
 
-    const newRow = rubricTable.locator('tr').last();
-    await newRow.locator('input[type="number"]').fill('3');
-    await newRow.locator('input[type="text"]').first().fill('Partial credit');
+    const newRow = await addRubricItem(page, rubricTable);
+    await newRow.getByRole('spinbutton', { name: 'Points' }).fill('3');
+    await newRow.getByRole('textbox', { name: 'Description' }).fill('Partial credit');
 
     await page.locator('#rubric-setting').getByRole('button', { name: 'Save' }).click();
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

This fixes a flaky manual grading rubric E2E by retrying the Add item interaction until a rubric row is actually present, then filling the row by accessible control names. The scenario also gets a 60s timeout because the full submit, grade, reload, and rubric-save flow can exceed the default 30s CI budget under load.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation was AI-assisted.

# Testing

- `yarn prettier --write apps/prairielearn/src/tests/e2e/manualGradingRubric.spec.ts`
- `yarn eslint --fix apps/prairielearn/src/tests/e2e/manualGradingRubric.spec.ts`
- `./scripts/typecheck-file.sh apps/prairielearn/src/tests/e2e/manualGradingRubric.spec.ts`
- `make format-changed`
- `yarn test:e2e apps/prairielearn/src/tests/e2e/manualGradingRubric.spec.ts`