### PR TITLE
Fix groups page "Updated" timestamp showing future-tense suffix

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -691,9 +691,11 @@ export function GroupsCard({
   const refreshMutation = useMutation(
     trpc.assessmentGroups.refreshGroups.mutationOptions({
       onSuccess: ({ groups: newGroups, notAssigned: newNotAssigned }) => {
+        const refreshedAt = Date.now();
         setGroups(newGroups);
         setNotAssigned(newNotAssigned);
-        setLastRefreshedAt(Date.now());
+        setLastRefreshedAt(refreshedAt);
+        setNow(refreshedAt);
       },
     }),
   );


### PR DESCRIPTION
# Description

On the instructor assessment groups page, clicking Refresh briefly showed "Updated in less than a minute" — a future-tense suffix for a refresh that had already happened. The `now` state used as the baseDate in `formatDistance(lastRefreshedAt, now, ...)` only ticked every 30s, so immediately after refresh `lastRefreshedAt > now` and date-fns rendered the future-direction suffix. Fixed by capturing one `Date.now()` on refresh success and setting both `lastRefreshedAt` and `now` from it.

Implementation by Claude.

# Testing

Manually verified the fix by clicking Refresh on the groups page and confirming the timestamp reads "less than a minute ago" instead of "in less than a minute".