### PR TITLE
Add free AI grading credit redemption flow

### DIFF
--- a/apps/prairielearn/src/ee/components/ai-grading-credits/CreditPoolDashboard.tsx
+++ b/apps/prairielearn/src/ee/components/ai-grading-credits/CreditPoolDashboard.tsx
@@ -19,6 +19,7 @@ export function CreditPoolDashboard({
   balanceContext,
   dimmed,
   onPurchaseClick,
+  onRedeemFreeCreditClick,
   header,
   children,
   showRefundActions,
@@ -29,6 +30,7 @@ export function CreditPoolDashboard({
   balanceContext: 'admin' | 'instructor';
   dimmed?: boolean;
   onPurchaseClick?: () => void;
+  onRedeemFreeCreditClick?: () => void;
   header?: React.ReactNode;
   children?: React.ReactNode;
   showRefundActions?: boolean;
@@ -97,16 +99,28 @@ export function CreditPoolDashboard({
           />
           <h3 className="h5 mb-2">Get started with AI grading</h3>
           <p className="text-muted mb-3">Buy credits to start grading submissions with AI.</p>
-          {onPurchaseClick && (
-            <button
-              type="button"
-              className="btn btn-primary d-inline-flex align-items-center gap-2"
-              onClick={onPurchaseClick}
-            >
-              <i className="bi bi-cart-plus" aria-hidden="true" />
-              Purchase credits
-            </button>
-          )}
+          <div className="d-flex flex-column align-items-center gap-2">
+            {onRedeemFreeCreditClick && (
+              <button
+                type="button"
+                className="btn btn-success d-inline-flex align-items-center gap-2 fw-semibold"
+                onClick={onRedeemFreeCreditClick}
+              >
+                <i className="bi bi-gift-fill" aria-hidden="true" />
+                Redeem free credit
+              </button>
+            )}
+            {onPurchaseClick && (
+              <button
+                type="button"
+                className="btn btn-primary d-inline-flex align-items-center gap-2"
+                onClick={onPurchaseClick}
+              >
+                <i className="bi bi-cart-plus" aria-hidden="true" />
+                Purchase credits
+              </button>
+            )}
+          </div>
         </div>
       );
     }

--- a/apps/prairielearn/src/ee/lib/ai-grading-free-credit-constants.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading-free-credit-constants.ts
@@ -1,0 +1,5 @@
+/** Amount of credit granted per free redemption, in milli-dollars ($1.00). */
+export const FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION = 1000;
+
+/** Lifetime cap on free credit redemptions per course (across all instances). */
+export const MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE = 3;

--- a/apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.sql
+++ b/apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.sql
@@ -1,0 +1,25 @@
+-- BLOCK select_course_free_credit_redemptions_used
+SELECT
+  ai_grading_free_credit_redemptions_used
+FROM
+  courses
+WHERE
+  id = $course_id;
+
+-- BLOCK select_course_free_credit_redemptions_used_for_update
+SELECT
+  ai_grading_free_credit_redemptions_used
+FROM
+  courses
+WHERE
+  id = $course_id
+FOR UPDATE;
+
+-- BLOCK increment_course_free_credit_redemptions
+UPDATE courses
+SET
+  ai_grading_free_credit_redemptions_used = ai_grading_free_credit_redemptions_used + 1
+WHERE
+  id = $course_id
+RETURNING
+  ai_grading_free_credit_redemptions_used;

--- a/apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.test.ts
+++ b/apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest';
+
+import { selectCreditPool } from '../../models/ai-grading-credit-pool.js';
+import * as helperCourse from '../../tests/helperCourse.js';
+import * as helperDb from '../../tests/helperDb.js';
+import { getOrCreateUser } from '../../tests/utils/auth.js';
+import {
+  FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION,
+  MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE,
+} from '../lib/ai-grading-free-credit-constants.js';
+
+import {
+  redeemFreeAiGradingCredit,
+  selectCourseFreeCreditRedemptionsUsed,
+} from './ai-grading-free-credit-redemption.js';
+
+const COURSE_ID = '1';
+const COURSE_INSTANCE_ID = '1';
+
+async function createTestUser() {
+  const user = await getOrCreateUser({
+    uid: 'free-credit-user@example.com',
+    name: 'Free Credit User',
+    uin: 'freecredit',
+    email: 'free-credit-user@example.com',
+  });
+  return user.id;
+}
+
+describe('ai-grading-free-credit-redemption', () => {
+  beforeEach(async () => {
+    await helperDb.before();
+    await helperCourse.syncCourse();
+  });
+
+  afterEach(async () => {
+    await helperDb.after();
+  });
+
+  it('adds non-transferable credit and increments the course counter', async () => {
+    const userId = await createTestUser();
+    const poolBefore = await selectCreditPool(COURSE_INSTANCE_ID);
+
+    const result = await redeemFreeAiGradingCredit({
+      course_id: COURSE_ID,
+      course_instance_id: COURSE_INSTANCE_ID,
+      user_id: userId,
+    });
+
+    assert.equal(result.redemptions_used, 1);
+    assert.equal(
+      result.redemptions_remaining,
+      MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE - 1,
+    );
+    assert.equal(result.amount_milli_dollars, FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION);
+
+    const poolAfter = await selectCreditPool(COURSE_INSTANCE_ID);
+    assert.equal(
+      poolAfter.credit_non_transferable_milli_dollars,
+      poolBefore.credit_non_transferable_milli_dollars +
+        FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION,
+    );
+    assert.equal(
+      poolAfter.credit_transferable_milli_dollars,
+      poolBefore.credit_transferable_milli_dollars,
+    );
+
+    const used = await selectCourseFreeCreditRedemptionsUsed(COURSE_ID);
+    assert.equal(used, 1);
+  });
+
+  it('enforces the lifetime cap per course', async () => {
+    const userId = await createTestUser();
+
+    for (let i = 0; i < MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE; i++) {
+      await redeemFreeAiGradingCredit({
+        course_id: COURSE_ID,
+        course_instance_id: COURSE_INSTANCE_ID,
+        user_id: userId,
+      });
+    }
+
+    const used = await selectCourseFreeCreditRedemptionsUsed(COURSE_ID);
+    assert.equal(used, MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE);
+
+    await expect(
+      redeemFreeAiGradingCredit({
+        course_id: COURSE_ID,
+        course_instance_id: COURSE_INSTANCE_ID,
+        user_id: userId,
+      }),
+    ).rejects.toThrow(/free AI grading credit redemptions/);
+
+    const usedAfter = await selectCourseFreeCreditRedemptionsUsed(COURSE_ID);
+    assert.equal(usedAfter, MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE);
+  });
+});

--- a/apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.ts
+++ b/apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+
+import { loadSqlEquiv, queryRow, runInTransactionAsync } from '@prairielearn/postgres';
+
+import { adjustCreditPool } from '../../models/ai-grading-credit-pool.js';
+import { insertAuditEvent } from '../../models/audit-event.js';
+import {
+  FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION,
+  MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE,
+} from '../lib/ai-grading-free-credit-constants.js';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const RedemptionsUsedSchema = z.object({
+  ai_grading_free_credit_redemptions_used: z.number(),
+});
+
+export async function selectCourseFreeCreditRedemptionsUsed(course_id: string): Promise<number> {
+  const row = await queryRow(
+    sql.select_course_free_credit_redemptions_used,
+    { course_id },
+    RedemptionsUsedSchema,
+  );
+  return row.ai_grading_free_credit_redemptions_used;
+}
+
+/**
+ * Redeem one free AI grading credit for a course. The redemption counter lives
+ * at the course level (lifetime cap of
+ * {@link MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE} across all course
+ * instances), but the credit is added to the specified course instance's pool.
+ *
+ * Locks the course row FOR UPDATE before checking the cap to serialize
+ * concurrent redemptions from the same course. Adds non-transferable credit so
+ * the free credit cannot be refunded or carried across course instances.
+ */
+export async function redeemFreeAiGradingCredit({
+  course_id,
+  course_instance_id,
+  user_id,
+}: {
+  course_id: string;
+  course_instance_id: string;
+  user_id: string;
+}): Promise<{
+  redemptions_used: number;
+  redemptions_remaining: number;
+  amount_milli_dollars: number;
+}> {
+  return await runInTransactionAsync(async () => {
+    const before = await queryRow(
+      sql.select_course_free_credit_redemptions_used_for_update,
+      { course_id },
+      RedemptionsUsedSchema,
+    );
+
+    if (
+      before.ai_grading_free_credit_redemptions_used >=
+      MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE
+    ) {
+      throw new Error(
+        `This course has already used all ${MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE} free AI grading credit redemptions.`,
+      );
+    }
+
+    const after = await queryRow(
+      sql.increment_course_free_credit_redemptions,
+      { course_id },
+      RedemptionsUsedSchema,
+    );
+
+    await adjustCreditPool({
+      course_instance_id,
+      delta_milli_dollars: FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION,
+      credit_type: 'non_transferable',
+      user_id,
+      reason: 'Free credit redemption',
+    });
+
+    await insertAuditEvent({
+      tableName: 'courses',
+      action: 'update',
+      actionDetail: 'ai_grading_free_credit_redemption',
+      rowId: course_id,
+      agentAuthnUserId: user_id,
+      agentUserId: user_id,
+      courseId: course_id,
+      courseInstanceId: course_instance_id,
+      oldRow: {
+        ai_grading_free_credit_redemptions_used: before.ai_grading_free_credit_redemptions_used,
+      },
+      newRow: {
+        ai_grading_free_credit_redemptions_used: after.ai_grading_free_credit_redemptions_used,
+      },
+      context: {
+        amount_milli_dollars: FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION,
+      },
+    });
+
+    return {
+      redemptions_used: after.ai_grading_free_credit_redemptions_used,
+      redemptions_remaining:
+        MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE -
+        after.ai_grading_free_credit_redemptions_used,
+      amount_milli_dollars: FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION,
+    };
+  });
+}

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/RedeemFreeCreditModal.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/RedeemFreeCreditModal.tsx
@@ -72,8 +72,8 @@ export function RedeemFreeCreditModal({
         </dl>
         {hasRedemptionsAvailable && (
           <p className="text-muted small mt-3 mb-0">
-            You may redeem free credits {maxRedemptions} times across all {courseLabel} course
-            instance.
+            You may redeem free credits up to {maxRedemptions} times across all course instances of{' '}
+            {courseLabel}.
           </p>
         )}
       </Modal.Body>

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/RedeemFreeCreditModal.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/RedeemFreeCreditModal.tsx
@@ -1,0 +1,100 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Alert, Modal } from 'react-bootstrap';
+
+import { formatMilliDollars } from '../../../lib/ai-grading-credits.js';
+import { FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION } from '../../lib/ai-grading-free-credit-constants.js';
+
+import { useTRPC } from './utils/trpc-context.js';
+
+export function RedeemFreeCreditModal({
+  show,
+  onHide,
+  onExited,
+  onSuccess,
+  redemptionsRemaining,
+  maxRedemptions,
+  courseLabel,
+}: {
+  show: boolean;
+  onHide: () => void;
+  onExited: () => void;
+  onSuccess: (amountMilliDollars: number) => void;
+  redemptionsRemaining: number;
+  maxRedemptions: number;
+  courseLabel: string;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const redeemMutation = useMutation({
+    ...trpc.redeemFreeCredit.mutationOptions(),
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: trpc.creditPool.queryKey() });
+      void queryClient.invalidateQueries({
+        queryKey: trpc.creditPoolChanges.queryKey({ page: 1 }),
+      });
+      void queryClient.invalidateQueries({ queryKey: trpc.freeCreditStatus.queryKey() });
+      onSuccess(data.amount_milli_dollars);
+      onHide();
+    },
+  });
+
+  const hasRedemptionsAvailable = redemptionsRemaining > 0;
+
+  return (
+    <Modal
+      show={show}
+      backdrop="static"
+      onHide={onHide}
+      onExited={() => {
+        redeemMutation.reset();
+        onExited();
+      }}
+    >
+      <Modal.Header closeButton>
+        <Modal.Title>Redeem free credits</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {redeemMutation.isError && (
+          <Alert variant="danger" dismissible onClose={() => redeemMutation.reset()}>
+            {redeemMutation.error.message}
+          </Alert>
+        )}
+        <dl className="row mb-0">
+          <dt className="col-sm-5 fw-normal">Credits to add:</dt>
+          <dd className="col-sm-7 mb-2 fw-bold">
+            {formatMilliDollars(FREE_AI_GRADING_CREDIT_MILLI_DOLLARS_PER_REDEMPTION)}
+          </dd>
+          <dt className="col-sm-5 fw-normal">Free credit remaining:</dt>
+          <dd className="col-sm-7 mb-0 fw-bold">
+            {redemptionsRemaining} of {maxRedemptions}
+          </dd>
+        </dl>
+        {hasRedemptionsAvailable && (
+          <p className="text-muted small mt-3 mb-0">
+            You may redeem free credits {maxRedemptions} times across all {courseLabel} course
+            instance.
+          </p>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <button
+          type="button"
+          className="btn btn-outline-secondary"
+          disabled={redeemMutation.isPending}
+          onClick={onHide}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary"
+          disabled={redeemMutation.isPending || redemptionsRemaining <= 0}
+          onClick={() => redeemMutation.mutate()}
+        >
+          {redeemMutation.isPending ? 'Redeeming...' : 'Redeem'}
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/instructorInstanceAdminAiGrading.html.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/instructorInstanceAdminAiGrading.html.tsx
@@ -475,9 +475,7 @@ function CreditPoolSection({
   }, [initialCheckoutStatus, queryClient, trpc]);
 
   const freeCreditStatus = freeCreditStatusQuery.data;
-  const freeCreditStatusLoaded = freeCreditStatus != null;
-  const hasFreeCreditAvailable =
-    freeCreditStatusLoaded && freeCreditStatus.redemptions_remaining > 0;
+  const hasFreeCreditAvailable = (freeCreditStatus?.redemptions_remaining ?? 0) > 0;
 
   return (
     <div className="border-top pt-3 mt-3">
@@ -526,7 +524,7 @@ function CreditPoolSection({
                 Redeem free credit
               </button>
             )}
-            {stripePurchasingEnabled && freeCreditStatusLoaded && (
+            {stripePurchasingEnabled && (
               <button
                 type="button"
                 className="btn btn-sm btn-primary d-flex align-items-center gap-2"

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/instructorInstanceAdminAiGrading.html.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/instructorInstanceAdminAiGrading.html.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../lib/ai-grading/ai-grading-models.shared.js';
 
 import { PurchaseCreditsModal } from './PurchaseCreditsModal.js';
+import { RedeemFreeCreditModal } from './RedeemFreeCreditModal.js';
 import type { AiGradingApiKeyCredential } from './utils/format.js';
 import { createAiGradingSettingsTrpcClient } from './utils/trpc-client.js';
 import { TRPCProvider, useTRPC } from './utils/trpc-context.js';
@@ -213,6 +214,7 @@ export function InstructorInstanceAdminAiGrading({
   stripePurchasingEnabled,
   initialCheckoutStatus,
   initialCheckoutAmountMilliDollars,
+  courseLabel,
 }: {
   trpcCsrfToken: string;
   initialUseCustomApiKeys: boolean;
@@ -222,6 +224,7 @@ export function InstructorInstanceAdminAiGrading({
   stripePurchasingEnabled: boolean;
   initialCheckoutStatus: 'success' | 'cancelled' | null;
   initialCheckoutAmountMilliDollars: number | null;
+  courseLabel: string;
 }) {
   const [queryClient] = useState(() => new QueryClient());
   const [trpcClient] = useState(() =>
@@ -238,6 +241,7 @@ export function InstructorInstanceAdminAiGrading({
           stripePurchasingEnabled={stripePurchasingEnabled}
           initialCheckoutStatus={initialCheckoutStatus}
           initialCheckoutAmountMilliDollars={initialCheckoutAmountMilliDollars}
+          courseLabel={courseLabel}
         />
       </TRPCProvider>
     </QueryClientProviderDebug>
@@ -253,6 +257,7 @@ function AiGradingSettingsContent({
   stripePurchasingEnabled,
   initialCheckoutStatus,
   initialCheckoutAmountMilliDollars,
+  courseLabel,
 }: {
   initialUseCustomApiKeys: boolean;
   initialApiKeyCredentials: AiGradingApiKeyCredential[];
@@ -260,6 +265,7 @@ function AiGradingSettingsContent({
   stripePurchasingEnabled: boolean;
   initialCheckoutStatus: 'success' | 'cancelled' | null;
   initialCheckoutAmountMilliDollars: number | null;
+  courseLabel: string;
 }) {
   const trpc = useTRPC();
 
@@ -383,6 +389,7 @@ function AiGradingSettingsContent({
           stripePurchasingEnabled={stripePurchasingEnabled}
           initialCheckoutStatus={initialCheckoutStatus}
           initialCheckoutAmountMilliDollars={initialCheckoutAmountMilliDollars}
+          courseLabel={courseLabel}
         />
       </div>
 
@@ -422,17 +429,23 @@ function CreditPoolSection({
   stripePurchasingEnabled,
   initialCheckoutStatus,
   initialCheckoutAmountMilliDollars,
+  courseLabel,
 }: {
   useCustomApiKeys: boolean;
   canEdit: boolean;
   stripePurchasingEnabled: boolean;
   initialCheckoutStatus: 'success' | 'cancelled' | null;
   initialCheckoutAmountMilliDollars: number | null;
+  courseLabel: string;
 }) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const purchaseModalState = useModalState();
+  const redeemModalState = useModalState();
   const [checkoutStatus, setCheckoutStatus] = useState(initialCheckoutStatus);
+  const [redeemSuccessAmount, setRedeemSuccessAmount] = useState<number | null>(null);
+
+  const freeCreditStatusQuery = useQuery(trpc.freeCreditStatus.queryOptions());
 
   // Mirror the empty-state detection in `CreditPoolDashboard`. These reads share
   // a TanStack cache with the dashboard, so they don't trigger extra fetches.
@@ -461,6 +474,11 @@ function CreditPoolSection({
     }
   }, [initialCheckoutStatus, queryClient, trpc]);
 
+  const freeCreditStatus = freeCreditStatusQuery.data;
+  const freeCreditStatusLoaded = freeCreditStatus != null;
+  const hasFreeCreditAvailable =
+    freeCreditStatusLoaded && freeCreditStatus.redemptions_remaining > 0;
+
   return (
     <div className="border-top pt-3 mt-3">
       {checkoutStatus === 'success' && (
@@ -472,6 +490,12 @@ function CreditPoolSection({
           added to your course instance.
         </Alert>
       )}
+      {redeemSuccessAmount != null && (
+        <Alert variant="success" dismissible onClose={() => setRedeemSuccessAmount(null)}>
+          <i className="bi bi-check-circle-fill me-2" aria-hidden="true" />
+          {formatMilliDollars(redeemSuccessAmount)} in credits were added to your course instance.
+        </Alert>
+      )}
       {checkoutStatus === 'cancelled' && (
         <Alert variant="info" dismissible onClose={() => setCheckoutStatus(null)}>
           Payment cancelled. No credits were added.
@@ -479,7 +503,7 @@ function CreditPoolSection({
       )}
       <div
         className={clsx(
-          'd-flex justify-content-between align-items-center',
+          'd-flex justify-content-between align-items-center flex-wrap gap-2',
           useCustomApiKeys ? 'mb-1' : 'mb-3',
         )}
       >
@@ -487,18 +511,35 @@ function CreditPoolSection({
           <h2 className="h5 mb-0">AI grading credits</h2>
           {useCustomApiKeys && <span className="badge text-bg-secondary">Inactive</span>}
         </div>
-        {stripePurchasingEnabled && !isCreditPoolEmpty && (
-          <button
-            type="button"
-            className="btn btn-sm btn-primary d-flex align-items-center gap-2"
-            disabled={!canEdit}
-            title={!canEdit ? 'You must be a course owner to purchase credits' : undefined}
-            style={!canEdit ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
-            onClick={() => purchaseModalState.showWithData(null)}
-          >
-            <i className="bi bi-cart-plus" aria-hidden="true" />
-            Purchase credits
-          </button>
+        {!isCreditPoolEmpty && (
+          <div className="d-flex align-items-center gap-2 flex-wrap">
+            {hasFreeCreditAvailable && (
+              <button
+                type="button"
+                className="btn btn-sm btn-success d-flex align-items-center gap-2"
+                disabled={!canEdit}
+                title={!canEdit ? 'You must be a course owner to redeem free credit' : undefined}
+                style={!canEdit ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
+                onClick={() => redeemModalState.showWithData(null)}
+              >
+                <i className="bi bi-gift" aria-hidden="true" />
+                Redeem free credit
+              </button>
+            )}
+            {stripePurchasingEnabled && freeCreditStatusLoaded && (
+              <button
+                type="button"
+                className="btn btn-sm btn-primary d-flex align-items-center gap-2"
+                disabled={!canEdit}
+                title={!canEdit ? 'You must be a course owner to purchase credits' : undefined}
+                style={!canEdit ? { opacity: 0.5, cursor: 'not-allowed' } : undefined}
+                onClick={() => purchaseModalState.showWithData(null)}
+              >
+                <i className="bi bi-cart-plus" aria-hidden="true" />
+                Purchase credits
+              </button>
+            )}
+          </div>
         )}
       </div>
       {useCustomApiKeys && (
@@ -515,8 +556,18 @@ function CreditPoolSection({
             ? () => purchaseModalState.showWithData(null)
             : undefined
         }
+        onRedeemFreeCreditClick={
+          hasFreeCreditAvailable && canEdit ? () => redeemModalState.showWithData(null) : undefined
+        }
       />
       <PurchaseCreditsModal {...purchaseModalState} />
+      <RedeemFreeCreditModal
+        {...redeemModalState}
+        redemptionsRemaining={freeCreditStatus?.redemptions_remaining ?? 0}
+        maxRedemptions={freeCreditStatus?.max_redemptions ?? 0}
+        courseLabel={courseLabel}
+        onSuccess={setRedeemSuccessAmount}
+      />
     </div>
   );
 }

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/instructorInstanceAdminAiGrading.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/instructorInstanceAdminAiGrading.tsx
@@ -39,6 +39,7 @@ router.get(
     }
 
     const {
+      course,
       course_instance: courseInstance,
       authz_data: authzData,
       authn_user,
@@ -123,6 +124,7 @@ router.get(
               stripePurchasingEnabled={stripePurchasingEnabled}
               initialCheckoutStatus={checkoutStatus}
               initialCheckoutAmountMilliDollars={checkoutAmountMilliDollars}
+              courseLabel={course.short_name}
             />
           </Hydrate>
         ),

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/trpc.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/trpc.ts
@@ -18,9 +18,14 @@ import {
   MIN_PURCHASE_MILLI_DOLLARS,
   calculateCreditPurchaseCharge,
 } from '../../lib/ai-grading-credit-purchase-constants.js';
+import { MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE } from '../../lib/ai-grading-free-credit-constants.js';
 import { getOrCreateStripeCustomerId, getStripeClient } from '../../lib/billing/stripe.js';
 import { creditPoolProcedures, requireAiGradingFeature } from '../../lib/credit-pool-trpc.js';
 import { insertCreditCheckoutSession } from '../../models/ai-grading-credit-checkout-sessions.js';
+import {
+  redeemFreeAiGradingCredit,
+  selectCourseFreeCreditRedemptionsUsed,
+} from '../../models/ai-grading-free-credit-redemption.js';
 
 import { formatCredential } from './utils/format.js';
 
@@ -196,12 +201,45 @@ const createCheckoutMutation = t.procedure
     return { checkoutUrl: session.url };
   });
 
+const freeCreditStatusQuery = t.procedure.use(requireAiGradingFeature).query(async (opts) => {
+  const redemptionsUsed = await selectCourseFreeCreditRedemptionsUsed(opts.ctx.course.id);
+  return {
+    redemptions_used: redemptionsUsed,
+    redemptions_remaining: Math.max(
+      0,
+      MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE - redemptionsUsed,
+    ),
+    max_redemptions: MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE,
+  };
+});
+
+const redeemFreeCreditMutation = t.procedure
+  .use(requireEditPermission)
+  .use(requireAiGradingFeature)
+  .mutation(async (opts) => {
+    const redemptionsUsed = await selectCourseFreeCreditRedemptionsUsed(opts.ctx.course.id);
+    if (redemptionsUsed >= MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: `This course has already used all ${MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE} free AI grading credit redemptions.`,
+      });
+    }
+
+    return await redeemFreeAiGradingCredit({
+      course_id: opts.ctx.course.id,
+      course_instance_id: opts.ctx.course_instance.id,
+      user_id: opts.ctx.authn_user.id,
+    });
+  });
+
 export const aiGradingSettingsRouter = t.router({
   ...creditPoolProcedures,
   updateUseCustomApiKeys: updateUseCustomApiKeysMutation,
   addCredential: addCredentialMutation,
   deleteCredential: deleteCredentialMutation,
   createCheckout: createCheckoutMutation,
+  freeCreditStatus: freeCreditStatusQuery,
+  redeemFreeCredit: redeemFreeCreditMutation,
 });
 
 export type AiGradingSettingsRouter = typeof aiGradingSettingsRouter;

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/trpc.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminAiGrading/trpc.ts
@@ -217,14 +217,6 @@ const redeemFreeCreditMutation = t.procedure
   .use(requireEditPermission)
   .use(requireAiGradingFeature)
   .mutation(async (opts) => {
-    const redemptionsUsed = await selectCourseFreeCreditRedemptionsUsed(opts.ctx.course.id);
-    if (redemptionsUsed >= MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE) {
-      throw new TRPCError({
-        code: 'PRECONDITION_FAILED',
-        message: `This course has already used all ${MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE} free AI grading credit redemptions.`,
-      });
-    }
-
     return await redeemFreeAiGradingCredit({
       course_id: opts.ctx.course.id,
       course_instance_id: opts.ctx.course_instance.id,

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -722,6 +722,7 @@ export const ClientFingerprintSchema = z.object({
 export type ClientFingerprint = z.infer<typeof ClientFingerprintSchema>;
 
 export const CourseSchema = z.object({
+  ai_grading_free_credit_redemptions_used: z.number(),
   announcement_color: z.string().nullable(),
   announcement_html: z.string().nullable(),
   branch: z.string(),

--- a/apps/prairielearn/src/migrations/20260425024058_courses__ai_grading_free_credit_redemptions_used__add.sql
+++ b/apps/prairielearn/src/migrations/20260425024058_courses__ai_grading_free_credit_redemptions_used__add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE courses
+ADD COLUMN ai_grading_free_credit_redemptions_used INT NOT NULL DEFAULT 0 CONSTRAINT courses_ai_grading_free_credit_redemptions_used_check CHECK (ai_grading_free_credit_redemptions_used >= 0);

--- a/apps/prairielearn/src/models/audit-event.types.ts
+++ b/apps/prairielearn/src/models/audit-event.types.ts
@@ -40,7 +40,7 @@ export type SupportedTableActionCombination =
     }
   | {
       tableName: 'courses';
-      actionDetail?: null;
+      actionDetail?: 'ai_grading_free_credit_redemption' | null;
     }
   | {
       tableName: 'users';

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AiGradingModelSelectionModal.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AiGradingModelSelectionModal.tsx
@@ -22,8 +22,11 @@ type AiGradingAvailabilityState =
   | { kind: 'concurrency_limit'; maxConcurrentJobs: number }
   | { kind: 'no_keys' }
   | { kind: 'ready_with_keys' }
-  | { kind: 'no_credits' }
-  | { kind: 'ready_with_credits'; creditBalanceMilliDollars: number };
+  | { kind: 'no_credits'; freeCreditRedemptionsRemaining: number }
+  | {
+      kind: 'ready_with_credits';
+      creditBalanceMilliDollars: number;
+    };
 
 export type AiGradingModelSelectionModalState =
   | { type: 'all'; numToGrade: number }
@@ -300,11 +303,20 @@ function AiGradingAvailabilityAlert({
         };
       case 'no_credits':
         return {
-          variant: 'danger',
+          variant: 'info',
           content: (
             <>
-              No credits remaining. Purchase credits on the{' '}
-              <SettingsLink url={aiGradingSettingsUrl} text="AI grading settings" /> page.
+              No credits added.{' '}
+              {state.freeCreditRedemptionsRemaining > 0 ? (
+                <>
+                  Redeem <strong>free credit</strong> or purchase credits{' '}
+                  <SettingsLink url={aiGradingSettingsUrl} text="here" />.
+                </>
+              ) : (
+                <>
+                  Purchase credits <SettingsLink url={aiGradingSettingsUrl} text="here" />.
+                </>
+              )}
             </>
           ),
         };
@@ -314,7 +326,7 @@ function AiGradingAvailabilityAlert({
   });
 
   return (
-    <Alert variant={variant} className="mb-3 py-2 small">
+    <Alert variant={variant} className="mb-3 py-2">
       {content}
     </Alert>
   );
@@ -401,8 +413,12 @@ export function AiGradingModelSelectionModal({
     if (isAvailabilityFetching || aiGradingAvailabilityInfo == null) return { kind: 'loading' };
     if (isAvailabilityError) return { kind: 'error' };
 
-    const { running_job_count, max_concurrent_jobs, credit_balance_milli_dollars } =
-      aiGradingAvailabilityInfo;
+    const {
+      running_job_count,
+      max_concurrent_jobs,
+      credit_balance_milli_dollars,
+      free_credit_redemptions_remaining,
+    } = aiGradingAvailabilityInfo;
 
     if (running_job_count >= max_concurrent_jobs) {
       return { kind: 'concurrency_limit', maxConcurrentJobs: max_concurrent_jobs };
@@ -411,7 +427,12 @@ export function AiGradingModelSelectionModal({
       if (availableProviders.length === 0) return { kind: 'no_keys' };
       return { kind: 'ready_with_keys' };
     }
-    if (credit_balance_milli_dollars <= 0) return { kind: 'no_credits' };
+    if (credit_balance_milli_dollars <= 0) {
+      return {
+        kind: 'no_credits',
+        freeCreditRedemptionsRemaining: free_credit_redemptions_remaining,
+      };
+    }
     return {
       kind: 'ready_with_credits',
       creditBalanceMilliDollars: credit_balance_milli_dollars,

--- a/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
+++ b/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
@@ -20,8 +20,10 @@ import {
   aiGrade,
   getRunningAiGradingJobCountForCourseInstance,
 } from '../../ee/lib/ai-grading/ai-grading.js';
+import { MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE } from '../../ee/lib/ai-grading-free-credit-constants.js';
 import { deleteAiInstanceQuestionGroups } from '../../ee/lib/ai-instance-question-grouping/ai-instance-question-grouping-util.js';
 import { aiInstanceQuestionGrouping } from '../../ee/lib/ai-instance-question-grouping/ai-instance-question-grouping.js';
+import { selectCourseFreeCreditRedemptionsUsed } from '../../ee/models/ai-grading-free-credit-redemption.js';
 import { features } from '../../lib/features/index.js';
 import { generateJobSequenceToken } from '../../lib/generateJobSequenceToken.js';
 import { idsEqual } from '../../lib/id.js';
@@ -230,19 +232,26 @@ const aiGradingAvailabilityInfo = t.procedure
       max_concurrent_jobs: z.number(),
       credit_balance_milli_dollars: z.number(),
       has_prior_jobs: z.boolean(),
+      free_credit_redemptions_remaining: z.number(),
     }),
   )
   .query(async (opts) => {
-    const [running_job_count, creditPool, has_prior_jobs] = await Promise.all([
-      getRunningAiGradingJobCountForCourseInstance(opts.ctx.course_instance.id),
-      selectCreditPool(opts.ctx.course_instance.id),
-      hasPriorAiGradingJobs(opts.ctx.assessment_question.id),
-    ]);
+    const [running_job_count, creditPool, has_prior_jobs, freeCreditRedemptionsUsed] =
+      await Promise.all([
+        getRunningAiGradingJobCountForCourseInstance(opts.ctx.course_instance.id),
+        selectCreditPool(opts.ctx.course_instance.id),
+        hasPriorAiGradingJobs(opts.ctx.assessment_question.id),
+        selectCourseFreeCreditRedemptionsUsed(opts.ctx.course.id),
+      ]);
     return {
       running_job_count,
       max_concurrent_jobs: MAX_CONCURRENT_AI_GRADING_JOBS_PER_COURSE_INSTANCE,
       credit_balance_milli_dollars: creditPool.total_milli_dollars,
       has_prior_jobs,
+      free_credit_redemptions_remaining: Math.max(
+        0,
+        MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE - freeCreditRedemptionsUsed,
+      ),
     };
   });
 

--- a/database/tables/courses.pg
+++ b/database/tables/courses.pg
@@ -1,4 +1,5 @@
 columns
+    ai_grading_free_credit_redemptions_used: integer not null default 0
     announcement_color: text
     announcement_html: text
     branch: text not null default 'master'::text
@@ -31,6 +32,9 @@ indexes
     courses_sharing_name_key: UNIQUE (sharing_name) USING btree (sharing_name)
     courses_sharing_token_key: UNIQUE (sharing_token) USING btree (sharing_token)
     courses_example_course_key: USING btree (example_course)
+
+check constraints
+    courses_ai_grading_free_credit_redemptions_used_check: CHECK (ai_grading_free_credit_redemptions_used >= 0)
 
 foreign-key constraints
     courses_institution_id_fkey: FOREIGN KEY (institution_id) REFERENCES institutions(id) ON UPDATE CASCADE ON DELETE SET NULL


### PR DESCRIPTION
# Description

Adds a free AI grading credit redemption flow. Each course can redeem $1 of non-transferable AI grading credits up to 3 times across all of its course instances.

- Adds a `courses.ai_grading_free_credit_redemptions_used` column (with a non-negative `CHECK` constraint) and a corresponding migration.
- Adds an `ai_grading_free_credit_redemption` audit event type, written in the same transaction as the credit pool update and counter increment.
- Adds a `RedeemFreeCreditModal` and a tRPC endpoint that powers a "Redeem free credit" button on the AI grading settings page and on the credit-pool empty state.
- Surfaces the redemption option in the AI grading model-selection modal when the course instance has no remaining credits, so instructors can unblock themselves without leaving the grading flow.

This PR is **stacked on #14938** (`miguelaenlle/ai-grading-ux-enhancements`) and should be merged after that one. To review only this PR's changes, set the GitHub base picker to `miguelaenlle/ai-grading-ux-enhancements`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

- New unit tests in `apps/prairielearn/src/ee/models/ai-grading-free-credit-redemption.test.ts` cover the happy path (credits added, counter incremented) and the lifetime cap (rejecting redemptions past `MAX_FREE_AI_GRADING_CREDIT_REDEMPTIONS_PER_COURSE`).