### PR TITLE
Make PrairieTest JWT aud claim optional

### DIFF
--- a/apps/prairielearn/src/ee/auth/prairietestCallback.ts
+++ b/apps/prairielearn/src/ee/auth/prairietestCallback.ts
@@ -30,7 +30,9 @@ router.post(
     const key = crypto.createSecretKey(config.prairieTestSharedAuthSecret, 'utf-8');
     let payload: jose.JWTPayload;
     try {
-      const verifyResult = await jose.jwtVerify(jwt, key, { audience: 'prairielearn' });
+      // TODO: require `audience: 'prairielearn'` once all PrairieTest deployments
+      // are issuing JWTs with the `aud` claim set.
+      const verifyResult = await jose.jwtVerify(jwt, key);
       payload = verifyResult.payload;
     } catch (err) {
       if (err instanceof jose.errors.JWSSignatureVerificationFailed) {


### PR DESCRIPTION
# Description

PrairieTest JWTs were failing verification with `missing required "aud" claim` because not all deployments are issuing the claim yet. This drops the `audience: 'prairielearn'` option from `jose.jwtVerify` so existing tokens continue to work. A `TODO` is left to re-require the claim once all PrairieTest deployments are updated.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation.

# Testing

- Verified the previously-failing PrairieTest callback now accepts JWTs without an `aud` claim.