### PR TITLE
Fix always dirty bug on access control form

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -127,12 +127,8 @@ export function AccessControlForm({
   }, [clearErrors, getFieldState, setError, watchedData, errors, displayTimezone]);
 
   const handleFormSubmit = async (data: AccessControlFormData) => {
-    try {
-      await onSubmit(formDataToJson(data));
-      reset(data);
-    } catch {
-      // Mutation errors are surfaced via the `alert` prop.
-    }
+    await onSubmit(formDataToJson(data));
+    reset(data);
   };
 
   const addOverride = () => {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -47,7 +47,7 @@ export function AccessControlForm({
   initialData?: AccessControlJsonWithId[];
   prairieTestExamMetadata: PrairieTestExamMetadata[];
   ptHost: string;
-  onSubmit: (data: AccessControlJsonWithId[]) => void;
+  onSubmit: (data: AccessControlJsonWithId[]) => Promise<void>;
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   assessmentId: string;
   isSaving?: boolean;
@@ -126,8 +126,13 @@ export function AccessControlForm({
     manualErrorPathsRef.current = new Set(nextManualErrors.keys());
   }, [clearErrors, getFieldState, setError, watchedData, errors, displayTimezone]);
 
-  const handleFormSubmit = (data: AccessControlFormData) => {
-    onSubmit(formDataToJson(data));
+  const handleFormSubmit = async (data: AccessControlFormData) => {
+    try {
+      await onSubmit(formDataToJson(data));
+      reset(data);
+    } catch {
+      // Mutation errors are surfaced via the `alert` prop.
+    }
   };
 
   const addOverride = () => {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AssessmentAccessControl.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AssessmentAccessControl.tsx
@@ -49,7 +49,7 @@ function AssessmentAccessControlInner({
     }),
   );
 
-  const handleFormSubmit = (data: AccessControlJsonWithId[]) => {
+  const handleFormSubmit = async (data: AccessControlJsonWithId[]) => {
     const jsonRules = data.filter((r) => r.ruleType !== 'enrollment');
     const enrollmentRules = data
       .filter((r) => r.ruleType === 'enrollment')
@@ -59,7 +59,7 @@ function AssessmentAccessControlInner({
         ruleJson,
       }));
 
-    saveMutation.mutate({
+    await saveMutation.mutateAsync({
       rules: jsonRules,
       enrollmentRules,
       origHash,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Currently, the access control form has a bug in which despite saving changes, it stays dirty, causing the sticky save bar to never disappear and always say "You have unsaved changes". This PR fixes it by resetting the form values with the new values after the save mutation is successful.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): none.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

The existing tests for this page work, and manually tested editing configuration.