### PR TITLE
Improve text in access column for release date

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -205,7 +205,7 @@ export function generateDefaultRuleDateTableRows(
         'No date set'
       ),
       label: 'Release',
-      access: '—',
+      access: 'Opens',
       error: releaseDateError,
     });
   }


### PR DESCRIPTION
# Description

Here's how the date control table looked before this PR:

<img width="736" height="307" alt="Screenshot 2026-05-13 at 16 31 04" src="https://github.com/user-attachments/assets/192094d4-693e-4632-8cad-dfe1fca7baf1" />

The contents of the second column on the "release" row have been bugging me for a while now. Now that the column is called "Access" and not "Credit", IMO we can put better text there. I considered "Released" but ultimately went with "Opens" to avoid just repeating what the first column says. My only hesitation with "open" is we use that for assessment instances elsewhere (the opposite of the "close" action) - but from context I think it should be clear.

# Testing

<img width="738" height="306" alt="Screenshot 2026-05-13 at 16 31 33" src="https://github.com/user-attachments/assets/1ec0f734-4a9d-43db-a220-6d0c5e233ef7" />
