### PR TITLE
Add support for preferences in pl-template

### DIFF
--- a/apps/prairielearn/elements/pl-template/pl-template.py
+++ b/apps/prairielearn/elements/pl-template/pl-template.py
@@ -26,7 +26,7 @@ ALLOWED_PL_TAGS = frozenset((
 ))
 
 # Entries from the data dict to copy
-DATA_ENTRIES_TO_COPY = ("params",)
+DATA_ENTRIES_TO_COPY = ("params", "preferences")
 
 
 def check_tags(element_html: str) -> None:

--- a/apps/prairielearn/python/prairielearn/question_utils.py
+++ b/apps/prairielearn/python/prairielearn/question_utils.py
@@ -40,6 +40,7 @@ class QuestionData(TypedDict):
 
     Attributes:
         params: Parameters that describe the question variant.
+        preferences: Preferences for the question variant. These can be set to different values in different assessments.
         correct_answers: The true answer (if any) for the variant.
         submitted_answers: The answer submitted by the student (after parsing).
         format_errors: Any errors encountered while parsing the student input.
@@ -62,6 +63,9 @@ class QuestionData(TypedDict):
 
     params: dict[str, Any]
     """Parameters that describe the question variant."""
+
+    preferences: dict[str, Any]
+    """Preferences for the question variant. These can be set to different values in different assessments."""
 
     correct_answers: dict[str, Any]
     """The true answer (if any) for the variant."""

--- a/apps/prairielearn/python/test/conftest.py
+++ b/apps/prairielearn/python/test/conftest.py
@@ -7,6 +7,7 @@ def question_data() -> QuestionData:
     """Fixture for a question data dictionary."""
     return {
         "params": {},
+        "preferences": {},
         "correct_answers": {},
         "submitted_answers": {},
         "format_errors": {},

--- a/docs/elements/pl-template.md
+++ b/docs/elements/pl-template.md
@@ -61,7 +61,7 @@ Inside the `pl-template` element, variables for use in rendering the template ma
 
 ## Details
 
-Because of the way that elements are rendered in PrairieLearn, templates should only contain other decorative elements. In particular, **elements that accept and/or grade student input used within this element will not work correctly.** When rendering a template, all entries from `data["params"]` are included as available variables and may be used when the template is rendered. Each instance of the `pl-template` element also has a unique `uuid` variable available for rendering. Templates may also be used within other templates.
+Because of the way that elements are rendered in PrairieLearn, templates should only contain other decorative elements. In particular, **elements that accept and/or grade student input used within this element will not work correctly.** When rendering a template, all entries from `data["params"]` and `data["preferences"]` are included as available variables and may be used when the template is rendered, using the `{{params.variable_name}}` or `{{preferences.variable_name}}` syntax. Each instance of the `pl-template` element also has a unique `uuid` variable available for rendering. Templates may also be used within other templates.
 
 !!! note
 

--- a/exampleCourse/questions/element/template/info.json
+++ b/exampleCourse/questions/element/template/info.json
@@ -3,5 +3,8 @@
   "title": "Element pl-template: Template element for display",
   "topic": "Element",
   "tags": ["erobson2"],
-  "type": "v3"
+  "type": "v3",
+  "preferences": {
+    "footer": { "type": "string", "default": "This footer is set as a question preference" }
+  }
 }

--- a/exampleCourse/serverFilesCourse/templates/card_template.mustache
+++ b/exampleCourse/serverFilesCourse/templates/card_template.mustache
@@ -1,4 +1,7 @@
 <div class="card my-2">
   <div class="card-header">{{{header}}}</div>
   <div class="card-body">{{{params.inner-text}}}</div>
+  {{#preferences.footer}}
+    <div class="card-footer">{{{preferences.footer}}}</div>
+  {{/preferences.footer}}
 </div>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Closes #14968. The pl-template element is able to retrieve values from `data["params"]` during rendering. This PR also adds support for `data["preferences"]` in the element. It also adds an example in the existing question using templates, and updates the docs.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: minor auto-complete.

# Testing

Tested manually with the existing question, the preference is rendered as expected.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
