### PR TITLE
Default new late deadlines to a clean -10 credit step

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -89,12 +89,18 @@ function computeNextDeadline({
 
   const defaultDate = candidateDate ? endOfDayDatetime(candidateDate) : '';
   const previousCredit = deadlines.at(-1)?.credit;
-  const defaultCredit =
-    previousCredit !== undefined
-      ? clampCredit(previousCredit - 1, type)
-      : isEarly
-        ? clampCredit(dueCredit + 10, 'early')
-        : clampCredit(dueCredit - 10, 'late');
+  const defaultCredit = run(() => {
+    if (isEarly) {
+      return clampCredit(
+        previousCredit !== undefined ? previousCredit - 1 : dueCredit + 10,
+        'early',
+      );
+    }
+    // Anchor at min(dueCredit, 100) so dueCredit > 100 still lands on a clean
+    // 90 instead of clamping to 99.
+    const anchor = previousCredit ?? Math.min(dueCredit, 100);
+    return clampCredit(anchor - 10, 'late');
+  });
   return { date: defaultDate, credit: defaultCredit };
 }
 


### PR DESCRIPTION
# Description

Minor UX change, largely cosmetic. Previously the first late deadline defaulted to `clampCredit(dueCredit - 10, 'late')`, which lands at 99% whenever `dueCredit > 100`, and subsequent adds stepped by only 1pt (e.g. 99 → 98 → 97). The new logic anchors the first-late default at `min(dueCredit, 100) - 10` and steps subsequent late deadlines by 10, so `dueCredit=110` yields 90 → 80 → 70 instead of 99 → 98 → 97. Early deadlines keep the -1pt step since `dueCredit + 1` is the floor and a 10pt step would immediately violate validation.

Implementation done with Claude Code.

# Testing

Manually verified: with due credit 110%, clicking "Add late" three times produces 90/80/70; with due credit 50%, two clicks produce 40/30; no validation errors in either case.