### PR TITLE
Align question and score visibility dropdowns

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -46,19 +46,19 @@ const QUESTION_VISIBILITY_ITEMS: RichSelectItem<HideQuestionsMode>[] = [
 
 const SCORE_VISIBILITY_ITEMS: RichSelectItem<HideScoreMode>[] = [
   {
-    value: 'show_score',
-    label: 'Show score after completion',
-    description: 'Students can see their score immediately after completing the assessment',
-  },
-  {
     value: 'hide_score_forever',
     label: 'Hide score permanently',
     description: 'Score will never be visible after completion',
   },
   {
+    value: 'show_score',
+    label: 'Show score after completion',
+    description: 'Students can see their score immediately after completing the assessment',
+  },
+  {
     value: 'hide_score_until_date',
-    label: 'Hide score until date',
-    description: 'Score will be hidden after completion and become visible again on this date',
+    label: 'Show score after date',
+    description: 'Score will be hidden after completion and become visible on this date',
   },
 ];
 
@@ -327,7 +327,7 @@ function ScoreVisibilityInput({
             id={`${idPrefix}-show-score-date`}
             type="datetime-local"
             step={1}
-            aria-label="Show score again on"
+            aria-label="Show score on"
             value={value.visibleFromDate ?? ''}
             isInvalid={visibleFromDateInvalid}
             aria-invalid={visibleFromDateInvalid}

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -121,9 +121,9 @@ Question visibility options:
 
 Score visibility options:
 
-- **Show score after completion**: students can see their score immediately.
 - **Hide score permanently**: the score is never visible after completion.
-- **Hide score until date**: the score is hidden after completion and becomes visible on the chosen date.
+- **Show score after completion**: students can see their score immediately.
+- **Show score after date**: the score is hidden after completion and becomes visible on the chosen date.
 
 For PrairieTest exams, top-level after-completion settings apply outside an active reservation. Use the per-exam PrairieTest visibility setting to control what students see while their reservation is still active.
 
@@ -316,7 +316,7 @@ In the UI:
 4. Enable **Time limit** and enter 90 minutes.
 5. Enable **Password** and enter the password.
 6. Under **After completion**, set **Question visibility** to **Hide questions permanently**.
-7. Set **Score visibility** to **Hide score until date** and enter Mar 12.
+7. Set **Score visibility** to **Show score after date** and enter Mar 12.
 
 ??? info "JSON"
 


### PR DESCRIPTION
# Description

Addresses one of the items in #14469. Two small consistency tweaks to the "After completion" visibility dropdowns on the assessment access page:

- Reorder the **Score visibility** dropdown so "Hide score permanently" is first, matching the **Question visibility** dropdown (which already had "Hide questions permanently" first).
- Rename the date-based score option from "Hide score until date" to "Show score after date" so the paired date-based options in both dropdowns are framed the same way (previously one said "show questions after date" while the other said "hide score until date").

Docs in `accessControlModern.md` were updated to match.

Majority of implementation by Claude.

# Testing

I opened the assessment access page and confirmed the score visibility dropdown order and the renamed "Show score after date" option.

<img width="557" height="418" alt="Screenshot 2026-05-11 at 10 51 04" src="https://github.com/user-attachments/assets/b5b1374f-0eff-4559-ba4a-458f78b6f424" />
