### PR TITLE
Fix shift-click range selection in sorted/filtered tables

### DIFF
--- a/.changeset/fix-shift-click-sorted-table.md
+++ b/.changeset/fix-shift-click-sorted-table.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': patch
+---
+
+Fix `useShiftClickCheckbox` so shift-click range selection works correctly when the table is sorted or filtered. The hook now tracks the last-clicked row's id and computes the range against the current row-model positions, instead of `row.index` (which is the pre-sort data index).

--- a/packages/ui/src/components/useShiftClickCheckbox.tsx
+++ b/packages/ui/src/components/useShiftClickCheckbox.tsx
@@ -7,7 +7,7 @@ import { type MouseEvent, useCallback, useState } from 'react';
  *
  * @example
  * ```tsx
- * const { lastClickedRowIndex, createCheckboxProps } = useShiftClickCheckbox();
+ * const { lastClickedRowId, createCheckboxProps } = useShiftClickCheckbox();
  *
  * // In your column definition:
  * cell: ({ row, table }) => {
@@ -16,7 +16,7 @@ import { type MouseEvent, useCallback, useState } from 'react';
  * ```
  */
 export function useShiftClickCheckbox<TData>() {
-  const [lastClickedRowIndex, setLastClickedRowIndex] = useState<number | null>(null);
+  const [lastClickedRowId, setLastClickedRowId] = useState<string | null>(null);
 
   /**
    * Creates props for a checkbox that supports shift-click range selection.
@@ -27,27 +27,34 @@ export function useShiftClickCheckbox<TData>() {
   const createCheckboxProps = useCallback(
     (row: Row<TData>, table: Table<TData>) => {
       const handleClick = (e: MouseEvent<HTMLInputElement>) => {
-        if (e.shiftKey && lastClickedRowIndex !== null) {
-          // Shift-click: select range
-          const currentIndex = row.index;
-          const start = Math.min(lastClickedRowIndex, currentIndex);
-          const end = Math.max(lastClickedRowIndex, currentIndex);
+        const rows = table.getRowModel().rows;
+        if (e.shiftKey && lastClickedRowId !== null) {
+          // Shift-click: select range using current visible positions, so the
+          // range reflects the user's current sort/filter rather than the
+          // pre-sort data order (`row.index` is the original data index).
+          const currentPos = rows.findIndex((r) => r.id === row.id);
+          const lastPos = rows.findIndex((r) => r.id === lastClickedRowId);
 
-          // Get all rows in the range
-          const rows = table.getRowModel().rows;
-          const shouldSelect = !row.getIsSelected();
+          if (currentPos !== -1 && lastPos !== -1) {
+            const start = Math.min(lastPos, currentPos);
+            const end = Math.max(lastPos, currentPos);
+            const shouldSelect = !row.getIsSelected();
 
-          // Select or deselect all rows in the range
-          for (let i = start; i <= end; i++) {
-            if (rows[i]?.getCanSelect()) {
-              rows[i].toggleSelected(shouldSelect);
+            for (let i = start; i <= end; i++) {
+              if (rows[i]?.getCanSelect()) {
+                rows[i].toggleSelected(shouldSelect);
+              }
             }
+          } else {
+            // Anchor row is no longer visible (e.g. filtered out): fall back
+            // to a single toggle.
+            row.getToggleSelectedHandler()(e);
           }
         } else {
           // Normal click: toggle this row
           row.getToggleSelectedHandler()(e);
         }
-        setLastClickedRowIndex(row.index);
+        setLastClickedRowId(row.id);
       };
 
       return {
@@ -59,12 +66,12 @@ export function useShiftClickCheckbox<TData>() {
         onChange: () => {},
       };
     },
-    [lastClickedRowIndex],
+    [lastClickedRowId],
   );
 
   return {
-    lastClickedRowIndex,
-    setLastClickedRowIndex,
+    lastClickedRowId,
+    setLastClickedRowId,
     createCheckboxProps,
   };
 }


### PR DESCRIPTION
# Description

`useShiftClickCheckbox` in `@prairielearn/ui` tracked the anchor row by `row.index`, which TanStack Table preserves from the pre-sort data order — so shift-clicking a range in a sorted or filtered view selected the wrong rows (visibly broken on the AI / manual grading table whenever a non-default sort was applied). The hook now tracks the last-clicked row's id and computes the range against the current `getRowModel().rows` positions, with a fallback to a single toggle if the anchor row is no longer visible (e.g. filtered out). The previously-exported `lastClickedRowIndex`/`setLastClickedRowIndex` are renamed to `lastClickedRowId`/`setLastClickedRowId` (no external consumers).

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation (Claude Code).

# Testing

- On the assessment-question manual grading table, click a column header to reverse the sort, then click one checkbox and shift-click another row a few positions away — the inclusive visible range is now selected. Repeat with a filter applied. Repeat the same checks for the default sort order to confirm no regression.
- The other two consumers of this hook (instructor students table and course admin staff table) both set `getRowId`, so they pick up the fix automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)