### PR TITLE
Clarify behavior of student labels on access control overrides

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AppliesToField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AppliesToField.tsx
@@ -139,42 +139,47 @@ export function AppliesToField({
             )}
           </div>
         ) : (
-          <div className="d-flex flex-wrap align-items-baseline gap-2">
-            <StudentLabelDropdown
-              labels={allLabels ?? []}
-              selectedIds={excludedStudentLabelIds}
-              buttonLabel="Select labels"
-              onToggle={(label) => {
-                if (excludedStudentLabelIds.has(label.id)) {
-                  handleRemoveStudentLabelById(label.id);
-                } else {
-                  appendStudentLabel({
-                    studentLabelId: label.id,
-                    name: label.name,
-                    color: label.color,
-                  });
-                }
-              }}
-            />
-            {studentLabels.length === 0 ? (
-              <span className="text-muted small">No student labels selected</span>
-            ) : (
-              studentLabels.map((sl) => (
-                <StudentLabelBadge
-                  key={sl.studentLabelId}
-                  label={{ name: sl.name, color: sl.color ?? 'gray1' }}
-                >
-                  <button
-                    type="button"
-                    className="btn p-0 lh-1"
-                    aria-label={`Remove label "${sl.name}"`}
-                    onClick={() => handleRemoveStudentLabelById(sl.studentLabelId)}
+          <div>
+            <div className="d-flex flex-wrap align-items-baseline gap-2">
+              <StudentLabelDropdown
+                labels={allLabels ?? []}
+                selectedIds={excludedStudentLabelIds}
+                buttonLabel="Select labels"
+                onToggle={(label) => {
+                  if (excludedStudentLabelIds.has(label.id)) {
+                    handleRemoveStudentLabelById(label.id);
+                  } else {
+                    appendStudentLabel({
+                      studentLabelId: label.id,
+                      name: label.name,
+                      color: label.color,
+                    });
+                  }
+                }}
+              />
+              {studentLabels.length === 0 ? (
+                <span className="text-muted small">No student labels selected</span>
+              ) : (
+                studentLabels.map((sl) => (
+                  <StudentLabelBadge
+                    key={sl.studentLabelId}
+                    label={{ name: sl.name, color: sl.color ?? 'gray1' }}
                   >
-                    <i className="bi bi-x text-danger" aria-hidden="true" />
-                  </button>
-                </StudentLabelBadge>
-              ))
-            )}
+                    <button
+                      type="button"
+                      className="btn p-0 lh-1"
+                      aria-label={`Remove label "${sl.name}"`}
+                      onClick={() => handleRemoveStudentLabelById(sl.studentLabelId)}
+                    >
+                      <i className="bi bi-x text-danger" aria-hidden="true" />
+                    </button>
+                  </StudentLabelBadge>
+                ))
+              )}
+            </div>
+            <div className="form-text mt-2">
+              Applies to students with any of the selected labels.
+            </div>
           </div>
         )}
       </div>

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -138,7 +138,7 @@ Click **Add override** in the **Overrides** section.
 Choose who the override applies to:
 
 - **Specific students**: select individual enrolled students.
-- **Students by label**: select one or more student labels, such as "Section A" or "Extra time".
+- **Students by label**: select one or more student labels, such as "Section A" or "Extra time". The override applies to students with _any_ of the selected labels (not all of them).
 
 [Student labels](../courseInstance/index.md#student-labels) are managed on the course instance **Students** page. They are the recommended way to handle repeated accommodations, sections, or cohort-specific deadlines.
 


### PR DESCRIPTION
# Description

When an access control override targets students by label, the override applies to students who have _any_ of the selected labels, but the UI and docs didn't make that explicit. This adds a help text below the label selector and a clarifying sentence in the docs. Addresses an item from #14469.

<img width="557" height="220" alt="Screenshot 2026-05-08 at 11 13 43" src="https://github.com/user-attachments/assets/4ede13c8-18dc-4a88-aa4f-49dcedb2f4d5" />

AI assistance: majority of implementation.

# Testing

Confirmed help text renders below the label selector when "Students by label" is chosen on an override.