### PR TITLE
Redirect to assessment after PrairieTest -> PrairieLearn auth

### DIFF
--- a/apps/prairielearn/src/ee/auth/prairietestCallback.ts
+++ b/apps/prairielearn/src/ee/auth/prairietestCallback.ts
@@ -8,12 +8,15 @@ import { z } from 'zod';
 import { HttpStatusError } from '@prairielearn/error';
 
 import * as authnLib from '../../lib/authn.js';
+import { getStudentAssessmentUrl } from '../../lib/client/url.js';
 import { config } from '../../lib/config.js';
 
 const router = Router({ mergeParams: true });
 
 const PrairieTestJwtPayloadSchema = z.object({
-  user_id: z.union([z.string(), z.number()]),
+  user_id: z.string(),
+  course_instance_id: z.string().optional(),
+  assessment_id: z.string().optional(),
 });
 
 router.post(
@@ -26,9 +29,27 @@ router.post(
 
     const key = crypto.createSecretKey(config.prairieTestAuthSecret, 'utf-8');
     const { payload } = await jose.jwtVerify(jwt, key, { audience: 'prairielearn' });
-    const { user_id } = PrairieTestJwtPayloadSchema.parse(payload);
+    const { user_id, course_instance_id, assessment_id } =
+      PrairieTestJwtPayloadSchema.parse(payload);
 
-    await authnLib.loadUser(req, res, { user_id, provider: 'PrairieTest' }, { redirect: true });
+    if ((course_instance_id === undefined) !== (assessment_id === undefined)) {
+      throw new HttpStatusError(
+        400,
+        'course_instance_id and assessment_id must both be present or both absent',
+      );
+    }
+
+    const redirectUrl =
+      course_instance_id !== undefined && assessment_id !== undefined
+        ? getStudentAssessmentUrl(course_instance_id, assessment_id)
+        : undefined;
+
+    await authnLib.loadUser(
+      req,
+      res,
+      { user_id, provider: 'PrairieTest' },
+      { redirect: true, redirectUrl },
+    );
   }),
 );
 

--- a/apps/prairielearn/src/lib/authn.ts
+++ b/apps/prairielearn/src/lib/authn.ts
@@ -57,6 +57,8 @@ async function handlePendingLti13User({
 interface LoadUserOptions {
   /** Redirect after processing? */
   redirect?: boolean;
+  /** Override the post-auth redirect target. Only used when `redirect` is true. */
+  redirectUrl?: string;
 }
 
 export async function loadUser(
@@ -141,7 +143,9 @@ export async function loadUser(
 
   if (options.redirect) {
     let redirUrl = '/';
-    if ('pl2_pre_auth_url' in req.cookies) {
+    if (options.redirectUrl !== undefined) {
+      redirUrl = options.redirectUrl;
+    } else if ('pl2_pre_auth_url' in req.cookies) {
       redirUrl = req.cookies.pl2_pre_auth_url;
       clearCookie(res, ['preAuthUrl', 'pl2_pre_auth_url']);
     }

--- a/apps/prairielearn/src/lib/authn.ts
+++ b/apps/prairielearn/src/lib/authn.ts
@@ -145,6 +145,8 @@ export async function loadUser(
     let redirUrl = '/';
     if (options.redirectUrl !== undefined) {
       redirUrl = options.redirectUrl;
+      // Clear cookies here as well so it doesn't affect a later login redirect
+      clearCookie(res, ['preAuthUrl', 'pl2_pre_auth_url']);
     } else if ('pl2_pre_auth_url' in req.cookies) {
       redirUrl = req.cookies.pl2_pre_auth_url;
       clearCookie(res, ['preAuthUrl', 'pl2_pre_auth_url']);

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -474,7 +474,7 @@ export async function initExpress(): Promise<Express> {
     // Must come before the authn middleware since the user isn't authenticated yet,
     // and before the CSRF middleware since the JWT signature is the auth proof.
     app.use(
-      '/pl/prairietest/auth/callback',
+      '/pl/auth/prairietest/callback',
       (await import('./ee/auth/prairietestCallback.js')).default,
     );
   }


### PR DESCRIPTION
# Description

Follow-up to #14920. Extends the inbound PT → PL auth callback so PrairieTest can hand a student directly into a specific assessment, instead of dropping them on PL's home page where they'd otherwise navigate to the assessment via a separately-constructed URL (and possibly hit a login wall first).

- `LoadUserOptions` gains an optional `redirectUrl`. When set, it takes precedence over the `pl2_pre_auth_url` cookie inside `loadUser`. The existing terms-page gate (`redirectToTermsPageIfNeeded`) still wraps the final redirect — kept inside `authn.ts` so it doesn't get duplicated into the EE callback.
- `prairietestCallback.ts` now accepts optional `course_instance_id` + `assessment_id` claims. They must be present or absent together (400 if only one is present). When both are present, the callback builds the URL via the existing `getStudentAssessmentUrl` helper in `lib/client/url.ts` and passes it through as `redirectUrl`.
- Tightened the JWT payload schema to `z.string()` for all id fields. PrairieTest is the only caller and reads these from Postgres queries, so they always arrive as strings.

The matching PrairieTest-side change (replacing the direct `res.redirect(${plHost}/pl/course_instance/.../assessment/...)` in `studentReservation.tsx` with a self-submitting JWT POST form to this callback) will land in a separate PT PR.

- [x] AI assistance disclosure: drafted with Claude Code; reviewed and adjusted by hand.

# Testing

End-to-end testing requires the matching PrairieTest-side PR. Once that lands, manual verification will be: trigger PT's "Start exam" flow on an exam with one linked PL assessment, confirm the user lands authenticated on the assessment page (not on PL's home or login). Confirm that a JWT carrying only `course_instance_id` (without `assessment_id`, or vice versa) is rejected with a 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)