### PR TITLE
Span time limits across submittable access windows

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1564,6 +1564,21 @@ describe('resolveAccessControl', () => {
         expect: { authorized: true, submittable: true, timeLimitMin: null },
       },
       {
+        // 30m30s until deadline minus 31 seconds = 1799s / 60 = 29.983 → rounds to 30
+        name: 'rounds capped time limit to nearest minute',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-01-01T00:00:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
+              durationMinutes: 60,
+            },
+          }),
+        ],
+        date: new Date('2025-03-15T11:29:30Z'),
+        expect: { authorized: true, submittable: true, timeLimitMin: 30 },
+      },
+      {
         // 20 seconds until deadline minus 31 seconds → clamp to 0
         name: 'clamps to zero when deadline is less than 31 seconds away',
         rules: [

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1167,9 +1167,7 @@ describe('resolveAccessControl', () => {
           {
             // Top-level afterComplete visibility has unlocked, so the resolver
             // grants a review-only path: authorized=true lets the middleware
-            // serve the page, active=false prevents submissions. Pins the full
-            // result shape so a future refactor can't silently change defaults
-            // (e.g., leaking a credit string or a non-null nextActiveDate).
+            // serve the page, active=false prevents submissions.
             name: 'at home after visible date: review-only',
             rules: [ruleWithDeferredRelease],
             authzMode: 'Public',
@@ -1533,8 +1531,8 @@ describe('resolveAccessControl', () => {
         expect: { authorized: true, submittable: true, timeLimitMin: 60 },
       },
       {
-        // 10 minutes until deadline, minus 31 seconds = 569s / 60 = 9.48 → 9
-        name: 'caps time limit by seconds until next deadline',
+        // 10 minutes until the only deadline, minus 31 seconds = 569s / 60 = 9.48 → 9
+        name: 'caps time limit by seconds until the last submittable deadline',
         rules: [
           makeDefaultRule({
             dateControl: {
@@ -1593,14 +1591,11 @@ describe('resolveAccessControl', () => {
         expect: { authorized: true, submittable: true, timeLimitMin: null },
       },
       {
-        // Pins current behavior: the time limit caps at the *next* deadline
-        // (the due date), even when a submittable late window follows. A
-        // student starting 10 minutes before the due date has only ~9 minutes
-        // on their 60-minute clock — remaining minutes do not roll into the
-        // late window. This diverges from the design intent that the time
-        // limit should span access windows (100% for 10 min, then 80% for the
-        // rest, up to 60 min total).
-        name: 'caps at next deadline even when a submittable late window follows',
+        // Time limit spans submittable access windows: a student starting 10
+        // minutes before the due date keeps the full 60-minute clock, with
+        // 100% credit for the first 10 minutes (until the due date) and 80%
+        // for the remaining 50 minutes (until the late deadline 7 days out).
+        name: 'spans into late window: full duration, 100% credit currently',
         rules: [
           makeDefaultRule({
             dateControl: {
@@ -1612,7 +1607,7 @@ describe('resolveAccessControl', () => {
           }),
         ],
         date: new Date('2025-03-15T11:50:00Z'),
-        expect: { authorized: true, submittable: true, credit: 100, timeLimitMin: 9 },
+        expect: { authorized: true, submittable: true, credit: 100, timeLimitMin: 60 },
       },
       {
         // Once inside the late window, the cap is the late deadline. With 6+
@@ -1647,6 +1642,23 @@ describe('resolveAccessControl', () => {
         ],
         date: new Date('2025-03-22T11:30:00Z'),
         expect: { authorized: true, submittable: true, credit: 80, timeLimitMin: 29 },
+      },
+      {
+        // afterLastDeadline allowing submissions has no end, so submissions
+        // remain open indefinitely — the duration cap doesn't shrink.
+        name: 'no cap when afterLastDeadline allows submissions',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-01-01T00:00:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
+              afterLastDeadline: { credit: 25, allowSubmissions: true },
+              durationMinutes: 60,
+            },
+          }),
+        ],
+        date: new Date('2025-03-15T11:50:00Z'),
+        expect: { authorized: true, submittable: true, credit: 100, timeLimitMin: 60 },
       },
     ])('$name', (c) => {
       expect(runCase(c)).toMatchObject(c.expect);

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1644,9 +1644,10 @@ describe('resolveAccessControl', () => {
         expect: { authorized: true, submittable: true, credit: 80, timeLimitMin: 29 },
       },
       {
-        // afterLastDeadline allowing submissions has no end, so submissions
-        // remain open indefinitely — the duration cap doesn't shrink.
-        name: 'no cap when afterLastDeadline allows submissions',
+        // afterLastDeadline allowing submissions has no end, so the duration
+        // runs uncapped against the configured 60 min: 10 min at 100% credit
+        // before the due date, then 50 min at 25% credit afterwards.
+        name: 'spans through afterLastDeadline when submissions are allowed',
         rules: [
           makeDefaultRule({
             dateControl: {

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1533,19 +1533,19 @@ describe('resolveAccessControl', () => {
         expect: { authorized: true, submittable: true, timeLimitMin: 60 },
       },
       {
-        // 30 minutes until deadline, minus 31 seconds = 1769s / 60 = 29.48 → 29
+        // 10 minutes until deadline, minus 31 seconds = 569s / 60 = 9.48 → 9
         name: 'caps time limit by seconds until next deadline',
         rules: [
           makeDefaultRule({
             dateControl: {
               release: { date: '2025-01-01T00:00:00Z' },
-              due: { date: '2025-03-15T12:30:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
               durationMinutes: 60,
             },
           }),
         ],
-        date: new Date('2025-03-15T12:00:00Z'),
-        expect: { authorized: true, submittable: true, timeLimitMin: 29 },
+        date: new Date('2025-03-15T11:50:00Z'),
+        expect: { authorized: true, submittable: true, timeLimitMin: 9 },
       },
       {
         name: 'returns null in Exam mode',
@@ -1591,6 +1591,62 @@ describe('resolveAccessControl', () => {
           }),
         ],
         expect: { authorized: true, submittable: true, timeLimitMin: null },
+      },
+      {
+        // Pins current behavior: the time limit caps at the *next* deadline
+        // (the due date), even when a submittable late window follows. A
+        // student starting 10 minutes before the due date has only ~9 minutes
+        // on their 60-minute clock — remaining minutes do not roll into the
+        // late window. This diverges from the design intent that the time
+        // limit should span access windows (100% for 10 min, then 80% for the
+        // rest, up to 60 min total).
+        name: 'caps at next deadline even when a submittable late window follows',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-01-01T00:00:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
+              lateDeadlines: [{ date: '2025-03-22T12:00:00Z', credit: 80 }],
+              durationMinutes: 60,
+            },
+          }),
+        ],
+        date: new Date('2025-03-15T11:50:00Z'),
+        expect: { authorized: true, submittable: true, credit: 100, timeLimitMin: 9 },
+      },
+      {
+        // Once inside the late window, the cap is the late deadline. With 6+
+        // days of headroom, the full 60-minute duration is available at 80%.
+        name: 'late window: full duration available, capped by late deadline',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-01-01T00:00:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
+              lateDeadlines: [{ date: '2025-03-22T12:00:00Z', credit: 80 }],
+              durationMinutes: 60,
+            },
+          }),
+        ],
+        date: new Date('2025-03-16T12:00:00Z'),
+        expect: { authorized: true, submittable: true, credit: 80, timeLimitMin: 60 },
+      },
+      {
+        // Approaching the final late deadline, the cap shrinks to the time
+        // remaining in the late window (30 min minus 31s legacy buffer = 29).
+        name: 'caps at late deadline as it approaches',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-01-01T00:00:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
+              lateDeadlines: [{ date: '2025-03-22T12:00:00Z', credit: 80 }],
+              durationMinutes: 60,
+            },
+          }),
+        ],
+        date: new Date('2025-03-22T11:30:00Z'),
+        expect: { authorized: true, submittable: true, credit: 80, timeLimitMin: 29 },
       },
     ])('$name', (c) => {
       expect(runCase(c)).toMatchObject(c.expect);

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1661,6 +1661,23 @@ describe('resolveAccessControl', () => {
         date: new Date('2025-03-15T11:50:00Z'),
         expect: { authorized: true, submittable: true, credit: 100, timeLimitMin: 60 },
       },
+      {
+        // Same rule, started after the due date: full duration available at
+        // the afterLastDeadline credit (25%).
+        name: 'after due in afterLastDeadline: full duration at reduced credit',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-01-01T00:00:00Z' },
+              due: { date: '2025-03-15T12:00:00Z' },
+              afterLastDeadline: { credit: 25, allowSubmissions: true },
+              durationMinutes: 60,
+            },
+          }),
+        ],
+        date: new Date('2025-03-16T00:00:00Z'),
+        expect: { authorized: true, submittable: true, credit: 25, timeLimitMin: 60 },
+      },
     ])('$name', (c) => {
       expect(runCase(c)).toMatchObject(c.expect);
     });

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -352,10 +352,14 @@ function computeTimeLimitMin(
   if (authzMode === 'Exam') return null;
   if (!lastSubmittableEnd) return durationMinutes;
 
-  // Cap time limit by seconds until the last reachable submittable deadline,
-  // minus 31 seconds (legacy behavior).
+  // Cap time limit by the time remaining until the last reachable submittable
+  // deadline. If the timer hits 0:00 exactly at the deadline, the exam might
+  // end fractionally after the deadline (overdue submission), so we subtract
+  // 31 seconds to avoid that race. 31 (rather than 30) forces the final value
+  // to round down when the cap falls on a half-minute boundary (time limits
+  // are stored in whole minutes).
   const secondsUntilDeadline = (lastSubmittableEnd.getTime() - date.getTime()) / 1000 - 31;
-  return Math.max(0, Math.floor(Math.min(durationMinutes, secondsUntilDeadline / 60)));
+  return Math.max(0, Math.round(Math.min(durationMinutes, secondsUntilDeadline / 60)));
 }
 
 /**

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -344,17 +344,40 @@ function formatCreditDateString(
 
 function computeTimeLimitMin(
   durationMinutes: number | null | undefined,
-  nextDeadline: Date | null,
+  lastSubmittableEnd: Date | null,
   date: Date,
   authzMode: EnumMode,
 ): number | null {
   if (!durationMinutes) return null;
   if (authzMode === 'Exam') return null;
-  if (!nextDeadline) return durationMinutes;
+  if (!lastSubmittableEnd) return durationMinutes;
 
-  // Cap time limit by seconds until next deadline, minus 31 seconds (legacy behavior).
-  const secondsUntilDeadline = (nextDeadline.getTime() - date.getTime()) / 1000 - 31;
+  // Cap time limit by seconds until the last reachable submittable deadline,
+  // minus 31 seconds (legacy behavior).
+  const secondsUntilDeadline = (lastSubmittableEnd.getTime() - date.getTime()) / 1000 - 31;
   return Math.max(0, Math.floor(Math.min(durationMinutes, secondsUntilDeadline / 60)));
+}
+
+/**
+ * Returns the latest endDate the student can still submit at, walking forward
+ * from `current` through contiguous submittable timeline entries. The time
+ * limit caps here so duration can span access windows (e.g. 100% credit
+ * window → 80% late window) without truncating at the credit drop. Returns
+ * `null` if a submittable entry has no end (afterLastDeadline allowing
+ * submissions, or an indefinite due date).
+ */
+function findLastSubmittableEnd(
+  accessTimeline: AccessTimelineEntry[],
+  currentIdx: number,
+): Date | null {
+  let end: Date | null = null;
+  for (let i = currentIdx; i < accessTimeline.length; i++) {
+    const entry = accessTimeline[i];
+    if (!entry.submittable) break;
+    if (entry.endDate === null) return null;
+    end = entry.endDate;
+  }
+  return end;
 }
 
 /**
@@ -450,7 +473,8 @@ export function resolveAccessControl(
   }
   // `hasRelease` is true, so `current` is defined unless we have a degenerate window where due ≤ release.
   // Treat degenerate windows as fully unauthorized.
-  const current = accessTimeline.find((e) => e.current);
+  const currentIdx = accessTimeline.findIndex((e) => e.current);
+  const current = currentIdx !== -1 ? accessTimeline[currentIdx] : undefined;
   if (!current) {
     return { ...UNAUTHORIZED_RESULT, ...visibility, accessTimeline };
   }
@@ -476,7 +500,7 @@ export function resolveAccessControl(
     ),
     timeLimitMin: computeTimeLimitMin(
       rule.dateControl?.durationMinutes,
-      current.endDate,
+      findLastSubmittableEnd(accessTimeline, currentIdx),
       date,
       authzMode,
     ),


### PR DESCRIPTION
# Description

`resolveAccessControl` was capping `timeLimitMin` at `current.endDate` (the *next* deadline), so a 60-minute time limit started 10 minutes before the due date truncated to 9 — minutes did not roll into a submittable late window.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). — majority of implementation, human review and direction throughout.

# Testing

Adds new tests for the new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)