### PR TITLE
Fix double-unescape of HTML entities in question traverse

### DIFF
--- a/apps/prairielearn/python/prairielearn/internal/traverse.py
+++ b/apps/prairielearn/python/prairielearn/internal/traverse.py
@@ -1,7 +1,6 @@
 from collections import deque
 from collections.abc import Callable, Sequence
 from html import escape as html_escape
-from html import unescape as html_unescape
 from itertools import chain
 
 import lxml.html
@@ -63,17 +62,8 @@ def get_source_definition(
     return f"<{' '.join((element.tag, *attributes))}>"
 
 
-# `lxml` uses `libxml2` under the hood, which does not support the full set
-# of HTML5 named entities:
-# https://gitlab.gnome.org/GNOME/libxml2/-/issues/857
-# This means that with a naive approach, we'd end up double escaping entities
-# like `&langle;` into `&amp;langle;`. To work around this (at least until
-# `libxml2` hopefully adds support for HTML5 named entities), we first
-# unescape the text to get the actual Unicode characters, and then escape them
-# again. Escaping will only escape `&`, `<`, and `>`; it won't escape everything
-# that could possibly be represented by a named entity.
 def prepare_text(text: str) -> str:
-    return html_escape(html_unescape(text))
+    return html_escape(text)
 
 
 def traverse_and_replace(

--- a/apps/prairielearn/python/test/traverse_test.py
+++ b/apps/prairielearn/python/test/traverse_test.py
@@ -333,6 +333,16 @@ def test_traverse_and_replace_angle_brackets() -> None:
     assert html == "<pre><code>&lt;div&gt;</code></pre>"
 
 
+def test_traverse_and_replace_escaped_entities() -> None:
+    def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
+        if e.tag == "pl-string":
+            return "<div>&amp;lt; &amp;langle;v, w&amp;rangle; &amp;gt;</div>"
+        return e
+
+    html = traverse_and_replace("<pl-string></pl-string>", replace)
+    assert html == "<div>&amp;lt; &amp;langle;v, w&amp;rangle; &amp;gt;</div>"
+
+
 def test_traverse_and_replace_trailing_entity() -> None:
     def replace(e: lxml.html.HtmlElement) -> ElementReplacement:
         if e.tag == "div":


### PR DESCRIPTION
# Description

Closes #14926.

`prepare_text` in `traverse.py` was unescaping HTML entities and then re-escaping them as a workaround for libxml2 not supporting HTML5 named entities. libxml2 has since added that support (verified against the pinned 2.14.6 / lxml 6.1.0), so the workaround is no longer needed and was actively buggy: text like `&amp;gt;` (which lxml had already decoded to `&gt;`) was being unescaped a second time to `>` and re-escaped to `&gt;`, dropping a level of escaping. This change removes the redundant `html_unescape` call and its outdated comment.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation.

# Testing

- Added `test_traverse_and_replace_escaped_entities`, which mirrors the issue's repro and additionally covers HTML5 entities (`&amp;langle;`, `&amp;rangle;`) alongside HTML4 (`&amp;lt;`, `&amp;gt;`).
- Existing `test_traverse_pre_html5_entities` still passes, confirming `&langle;` is still decoded to `⟨` (now via libxml2 directly rather than the workaround).