### PR TITLE
Fix override section grouping and ordering on Access page

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/data.sql
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.sql
@@ -81,8 +81,8 @@ ORDER BY
   aacr.assessment_id,
   CASE aacr.target_type
     WHEN 'none' THEN 0
-    WHEN 'enrollment' THEN 1
-    WHEN 'student_label' THEN 2
+    WHEN 'student_label' THEN 1
+    WHEN 'enrollment' THEN 2
   END,
   aacr.number;
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -16,6 +16,7 @@ import { OverrideRuleContent } from './OverrideRuleContent.js';
 import { AppliesToField } from './fields/AppliesToField.js';
 import {
   type AccessControlFormData,
+  type TargetType,
   createDefaultOverrideFormData,
   formDataToJson,
   jsonToDefaultRuleFormData,
@@ -75,6 +76,7 @@ export function AccessControlForm({
     getFieldState,
     handleSubmit,
     setError,
+    setValue,
     watch,
     reset,
     formState: { isDirty, isValid, errors },
@@ -84,7 +86,6 @@ export function AccessControlForm({
     append: appendOverride,
     remove: removeOverride,
     move: moveOverride,
-    insert: insertOverride,
   } = useFieldArray({
     control,
     name: 'overrides',
@@ -131,17 +132,32 @@ export function AccessControlForm({
 
   const addOverride = () => {
     const newOverride = createDefaultOverrideFormData(watchedData.defaultRule);
-    // Enrollment overrides are inserted before student-label overrides
-    const firstLabelIndex = watchedData.overrides.findIndex(
-      (o) => o.appliesTo.targetType === 'student_label',
-    );
-    if (firstLabelIndex === -1) {
-      appendOverride(newOverride);
-      setSelectedRule({ type: 'override', index: watchedData.overrides.length });
-    } else {
-      insertOverride(firstLabelIndex, newOverride);
-      setSelectedRule({ type: 'override', index: firstLabelIndex });
+    appendOverride(newOverride);
+    setSelectedRule({ type: 'override', index: watchedData.overrides.length });
+  };
+
+  const handleOverrideTargetTypeChange = (index: number, targetType: TargetType) => {
+    if (watchedData.overrides[index].appliesTo.targetType === targetType) return;
+
+    const labelCount = watchedData.overrides.filter(
+      (o, i) => i !== index && o.appliesTo.targetType === 'student_label',
+    ).length;
+    const newIndex = targetType === 'student_label' ? labelCount : watchedData.overrides.length - 1;
+
+    if (newIndex !== index) {
+      moveOverride(index, newIndex);
     }
+
+    setValue(
+      `overrides.${newIndex}.appliesTo`,
+      {
+        targetType,
+        enrollments: [],
+        studentLabels: [],
+      },
+      { shouldDirty: true, shouldValidate: true },
+    );
+    setSelectedRule({ type: 'override', index: newIndex });
   };
 
   const handleDeleteClick = (index: number) => {
@@ -235,6 +251,9 @@ export function AccessControlForm({
             <AppliesToField
               namePrefix={`overrides.${selectedRule.index}`}
               courseInstanceId={courseInstance.id}
+              onTargetTypeChange={(targetType) =>
+                handleOverrideTargetTypeChange(selectedRule.index, targetType)
+              }
             />
             <OverrideRuleContent
               index={selectedRule.index}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlSummary.tsx
@@ -9,6 +9,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import clsx from 'clsx';
 import { Fragment, type ReactNode, useId, useMemo } from 'react';
 import { Badge, Button } from 'react-bootstrap';
 import { useFormState } from 'react-hook-form';
@@ -206,7 +207,7 @@ export function AccessControlSummary({
     const newIndex = sortableIds.indexOf(String(over.id));
     if (oldIndex === -1 || newIndex === -1) return;
 
-    // Prevent reordering across override types (enrollment must stay before student_label)
+    // Prevent reordering across override types; each target type has its own precedence section.
     if (overrides[oldIndex].appliesTo.targetType !== overrides[newIndex].appliesTo.targetType) {
       return;
     }
@@ -299,22 +300,21 @@ export function AccessControlSummary({
           >
             <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
               {overrides.map((override, index) => {
-                const isFirstEnrollment =
-                  index === 0 && override.appliesTo.targetType === 'enrollment';
-                const isFirstLabel =
-                  override.appliesTo.targetType === 'student_label' &&
-                  (index === 0 || overrides[index - 1].appliesTo.targetType !== 'student_label');
+                const isFirstOfSection =
+                  index === 0 ||
+                  overrides[index - 1].appliesTo.targetType !== override.appliesTo.targetType;
+                const sectionLabel =
+                  override.appliesTo.targetType === 'enrollment'
+                    ? 'Overrides for specific students'
+                    : 'Overrides for student labels';
 
                 return (
                   <Fragment key={sortableIds[index]}>
-                    {isFirstEnrollment && (
-                      <small className="text-muted fw-semibold d-block mb-2">
-                        Overrides for specific students
-                      </small>
-                    )}
-                    {isFirstLabel && (
-                      <small className="text-muted fw-semibold d-block mb-2 mt-3">
-                        Overrides for student labels
+                    {isFirstOfSection && (
+                      <small
+                        className={clsx('text-muted fw-semibold d-block mb-2', index > 0 && 'mt-3')}
+                      >
+                        {sectionLabel}
                       </small>
                     )}
                     <SortableOverrideCard

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AppliesToField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AppliesToField.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { Alert, Button, Form, ListGroup } from 'react-bootstrap';
-import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { useFieldArray, useWatch } from 'react-hook-form';
 
 import { StudentLabelBadge } from '../../../../components/StudentLabelBadge.js';
 import { StudentLabelDropdown } from '../../../../components/StudentLabelDropdown.js';
@@ -14,11 +14,12 @@ import { AddStudentsModal } from './AddStudentsModal.js';
 export function AppliesToField({
   namePrefix,
   courseInstanceId,
+  onTargetTypeChange,
 }: {
   namePrefix: `overrides.${number}`;
   courseInstanceId: string;
+  onTargetTypeChange: (targetType: TargetType) => void;
 }) {
-  const { setValue } = useFormContext<AccessControlFormData>();
   const trpc = useTRPC();
 
   const { data: allLabels } = useQuery(trpc.accessControl.studentLabels.queryOptions());
@@ -34,18 +35,6 @@ export function AppliesToField({
   const { append: appendStudentLabel, remove: removeStudentLabel } = useFieldArray({
     name: `${namePrefix}.appliesTo.studentLabels`,
   });
-
-  const handleTargetTypeChange = (newType: TargetType) => {
-    setValue(
-      `${namePrefix}.appliesTo`,
-      {
-        targetType: newType,
-        enrollments: [],
-        studentLabels: [],
-      },
-      { shouldDirty: true },
-    );
-  };
 
   const handleSaveStudents = (students: EnrollmentTarget[]) => {
     replaceEnrollments(students);
@@ -80,7 +69,7 @@ export function AppliesToField({
           name={`${namePrefix}-target-type`}
           label="Specific students"
           checked={targetType === 'enrollment'}
-          onChange={() => handleTargetTypeChange('enrollment')}
+          onChange={() => onTargetTypeChange('enrollment')}
         />
         <Form.Check
           type="radio"
@@ -88,7 +77,7 @@ export function AppliesToField({
           name={`${namePrefix}-target-type`}
           label="Students by label"
           checked={targetType === 'student_label'}
-          onChange={() => handleTargetTypeChange('student_label')}
+          onChange={() => onTargetTypeChange('student_label')}
         />
       </fieldset>
 


### PR DESCRIPTION
# Description

Lifts the non-docs UI fixes from #14891 onto a standalone branch.

- **Override array order** (`data.sql`, `AccessControlForm.tsx`): orders overrides as `student_label` then `enrollment` everywhere — both rule queries and the form. The in-summary help text says student-specific overrides take priority and "overrides lower in the list take priority", so the higher-priority enrollment section must render below the label section. This also matches `pickEffectiveRule`'s cascade. Master had the queries inconsistent with each other and the form inserted new overrides before any label override; both are now aligned.
- **Section grouping when switching target type** (`AccessControlForm.tsx`, `AppliesToField.tsx`): switching an override's "Applies to" radio used to update the value in place, which produced repeated section headers like "labels / specific / labels". The form now moves the override into the tail of its new section before updating `appliesTo`. `AppliesToField` accepts an `onTargetTypeChange` callback so the parent owns array ordering.
- **Summary cleanup** (`AccessControlSummary.tsx`): collapses the duplicated `isFirstEnrollment` / `isFirstLabel` logic into a single `isFirstOfSection` boundary check, and moves the inter-section `mt-3` from "always on the label header" to "any header that isn't the first" — without that, the order swap puts the top margin on the wrong section.

AI performed the majority of implementation here.

# Testing

Reproduce the section-grouping bug on master:

1. Open an assessment's Access page with one student-label override already configured.
2. Click "Add override" twice.
3. Edit the second new override and switch "Applies to" from Specific students to Students by label.
4. Before this PR, the summary shows "labels / specific / labels". After, it shows a single grouped sequence.

Also verified that switching types in either direction lands the moved override at the end of its new section, that drag-reordering still can't cross sections, and that the section header spacing is correct in both single-section and dual-section configurations.