### PR TITLE
Clarify "After completion" controls in assessment access UI

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -367,8 +367,8 @@ const infoPopoverConfig = {
     <>
       <p>
         An assessment is complete when students can no longer answer questions — for example, after
-        the due date and any late deadlines pass, after a time limit expires, or once the assessment
-        is closed (manually or via autoclose).
+        the due date and any late deadlines pass, after a time limit expires, or once their
+        assessment instance is closed (manually or via autoclose).
       </p>
       <p>
         The completion time can vary between students based on when they started or any

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -110,6 +110,9 @@ function QuestionVisibilityInput({
   displayTimezone: string;
 }) {
   const hideQuestionsMode = getHideQuestionsMode(value);
+  const selectedDescription = QUESTION_VISIBILITY_ITEMS.find(
+    (item) => item.value === hideQuestionsMode,
+  )?.description;
 
   const handleModeChange = (newMode: HideQuestionsMode) => {
     switch (newMode) {
@@ -153,6 +156,9 @@ function QuestionVisibilityInput({
           errorMessage={errorMessage}
           onChange={handleModeChange}
         />
+        {selectedDescription && (
+          <Form.Text className="text-muted d-block">{selectedDescription}</Form.Text>
+        )}
       </div>
       {hideQuestionsMode === 'hide_questions_between_dates' && (
         <div className="mt-2">
@@ -288,6 +294,9 @@ function ScoreVisibilityInput({
   displayTimezone: string;
 }) {
   const hideScoreMode = getHideScoreMode(value);
+  const selectedDescription = SCORE_VISIBILITY_ITEMS.find(
+    (item) => item.value === hideScoreMode,
+  )?.description;
 
   const handleModeChange = (newMode: HideScoreMode) => {
     switch (newMode) {
@@ -320,6 +329,9 @@ function ScoreVisibilityInput({
           errorMessage={errorMessage}
           onChange={handleModeChange}
         />
+        {selectedDescription && (
+          <Form.Text className="text-muted d-block">{selectedDescription}</Form.Text>
+        )}
       </div>
       {hideScoreMode === 'hide_score_until_date' && (
         <div className="mt-2">
@@ -354,23 +366,17 @@ const infoPopoverConfig = {
   body: (
     <>
       <p>
-        An assessment is considered complete when students can no longer answer questions. This
-        typically happens when:
-      </p>
-      <ul>
-        <li>The last late deadline passes (or due date if no late deadlines)</li>
-        <li>
-          The assessment is closed (e.g., time limit expires, autoclose, or instructor closes it)
-        </li>
-      </ul>
-      <p>
-        The completion date can be different for different students based on when they started or
-        their specific accommodations.
+        An assessment is complete when students can no longer answer questions — for example, after
+        the due date and any late deadlines pass, after a time limit expires, or once the assessment
+        is closed (manually or via autoclose).
       </p>
       <p>
-        These settings apply only when the student does not have an active PrairieTest reservation.
-        While a PrairieTest reservation is active, the per-exam settings on each PrairieTest exam
-        govern visibility instead.
+        The completion time can vary between students based on when they started or any
+        accommodations they have.
+      </p>
+      <p>
+        While a student has an active PrairieTest reservation, the per-exam settings on each
+        PrairieTest exam govern visibility instead.
       </p>
     </>
   ),
@@ -399,6 +405,9 @@ function AfterCompleteCard({
               <i className="bi bi-info-circle" aria-hidden="true" />
             </Button>
           </OverlayTrigger>
+        </div>
+        <div className="text-muted small mt-1">
+          What students can see once they can no longer answer questions on the assessment.
         </div>
       </div>
       <Row className="gy-3">{children}</Row>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
@@ -28,7 +28,8 @@ const AFTER_COMPLETE_VISIBILITY_ITEMS: RichSelectItem<AfterCompleteVisibilityMod
   {
     value: 'show_score_only',
     label: 'Show score only',
-    description: 'Students see their score but not the questions while the reservation is active',
+    description:
+      'Students see their score but not the questions after finishing while the reservation is still active',
   },
   {
     value: 'hide_questions_and_score',

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
@@ -68,6 +68,9 @@ function ExamAfterCompleteFields({ index }: { index: number }) {
   });
 
   const mode = getAfterCompleteVisibilityMode(questionsHiddenField.value, scoreHiddenField.value);
+  const selectedDescription = AFTER_COMPLETE_VISIBILITY_ITEMS.find(
+    (item) => item.value === mode,
+  )?.description;
 
   const handleModeChange = (newMode: AfterCompleteVisibilityMode) => {
     questionsHiddenField.onChange(newMode !== 'show_questions_and_score');
@@ -77,7 +80,7 @@ function ExamAfterCompleteFields({ index }: { index: number }) {
   return (
     <div className="mt-3">
       <Form.Label className="fw-bold" htmlFor={`defaultRule-exam-after-complete-${index}`}>
-        After completion (during reservation)
+        After completion
       </Form.Label>
       <RichSelect
         items={AFTER_COMPLETE_VISIBILITY_ITEMS}
@@ -88,6 +91,9 @@ function ExamAfterCompleteFields({ index }: { index: number }) {
         disabled={readOnly}
         onChange={handleModeChange}
       />
+      {!readOnly && selectedDescription && (
+        <Form.Text className="text-muted d-block">{selectedDescription}</Form.Text>
+      )}
       {readOnly && (
         <Form.Text className="text-muted d-block">
           Questions and scores are always shown during read-only reservations.

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -348,7 +348,7 @@ In the UI:
 1. Edit **Defaults**.
 2. Enable **PrairieTest** under **Integrations**.
 3. Enter the PrairieTest exam UUID.
-4. For **After completion**, choose what students can see while their reservation is still active.
+4. For **After completion**, choose what students can see after they finish, while their reservation is still active.
 5. Use the top-level **After completion** settings for what students can see after the reservation ends.
 6. Do not configure an ordinary date-control access window unless students should also be able to access the assessment outside PrairieTest.
 

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -348,7 +348,7 @@ In the UI:
 1. Edit **Defaults**.
 2. Enable **PrairieTest** under **Integrations**.
 3. Enter the PrairieTest exam UUID.
-4. For **After completion (during reservation)**, choose what students can see while their reservation is still active.
+4. For **After completion**, choose what students can see while their reservation is still active.
 5. Use the top-level **After completion** settings for what students can see after the reservation ends.
 6. Do not configure an ordinary date-control access window unless students should also be able to access the assessment outside PrairieTest.
 


### PR DESCRIPTION
# Description

Addresses two clarity items from #14469:

- The PrairieTest per-exam control labeled **"After completion (during reservation)"** dropped the parenthetical (now just **"After completion"**) and renders the selected option's description as muted help text below the select, so the picked option's meaning is visible at a glance instead of disappearing once a `RichSelect` choice is made. The same description-below-select treatment was applied to the question/score visibility selects in the top-level **After completion** card for consistency.
- The top-level **After completion** card now has a one-line subtitle (*"What students can see once they can no longer answer questions on the assessment."*) so the basic mental model doesn't require opening the popover. The popover body was reframed: the confusing bullet split between "last late deadline passes" and "assessment is closed" is replaced with prose that lists the concrete triggers (due date, late deadlines, time-limit expiry, autoclose, manual close) inline.

Docs in `accessControlModern.md` updated to match the new label.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation (Claude Code).

# Testing

New UI looks correct:

<img width="543" height="891" alt="Screenshot 2026-05-11 at 13 21 28" src="https://github.com/user-attachments/assets/1cd193eb-6500-4dd0-969f-4b9844fc43d7" />
