### PR TITLE
Use granular permissions on assessment group settings page

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-instance-question-grouping/ai-instance-question-grouping-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-instance-question-grouping/ai-instance-question-grouping-util.ts
@@ -80,7 +80,7 @@ export async function updateAiInstanceQuestionGroup({
 
 /**
  * Set the instance question group of an instance question manually.
- * Manual group assignments take precedence over AI assignments.
+ * Manual grouping choices take precedence over AI grouping.
  */
 export async function updateManualInstanceQuestionGroup({
   instance_question_id,

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -143,7 +143,8 @@ export function getNavPageTabs() {
         urlSuffix: ({ assessment }) => `/assessment/${assessment.id}/groups`,
         iconClasses: 'fas fa-users',
         tabLabel: 'Groups',
-        renderCondition: ({ authz_data }) => authz_data.has_course_instance_permission_view,
+        renderCondition: ({ authz_data }) =>
+          authz_data.has_course_permission_view || authz_data.has_course_instance_permission_view,
       },
       {
         activeSubPage: 'questions',

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -143,8 +143,6 @@ export function getNavPageTabs() {
         urlSuffix: ({ assessment }) => `/assessment/${assessment.id}/groups`,
         iconClasses: 'fas fa-users',
         tabLabel: 'Groups',
-        renderCondition: ({ authz_data }) =>
-          authz_data.has_course_permission_view || authz_data.has_course_instance_permission_view,
       },
       {
         activeSubPage: 'questions',

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
@@ -12,6 +12,7 @@ import { type StaffGroupConfig } from '../../../lib/client/safe-db-types.js';
 import { type GroupSettingsFormValues, makeRole } from '../../../lib/group-config.js';
 import type { AssessmentGroupsError } from '../../../trpc/assessment/assessment-groups.js';
 import { useTRPC } from '../../../trpc/assessment/context.js';
+import type { ActionAccess } from '../types.js';
 
 const SAVE_FAILED_FALLBACK = 'Failed to save group configuration.';
 
@@ -81,8 +82,7 @@ export function GroupSettingsCard({
   groupConfigInfo,
   groupSettingsDefaults,
   origHash,
-  canEdit,
-  editUnavailableReason,
+  editAccess,
   onOrigHashChange,
   onGroupSizeSaved,
   onSaved,
@@ -92,8 +92,7 @@ export function GroupSettingsCard({
   groupConfigInfo: StaffGroupConfig;
   groupSettingsDefaults: GroupSettingsFormValues | null;
   origHash: string | null;
-  canEdit: boolean;
-  editUnavailableReason?: string;
+  editAccess: ActionAccess;
   onOrigHashChange: (hash: string | null) => void;
   onGroupSizeSaved: (min: number | null, max: number | null) => void;
   onSaved: () => void;
@@ -101,6 +100,7 @@ export function GroupSettingsCard({
   onClearSaveStatus: () => void;
 }) {
   const [showRecommendedRolesModal, setShowRecommendedRolesModal] = useState(false);
+  const canEdit = editAccess.status === 'allowed';
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.updateGroupConfig.mutationOptions());
 
@@ -245,9 +245,9 @@ export function GroupSettingsCard({
           <div className="text-muted small mb-4">
             Configure how groups work for this assessment.
           </div>
-          {!canEdit && editUnavailableReason && (
+          {editAccess.status === 'denied' && (
             <Alert variant="info" className="mb-4">
-              {editUnavailableReason}
+              {editAccess.reason}
             </Alert>
           )}
           <fieldset disabled={!canEdit}>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
@@ -82,6 +82,7 @@ export function GroupSettingsCard({
   groupSettingsDefaults,
   origHash,
   canEdit,
+  editUnavailableReason,
   onOrigHashChange,
   onGroupSizeSaved,
   onSaved,
@@ -92,6 +93,7 @@ export function GroupSettingsCard({
   groupSettingsDefaults: GroupSettingsFormValues | null;
   origHash: string | null;
   canEdit: boolean;
+  editUnavailableReason?: string;
   onOrigHashChange: (hash: string | null) => void;
   onGroupSizeSaved: (min: number | null, max: number | null) => void;
   onSaved: () => void;
@@ -243,6 +245,11 @@ export function GroupSettingsCard({
           <div className="text-muted small mb-4">
             Configure how groups work for this assessment.
           </div>
+          {!canEdit && editUnavailableReason && (
+            <Alert variant="info" className="mb-4">
+              {editUnavailableReason}
+            </Alert>
+          )}
           <fieldset disabled={!canEdit}>
             <div className="mb-4">
               <h6>Student permissions</h6>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -874,8 +874,8 @@ export function GroupsCard({
 
           {!canEdit && (
             <Alert variant="info" className="mb-3">
-              You can view group memberships, but editing memberships requires Student Data Editor
-              permission.
+              You can view group memberships, but editing memberships requires student data editor
+              permissions.
             </Alert>
           )}
 

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -672,6 +672,7 @@ export function GroupsCard({
   courseInstanceId,
   csrfToken,
   canEdit,
+  editUnavailableReason,
   minGroupSize,
   maxGroupSize,
 }: {
@@ -683,6 +684,7 @@ export function GroupsCard({
   courseInstanceId: string;
   csrfToken: string;
   canEdit: boolean;
+  editUnavailableReason?: string;
   minGroupSize: number;
   maxGroupSize: number;
 }) {
@@ -872,10 +874,9 @@ export function GroupsCard({
             </div>
           </div>
 
-          {!canEdit && (
+          {!canEdit && editUnavailableReason && (
             <Alert variant="info" className="mb-3">
-              You can view group memberships, but editing memberships requires student data editor
-              permissions.
+              {editUnavailableReason}
             </Alert>
           )}
 

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -676,7 +676,7 @@ export function GroupsCard({
   minGroupSize,
   maxGroupSize,
 }: {
-  groupsCsvFilename?: string;
+  groupsCsvFilename: string;
   initialGroups?: GroupUsersRow[];
   initialNotAssigned?: string[];
   assessment: StaffAssessment;
@@ -827,37 +827,41 @@ export function GroupsCard({
                 </button>
               )}
               <DropdownButton as={ButtonGroup} title="Actions" variant="outline-secondary">
-                <Dropdown.Item
-                  as="button"
-                  type="button"
-                  disabled={!canEdit}
-                  onClick={() => uploadModal.showWithData(null)}
-                >
-                  <i className="bi bi-upload me-2" aria-hidden="true" />
-                  Import CSV
-                </Dropdown.Item>
+                {canEdit && (
+                  <Dropdown.Item
+                    as="button"
+                    type="button"
+                    onClick={() => uploadModal.showWithData(null)}
+                  >
+                    <i className="bi bi-upload me-2" aria-hidden="true" />
+                    Import CSV
+                  </Dropdown.Item>
+                )}
                 <Dropdown.Item
                   as="a"
                   href={getAssessmentDownloadUrl({
                     courseInstanceId,
                     assessmentId: assessment.id,
-                    filename: groupsCsvFilename ?? '',
+                    filename: groupsCsvFilename,
                   })}
                 >
                   <i className="bi bi-download me-2" aria-hidden="true" />
                   Export CSV
                 </Dropdown.Item>
-                <Dropdown.Divider />
-                <Dropdown.Item
-                  as="button"
-                  type="button"
-                  disabled={!canEdit}
-                  className="text-danger"
-                  onClick={() => deleteAllModal.showWithData(null)}
-                >
-                  <i className="bi bi-trash me-2" aria-hidden="true" />
-                  Delete all
-                </Dropdown.Item>
+                {canEdit && (
+                  <>
+                    <Dropdown.Divider />
+                    <Dropdown.Item
+                      as="button"
+                      type="button"
+                      className="text-danger"
+                      onClick={() => deleteAllModal.showWithData(null)}
+                    >
+                      <i className="bi bi-trash me-2" aria-hidden="true" />
+                      Delete all
+                    </Dropdown.Item>
+                  </>
+                )}
               </DropdownButton>
               <Button
                 variant="outline-secondary"

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -25,6 +25,7 @@ import {
 import type { GroupUsersRow } from '../../../models/group.js';
 import type { AssessmentGroupsError } from '../../../trpc/assessment/assessment-groups.js';
 import { useTRPC } from '../../../trpc/assessment/context.js';
+import type { ActionAccess } from '../types.js';
 
 function EditGroupModal({
   row,
@@ -671,8 +672,7 @@ export function GroupsCard({
   assessmentSet,
   courseInstanceId,
   csrfToken,
-  canEdit,
-  editUnavailableReason,
+  editAccess,
   minGroupSize,
   maxGroupSize,
 }: {
@@ -683,8 +683,7 @@ export function GroupsCard({
   assessmentSet: StaffAssessmentSet;
   courseInstanceId: string;
   csrfToken: string;
-  canEdit: boolean;
-  editUnavailableReason?: string;
+  editAccess: ActionAccess;
   minGroupSize: number;
   maxGroupSize: number;
 }) {
@@ -692,6 +691,7 @@ export function GroupsCard({
   const [notAssigned, setNotAssigned] = useState(initialNotAssigned);
   const [lastRefreshedAt, setLastRefreshedAt] = useState(() => Date.now());
   const [now, setNow] = useState(() => Date.now());
+  const canEdit = editAccess.status === 'allowed';
   const trpc = useTRPC();
   const refreshMutation = useMutation(
     trpc.assessmentGroups.refreshGroups.mutationOptions({
@@ -878,9 +878,9 @@ export function GroupsCard({
             </div>
           </div>
 
-          {!canEdit && editUnavailableReason && (
+          {editAccess.status === 'denied' && (
             <Alert variant="info" className="mb-3">
-              {editUnavailableReason}
+              {editAccess.reason}
             </Alert>
           )}
 

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -228,7 +228,7 @@ function UploadAssessmentGroupsModal({
     <Modal show={show} onHide={onHide}>
       <form method="POST" encType="multipart/form-data">
         <Modal.Header>
-          <Modal.Title>Upload new group assignments</Modal.Title>
+          <Modal.Title>Upload group memberships</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <p>Upload a CSV file in the format of:</p>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -872,6 +872,13 @@ export function GroupsCard({
             </div>
           </div>
 
+          {!canEdit && (
+            <Alert variant="info" className="mb-3">
+              You can view group memberships, but editing memberships requires Student Data Editor
+              permission.
+            </Alert>
+          )}
+
           {notAssigned && notAssigned.length > 0 && (
             <Alert
               variant="warning"

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
@@ -64,12 +64,16 @@ export function ManageGroupWorkCard({
   hasAssessmentInstances,
   courseInstanceId,
   assessmentId,
+  canDisable,
+  disableUnavailableReason,
   onDisable,
 }: {
   origHash: string | null;
   hasAssessmentInstances: boolean;
   courseInstanceId: string;
   assessmentId: string;
+  canDisable: boolean;
+  disableUnavailableReason?: string;
   onDisable: (result: { origHash: string }) => void;
 }) {
   const [showDisableModal, setShowDisableModal] = useState(false);
@@ -105,6 +109,9 @@ export function ManageGroupWorkCard({
             {appError.message}
           </Alert>
         )}
+        {!canDisable && disableUnavailableReason && (
+          <Alert variant="info">{disableUnavailableReason}</Alert>
+        )}
         <div className="d-flex align-items-center gap-3">
           <div className="flex-grow-1">
             <div className="fw-bold">Disable group work</div>
@@ -115,7 +122,7 @@ export function ManageGroupWorkCard({
           </div>
           <Button
             variant="outline-danger"
-            disabled={mutation.isPending}
+            disabled={mutation.isPending || !canDisable}
             onClick={() => setShowDisableModal(true)}
           >
             Disable

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
@@ -5,6 +5,7 @@ import { Alert, Button, Modal } from 'react-bootstrap';
 import { getAppError } from '../../../lib/client/errors.js';
 import type { AssessmentGroupsError } from '../../../trpc/assessment/assessment-groups.js';
 import { useTRPC } from '../../../trpc/assessment/context.js';
+import type { ActionAccess } from '../types.js';
 
 import { GroupWorkInstancesWarning } from './GroupWorkInstancesWarning.js';
 
@@ -32,8 +33,8 @@ function DisableGroupWorkModal({
       </Modal.Header>
       <Modal.Body>
         <p className="mb-2">
-          All groups, group memberships, and the group configuration for this assessment will be
-          permanently removed.
+          All group configuration for this assessment, including groups and their memberships, will
+          be permanently removed.
         </p>
         <p className="mb-0 text-muted small">
           Students will need to be re-grouped if you enable group work again later.
@@ -64,19 +65,18 @@ export function ManageGroupWorkCard({
   hasAssessmentInstances,
   courseInstanceId,
   assessmentId,
-  canDisable,
-  disableUnavailableReason,
+  disableAccess,
   onDisable,
 }: {
   origHash: string | null;
   hasAssessmentInstances: boolean;
   courseInstanceId: string;
   assessmentId: string;
-  canDisable: boolean;
-  disableUnavailableReason?: string;
+  disableAccess: ActionAccess;
   onDisable: (result: { origHash: string }) => void;
 }) {
   const [showDisableModal, setShowDisableModal] = useState(false);
+  const canDisable = disableAccess.status === 'allowed';
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.disableGroupWork.mutationOptions());
   const appError = getAppError<AssessmentGroupsError['DisableGroupWork']>(mutation.error);
@@ -109,15 +109,13 @@ export function ManageGroupWorkCard({
             {appError.message}
           </Alert>
         )}
-        {!canDisable && disableUnavailableReason && (
-          <Alert variant="info">{disableUnavailableReason}</Alert>
-        )}
+        {disableAccess.status === 'denied' && <Alert variant="info">{disableAccess.reason}</Alert>}
         <div className="d-flex align-items-center gap-3">
           <div className="flex-grow-1">
             <div className="fw-bold">Disable group work</div>
             <div className="text-muted small">
-              All groups, group memberships, and the group configuration will be permanently
-              removed.
+              All group configuration for this assessment, including groups and their memberships,
+              will be permanently removed.
             </div>
           </div>
           <Button

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
@@ -32,7 +32,7 @@ function DisableGroupWorkModal({
       </Modal.Header>
       <Modal.Body>
         <p className="mb-2">
-          All groups, group assignments, and the group configuration for this assessment will be
+          All groups, group memberships, and the group configuration for this assessment will be
           permanently removed.
         </p>
         <p className="mb-0 text-muted small">
@@ -116,7 +116,7 @@ export function ManageGroupWorkCard({
           <div className="flex-grow-1">
             <div className="fw-bold">Disable group work</div>
             <div className="text-muted small">
-              All groups, group assignments, and the group configuration will be permanently
+              All groups, group memberships, and the group configuration will be permanently
               removed.
             </div>
           </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -94,7 +94,7 @@ function StudentDataPermissionCard() {
           View and manage student group assignments for this assessment.
         </div>
         <Alert variant="info" className="mb-0">
-          You must have Student Data Viewer permission to view group memberships and ungrouped
+          You must have student data viewer permissions to view group memberships and ungrouped
           students. Without it, group membership details are hidden.
         </Alert>
       </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -212,7 +212,7 @@ function InstructorAssessmentGroupsInner({
         assessment={assessment}
         enableUnavailableReason={run(() => {
           if (permissions.isExampleCourse) {
-            return 'Enabling group work is not available for example courses.';
+            return 'Enabling group work is not available for the example course.';
           }
           if (!permissions.hasCoursePermissionEdit) {
             return 'Enabling group work requires course editor permissions.';
@@ -245,7 +245,7 @@ function InstructorAssessmentGroupsInner({
           canEdit={canEditGroupSettings}
           editUnavailableReason={run(() => {
             if (permissions.isExampleCourse) {
-              return 'Editing group settings is not available for example courses.';
+              return 'Editing group settings is not available for the example course.';
             }
             if (!permissions.hasCoursePermissionEdit) {
               return 'Editing group settings requires course editor permissions.';
@@ -273,7 +273,7 @@ function InstructorAssessmentGroupsInner({
             canEdit={canEditStudentData}
             editUnavailableReason={run(() => {
               if (permissions.isExampleCourse) {
-                return 'Editing group memberships is not available for example courses.';
+                return 'Editing group memberships is not available for the example course.';
               }
               if (!permissions.hasCourseInstancePermissionEdit) {
                 return 'Editing group memberships requires student data editor permissions.';
@@ -305,7 +305,7 @@ function InstructorAssessmentGroupsInner({
             canDisable={canDisableGroupWork}
             disableUnavailableReason={run(() => {
               if (permissions.isExampleCourse) {
-                return 'Disabling group work is not available for example courses.';
+                return 'Disabling group work is not available for the example course.';
               }
               if (
                 !permissions.hasCoursePermissionEdit &&

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -287,10 +287,10 @@ function InstructorAssessmentGroupsInner({
             <div className="card-body">
               <h5 className="mb-1">Groups</h5>
               <div className="text-muted small mb-3">
-                View and manage student group assignments for this assessment.
+                View and manage student group memberships for this assessment.
               </div>
               <Alert variant="info" className="mb-0">
-                You must have student data viewer permissions to view student group assignments.
+                You must have student data viewer permissions to view student group memberships.
               </Alert>
             </div>
           </div>
@@ -311,13 +311,13 @@ function InstructorAssessmentGroupsInner({
                 !permissions.hasCoursePermissionEdit &&
                 !permissions.hasCourseInstancePermissionEdit
               ) {
-                return 'Disabling group work requires both course editor and student data editor permissions because it changes group settings and permanently removes group assignments.';
+                return 'Disabling group work requires both course editor and student data editor permissions because it changes group settings and permanently removes group memberships.';
               }
               if (!permissions.hasCoursePermissionEdit) {
                 return 'Disabling group work requires course editor permissions because it changes group settings.';
               }
               if (!permissions.hasCourseInstancePermissionEdit) {
-                return 'Disabling group work requires student data editor permissions because it permanently removes group assignments.';
+                return 'Disabling group work requires student data editor permissions because it permanently removes group memberships.';
               }
             })}
             onDisable={({ origHash: newHash }) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -107,7 +107,7 @@ interface InstructorAssessmentGroupsProps {
   assessmentSet: StaffAssessmentSet;
   permissions: InstructorAssessmentGroupsPermissions;
   csrfToken: string;
-  groupsCsvFilename?: string;
+  groupsCsvFilename: string;
   groupConfigInfo?: StaffGroupConfig;
   groups?: GroupUsersRow[];
   notAssigned?: string[];
@@ -311,7 +311,7 @@ function InstructorAssessmentGroupsInner({
                 !permissions.hasCoursePermissionEdit &&
                 !permissions.hasCourseInstancePermissionEdit
               ) {
-                return 'Disabling group work requires both course editor and student data editor permissions because it permanently removes group assignments.';
+                return 'Disabling group work requires both course editor and student data editor permissions because it changes group settings and permanently removes group assignments.';
               }
               if (!permissions.hasCoursePermissionEdit) {
                 return 'Disabling group work requires course editor permissions because it changes group settings.';

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -94,22 +94,6 @@ function NoGroupConfigCard({
   );
 }
 
-function StudentDataPermissionCard() {
-  return (
-    <div className="card">
-      <div className="card-body">
-        <h5 className="mb-1">Groups</h5>
-        <div className="text-muted small mb-3">
-          View and manage student group assignments for this assessment.
-        </div>
-        <Alert variant="info" className="mb-0">
-          You must have student data viewer permissions to view student group assignments.
-        </Alert>
-      </div>
-    </div>
-  );
-}
-
 interface InstructorAssessmentGroupsPermissions {
   isExampleCourse: boolean;
   hasCoursePermissionEdit: boolean;
@@ -276,6 +260,7 @@ function InstructorAssessmentGroupsInner({
           onSaveError={(message) => setSaveStatus({ kind: 'error', message })}
           onClearSaveStatus={() => setSaveStatus(null)}
         />
+
         {permissions.hasCourseInstancePermissionView ? (
           <GroupsCard
             groupsCsvFilename={groupsCsvFilename}
@@ -298,8 +283,19 @@ function InstructorAssessmentGroupsInner({
             maxGroupSize={maxGroupSize}
           />
         ) : (
-          <StudentDataPermissionCard />
+          <div className="card">
+            <div className="card-body">
+              <h5 className="mb-1">Groups</h5>
+              <div className="text-muted small mb-3">
+                View and manage student group assignments for this assessment.
+              </div>
+              <Alert variant="info" className="mb-0">
+                You must have student data viewer permissions to view student group assignments.
+              </Alert>
+            </div>
+          </div>
         )}
+
         {showManageGroupWork && (
           <ManageGroupWorkCard
             origHash={origHash}
@@ -334,6 +330,7 @@ function InstructorAssessmentGroupsInner({
           />
         )}
       </div>
+
       {canEditGroupSettings && saveStatus && (
         <div className="position-sticky bottom-0 z-3 bg-body border-top">
           {saveStatus.kind === 'success' && (

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -21,22 +21,23 @@ import { GroupSettingsCard } from './components/GroupSettingsCard.js';
 import { GroupWorkInstancesWarning } from './components/GroupWorkInstancesWarning.js';
 import { GroupsCard } from './components/GroupsCard.js';
 import { ManageGroupWorkCard } from './components/ManageGroupWorkCard.js';
+import type { ActionAccess } from './types.js';
+
+const ALLOWED_ACCESS = { status: 'allowed' } satisfies ActionAccess;
 
 function NoGroupConfigCard({
   origHash,
-  canEdit,
+  enableAccess,
   hasAssessmentInstances,
   courseInstanceId,
   assessment,
-  enableUnavailableReason,
   onEnable,
 }: {
   origHash: string | null;
-  canEdit: boolean;
+  enableAccess: ActionAccess;
   hasAssessmentInstances: boolean;
   courseInstanceId: string;
   assessment: StaffAssessment;
-  enableUnavailableReason?: string;
   onEnable: (result: {
     origHash: string;
     groupConfig: StaffGroupConfig;
@@ -49,6 +50,7 @@ function NoGroupConfigCard({
   const mutation = useMutation(trpc.assessmentGroups.enableGroupWork.mutationOptions());
   const appError = getAppError<AssessmentGroupsError['EnableGroupWork']>(mutation.error);
 
+  const canEdit = enableAccess.status === 'allowed';
   const description = canEdit
     ? 'Enable group work to allow students to collaborate and submit as groups.'
     : 'Group work is not enabled for this assessment.';
@@ -65,9 +67,9 @@ function NoGroupConfigCard({
           <i className="bi bi-people fs-1 mb-2" />
           <h2 className="h5">This is not a group assessment.</h2>
           <div className="text-muted">{description}</div>
-          {!canEdit && enableUnavailableReason && (
+          {enableAccess.status === 'denied' && (
             <Alert variant="info" className="mt-3 mb-0">
-              {enableUnavailableReason}
+              {enableAccess.reason}
             </Alert>
           )}
           {canEdit && hasAssessmentInstances && (
@@ -198,7 +200,6 @@ function InstructorAssessmentGroupsInner({
   const canEditGroupSettings = permissions.hasCoursePermissionEdit && !permissions.isExampleCourse;
   const canEditStudentData =
     permissions.hasCourseInstancePermissionEdit && !permissions.isExampleCourse;
-  const canDisableGroupWork = canEditGroupSettings && canEditStudentData;
   const showManageGroupWork =
     permissions.hasCoursePermissionEdit || permissions.hasCourseInstancePermissionEdit;
 
@@ -206,18 +207,22 @@ function InstructorAssessmentGroupsInner({
     return (
       <NoGroupConfigCard
         origHash={origHash}
-        canEdit={canEditGroupSettings}
+        enableAccess={run<ActionAccess>(() => {
+          if (canEditGroupSettings) return ALLOWED_ACCESS;
+          if (permissions.isExampleCourse) {
+            return {
+              status: 'denied',
+              reason: 'Enabling group work is not available for the example course.',
+            };
+          }
+          return {
+            status: 'denied',
+            reason: 'Enabling group work requires course editor permissions.',
+          };
+        })}
         hasAssessmentInstances={hasAssessmentInstances}
         courseInstanceId={courseInstanceId}
         assessment={assessment}
-        enableUnavailableReason={run(() => {
-          if (permissions.isExampleCourse) {
-            return 'Enabling group work is not available for the example course.';
-          }
-          if (!permissions.hasCoursePermissionEdit) {
-            return 'Enabling group work requires course editor permissions.';
-          }
-        })}
         onEnable={({
           origHash: newHash,
           groupConfig,
@@ -242,14 +247,18 @@ function InstructorAssessmentGroupsInner({
           groupConfigInfo={groupConfigInfo}
           groupSettingsDefaults={groupSettingsDefaults}
           origHash={origHash}
-          canEdit={canEditGroupSettings}
-          editUnavailableReason={run(() => {
+          editAccess={run<ActionAccess>(() => {
+            if (canEditGroupSettings) return ALLOWED_ACCESS;
             if (permissions.isExampleCourse) {
-              return 'Editing group settings is not available for the example course.';
+              return {
+                status: 'denied',
+                reason: 'Editing group settings is not available for the example course.',
+              };
             }
-            if (!permissions.hasCoursePermissionEdit) {
-              return 'Editing group settings requires course editor permissions.';
-            }
+            return {
+              status: 'denied',
+              reason: 'Editing group settings requires course editor permissions.',
+            };
           })}
           onOrigHashChange={setOrigHash}
           onGroupSizeSaved={(min, max) => {
@@ -270,14 +279,18 @@ function InstructorAssessmentGroupsInner({
             assessmentSet={assessmentSet}
             courseInstanceId={courseInstanceId}
             csrfToken={csrfToken}
-            canEdit={canEditStudentData}
-            editUnavailableReason={run(() => {
+            editAccess={run<ActionAccess>(() => {
+              if (canEditStudentData) return ALLOWED_ACCESS;
               if (permissions.isExampleCourse) {
-                return 'Editing group memberships is not available for the example course.';
+                return {
+                  status: 'denied',
+                  reason: 'Editing group memberships is not available for the example course.',
+                };
               }
-              if (!permissions.hasCourseInstancePermissionEdit) {
-                return 'Editing group memberships requires student data editor permissions.';
-              }
+              return {
+                status: 'denied',
+                reason: 'Editing group memberships requires student data editor permissions.',
+              };
             })}
             minGroupSize={minGroupSize}
             maxGroupSize={maxGroupSize}
@@ -302,23 +315,36 @@ function InstructorAssessmentGroupsInner({
             hasAssessmentInstances={hasAssessmentInstances}
             courseInstanceId={courseInstanceId}
             assessmentId={assessment.id}
-            canDisable={canDisableGroupWork}
-            disableUnavailableReason={run(() => {
+            disableAccess={run<ActionAccess>(() => {
+              if (canEditGroupSettings && canEditStudentData) return ALLOWED_ACCESS;
               if (permissions.isExampleCourse) {
-                return 'Disabling group work is not available for the example course.';
+                return {
+                  status: 'denied',
+                  reason: 'Disabling group work is not permitted for the example course.',
+                };
               }
               if (
                 !permissions.hasCoursePermissionEdit &&
                 !permissions.hasCourseInstancePermissionEdit
               ) {
-                return 'Disabling group work requires both course editor and student data editor permissions because it changes group settings and permanently removes group memberships.';
+                return {
+                  status: 'denied',
+                  reason:
+                    'Disabling group work requires both course editor and student data editor permissions because it changes group settings and permanently removes group memberships.',
+                };
               }
               if (!permissions.hasCoursePermissionEdit) {
-                return 'Disabling group work requires course editor permissions because it changes group settings.';
+                return {
+                  status: 'denied',
+                  reason:
+                    'Disabling group work requires course editor permissions because it changes group settings.',
+                };
               }
-              if (!permissions.hasCourseInstancePermissionEdit) {
-                return 'Disabling group work requires student data editor permissions because it permanently removes group memberships.';
-              }
+              return {
+                status: 'denied',
+                reason:
+                  'Disabling group work requires student data editor permissions because it permanently removes group memberships.',
+              };
             })}
             onDisable={({ origHash: newHash }) => {
               setOrigHash(newHash);

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -94,8 +94,7 @@ function StudentDataPermissionCard() {
           View and manage student group assignments for this assessment.
         </div>
         <Alert variant="info" className="mb-0">
-          You must have student data viewer permissions to view group memberships and ungrouped
-          students. Without it, group membership details are hidden.
+          You must have student data viewer permissions to view student group assignments.
         </Alert>
       </div>
     </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -2,6 +2,8 @@ import { QueryClient, useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Alert } from 'react-bootstrap';
 
+import { run } from '@prairielearn/run';
+
 import { getAppError } from '../../lib/client/errors.js';
 import type {
   StaffAssessment,
@@ -26,6 +28,7 @@ function NoGroupConfigCard({
   hasAssessmentInstances,
   courseInstanceId,
   assessment,
+  enableUnavailableReason,
   onEnable,
 }: {
   origHash: string | null;
@@ -33,6 +36,7 @@ function NoGroupConfigCard({
   hasAssessmentInstances: boolean;
   courseInstanceId: string;
   assessment: StaffAssessment;
+  enableUnavailableReason?: string;
   onEnable: (result: {
     origHash: string;
     groupConfig: StaffGroupConfig;
@@ -61,6 +65,11 @@ function NoGroupConfigCard({
           <i className="bi bi-people fs-1 mb-2" />
           <h2 className="h5">This is not a group assessment.</h2>
           <div className="text-muted">{description}</div>
+          {!canEdit && enableUnavailableReason && (
+            <Alert variant="info" className="mt-3 mb-0">
+              {enableUnavailableReason}
+            </Alert>
+          )}
           {canEdit && hasAssessmentInstances && (
             <GroupWorkInstancesWarning
               action="enabling"
@@ -101,13 +110,18 @@ function StudentDataPermissionCard() {
   );
 }
 
+interface InstructorAssessmentGroupsPermissions {
+  isExampleCourse: boolean;
+  hasCoursePermissionEdit: boolean;
+  hasCourseInstancePermissionView: boolean;
+  hasCourseInstancePermissionEdit: boolean;
+}
+
 interface InstructorAssessmentGroupsProps {
   courseInstanceId: string;
   assessment: StaffAssessment;
   assessmentSet: StaffAssessmentSet;
-  canEditGroupSettings: boolean;
-  canViewStudentData: boolean;
-  canEditStudentData: boolean;
+  permissions: InstructorAssessmentGroupsPermissions;
   csrfToken: string;
   groupsCsvFilename?: string;
   groupConfigInfo?: StaffGroupConfig;
@@ -124,9 +138,7 @@ export function InstructorAssessmentGroups({
   courseInstanceId,
   assessment,
   assessmentSet,
-  canEditGroupSettings,
-  canViewStudentData,
-  canEditStudentData,
+  permissions,
   csrfToken,
   groupsCsvFilename,
   groupConfigInfo,
@@ -154,9 +166,7 @@ export function InstructorAssessmentGroups({
           courseInstanceId={courseInstanceId}
           assessment={assessment}
           assessmentSet={assessmentSet}
-          canEditGroupSettings={canEditGroupSettings}
-          canViewStudentData={canViewStudentData}
-          canEditStudentData={canEditStudentData}
+          permissions={permissions}
           csrfToken={csrfToken}
           groupsCsvFilename={groupsCsvFilename}
           groupConfigInfo={groupConfigInfo}
@@ -177,9 +187,7 @@ function InstructorAssessmentGroupsInner({
   courseInstanceId,
   assessment,
   assessmentSet,
-  canEditGroupSettings,
-  canViewStudentData,
-  canEditStudentData,
+  permissions,
   csrfToken,
   groupsCsvFilename,
   groupConfigInfo: initialGroupConfigInfo,
@@ -203,6 +211,12 @@ function InstructorAssessmentGroupsInner({
   const [saveStatus, setSaveStatus] = useState<
     { kind: 'success' } | { kind: 'error'; message: string } | null
   >(null);
+  const canEditGroupSettings = permissions.hasCoursePermissionEdit && !permissions.isExampleCourse;
+  const canEditStudentData =
+    permissions.hasCourseInstancePermissionEdit && !permissions.isExampleCourse;
+  const canDisableGroupWork = canEditGroupSettings && canEditStudentData;
+  const showManageGroupWork =
+    permissions.hasCoursePermissionEdit || permissions.hasCourseInstancePermissionEdit;
 
   if (!groupConfigInfo) {
     return (
@@ -212,6 +226,14 @@ function InstructorAssessmentGroupsInner({
         hasAssessmentInstances={hasAssessmentInstances}
         courseInstanceId={courseInstanceId}
         assessment={assessment}
+        enableUnavailableReason={run(() => {
+          if (permissions.isExampleCourse) {
+            return 'Enabling group work is not available for example courses.';
+          }
+          if (!permissions.hasCoursePermissionEdit) {
+            return 'Enabling group work requires course editor permissions.';
+          }
+        })}
         onEnable={({
           origHash: newHash,
           groupConfig,
@@ -237,6 +259,14 @@ function InstructorAssessmentGroupsInner({
           groupSettingsDefaults={groupSettingsDefaults}
           origHash={origHash}
           canEdit={canEditGroupSettings}
+          editUnavailableReason={run(() => {
+            if (permissions.isExampleCourse) {
+              return 'Editing group settings is not available for example courses.';
+            }
+            if (!permissions.hasCoursePermissionEdit) {
+              return 'Editing group settings requires course editor permissions.';
+            }
+          })}
           onOrigHashChange={setOrigHash}
           onGroupSizeSaved={(min, max) => {
             setMinGroupSize(min ?? 2);
@@ -246,7 +276,7 @@ function InstructorAssessmentGroupsInner({
           onSaveError={(message) => setSaveStatus({ kind: 'error', message })}
           onClearSaveStatus={() => setSaveStatus(null)}
         />
-        {canViewStudentData ? (
+        {permissions.hasCourseInstancePermissionView ? (
           <GroupsCard
             groupsCsvFilename={groupsCsvFilename}
             initialGroups={groups}
@@ -256,18 +286,44 @@ function InstructorAssessmentGroupsInner({
             courseInstanceId={courseInstanceId}
             csrfToken={csrfToken}
             canEdit={canEditStudentData}
+            editUnavailableReason={run(() => {
+              if (permissions.isExampleCourse) {
+                return 'Editing group memberships is not available for example courses.';
+              }
+              if (!permissions.hasCourseInstancePermissionEdit) {
+                return 'Editing group memberships requires student data editor permissions.';
+              }
+            })}
             minGroupSize={minGroupSize}
             maxGroupSize={maxGroupSize}
           />
         ) : (
           <StudentDataPermissionCard />
         )}
-        {canEditGroupSettings && canEditStudentData && (
+        {showManageGroupWork && (
           <ManageGroupWorkCard
             origHash={origHash}
             hasAssessmentInstances={hasAssessmentInstances}
             courseInstanceId={courseInstanceId}
             assessmentId={assessment.id}
+            canDisable={canDisableGroupWork}
+            disableUnavailableReason={run(() => {
+              if (permissions.isExampleCourse) {
+                return 'Disabling group work is not available for example courses.';
+              }
+              if (
+                !permissions.hasCoursePermissionEdit &&
+                !permissions.hasCourseInstancePermissionEdit
+              ) {
+                return 'Disabling group work requires both course editor and student data editor permissions because it permanently removes group assignments.';
+              }
+              if (!permissions.hasCoursePermissionEdit) {
+                return 'Disabling group work requires course editor permissions because it changes group settings.';
+              }
+              if (!permissions.hasCourseInstancePermissionEdit) {
+                return 'Disabling group work requires student data editor permissions because it permanently removes group assignments.';
+              }
+            })}
             onDisable={({ origHash: newHash }) => {
               setOrigHash(newHash);
               setGroupSettingsDefaults(null);

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -94,7 +94,8 @@ function StudentDataPermissionCard() {
           View and manage student group assignments for this assessment.
         </div>
         <Alert variant="info" className="mb-0">
-          You must have student data permission to view and edit group memberships.
+          You must have Student Data Viewer permission to view group memberships and ungrouped
+          students. Without it, group membership details are hidden.
         </Alert>
       </div>
     </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -37,8 +37,8 @@ function NoGroupConfigCard({
     origHash: string;
     groupConfig: StaffGroupConfig;
     groupSettingsDefaults: GroupSettingsFormValues | null;
-    groups: GroupUsersRow[];
-    notAssigned: string[];
+    groups?: GroupUsersRow[];
+    notAssigned?: string[];
   }) => void;
 }) {
   const trpc = useTRPC();
@@ -46,7 +46,7 @@ function NoGroupConfigCard({
   const appError = getAppError<AssessmentGroupsError['EnableGroupWork']>(mutation.error);
 
   const description = canEdit
-    ? 'Enable group work to allow students to collaborate and submit as teams.'
+    ? 'Enable group work to allow students to collaborate and submit as groups.'
     : 'Group work is not enabled for this assessment.';
 
   return (
@@ -85,12 +85,29 @@ function NoGroupConfigCard({
   );
 }
 
+function StudentDataPermissionCard() {
+  return (
+    <div className="card">
+      <div className="card-body">
+        <h5 className="mb-1">Groups</h5>
+        <div className="text-muted small mb-3">
+          View and manage student group assignments for this assessment.
+        </div>
+        <Alert variant="info" className="mb-0">
+          You must have student data permission to view and edit group memberships.
+        </Alert>
+      </div>
+    </div>
+  );
+}
+
 interface InstructorAssessmentGroupsProps {
   courseInstanceId: string;
   assessment: StaffAssessment;
   assessmentSet: StaffAssessmentSet;
-  canEditCourse: boolean;
-  canEditCourseInstance: boolean;
+  canEditGroupSettings: boolean;
+  canViewStudentData: boolean;
+  canEditStudentData: boolean;
   csrfToken: string;
   groupsCsvFilename?: string;
   groupConfigInfo?: StaffGroupConfig;
@@ -107,8 +124,9 @@ export function InstructorAssessmentGroups({
   courseInstanceId,
   assessment,
   assessmentSet,
-  canEditCourse,
-  canEditCourseInstance,
+  canEditGroupSettings,
+  canViewStudentData,
+  canEditStudentData,
   csrfToken,
   groupsCsvFilename,
   groupConfigInfo,
@@ -136,8 +154,9 @@ export function InstructorAssessmentGroups({
           courseInstanceId={courseInstanceId}
           assessment={assessment}
           assessmentSet={assessmentSet}
-          canEditCourse={canEditCourse}
-          canEditCourseInstance={canEditCourseInstance}
+          canEditGroupSettings={canEditGroupSettings}
+          canViewStudentData={canViewStudentData}
+          canEditStudentData={canEditStudentData}
           csrfToken={csrfToken}
           groupsCsvFilename={groupsCsvFilename}
           groupConfigInfo={groupConfigInfo}
@@ -158,8 +177,9 @@ function InstructorAssessmentGroupsInner({
   courseInstanceId,
   assessment,
   assessmentSet,
-  canEditCourse,
-  canEditCourseInstance,
+  canEditGroupSettings,
+  canViewStudentData,
+  canEditStudentData,
   csrfToken,
   groupsCsvFilename,
   groupConfigInfo: initialGroupConfigInfo,
@@ -188,7 +208,7 @@ function InstructorAssessmentGroupsInner({
     return (
       <NoGroupConfigCard
         origHash={origHash}
-        canEdit={canEditCourse}
+        canEdit={canEditGroupSettings}
         hasAssessmentInstances={hasAssessmentInstances}
         courseInstanceId={courseInstanceId}
         assessment={assessment}
@@ -216,7 +236,7 @@ function InstructorAssessmentGroupsInner({
           groupConfigInfo={groupConfigInfo}
           groupSettingsDefaults={groupSettingsDefaults}
           origHash={origHash}
-          canEdit={canEditCourse}
+          canEdit={canEditGroupSettings}
           onOrigHashChange={setOrigHash}
           onGroupSizeSaved={(min, max) => {
             setMinGroupSize(min ?? 2);
@@ -226,19 +246,23 @@ function InstructorAssessmentGroupsInner({
           onSaveError={(message) => setSaveStatus({ kind: 'error', message })}
           onClearSaveStatus={() => setSaveStatus(null)}
         />
-        <GroupsCard
-          groupsCsvFilename={groupsCsvFilename}
-          initialGroups={groups}
-          initialNotAssigned={notAssigned}
-          assessment={assessment}
-          assessmentSet={assessmentSet}
-          courseInstanceId={courseInstanceId}
-          csrfToken={csrfToken}
-          canEdit={canEditCourseInstance}
-          minGroupSize={minGroupSize}
-          maxGroupSize={maxGroupSize}
-        />
-        {canEditCourse && (
+        {canViewStudentData ? (
+          <GroupsCard
+            groupsCsvFilename={groupsCsvFilename}
+            initialGroups={groups}
+            initialNotAssigned={notAssigned}
+            assessment={assessment}
+            assessmentSet={assessmentSet}
+            courseInstanceId={courseInstanceId}
+            csrfToken={csrfToken}
+            canEdit={canEditStudentData}
+            minGroupSize={minGroupSize}
+            maxGroupSize={maxGroupSize}
+          />
+        ) : (
+          <StudentDataPermissionCard />
+        )}
+        {canEditGroupSettings && canEditStudentData && (
           <ManageGroupWorkCard
             origHash={origHash}
             hasAssessmentInstances={hasAssessmentInstances}
@@ -254,7 +278,7 @@ function InstructorAssessmentGroupsInner({
           />
         )}
       </div>
-      {canEditCourse && saveStatus && (
+      {canEditGroupSettings && saveStatus && (
         <div className="position-sticky bottom-0 z-3 bg-body border-top">
           {saveStatus.kind === 'success' && (
             <Alert

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
@@ -55,10 +55,12 @@ router.get(
       accessType: 'instructor',
     });
     const { assessment, assessment_set, course, course_instance, authz_data } = pageContext;
-    const canEditGroupSettings = authz_data.has_course_permission_edit && !course.example_course;
-    const canViewStudentData = authz_data.has_course_instance_permission_view;
-    const canEditStudentData =
-      authz_data.has_course_instance_permission_edit && !course.example_course;
+    const permissions = {
+      isExampleCourse: course.example_course,
+      hasCoursePermissionEdit: authz_data.has_course_permission_edit,
+      hasCourseInstancePermissionView: authz_data.has_course_instance_permission_view,
+      hasCourseInstancePermissionEdit: authz_data.has_course_instance_permission_edit,
+    };
 
     const groupsCsvFilename =
       assessmentFilenamePrefix(assessment, assessment_set, course_instance, course) + 'groups.csv';
@@ -69,7 +71,7 @@ router.get(
       : undefined;
 
     const [groups, notAssigned] =
-      groupConfigInfo && canViewStudentData
+      groupConfigInfo && permissions.hasCourseInstancePermissionView
         ? await Promise.all([
             selectGroupsForConfig(groupConfigInfo.id),
             selectUidsNotInGroup({
@@ -125,11 +127,11 @@ router.get(
               courseInstanceId={course_instance.id}
               assessment={assessment}
               assessmentSet={assessment_set}
-              canEditGroupSettings={canEditGroupSettings}
-              canViewStudentData={canViewStudentData}
-              canEditStudentData={canEditStudentData}
+              permissions={permissions}
               csrfToken={pageContext.__csrf_token}
-              groupsCsvFilename={canViewStudentData ? groupsCsvFilename : undefined}
+              groupsCsvFilename={
+                permissions.hasCourseInstancePermissionView ? groupsCsvFilename : undefined
+              }
               groupConfigInfo={staffGroupConfigInfo}
               groups={groups}
               notAssigned={notAssigned}

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
@@ -129,9 +129,7 @@ router.get(
               assessmentSet={assessment_set}
               permissions={permissions}
               csrfToken={pageContext.__csrf_token}
-              groupsCsvFilename={
-                permissions.hasCourseInstancePermissionView ? groupsCsvFilename : undefined
-              }
+              groupsCsvFilename={groupsCsvFilename}
               groupConfigInfo={staffGroupConfigInfo}
               groups={groups}
               notAssigned={notAssigned}

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
@@ -46,7 +46,7 @@ function getAssessmentPath(
 router.get(
   '/',
   createAuthzMiddleware({
-    oneOfPermissions: ['has_course_instance_permission_view'],
+    oneOfPermissions: ['has_course_permission_view', 'has_course_instance_permission_view'],
     unauthorizedUsers: 'block',
   }),
   typedAsyncHandler<'assessment'>(async (_req, res) => {
@@ -55,8 +55,9 @@ router.get(
       accessType: 'instructor',
     });
     const { assessment, assessment_set, course, course_instance, authz_data } = pageContext;
-    const canEditCourse = authz_data.has_course_permission_edit && !course.example_course;
-    const canEditCourseInstance =
+    const canEditGroupSettings = authz_data.has_course_permission_edit && !course.example_course;
+    const canViewStudentData = authz_data.has_course_instance_permission_view;
+    const canEditStudentData =
       authz_data.has_course_instance_permission_edit && !course.example_course;
 
     const groupsCsvFilename =
@@ -67,15 +68,16 @@ router.get(
       ? StaffGroupConfigSchema.parse(groupConfigInfo)
       : undefined;
 
-    const [groups, notAssigned] = groupConfigInfo
-      ? await Promise.all([
-          selectGroupsForConfig(groupConfigInfo.id),
-          selectUidsNotInGroup({
-            group_config_id: groupConfigInfo.id,
-            course_instance_id: groupConfigInfo.course_instance_id,
-          }),
-        ])
-      : [undefined, undefined];
+    const [groups, notAssigned] =
+      groupConfigInfo && canViewStudentData
+        ? await Promise.all([
+            selectGroupsForConfig(groupConfigInfo.id),
+            selectUidsNotInGroup({
+              group_config_id: groupConfigInfo.id,
+              course_instance_id: groupConfigInfo.course_instance_id,
+            }),
+          ])
+        : [undefined, undefined];
 
     const trpcCsrfToken = generatePrefixCsrfToken(
       {
@@ -123,10 +125,11 @@ router.get(
               courseInstanceId={course_instance.id}
               assessment={assessment}
               assessmentSet={assessment_set}
-              canEditCourse={canEditCourse}
-              canEditCourseInstance={canEditCourseInstance}
+              canEditGroupSettings={canEditGroupSettings}
+              canViewStudentData={canViewStudentData}
+              canEditStudentData={canEditStudentData}
               csrfToken={pageContext.__csrf_token}
-              groupsCsvFilename={groupsCsvFilename}
+              groupsCsvFilename={canViewStudentData ? groupsCsvFilename : undefined}
               groupConfigInfo={staffGroupConfigInfo}
               groups={groups}
               notAssigned={notAssigned}

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.tsx
@@ -46,7 +46,7 @@ function getAssessmentPath(
 router.get(
   '/',
   createAuthzMiddleware({
-    oneOfPermissions: ['has_course_permission_view', 'has_course_instance_permission_view'],
+    oneOfPermissions: ['has_course_permission_preview', 'has_course_instance_permission_view'],
     unauthorizedUsers: 'block',
   }),
   typedAsyncHandler<'assessment'>(async (_req, res) => {

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/types.ts
@@ -1,0 +1,1 @@
+export type ActionAccess = { status: 'allowed' } | { status: 'denied'; reason: string };

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -430,8 +430,7 @@ ${submission.feedback?.manual}</textarea
                             </button>
 
                             <div class="dropdown-item-text text-muted small">
-                              AI can make mistakes. Review submission group assignments before
-                              grading.
+                              AI can make mistakes. Review submission groups before grading.
                             </div>
                           </div>
                         </div>

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.sql
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.sql
@@ -10,3 +10,16 @@ WHERE
   AND a.team_work IS TRUE
 LIMIT
   1;
+
+-- BLOCK select_individual_work_assessment
+SELECT
+  a.id
+FROM
+  assessments AS a
+  JOIN assessment_sets AS aset ON (aset.id = a.assessment_set_id)
+WHERE
+  a.course_instance_id = 1
+  AND aset.abbreviation = 'HW'
+  AND a.team_work IS FALSE
+LIMIT
+  1;

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -107,7 +107,7 @@ describe('Instructor group controls', () => {
       const body = await response.text();
       assert.include(
         body,
-        'You must have Student Data Viewer permission to view group memberships',
+        'You must have student data viewer permissions to view group memberships',
       );
       assert.include(body, 'Without it, group membership details are hidden.');
       assert.notInclude(body, users[0].uid);
@@ -130,7 +130,7 @@ describe('Instructor group controls', () => {
     const body = await response.text();
     assert.include(
       body,
-      'You can view group memberships, but editing memberships requires Student Data Editor',
+      'You can view group memberships, but editing memberships requires student data editor',
     );
     assert.notInclude(body, 'Add group');
     assert.include(body, users[0].uid);

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -52,12 +52,14 @@ describe('Instructor group controls', () => {
 
   let users: User[] = [];
   let assessment_id: string;
+  let individual_assessment_id: string;
   let trpcClient: ReturnType<typeof createAssessmentTrpcClient>;
   let group1RowId: string | undefined;
   let group2RowId: string | undefined;
 
   test.sequential('has group-based homework assessment', async () => {
     assessment_id = await queryScalar(sql.select_group_work_assessment, IdSchema);
+    individual_assessment_id = await queryScalar(sql.select_individual_work_assessment, IdSchema);
     const csrfToken = generatePrefixCsrfToken(
       {
         url: getAssessmentTrpcUrl({ courseInstanceId, assessmentId: assessment_id }),
@@ -71,6 +73,32 @@ describe('Instructor group controls', () => {
       assessmentId: assessment_id,
       urlBase: siteUrl,
     });
+  });
+
+  test.sequential('group work enable button reflects course edit permissions', async () => {
+    const groupsUrl = `${siteUrl}${getAssessmentUrl({
+      courseInstanceId,
+      assessmentId: individual_assessment_id,
+    })}/groups`;
+    const previewerResponse = await helperClient.fetchCheerio(groupsUrl, {
+      headers: {
+        cookie:
+          'pl_test_user=test_instructor; pl2_requested_course_role=Previewer; pl2_requested_course_instance_role=None',
+      },
+    });
+    assert.isTrue(previewerResponse.ok);
+    const previewerBody = await previewerResponse.text();
+    assert.include(previewerBody, 'Enabling group work requires course editor permissions.');
+    assert.lengthOf(previewerResponse.$('button:contains("Enable group work")'), 0);
+
+    const editorResponse = await helperClient.fetchCheerio(groupsUrl, {
+      headers: {
+        cookie:
+          'pl_test_user=test_instructor; pl2_requested_course_role=Editor; pl2_requested_course_instance_role=None',
+      },
+    });
+    assert.isTrue(editorResponse.ok);
+    assert.lengthOf(editorResponse.$('button:contains("Enable group work")'), 1);
   });
 
   test.sequential('enroll random users', async () => {
@@ -109,6 +137,35 @@ describe('Instructor group controls', () => {
         body,
         'You must have student data viewer permissions to view student group assignments.',
       );
+      assert.include(body, 'Editing group settings requires course editor permissions.');
+      assert.notInclude(body, users[0].uid);
+      assert.notInclude(body, users[1].uid);
+    },
+  );
+
+  test.sequential(
+    'course editor can edit group settings without seeing membership data',
+    async () => {
+      const groupsUrl = `${siteUrl}${getAssessmentUrl({
+        courseInstanceId,
+        assessmentId: assessment_id,
+      })}/groups`;
+      const response = await helperClient.fetchCheerio(groupsUrl, {
+        headers: {
+          cookie:
+            'pl_test_user=test_instructor; pl2_requested_course_role=Editor; pl2_requested_course_instance_role=None',
+        },
+      });
+      assert.isTrue(response.ok);
+      const body = await response.text();
+      assert.include(
+        body,
+        'You must have student data viewer permissions to view student group assignments.',
+      );
+      assert.include(
+        body,
+        'Disabling group work requires student data editor permissions because it permanently removes group assignments.',
+      );
       assert.notInclude(body, users[0].uid);
       assert.notInclude(body, users[1].uid);
     },
@@ -127,11 +184,32 @@ describe('Instructor group controls', () => {
     });
     assert.isTrue(response.ok);
     const body = await response.text();
+    assert.include(body, 'Editing group settings requires course editor permissions.');
+    assert.include(body, 'Editing group memberships requires student data editor permissions.');
+    assert.notInclude(body, 'Add group');
+    assert.include(body, users[0].uid);
+    assert.include(body, users[1].uid);
+  });
+
+  test.sequential('student data editor can edit memberships without editing settings', async () => {
+    const groupsUrl = `${siteUrl}${getAssessmentUrl({
+      courseInstanceId,
+      assessmentId: assessment_id,
+    })}/groups`;
+    const response = await helperClient.fetchCheerio(groupsUrl, {
+      headers: {
+        cookie:
+          'pl_test_user=test_instructor; pl2_requested_course_role=None; pl2_requested_course_instance_role=Student Data Editor',
+      },
+    });
+    assert.isTrue(response.ok);
+    const body = await response.text();
+    assert.include(body, 'Editing group settings requires course editor permissions.');
     assert.include(
       body,
-      'You can view group memberships, but editing memberships requires student data editor',
+      'Disabling group work requires course editor permissions because it changes group settings.',
     );
-    assert.notInclude(body, 'Add group');
+    assert.include(body, 'Add group');
     assert.include(body, users[0].uid);
     assert.include(body, users[1].uid);
   });

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -135,7 +135,7 @@ describe('Instructor group controls', () => {
       const body = await response.text();
       assert.include(
         body,
-        'You must have student data viewer permissions to view student group assignments.',
+        'You must have student data viewer permissions to view student group memberships.',
       );
       assert.include(body, 'Editing group settings requires course editor permissions.');
       assert.notInclude(body, users[0].uid);
@@ -160,11 +160,11 @@ describe('Instructor group controls', () => {
       const body = await response.text();
       assert.include(
         body,
-        'You must have student data viewer permissions to view student group assignments.',
+        'You must have student data viewer permissions to view student group memberships.',
       );
       assert.include(
         body,
-        'Disabling group work requires student data editor permissions because it permanently removes group assignments.',
+        'Disabling group work requires student data editor permissions because it permanently removes group memberships.',
       );
       assert.notInclude(body, users[0].uid);
       assert.notInclude(body, users[1].uid);

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -186,7 +186,7 @@ describe('Instructor group controls', () => {
     const body = await response.text();
     assert.include(body, 'Editing group settings requires course editor permissions.');
     assert.include(body, 'Editing group memberships requires student data editor permissions.');
-    assert.notInclude(body, 'Add group');
+    assert.lengthOf(response.$('button:contains("Add group")'), 0);
     assert.include(body, users[0].uid);
     assert.include(body, users[1].uid);
   });
@@ -209,7 +209,7 @@ describe('Instructor group controls', () => {
       body,
       'Disabling group work requires course editor permissions because it changes group settings.',
     );
-    assert.include(body, 'Add group');
+    assert.lengthOf(response.$('button:contains("Add group"):not(:disabled)'), 1);
     assert.include(body, users[0].uid);
     assert.include(body, users[1].uid);
   });

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -107,9 +107,8 @@ describe('Instructor group controls', () => {
       const body = await response.text();
       assert.include(
         body,
-        'You must have student data viewer permissions to view group memberships',
+        'You must have student data viewer permissions to view student group assignments.',
       );
-      assert.include(body, 'Without it, group membership details are hidden.');
       assert.notInclude(body, users[0].uid);
       assert.notInclude(body, users[1].uid);
     },

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -107,8 +107,9 @@ describe('Instructor group controls', () => {
       const body = await response.text();
       assert.include(
         body,
-        'You must have student data permission to view and edit group memberships.',
+        'You must have Student Data Viewer permission to view group memberships',
       );
+      assert.include(body, 'Without it, group membership details are hidden.');
       assert.notInclude(body, users[0].uid);
       assert.notInclude(body, users[1].uid);
     },
@@ -127,6 +128,11 @@ describe('Instructor group controls', () => {
     });
     assert.isTrue(response.ok);
     const body = await response.text();
+    assert.include(
+      body,
+      'You can view group memberships, but editing memberships requires Student Data Editor',
+    );
+    assert.notInclude(body, 'Add group');
     assert.include(body, users[0].uid);
     assert.include(body, users[1].uid);
   });

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -91,7 +91,7 @@ describe('Instructor group controls', () => {
   });
 
   test.sequential(
-    'course viewer can load groups page without receiving membership data',
+    'course previewer can load groups page without receiving membership data',
     async () => {
       const groupsUrl = `${siteUrl}${getAssessmentUrl({
         courseInstanceId,
@@ -100,7 +100,7 @@ describe('Instructor group controls', () => {
       const response = await helperClient.fetchCheerio(groupsUrl, {
         headers: {
           cookie:
-            'pl_test_user=test_instructor; pl2_requested_course_role=Viewer; pl2_requested_course_instance_role=None',
+            'pl_test_user=test_instructor; pl2_requested_course_role=Previewer; pl2_requested_course_instance_role=None',
         },
       });
       assert.isTrue(response.ok);

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -4,23 +4,51 @@ import { loadSqlEquiv, queryScalar } from '@prairielearn/postgres';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 import { IdSchema } from '@prairielearn/zod';
 
-import { getAssessmentTrpcUrl } from '../lib/client/url.js';
+import { getAssessmentTrpcUrl, getAssessmentUrl } from '../lib/client/url.js';
 import { config } from '../lib/config.js';
 import { type User } from '../lib/db-types.js';
+import {
+  insertCourseInstancePermissions,
+  insertCoursePermissionsByUserUid,
+} from '../models/course-permissions.js';
 import { generateAndEnrollUsers } from '../models/enrollment.js';
 import { createAssessmentTrpcClient } from '../trpc/assessment/client.js';
 
+import * as helperClient from './helperClient.js';
 import * as helperServer from './helperServer.js';
+import { getOrCreateUser } from './utils/auth.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
 describe('Instructor group controls', () => {
-  beforeAll(helperServer.before());
-
-  afterAll(helperServer.after);
-
   const siteUrl = 'http://localhost:' + config.serverPort;
   const courseInstanceId = '1';
+
+  beforeAll(helperServer.before());
+
+  beforeAll(async () => {
+    const instructor = await getOrCreateUser({
+      uid: 'instructor@example.com',
+      name: 'Instructor User',
+      uin: '100000000',
+      email: 'instructor@example.com',
+    });
+    await insertCoursePermissionsByUserUid({
+      course_id: '1',
+      uid: instructor.uid,
+      course_role: 'Owner',
+      authn_user_id: instructor.id,
+    });
+    await insertCourseInstancePermissions({
+      course_id: '1',
+      user_id: instructor.id,
+      course_instance_id: courseInstanceId,
+      course_instance_role: 'Student Data Editor',
+      authn_user_id: instructor.id,
+    });
+  });
+
+  afterAll(helperServer.after);
 
   let users: User[] = [];
   let assessment_id: string;
@@ -60,6 +88,47 @@ describe('Instructor group controls', () => {
     assert.equal(group.name, 'TestGroup');
     assert.deepEqual(group.users.map((u) => u.uid).sort(), [users[0].uid, users[1].uid].sort());
     group1RowId = group.group_id;
+  });
+
+  test.sequential(
+    'course viewer can load groups page without receiving membership data',
+    async () => {
+      const groupsUrl = `${siteUrl}${getAssessmentUrl({
+        courseInstanceId,
+        assessmentId: assessment_id,
+      })}/groups`;
+      const response = await helperClient.fetchCheerio(groupsUrl, {
+        headers: {
+          cookie:
+            'pl_test_user=test_instructor; pl2_requested_course_role=Viewer; pl2_requested_course_instance_role=None',
+        },
+      });
+      assert.isTrue(response.ok);
+      const body = await response.text();
+      assert.include(
+        body,
+        'You must have student data permission to view and edit group memberships.',
+      );
+      assert.notInclude(body, users[0].uid);
+      assert.notInclude(body, users[1].uid);
+    },
+  );
+
+  test.sequential('student data viewer can see group memberships', async () => {
+    const groupsUrl = `${siteUrl}${getAssessmentUrl({
+      courseInstanceId,
+      assessmentId: assessment_id,
+    })}/groups`;
+    const response = await helperClient.fetchCheerio(groupsUrl, {
+      headers: {
+        cookie:
+          'pl_test_user=test_instructor; pl2_requested_course_role=None; pl2_requested_course_instance_role=Student Data Viewer',
+      },
+    });
+    assert.isTrue(response.ok);
+    const body = await response.text();
+    assert.include(body, users[0].uid);
+    assert.include(body, users[1].uid);
   });
 
   test.sequential('cannot create a group with a user already in another group', async () => {

--- a/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
+++ b/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
@@ -307,13 +307,15 @@ const enableGroupWork = t.procedure
       });
     }
 
-    const [groups, notAssigned] = await Promise.all([
-      selectGroupsForConfig(groupConfig.id),
-      selectUidsNotInGroup({
-        group_config_id: groupConfig.id,
-        course_instance_id: groupConfig.course_instance_id,
-      }),
-    ]);
+    const [groups, notAssigned] = ctx.authz_data.has_course_instance_permission_view
+      ? await Promise.all([
+          selectGroupsForConfig(groupConfig.id),
+          selectUidsNotInGroup({
+            group_config_id: groupConfig.id,
+            course_instance_id: groupConfig.course_instance_id,
+          }),
+        ])
+      : [undefined, undefined];
 
     return {
       origHash: newHash,
@@ -425,6 +427,7 @@ const updateGroupConfig = t.procedure
 
 const disableGroupWork = t.procedure
   .use(requireCoursePermissionEdit)
+  .use(requireCourseInstancePermissionEdit)
   .input(z.object({ origHash: z.string().nullable() }))
   .mutation(async ({ input, ctx }) => {
     if (await selectAssessmentHasInstances(ctx.assessment.id)) {

--- a/docs/assessment/configuration.md
+++ b/docs/assessment/configuration.md
@@ -508,7 +508,7 @@ groupB,three@example.com
 groupB,four@example.com
 ```
 
-The assessment's "Downloads" tab has an `<assessment>_groups.csv` file that contains the current group assignments. This can be used to copy group assignments from one assessment to another. The same file is also listed at the bottom of the groups page.
+The assessment's "Downloads" tab has an `<assessment>_groups.csv` file that contains the current group memberships. This can be used to copy group memberships from one assessment to another. The same file is also listed at the bottom of the groups page.
 
 Alternatively, the "Random" button can be used to randomly assign students to groups based on a desired minimum/maximum group size.
 


### PR DESCRIPTION
# Description

Make the instructor assessment groups page visible to course previewers while gating group membership and ungrouped student data behind course instance student data permissions. General group settings now use course edit permissions, membership management uses student data editor permissions, and the groups section now explains both hidden membership data and disabled membership editing states. Disabling group work requires both course edit and student data editor permissions because it deletes membership data.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Added focused coverage for a course Previewer loading the groups page without receiving membership PII and for a student data viewer seeing memberships while receiving the edit-permissions explanation.