### PR TITLE
Skip password requirement in view-only access windows

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -442,6 +442,59 @@ describe('resolveAccessControl', () => {
     });
   });
 
+  describe('password', () => {
+    it.each<ResolveCase>([
+      {
+        name: 'propagated in submittable segment',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-03-01T00:00:00Z' },
+              due: { date: '2025-04-01T00:00:00Z' },
+              password: 'secret',
+            },
+          }),
+        ],
+        date: new Date('2025-03-15T00:00:00Z'),
+        expect: { authorized: true, submittable: true, password: 'secret' },
+      },
+      {
+        // Once submissions are disallowed, the password would gate review of
+        // already-completed work without protecting anything submittable.
+        name: 'null in view-only afterLastDeadline segment',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-03-01T00:00:00Z' },
+              due: { date: '2025-03-10T00:00:00Z' },
+              afterLastDeadline: { allowSubmissions: false },
+              password: 'secret',
+            },
+          }),
+        ],
+        date: new Date('2025-03-15T00:00:00Z'),
+        expect: { authorized: true, submittable: false, password: null },
+      },
+      {
+        name: 'propagated when afterLastDeadline still allows submissions',
+        rules: [
+          makeDefaultRule({
+            dateControl: {
+              release: { date: '2025-03-01T00:00:00Z' },
+              due: { date: '2025-03-10T00:00:00Z' },
+              afterLastDeadline: { credit: 50, allowSubmissions: true },
+              password: 'secret',
+            },
+          }),
+        ],
+        date: new Date('2025-03-15T00:00:00Z'),
+        expect: { authorized: true, submittable: true, password: 'secret' },
+      },
+    ])('$name', (c) => {
+      expect(runCase(c)).toMatchObject(c.expect);
+    });
+  });
+
   describe('beforeRelease.listed', () => {
     it.each<ResolveCase>([
       {

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -514,7 +514,11 @@ export function resolveAccessControl(
       date,
       authzMode,
     ),
-    password: rule.dateControl?.password ?? null,
+    // Password gates active participation only; once the student is in a
+    // view-only segment (e.g. afterLastDeadline.allowSubmissions: false),
+    // re-prompting for the password would gate review without protecting
+    // anything submittable.
+    password: current.submittable ? (rule.dateControl?.password ?? null) : null,
     submittable: current.submittable,
     ...visibility,
     examAccessEnd: null,

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -648,7 +648,7 @@ function generateOverrideFieldItems(
   if (overriddenFields.has('password')) {
     items.push({
       label: 'Password',
-      value: rule.password ? 'Password protected' : 'No password',
+      value: rule.password ? 'Required to start or submit' : 'No password',
       error: formErrors?.password?.message,
     });
   }
@@ -862,7 +862,7 @@ export function DateTableView({
   if (rule.password != null) {
     const error = formErrors?.password?.message;
     if (!error) {
-      footerItems.push('Password protected');
+      footerItems.push('Password required to start or submit');
     } else {
       footerItems.push(
         <span className="text-danger">

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.ts
@@ -139,6 +139,9 @@ router.post(
     // permission required to create an assessment for the effective user.
 
     if (req.body.__action === 'new_instance') {
+      if (!res.locals.authz_result.active) {
+        throw new HttpStatusError(403, 'Assessment is not currently active.');
+      }
       // Before allowing the user to create a new assessment instance, we need
       // to check if the current access rules require a password. If they do,
       // we'll ensure that the password has already been entered before allowing

--- a/apps/prairielearn/src/schemas/infoAssessment.ts
+++ b/apps/prairielearn/src/schemas/infoAssessment.ts
@@ -150,7 +150,10 @@ export const AssessmentAccessRuleJsonSchema = z
       .gte(0)
       .describe('The time limit to complete the assessment, in minutes (only for Exams).')
       .optional(),
-    password: z.string().describe('Password to begin the assessment (only for Exams).').optional(),
+    password: z
+      .string()
+      .describe('Password to begin the assessment. Typically used for proctored exams.')
+      .optional(),
     showClosedAssessment: z
       .boolean()
       .describe('Whether the student can view the assessment after it has been closed')

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -345,7 +345,7 @@
           "minimum": 0
         },
         "password": {
-          "description": "Password to begin the assessment (only for Exams).",
+          "description": "Password to begin the assessment. Typically used for proctored exams.",
           "type": "string"
         },
         "showClosedAssessment": {

--- a/docs/assessment/accessControl.md
+++ b/docs/assessment/accessControl.md
@@ -38,7 +38,7 @@ Each `accessRule` is an object that specifies a set of circumstances under which
 | [`startDate`](#dates)     | Only allow access after this date.                                                                                                         | `"startDate": "2015-01-19T00:00:01"`                       |
 | [`endDate`](#dates)       | Only allow access before this date.                                                                                                        | `"endDate": "2015-05-13T23:59:59"`                         |
 | [`mode`](#server-modes)   | Only allow access from this server mode. By default, the mode is Public, unless `examUuid` is provided, in which case the default is Exam. | `"mode": "Exam"`                                           |
-| [`password`](#passwords)  | Password required to start an assessment (only for assessments with type: Exam).                                                           | `"password": "mysecret"`                                   |
+| [`password`](#passwords)  | Password required to start an assessment. Typically used for proctored exams.                                                              | `"password": "mysecret"`                                   |
 | [`examUuid`](#exam-uuids) | PrairieTest UUID for the exam that students must register for.                                                                             | `"examUuid": "5719ebfe-ad20-42b1-b0dc-c47f0f714871"`       |
 
 Each access rule will only grant access if all the restrictions are satisfied.

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -76,7 +76,7 @@ Use **After last deadline** to decide what happens after the final due or late d
 
 Enable **Time limit** to give each student a fixed amount of working time after they start the assessment. The timer is independent of deadlines: a student who starts close to a deadline gets the full time limit, but the credit they earn shifts as each deadline passes during the attempt. For example, a student with a 60-minute time limit who starts 1 minute before the due date works for the full 60 minutes — the first minute earns the on-time credit, and the remainder earns the next late-deadline credit.
 
-Enable **Password** to require a password before a student can start the assessment. This is typically used for proctored exams.
+Enable **Password** to require a password before a student can start or continue an active attempt. This is typically used for proctored exams. The password gates active participation only — students do not need to re-enter it to review their work once submissions are no longer allowed (for example, in **No submissions allowed** mode after the last deadline).
 
 !!! info
 

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -76,7 +76,7 @@ Use **After last deadline** to decide what happens after the final due or late d
 
 Enable **Time limit** to give each student a fixed amount of working time after they start the assessment. The timer is independent of deadlines: a student who starts close to a deadline gets the full time limit, but the credit they earn shifts as each deadline passes during the attempt. For example, a student with a 60-minute time limit who starts 1 minute before the due date works for the full 60 minutes — the first minute earns the on-time credit, and the remainder earns the next late-deadline credit.
 
-Enable **Password** to require a password before a student can start or continue an active attempt. This is typically used for proctored exams. The password gates active participation only — students do not need to re-enter it to review their work once submissions are no longer allowed (for example, in **No submissions allowed** mode after the last deadline).
+Enable **Password** to require a password to start or continue working on the assessment. This is typically used for proctored exams. Students do not need to re-enter the password to review their work once submissions are no longer allowed (for example, in **No submissions allowed** mode after the last deadline).
 
 !!! info
 


### PR DESCRIPTION
# Description

Refs #14469.

In the modern access control system, the password from `dateControl.password` was propagated to `authz_result.password` regardless of which timeline segment the student was in, so the runtime password gate fired even in view-only segments (e.g. `afterLastDeadline.allowSubmissions: false`). That gated review of already-completed work without protecting anything submittable — out of step with how Canvas, Moodle, and Blackboard all scope their quiz/test passwords to active participation only.

The resolver now nulls `password` when `current.submittable` is false; the existing middleware short-circuit handles the rest. A defense-in-depth `active` check was added to the `new_instance` POST handler in `studentAssessment.ts`, since the password gate had implicitly been serving that role.

Note: this only affects modern access control. Legacy `accessRules` paths (sproc-based) are unchanged.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation (Claude Opus 4.7), reviewed and committed by Nathan.

# Testing

- Added unit tests in `resolver.test.ts` covering: password propagated in submittable segment, password nulled in `afterLastDeadline.allowSubmissions: false` segment, password propagated when `afterLastDeadline.allowSubmissions: true`.