### PR TITLE
Allow for removal of sharing sets via JSON file

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/sharing.sql
+++ b/apps/prairielearn/src/sync/fromDisk/sharing.sql
@@ -21,6 +21,12 @@ ON CONFLICT (course_id, name) DO UPDATE
 SET
   description = EXCLUDED.description;
 
+-- BLOCK delete_removed_course_sharing_sets
+DELETE FROM sharing_sets
+WHERE
+  course_id = $course_id
+  AND NOT (name = ANY ($sharing_set_names::text[]));
+
 -- BLOCK select_course_sharing_sets
 SELECT
   ss.name,

--- a/apps/prairielearn/src/sync/fromDisk/sharing.ts
+++ b/apps/prairielearn/src/sync/fromDisk/sharing.ts
@@ -24,6 +24,10 @@ export async function sync(
     new_course_sharing_sets: JSON.stringify(courseSharingSetsData),
   });
 
+  // Relies on `checkInvalidSharingSetDeletions` having gated the sync. With
+  // `checkSharingOnSync` disabled, this can cascade-delete rows in
+  // `sharing_set_questions` and `sharing_set_courses` via the ON DELETE CASCADE
+  // foreign keys.
   await sqldb.execute(sql.delete_removed_course_sharing_sets, {
     course_id: courseId,
     sharing_set_names: courseSharingSetsData.map((ss) => ss.name),

--- a/apps/prairielearn/src/sync/fromDisk/sharing.ts
+++ b/apps/prairielearn/src/sync/fromDisk/sharing.ts
@@ -17,9 +17,16 @@ export async function sync(
     return;
   }
 
+  const courseSharingSetsData = courseData.course.data?.sharingSets ?? [];
+
   await sqldb.execute(sql.sync_course_sharing_sets, {
     course_id: courseId,
-    new_course_sharing_sets: JSON.stringify(courseData.course.data?.sharingSets ?? []),
+    new_course_sharing_sets: JSON.stringify(courseSharingSetsData),
+  });
+
+  await sqldb.execute(sql.delete_removed_course_sharing_sets, {
+    course_id: courseId,
+    sharing_set_names: courseSharingSetsData.map((ss) => ss.name),
   });
 
   const courseSharingSets = await sqldb.queryRows(

--- a/apps/prairielearn/src/sync/sharing.sql
+++ b/apps/prairielearn/src/sync/sharing.sql
@@ -19,7 +19,7 @@ WHERE
     )
   );
 
--- BLOCK select_referenced_sharing_set_deletions
+-- BLOCK select_blocked_sharing_set_deletions
 SELECT
   ss.name
 FROM

--- a/apps/prairielearn/src/sync/sharing.sql
+++ b/apps/prairielearn/src/sync/sharing.sql
@@ -19,13 +19,32 @@ WHERE
     )
   );
 
--- BLOCK select_sharing_sets
+-- BLOCK select_referenced_sharing_set_deletions
 SELECT
   ss.name
 FROM
   sharing_sets AS ss
 WHERE
-  ss.course_id = $course_id;
+  ss.course_id = $course_id
+  AND NOT (ss.name = ANY ($sharing_set_names::text[]))
+  AND (
+    EXISTS (
+      SELECT
+        1
+      FROM
+        sharing_set_questions AS ssq
+      WHERE
+        ssq.sharing_set_id = ss.id
+    )
+    OR EXISTS (
+      SELECT
+        1
+      FROM
+        sharing_set_courses AS ssc
+      WHERE
+        ssc.sharing_set_id = ss.id
+    )
+  );
 
 -- BLOCK select_question_sharing_sets
 WITH

