### PR TITLE
Cap and center access settings content in the middle space

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -302,7 +302,7 @@ export function AccessControlForm({
                     {alert.message}
                   </Alert>
                 )}
-                <div className="p-3">
+                <div className="container py-3">
                   <AccessControlSummary
                     displayTimezone={courseInstance.display_timezone}
                     getOverrideName={getOverrideName}
@@ -336,7 +336,6 @@ export function AccessControlForm({
                   visible={isDirty}
                   isSaving={isSaving}
                   saveDisabledReason={saveDisabledReason}
-                  fullWidth
                   onCancel={() => reset()}
                 />
               </>


### PR DESCRIPTION
# Description

Adds a maximum width on the instructor assessment access settings page, patterned off the assessment settings page. The `SplitPane` still spans the viewport so the right detail panel stays pinned to the right edge; the summary content and the sticky save bar row are now capped to Bootstrap's responsive `container` widths and centered in the available middle space.

Implemented by Claude Code.

# Testing

<img width="2557" height="1351" alt="Screenshot 2026-05-13 at 16 04 03" src="https://github.com/user-attachments/assets/3c29f8d4-c3ed-4e15-9f82-22bbf1bd591c" />