### PR TITLE
Fix non sticky alert bug on the sticky save bar

### DIFF
--- a/.changeset/sticky-save-bar-alert.md
+++ b/.changeset/sticky-save-bar-alert.md
@@ -2,4 +2,4 @@
 '@prairielearn/ui': minor
 ---
 
-Add an `alert` slot to `StickySaveBar` that renders save feedback inside the sticky region.
+Add an `alert` slot to `StickySaveBar` that renders save feedback inside the sticky region, and a `fullWidth` prop that lets the actions row span the full width of full-width pages.

--- a/.changeset/sticky-save-bar-alert.md
+++ b/.changeset/sticky-save-bar-alert.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': minor
+---
+
+Add an `alert` slot to `StickySaveBar` that renders save feedback inside the sticky region.

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -337,6 +337,7 @@ export function AccessControlForm({
                   isSaving={isSaving}
                   saveDisabledReason={saveDisabledReason}
                   alert={alert}
+                  fullWidth
                   onCancel={() => reset()}
                 />
               </>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -336,8 +336,8 @@ export function AccessControlForm({
                   visible={isDirty}
                   isSaving={isSaving}
                   saveDisabledReason={saveDisabledReason}
-                  onCancel={() => reset()}
                   alert={alert}
+                  onCancel={() => reset()}
                 />
               </>
             ),

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -1,8 +1,8 @@
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Form, Modal } from 'react-bootstrap';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 
-import { SplitPane, StickySaveBar, useModalState } from '@prairielearn/ui';
+import { SplitPane, StickySaveBar, type StickySaveBarAlert, useModalState } from '@prairielearn/ui';
 
 import type { PageContext } from '../../../lib/client/page-context.js';
 import type {
@@ -51,7 +51,7 @@ export function AccessControlForm({
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   assessmentId: string;
   isSaving?: boolean;
-  alert?: ReactNode;
+  alert?: StickySaveBarAlert | null;
 }) {
   const [selectedRule, setSelectedRule] = useState<SelectedRule>(null);
   const deleteModal = useModalState<{ index: number; name: string }>();
@@ -332,12 +332,12 @@ export function AccessControlForm({
                     onEditOverride={(index) => setSelectedRule({ type: 'override', index })}
                   />
                 </div>
-                {alert}
                 <StickySaveBar
                   visible={isDirty}
                   isSaving={isSaving}
                   saveDisabledReason={saveDisabledReason}
                   onCancel={() => reset()}
+                  alert={alert}
                 />
               </>
             ),

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AssessmentAccessControl.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AssessmentAccessControl.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { Alert } from 'react-bootstrap';
 
-import { type AppError, getAppError } from '../../../lib/client/errors.js';
+import { run } from '@prairielearn/run';
+import type { StickySaveBarAlert } from '@prairielearn/ui';
+
+import { getAppError } from '../../../lib/client/errors.js';
 import type { PageContext } from '../../../lib/client/page-context.js';
 import { QueryClientProviderDebug } from '../../../lib/client/tanstackQuery.js';
 import { getCourseInstanceJobSequenceUrl } from '../../../lib/client/url.js';
@@ -66,17 +68,37 @@ function AssessmentAccessControlInner({
 
   const saveError = getAppError<AccessControlError['SaveAllRules']>(saveMutation.error);
 
-  const alert = saveMutation.isSuccess ? (
-    <Alert variant="success" dismissible onClose={() => saveMutation.reset()}>
-      Access control updated successfully.
-    </Alert>
-  ) : saveError ? (
-    <SaveErrorAlert
-      appError={saveError}
-      courseInstanceId={courseInstance.id}
-      onDismiss={() => saveMutation.reset()}
-    />
-  ) : null;
+  const saveAlert = run<StickySaveBarAlert | null>(() => {
+    if (saveMutation.isSuccess) {
+      return {
+        variant: 'success',
+        message: 'Access control updated successfully.',
+        onDismiss: () => saveMutation.reset(),
+      };
+    }
+    if (saveError?.code === 'SYNC_JOB_FAILED') {
+      return {
+        variant: 'danger',
+        message: (
+          <>
+            {saveError.message}{' '}
+            <a href={getCourseInstanceJobSequenceUrl(courseInstance.id, saveError.jobSequenceId)}>
+              View job logs
+            </a>
+          </>
+        ),
+        onDismiss: () => saveMutation.reset(),
+      };
+    }
+    if (saveError?.code === 'UNKNOWN') {
+      return {
+        variant: 'danger',
+        message: saveError.message,
+        onDismiss: () => saveMutation.reset(),
+      };
+    }
+    return null;
+  });
 
   return (
     <div style={{ height: '100%' }} data-split-pane-page>
@@ -87,39 +109,11 @@ function AssessmentAccessControlInner({
         prairieTestExamMetadata={prairieTestExamMetadata}
         ptHost={ptHost}
         isSaving={saveMutation.isPending}
-        alert={alert}
+        alert={saveAlert}
         onSubmit={handleFormSubmit}
       />
     </div>
   );
-}
-
-function SaveErrorAlert({
-  appError,
-  courseInstanceId,
-  onDismiss,
-}: {
-  appError: AppError<AccessControlError['SaveAllRules']>;
-  courseInstanceId: string;
-  onDismiss: () => void;
-}) {
-  switch (appError.code) {
-    case 'SYNC_JOB_FAILED':
-      return (
-        <Alert variant="danger" dismissible onClose={onDismiss}>
-          {appError.message}{' '}
-          <a href={getCourseInstanceJobSequenceUrl(courseInstanceId, appError.jobSequenceId)}>
-            View job logs
-          </a>
-        </Alert>
-      );
-    case 'UNKNOWN':
-      return (
-        <Alert variant="danger" dismissible onClose={onDismiss}>
-          {appError.message}
-        </Alert>
-      );
-  }
 }
 
 export function AssessmentAccessControl(props: AssessmentAccessControlProps) {

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
@@ -1209,12 +1209,12 @@ function InstructorAssessmentSettingsInner({
           <StickySaveBar
             visible={isDirty}
             isSaving={isSubmitting || saveMutation.isPending}
+            alert={saveAlert}
             onCancel={() => {
               reset();
               setUseCustomMaxPoints(getValues('max_points') !== '');
               saveMutation.reset();
             }}
-            alert={saveAlert}
           />
         )}
       </form>

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import { Alert, Button, Form, InputGroup, Modal } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 
-import { StickySaveBar, useModalState } from '@prairielearn/ui';
+import { run } from '@prairielearn/run';
+import { StickySaveBar, type StickySaveBarAlert, useModalState } from '@prairielearn/ui';
 
 import { GitHubButton } from '../../components/GitHubButton.js';
 import { PublicLinkSharing, StudentLinkSharing } from '../../components/LinkSharing.js';
@@ -432,6 +433,24 @@ function InstructorAssessmentSettingsInner({
   const deleteError = getAppError<AssessmentSettingsError['DeleteAssessment']>(
     deleteMutation.error,
   );
+
+  const saveAlert = run<StickySaveBarAlert | null>(() => {
+    if (saveMutation.isSuccess) {
+      return {
+        variant: 'success',
+        message: 'Assessment updated successfully.',
+        onDismiss: () => saveMutation.reset(),
+      };
+    }
+    if (appError?.message) {
+      return {
+        variant: 'danger',
+        message: appError.message,
+        onDismiss: () => saveMutation.reset(),
+      };
+    }
+    return null;
+  });
 
   const toNullableNumber = (v: string) => (v === '' ? null : Number(v));
 
@@ -1187,37 +1206,16 @@ function InstructorAssessmentSettingsInner({
         </div>
 
         {canEdit && (
-          <>
-            {saveMutation.isSuccess && (
-              <Alert
-                className="mb-0 rounded-0 border-start-0 border-end-0 border-bottom"
-                variant="success"
-                dismissible
-                onClose={() => saveMutation.reset()}
-              >
-                Assessment updated successfully.
-              </Alert>
-            )}
-            {appError?.message && (
-              <Alert
-                className="mb-0 rounded-0 border-start-0 border-end-0 border-bottom"
-                variant="danger"
-                dismissible
-                onClose={() => saveMutation.reset()}
-              >
-                {appError.message}
-              </Alert>
-            )}
-            <StickySaveBar
-              visible={isDirty}
-              isSaving={isSubmitting || saveMutation.isPending}
-              onCancel={() => {
-                reset();
-                setUseCustomMaxPoints(getValues('max_points') !== '');
-                saveMutation.reset();
-              }}
-            />
-          </>
+          <StickySaveBar
+            visible={isDirty}
+            isSaving={isSubmitting || saveMutation.isPending}
+            onCancel={() => {
+              reset();
+              setUseCustomMaxPoints(getValues('max_points') !== '');
+              saveMutation.reset();
+            }}
+            alert={saveAlert}
+          />
         )}
       </form>
     </>

--- a/packages/ui/src/components/StickySaveBar.tsx
+++ b/packages/ui/src/components/StickySaveBar.tsx
@@ -1,6 +1,14 @@
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
+import Alert from 'react-bootstrap/Alert';
 
 import { OverlayTrigger } from './OverlayTrigger.js';
+
+export interface StickySaveBarAlert {
+  variant: 'success' | 'danger';
+  message: ReactNode;
+  onDismiss?: () => void;
+}
 
 export interface StickySaveBarProps {
   /** Whether the bar is visible. Typically driven by the form's dirty state. */
@@ -16,6 +24,12 @@ export interface StickySaveBarProps {
    * disabled and a tooltip with this message is shown on hover/focus.
    */
   saveDisabledReason?: string | null;
+  /**
+   * Optional alert rendered inside the sticky region, above the actions row.
+   * Use this for save success/error feedback so it stays visible regardless
+   * of the user's scroll position.
+   */
+  alert?: StickySaveBarAlert | null;
 }
 
 export function StickySaveBar({
@@ -24,6 +38,7 @@ export function StickySaveBar({
   onCancel,
   formId,
   saveDisabledReason,
+  alert,
 }: StickySaveBarProps) {
   const isSaveDisabled = isSaving || Boolean(saveDisabledReason);
 
@@ -40,6 +55,16 @@ export function StickySaveBar({
 
   return (
     <div className="pl-ui-sticky-save-bar">
+      {alert && (
+        <Alert
+          className="mb-0 rounded-0 border-start-0 border-end-0 border-bottom"
+          variant={alert.variant}
+          dismissible={Boolean(alert.onDismiss)}
+          onClose={alert.onDismiss}
+        >
+          {alert.message}
+        </Alert>
+      )}
       <div
         className={clsx(
           'container align-items-center justify-content-between gap-2 py-3',

--- a/packages/ui/src/components/StickySaveBar.tsx
+++ b/packages/ui/src/components/StickySaveBar.tsx
@@ -30,6 +30,13 @@ export interface StickySaveBarProps {
    * of the user's scroll position.
    */
   alert?: StickySaveBarAlert | null;
+  /**
+   * When true, the actions row spans the full width of the bar's container
+   * (using `container-fluid`) instead of being capped at the Bootstrap
+   * breakpoint max-widths. Use on full-width pages so the bar aligns with
+   * edge-to-edge page content.
+   */
+  fullWidth?: boolean;
 }
 
 export function StickySaveBar({
@@ -39,6 +46,7 @@ export function StickySaveBar({
   formId,
   saveDisabledReason,
   alert,
+  fullWidth,
 }: StickySaveBarProps) {
   const isSaveDisabled = isSaving || Boolean(saveDisabledReason);
 
@@ -67,7 +75,8 @@ export function StickySaveBar({
       )}
       <div
         className={clsx(
-          'container align-items-center justify-content-between gap-2 py-3',
+          fullWidth ? 'container-fluid' : 'container',
+          'align-items-center justify-content-between gap-2 py-3',
           visible ? 'd-flex' : 'd-none',
         )}
       >

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -33,7 +33,11 @@ export {
 export { useColumnVisibilityQueryState } from './hooks/use-column-visibility-query-state.js';
 
 export { SplitPane, type SplitPaneProps } from './components/SplitPane.js';
-export { StickySaveBar, type StickySaveBarProps } from './components/StickySaveBar.js';
+export {
+  StickySaveBar,
+  type StickySaveBarAlert,
+  type StickySaveBarProps,
+} from './components/StickySaveBar.js';
 
 export { useModalState } from './hooks/use-modal-state.js';
 export { useResizeHandle } from './hooks/use-resize-handle.js';


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

A bug introduced by the creation of the `StickySaveBar` new ui component. The separate settings pages that used this component showed alerts for success/failure on updating the configuration, and before the StickySaveBar component was added to `@prairielearn/ui`, the alerts were part of it and different between pages. With the addition of this component, the alerts were made siblings of this component, and the sticky property was not kept for them, causing them to be rendered at the end of the page and outside user view.

This PR adds a typed alert prop to StickySaveBar. The bar renders the alert inside its own sticky container, above the action row, so feedback stays pinned alongside the bar regardless of scroll position. Both consumer pages are updated to pass their save feedback through the new slot.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Tested updating any assessment on either the assessment settings or access control pages. Also, tested causing an error, and seeing if the alert is correctly rendered. The reviewer should sanity check this.