### PR TITLE
Clarify PrairieTest scope on the assessment access page

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/IntegrationsSection.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/IntegrationsSection.tsx
@@ -1,5 +1,7 @@
-import { Form } from 'react-bootstrap';
+import { Alert, Form } from 'react-bootstrap';
 import { useFormContext, useWatch } from 'react-hook-form';
+
+import { run } from '@prairielearn/run';
 
 import { PrairieTestControlForm } from './PrairieTestControlForm.js';
 import type { AccessControlFormData } from './types.js';
@@ -10,8 +12,28 @@ export function IntegrationsSection() {
   const prairieTestExams = useWatch<AccessControlFormData, 'defaultRule.prairieTestExams'>({
     name: 'defaultRule.prairieTestExams',
   });
+  const password = useWatch<AccessControlFormData, 'defaultRule.password'>({
+    name: 'defaultRule.password',
+  });
+  const durationMinutes = useWatch<AccessControlFormData, 'defaultRule.durationMinutes'>({
+    name: 'defaultRule.durationMinutes',
+  });
 
   const prairieTestEnabled = prairieTestExams.length > 0;
+  const hasPassword = password != null;
+  const hasDuration = durationMinutes != null;
+  const conflictText = run(() => {
+    if (hasPassword && hasDuration) {
+      return 'The password and time limit set under "Date control" don\'t apply during PrairieTest reservations.';
+    }
+    if (hasPassword) {
+      return 'The password set under "Date control" doesn\'t apply during PrairieTest reservations.';
+    }
+    if (hasDuration) {
+      return 'The time limit set under "Date control" doesn\'t apply during PrairieTest reservations.';
+    }
+    return null;
+  });
 
   return (
     <div>
@@ -54,6 +76,11 @@ export function IntegrationsSection() {
       <Form.Text id="defaultRule-prairietest-help" className="text-muted">
         Control access to your assessment through PrairieTest exams.
       </Form.Text>
+      {prairieTestEnabled && conflictText && (
+        <Alert variant="info" className="mt-3">
+          {conflictText}
+        </Alert>
+      )}
       {prairieTestEnabled && <PrairieTestControlForm />}
     </div>
   );

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -1242,7 +1242,9 @@ export function PrairieTestExamsTable({
         </tbody>
       </table>
       <div className="border-top px-3 py-2 text-body-secondary small">
-        {formatListedForStudents(beforeReleaseListed)} before the exam
+        <span>{formatListedForStudents(beforeReleaseListed)} before the exam</span>
+        <span className="mx-1">·</span>
+        <span>PrairieTest controls access and time limits during reservations</span>
       </div>
     </div>
   );


### PR DESCRIPTION
# Description

Two small clarifications on the instructor assessment access page so it's obvious that PrairieTest, not the date-control fields, governs access and timing during a reservation:

- **PrairieTest summary card** now has an always-on footer line ("PrairieTest controls access and time limits during reservations") alongside the existing "Listed/Hidden for students before the exam" line, so anyone reading the summary knows where reservation timing/entry actually comes from.
- **PrairieTest section in the edit form** shows a conflict-conditional `<Alert variant="info">` at the top of the section when the same default rule has a password and/or time limit set under "Date control", dynamically naming the offending field(s) ("The password and time limit set under \"Date control\" don't apply during PrairieTest reservations.").

Both pieces of copy land in the PT surface (summary card footer, top of the PT form section) rather than under the date-control fields themselves — those fields are still meaningful for non-reservation access, so framing them as "broken" would be misleading. The alert uses `variant="info"` per the page's convention (`info` = FYI, `warning` = real risk, `secondary` = disabled-state), matching `AfterCompleteForm.tsx`. Resolves a bullet of #14469.

<img width="627" height="191" alt="Screenshot 2026-05-12 at 12 52 05" src="https://github.com/user-attachments/assets/633f95d2-1b9b-4496-854e-3b6cff86fdb6" />

<img width="544" height="312" alt="Screenshot 2026-05-12 at 12 53 00" src="https://github.com/user-attachments/assets/1f194d68-5f0b-4df2-b01d-6d2b1b65d402" />

Claude did the implementation here.

# Testing

Manually exercised the access page in a browser:
- PT-only configuration: PT footer renders, no form alert.
- PT + password only: alert says `The password set under "Date control" doesn't apply…`.
- PT + time limit only: alert says `The time limit set under "Date control" doesn't apply…`.
- PT + both: alert says `The password and time limit set under "Date control" don't apply…`.
- PT disabled: neither footer line nor alert renders.