### PR TITLE
Hide "best N of M questions" zone info when not relevant

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/QuestionTableBody.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/QuestionTableBody.tsx
@@ -46,8 +46,9 @@ export function QuestionTableBody({
   let previousZoneHadInfo = false;
 
   return rows.map((row) => {
-    const zoneHasInfo =
-      row.zone.title != null || row.zone.max_points != null || row.zone.best_questions != null;
+    const showBestQuestions =
+      row.zone.best_questions != null && row.zone.best_questions < row.zone_question_count;
+    const zoneHasInfo = row.zone.title != null || row.zone.max_points != null || showBestQuestions;
 
     // Show zone info if this zone has info, or if the previous zone
     // had info (blank zone info to visually separate).
@@ -84,7 +85,7 @@ export function QuestionTableBody({
                               content: `Of the points that you are awarded for answering these ${row.zone_question_count} questions, at most ${row.zone.max_points} will count toward your total points.`,
                             })
                           : ''}
-                        ${row.zone.best_questions != null
+                        ${showBestQuestions
                           ? ZoneInfoPopover({
                               label:
                                 row.zone.title || row.zone.max_points != null

--- a/exampleCourse/courseInstances/SectionA/assessments/groupWork/template/infoAssessment.json
+++ b/exampleCourse/courseInstances/SectionA/assessments/groupWork/template/infoAssessment.json
@@ -28,7 +28,6 @@
   "zones": [
     {
       "title": "Fundamental questions",
-      "bestQuestions": 3,
       "questions": [
         {
           "id": "demo/demoNewton-page1",

--- a/testCourse/courseInstances/Sp15/assessments/hw5-templateGroupWork/infoAssessment.json
+++ b/testCourse/courseInstances/Sp15/assessments/hw5-templateGroupWork/infoAssessment.json
@@ -29,7 +29,6 @@
     {
       "canSubmit": ["Recorder"],
       "title": "Fundamental questions",
-      "bestQuestions": 3,
       "questions": [
         { "id": "demo/demoNewton-page1", "autoPoints": 1, "maxAutoPoints": 5 },
         {


### PR DESCRIPTION
# Description

The student-facing assessment instance page renders a "best N of M questions" popover for any zone with `bestQuestions` set, even when N equals or exceeds the number of questions in the zone (which is a no-op or invalid configuration). This results in nonsensical student-facing information:

<img width="642" height="146" alt="Screenshot 2026-05-12 at 17 02 29" src="https://github.com/user-attachments/assets/3bc725b3-6737-48dd-ae50-27a032dc5f4e" />

This PR guards the popover so it only renders when `bestQuestions < zone_question_count`.

Majority of implementation done with Claude Code.

# Testing

Things work!