--- a/apps/prairielearn/src/sync/sharing.ts
+++ b/apps/prairielearn/src/sync/sharing.ts
@@ -82,7 +82,7 @@ export async function checkInvalidSharingSetDeletions(
 ): Promise<boolean> {
   const sharingSetNames = (courseData.course.data?.sharingSets ?? []).map((ss) => ss.name);
   const invalidSharingSetDeletions = await sqldb.queryScalars(
-    sql.select_referenced_sharing_set_deletions,
+    sql.select_blocked_sharing_set_deletions,
     { course_id: courseId, sharing_set_names: sharingSetNames },
     z.string(),
   );

--- a/apps/prairielearn/src/sync/sharing.ts
+++ b/apps/prairielearn/src/sync/sharing.ts
@@ -80,24 +80,17 @@ export async function checkInvalidSharingSetDeletions(
   courseData: CourseData,
   logger: ServerJobLogger,
 ): Promise<boolean> {
-  const sharingSets = await sqldb.queryScalars(
-    sql.select_sharing_sets,
-    { course_id: courseId },
+  const sharingSetNames = (courseData.course.data?.sharingSets ?? []).map((ss) => ss.name);
+  const invalidSharingSetDeletions = await sqldb.queryScalars(
+    sql.select_referenced_sharing_set_deletions,
+    { course_id: courseId, sharing_set_names: sharingSetNames },
     z.string(),
   );
-
-  const invalidSharingSetDeletions: string[] = [];
-  const sharingSetNames = new Set((courseData.course.data?.sharingSets || []).map((ss) => ss.name));
-  sharingSets.forEach((sharingSet) => {
-    if (!sharingSetNames.has(sharingSet)) {
-      invalidSharingSetDeletions.push(sharingSet);
-    }
-  });
 
   const existInvalidSharingSetDeletions = invalidSharingSetDeletions.length > 0;
   if (existInvalidSharingSetDeletions) {
     logger.error(
-      `✖ Course sync completely failed. The following sharing sets cannot be removed from 'infoCourse.json': ${invalidSharingSetDeletions.join(', ')}`,
+      `✖ Course sync completely failed. The following sharing sets are still in use and cannot be removed from 'infoCourse.json': ${invalidSharingSetDeletions.join(', ')}`,
     );
   }
   return existInvalidSharingSetDeletions;

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -612,6 +612,83 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
     });
 
     test.sequential(
+      'Delete a referenced sharing set, ensure sync error message identifies it',
+      async () => {
+        const saveSharingSets = sharingCourseData.course.sharingSets || [];
+        sharingCourseData.course.sharingSets = saveSharingSets.filter(
+          (ss) => ss.name !== SHARING_SET_NAME,
+        );
+        await fs.writeJSON(
+          path.join(courseRepo.courseLiveDir, 'infoCourse.json'),
+          sharingCourseData.course,
+        );
+
+        const { logger: capturedLogger, getOutput } = makeMockLogger();
+        const syncResult = await syncFromDisk.syncOrCreateDiskToSql(
+          courseRepo.courseLiveDir,
+          capturedLogger,
+        );
+        assert.equal(syncResult.status, 'sharing_error');
+        assert.match(
+          getOutput(),
+          new RegExp(
+            `The following sharing sets are still in use and cannot be removed from 'infoCourse\\.json': ${SHARING_SET_NAME}`,
+          ),
+        );
+
+        await execa('git', ['clean', '-fdx'], { cwd: courseRepo.courseLiveDir });
+        await execa('git', ['reset', '--hard', 'HEAD'], { cwd: courseRepo.courseLiveDir });
+        const restoreSync = await syncFromDisk.syncOrCreateDiskToSql(
+          courseRepo.courseLiveDir,
+          logger,
+        );
+        assert.equal(restoreSync.status, 'complete');
+
+        sharingCourseData.course.sharingSets = saveSharingSets;
+      },
+    );
+
+    test.sequential(
+      'Delete an unreferenced sharing set, ensure live syncs and removes it',
+      async () => {
+        const newSharingSetName = 'unreferenced-share-set';
+        const saveSharingSets = sharingCourseData.course.sharingSets || [];
+        sharingCourseData.course.sharingSets = [
+          ...saveSharingSets,
+          { name: newSharingSetName, description: 'no references' },
+        ];
+        await fs.writeJSON(
+          path.join(courseRepo.courseLiveDir, 'infoCourse.json'),
+          sharingCourseData.course,
+        );
+
+        let syncResult = await syncUtil.syncCourseData(courseRepo.courseLiveDir);
+        assert.equal(syncResult.status, 'complete');
+        const createdId = await sqldb.queryOptionalScalar(
+          sql.select_sharing_set,
+          { sharing_set_name: newSharingSetName },
+          IdSchema,
+        );
+        assert.isNotNull(createdId);
+
+        sharingCourseData.course.sharingSets = saveSharingSets;
+        await fs.writeJSON(
+          path.join(courseRepo.courseLiveDir, 'infoCourse.json'),
+          sharingCourseData.course,
+        );
+
+        syncResult = await syncUtil.syncCourseData(courseRepo.courseLiveDir);
+        assert.equal(syncResult.status, 'complete');
+        const remainingId = await sqldb.queryOptionalScalar(
+          sql.select_sharing_set,
+          { sharing_set_name: newSharingSetName },
+          IdSchema,
+        );
+        assert.isNull(remainingId);
+      },
+    );
+
+    test.sequential(
       'Adding question to sharing set that does not exist, ensure sync error is created',
       async () => {
         const saveSharingSets = sharingCourseData.questions[SHARING_QUESTION_QID].sharingSets || [];

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -601,7 +601,8 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
     test.sequential(
       'Delete a referenced sharing set, ensure sync error message identifies it',
       async () => {
-        const saveSharingSets = sharingCourseData.course.sharingSets || [];
+        assert(sharingCourseData.course.sharingSets);
+        const saveSharingSets = sharingCourseData.course.sharingSets;
         sharingCourseData.course.sharingSets = saveSharingSets.filter(
           (ss) => ss.name !== SHARING_SET_NAME,
         );
@@ -639,7 +640,8 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
       'Delete an unreferenced sharing set, ensure live syncs and removes it',
       async () => {
         const newSharingSetName = 'unreferenced-share-set';
-        const saveSharingSets = sharingCourseData.course.sharingSets || [];
+        assert(sharingCourseData.course.sharingSets);
+        const saveSharingSets = sharingCourseData.course.sharingSets;
         sharingCourseData.course.sharingSets = [
           ...saveSharingSets,
           { name: newSharingSetName, description: 'no references' },

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -598,19 +598,6 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
       },
     );
 
-    test.sequential('Delete a sharing set, ensure live does not sync it', async () => {
-      const saveSharingSets = sharingCourseData.course.sharingSets || [];
-      sharingCourseData.course.sharingSets = [];
-      await fs.writeJSON(
-        path.join(courseRepo.courseLiveDir, 'infoCourse.json'),
-        sharingCourseData.course,
-      );
-
-      await ensureInvalidSharingOperationFailsToSync();
-
-      sharingCourseData.course.sharingSets = saveSharingSets;
-    });
-
     test.sequential(
       'Delete a referenced sharing set, ensure sync error message identifies it',
       async () => {
@@ -685,6 +672,9 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
           IdSchema,
         );
         assert.isNull(remainingId);
+
+        await execa('git', ['clean', '-fdx'], { cwd: courseRepo.courseLiveDir });
+        await execa('git', ['reset', '--hard', 'HEAD'], { cwd: courseRepo.courseLiveDir });
       },
     );
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Removing a sharing set from infoCourse.json produces a sync error. Course staff must first delete the row out of the DB through some other means before they can drop it from the JSON, which can cause an inconsistent state.

This PR makes it so the json file is the source of truth. The sharing sets listed on it are the correct ones, which means that when a sharing set is removed from the JSON, the sync code verifies if it is referenced by any questions or courses, and if it isn't, the sharing set is removed. If it is, sync fails normally.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

The existing sharing set tests pass, and new tests have been added for both of the possible sync results (fail and removal)