### PR TITLE
Fix comment popups being double escaped

### DIFF
--- a/apps/prairielearn/src/components/CommentPopover.tsx
+++ b/apps/prairielearn/src/components/CommentPopover.tsx
@@ -1,4 +1,3 @@
-import { html } from '@prairielearn/html';
 import { renderHtml } from '@prairielearn/react';
 
 import { isRenderableComment } from '../lib/comments.js';
@@ -21,8 +20,7 @@ export function CommentPopover({
       data-bs-toggle="popover"
       data-bs-container="body"
       data-bs-placement="auto"
-      data-bs-html="true"
-      data-bs-content={html`${content}`}
+      data-bs-content={content}
     >
       <i className="bi bi-chat-left-text" />
     </button>

--- a/apps/prairielearn/src/components/CommentPopover.tsx
+++ b/apps/prairielearn/src/components/CommentPopover.tsx
@@ -1,4 +1,4 @@
-import { escapeHtml, html } from '@prairielearn/html';
+import { html } from '@prairielearn/html';
 import { renderHtml } from '@prairielearn/react';
 
 import { isRenderableComment } from '../lib/comments.js';
@@ -22,7 +22,7 @@ export function CommentPopover({
       data-bs-container="body"
       data-bs-placement="auto"
       data-bs-html="true"
-      data-bs-content={escapeHtml(html`${content}`).toString()}
+      data-bs-content={html`${content}`}
     >
       <i className="bi bi-chat-left-text" />
     </button>


### PR DESCRIPTION
Closes #14981

<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->
Comments seem to be double-escaped, as can be seen from an apostrophe being included:

<img height="350" alt="apostrophe-broken" src="https://github.com/user-attachments/assets/cd97ccba-e36a-4d7a-91d8-795422432517" />

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

I did not use AI at all.

# Testing


With this patch, the popup renders correctly, but I'm probably not handling actual inline HTML correctly at that point:

<img height="376" alt="apostrophe-fixed" src="https://github.com/user-attachments/assets/a6780576-d43a-42f0-94f7-3eb0a8e877ab" />

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
