### PR TITLE
False positives for file downloads

### DIFF
--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -119,8 +119,6 @@
     },
     {
       "id": "pl-prefer-pl-file-download",
-      // Only fire on extensions that are unambiguously downloads.
-      // Notably, pdfs, images, and html files may be meant to be previewed instead of downloaded.
       "selector": "a[href*=\"client_files_course_url\"], a[href*=\"client_files_question_url\"], a[href*=\"client_files_question_dynamic_url\"]",
       "message": "Prefer pl-file-download over a plain <a> tag for links to course or question resources. See https://docs.prairielearn.com/elements/pl-file-download/.",
       "severity": "warning"

--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -119,7 +119,9 @@
     },
     {
       "id": "pl-prefer-pl-file-download",
-      "selector": "a[href*=\"client_files_course_url\"], a[href*=\"client_files_question_url\"], a[href*=\"client_files_question_dynamic_url\"]",
+      // Only fire on extensions that are unambiguously downloads.
+      // Notably, pdfs, images, and html files may be meant to be previewed instead of downloaded.
+      "selector": ":is(a[href*=\"client_files_course_url\"], a[href*=\"client_files_question_url\"], a[href*=\"client_files_question_dynamic_url\"]):is([href$=\".zip\"], [href$=\".tar\"], [href$=\".tgz\"], [href$=\".gz\"], [href$=\".docx\"], [href$=\".xlsx\"], [href$=\".pptx\"], [href$=\".csv\"], [href$=\".ipynb\"])",
       "message": "Prefer pl-file-download over a plain <a> link for downloadable files. See https://docs.prairielearn.com/elements/pl-file-download/.",
       "severity": "warning"
     },

--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -121,8 +121,8 @@
       "id": "pl-prefer-pl-file-download",
       // Only fire on extensions that are unambiguously downloads.
       // Notably, pdfs, images, and html files may be meant to be previewed instead of downloaded.
-      "selector": ":is(a[href*=\"client_files_course_url\"], a[href*=\"client_files_question_url\"], a[href*=\"client_files_question_dynamic_url\"]):is([href$=\".zip\"], [href$=\".tar\"], [href$=\".tgz\"], [href$=\".gz\"], [href$=\".docx\"], [href$=\".xlsx\"], [href$=\".pptx\"], [href$=\".csv\"], [href$=\".ipynb\"])",
-      "message": "Prefer pl-file-download over a plain <a> link for downloadable files. See https://docs.prairielearn.com/elements/pl-file-download/.",
+      "selector": "a[href*=\"client_files_course_url\"], a[href*=\"client_files_question_url\"], a[href*=\"client_files_question_dynamic_url\"]",
+      "message": "Prefer pl-file-download over a plain <a> tag for links to course or question resources. See https://docs.prairielearn.com/elements/pl-file-download/.",
       "severity": "warning"
     },
     // Improper nesting of elements

--- a/apps/prairielearn/assets/scripts/lib/htmlMustacheConfig.ts
+++ b/apps/prairielearn/assets/scripts/lib/htmlMustacheConfig.ts
@@ -132,8 +132,10 @@ export const htmlMustacheConfig: Config = {
     },
     {
       id: 'pl-prefer-pl-file-download',
+      // Only fire on extensions that are unambiguously downloads.
+      // Notably, pdfs, images, and html files may be meant to be previewed instead of downloaded.
       selector:
-        'a[href*="client_files_course_url"], a[href*="client_files_question_url"], a[href*="client_files_question_dynamic_url"]',
+        ':is(a[href*="client_files_course_url"], a[href*="client_files_question_url"], a[href*="client_files_question_dynamic_url"]):is([href$=".zip"], [href$=".tar"], [href$=".tgz"], [href$=".gz"], [href$=".docx"], [href$=".xlsx"], [href$=".pptx"], [href$=".csv"], [href$=".ipynb"])',
       message:
         'Prefer pl-file-download over a plain <a> link for downloadable files. See https://docs.prairielearn.com/elements/pl-file-download/.',
       severity: 'warning',

--- a/apps/prairielearn/assets/scripts/lib/htmlMustacheConfig.ts
+++ b/apps/prairielearn/assets/scripts/lib/htmlMustacheConfig.ts
@@ -132,12 +132,10 @@ export const htmlMustacheConfig: Config = {
     },
     {
       id: 'pl-prefer-pl-file-download',
-      // Only fire on extensions that are unambiguously downloads.
-      // Notably, pdfs, images, and html files may be meant to be previewed instead of downloaded.
       selector:
-        ':is(a[href*="client_files_course_url"], a[href*="client_files_question_url"], a[href*="client_files_question_dynamic_url"]):is([href$=".zip"], [href$=".tar"], [href$=".tgz"], [href$=".gz"], [href$=".docx"], [href$=".xlsx"], [href$=".pptx"], [href$=".csv"], [href$=".ipynb"])',
+        'a[href*="client_files_course_url"], a[href*="client_files_question_url"], a[href*="client_files_question_dynamic_url"]',
       message:
-        'Prefer pl-file-download over a plain <a> link for downloadable files. See https://docs.prairielearn.com/elements/pl-file-download/.',
+        'Prefer pl-file-download over a plain <a> tag for links to course or question resources. See https://docs.prairielearn.com/elements/pl-file-download/.',
       severity: 'warning',
     },
     // Improper nesting of elements


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

While testing, I came across this false positive for the htmlmustache lint rule:

```
  <p><a href="{{ options.client_files_course_url }}/cbtf_website/cbtf.illinois.edu/students/dres.html" target="_blank">DRES page</a></p>
```

> Prefer pl-file-download over a plain <a> link for downloadable files. See https://docs.prairielearn.com/elements/pl-file-download/.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: majority of implementation

# Testing

N/A
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
