### PR TITLE
Fix formula editor set insertion

### DIFF
--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
@@ -464,7 +464,7 @@
           '[separator]',
           allowSets ? '[' : 'x',
           allowSets ? ']' : 'y',
-          ...onlyIfSets(makeShortcutProxy({ latex: '\\cup', insert: '{#?} \\cup {#?}' }, mf)),
+          ...onlyIfSets(makeShortcutProxy({ latex: '\\cup', key: 'U' }, mf)),
           imaginaryUnit,
         ],
         [
@@ -486,7 +486,7 @@
           '[separator]',
           '(',
           ')',
-          ...onlyIfSets(makeShortcutProxy({ latex: '\\cap', insert: '{#?} \\cap {#?}' }, mf)),
+          ...onlyIfSets(makeShortcutProxy({ latex: '\\cap', key: '&' }, mf)),
           allowSets ? 'x' : signKey,
         ],
         [
@@ -734,11 +734,11 @@
     };
 
     if (allowSets) {
-      inlineShortcuts.cup = { value: '{#@} \\cup {#?}' };
+      inlineShortcuts.cup = { value: '{#@}\\cup{#?}' };
       inlineShortcuts['\\cup'] = inlineShortcuts.cup;
       inlineShortcuts.U = inlineShortcuts.cup;
 
-      inlineShortcuts.cap = { value: '{#@} \\cap {#?}' };
+      inlineShortcuts.cap = { value: '{#@}\\cap{#?}' };
       inlineShortcuts['\\cap'] = inlineShortcuts.cap;
       inlineShortcuts['&'] = inlineShortcuts.cap;
     }

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
@@ -734,11 +734,11 @@
     };
 
     if (allowSets) {
-      inlineShortcuts.cup = { value: '{#@}\\cup{#?}' };
+      inlineShortcuts.cup = { value: '{#@}\\cup}' };
       inlineShortcuts['\\cup'] = inlineShortcuts.cup;
       inlineShortcuts.U = inlineShortcuts.cup;
 
-      inlineShortcuts.cap = { value: '{#@}\\cap{#?}' };
+      inlineShortcuts.cap = { value: '{#@}\\cap' };
       inlineShortcuts['\\cap'] = inlineShortcuts.cap;
       inlineShortcuts['&'] = inlineShortcuts.cap;
     }


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

https://github.com/user-attachments/assets/ea9be6e3-3ed2-4354-a06c-76120c8dadfd

Major Notes from the Video:
- The operators now follow the same syntax rules no matter if you type or click a virtual key
- The operators now both follow the multiplication (*) pattern, ie `{#@}\operator`. This means there is no right-side placeholder inserted.
  - This leads to the pile up of operators if you spam, as seen in the video
- The primary bug is fixed, but syntax highlighting remains problematic

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
  - Codex helped to identify the bug and draft a first fix, that I editted

# Testing

Original Repro:
- In a sets-enabled, formula-editor-enabled pl-symbolic-input editor...
- Type "{2}"
- In the formula editor, click cap/cup

No tests written, as per Peter's instructions.
