### PR TITLE
Split prettier caches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -107,6 +107,7 @@ jobs:
           key: >-
             lint-${{ runner.os }}-${{ hashFiles(
               'yarn.lock',
+              'Makefile',
               'eslint.config.mjs',
               'packages/eslint-config/**',
               'packages/eslint-plugin-prairielearn/**',

--- a/Makefile
+++ b/Makefile
@@ -123,16 +123,17 @@ lint-js:
 # Separate target since the caches don't respect updates to plugins.
 # Split into two passes: the first pass lints the type-aware files without a cache (see `typeAwareFiles` in eslint.config.mjs), and the second
 # pass lints the non-type-aware files with a cache. We check apps/prairielearn first since it is more likely to have lint errors.
+# Keep the Prettier cache locations split too: each Prettier run reconciles all entries in its cache, even entries outside the current glob.
 lint-js-cached:
 	@yarn eslint "apps/prairielearn/**/*.{ts,tsx}"
-	@yarn prettier "apps/prairielearn/**/*.{ts,tsx}" --check --cache --cache-strategy content
+	@yarn prettier "apps/prairielearn/**/*.{ts,tsx}" --check --cache --cache-strategy content --cache-location node_modules/.cache/prettier/apps-prairielearn-tsx
 	@yarn eslint --cache --cache-strategy content \
 		--ignore-pattern "apps/prairielearn/**/*.{ts,tsx}" \
 		"**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,html,mustache}"
 	@yarn prettier \
 		"**/*.{js,jsx,ts,tsx,mjs,cjs,mts,cts,md,sql,json,yml,toml,html,css,scss,sh}" \
 		"!apps/prairielearn/**/*.{ts,tsx}" \
-		--check --cache --cache-strategy content
+		--check --cache --cache-strategy content --cache-location node_modules/.cache/prettier/non-apps-prairielearn-tsx
 lint-python:
 	@uv run ruff check ./
 	@uv run ruff format --check ./

--- a/packages/formatter/src/interval.test.ts
+++ b/packages/formatter/src/interval.test.ts
@@ -32,10 +32,7 @@ describe('interval formatting', () => {
       assert.equal(formatInterval(0), '0s');
     });
     it('should handle negative intervals', () => {
-      assert.equal(
-        formatInterval(-(((4 * 24 + 3) * 60 + 2) * 60 + 7) * 1000),
-        '-4d -3h -2min -7s',
-      );
+      assert.equal(formatInterval(-(((4 * 24 + 3) * 60 + 2) * 60 + 7) * 1000), '-4d -3h -2min -7s');
     });
   });
   describe('formatIntervalRelative()', () => {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

This PR splits the prettier caches, which was causing issues in CI. The path used for the cache is similar to the default location.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used:  majority of implementation

# Testing

None
<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
