### PR TITLE
Add PrairieTest -> PrairieLearn auth callback

### DIFF
--- a/apps/prairielearn/src/ee/auth/prairietest.ts
+++ b/apps/prairielearn/src/ee/auth/prairietest.ts
@@ -30,6 +30,7 @@ router.get(
       .setProtectedHeader({ alg: 'HS512' })
       .setIssuedAt()
       .setExpirationTime('1m')
+      .setAudience('prairietest')
       .sign(key);
 
     // This renders a self-submitting form that will submit the JWT to PrairieTest.

--- a/apps/prairielearn/src/ee/auth/prairietestCallback.ts
+++ b/apps/prairielearn/src/ee/auth/prairietestCallback.ts
@@ -1,0 +1,35 @@
+import * as crypto from 'node:crypto';
+
+import { Router } from 'express';
+import asyncHandler from 'express-async-handler';
+import * as jose from 'jose';
+import { z } from 'zod';
+
+import { HttpStatusError } from '@prairielearn/error';
+
+import * as authnLib from '../../lib/authn.js';
+import { config } from '../../lib/config.js';
+
+const router = Router({ mergeParams: true });
+
+const PrairieTestJwtPayloadSchema = z.object({
+  user_id: z.union([z.string(), z.number()]),
+});
+
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const jwt = req.body.jwt;
+    if (typeof jwt !== 'string' || jwt.length === 0) {
+      throw new HttpStatusError(400, 'Missing JWT');
+    }
+
+    const key = crypto.createSecretKey(config.prairieTestAuthSecret, 'utf-8');
+    const { payload } = await jose.jwtVerify(jwt, key, { audience: 'prairielearn' });
+    const { user_id } = PrairieTestJwtPayloadSchema.parse(payload);
+
+    await authnLib.loadUser(req, res, { user_id, provider: 'PrairieTest' }, { redirect: true });
+  }),
+);
+
+export default router;

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -465,6 +465,14 @@ export async function initExpress(): Promise<Express> {
       '/pl/auth/institution/:institution_id(\\d+)/saml',
       (await import('./ee/auth/saml/router.js')).default,
     );
+
+    // Receives a JWT minted by PrairieTest and starts a PrairieLearn session.
+    // Must come before the authn middleware since the user isn't authenticated yet,
+    // and before the CSRF middleware since the JWT signature is the auth proof.
+    app.use(
+      '/pl/prairietest/auth/callback',
+      (await import('./ee/auth/prairietestCallback.js')).default,
+    );
   }
 
   app.use('/pl/lti', (await import('./pages/authCallbackLti/authCallbackLti.js')).default);


### PR DESCRIPTION
# Description

Adds the PrairieLearn-side receiver for the inverse of the existing PL → PT auth handoff: PrairieTest can now mint a JWT for a user and start a session in PrairieLearn.

- New EE-only POST endpoint at `/pl/prairietest/auth/callback` (`apps/prairielearn/src/ee/auth/prairietestCallback.ts`). Verifies the JWT with the existing shared `prairieTestAuthSecret`, then calls `authnLib.loadUser({ user_id, provider: 'PrairieTest' }, { redirect: true })` to start the session and redirect to `pl2_pre_auth_url` (or `/`).
- Mounted in `server.ts` inside the `isEnterprise()` block, before the authn middleware (user isn't logged in yet) and before CSRF (the JWT signature is the auth proof).
- Adds an `aud` claim to both directions so a JWT minted for one side can't be replayed at the other:
  - PL → PT outbound: `aud: 'prairietest'`
  - PT → PL inbound (this endpoint): requires `aud: 'prairielearn'`

The PT-side outbound flow that POSTs to this endpoint will be added in a separate PrairieTest PR.

**Contract for PrairieTest:**
- POST to `${plHost}/pl/prairietest/auth/callback` with form field `jwt`
- HS512-signed with the shared secret (`prairieLearnAuthSecret` in PT config)
- Payload: `{ user_id, aud: 'prairielearn' }`, with `iat`/`exp` (1m expiry recommended, matching the existing direction)

- [x] AI assistance disclosure: majority of implementation drafted with Claude Code; reviewed and adjusted by hand.

# Testing

End-to-end testing requires the matching PrairieTest-side PR. Once that lands, manual verification will be: trigger the PT → PL flow, confirm the user lands authenticated in PL with `authn_provider_name = 'PrairieTest'` in the session, and confirm a tampered/expired/mismatched-`aud` JWT is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)