### PR TITLE
Hide links that could lead the students out of PL when in LockDown Browser

### DIFF
--- a/apps/prairielearn/src/components/PageLayout.tsx
+++ b/apps/prairielearn/src/components/PageLayout.tsx
@@ -440,7 +440,9 @@ export function PageLayout({
             </div>
           </div>
         </div>
-        ${resolvedOptions.showFooter ? renderHtml(<PageFooter />) : ''}
+        ${resolvedOptions.showFooter && !resLocals.lockdown_browser
+          ? renderHtml(<PageFooter />)
+          : ''}
       </body>
     </html>
   `.toString();

--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -12,6 +12,7 @@ export function PersonalNotesPanel({
   authz_result,
   variantId,
   allowNewUploads = true,
+  lockdownBrowser = false,
   csrfToken,
   context,
 }: {
@@ -21,6 +22,8 @@ export function PersonalNotesPanel({
   authz_result: Record<string, any>;
   variantId?: string;
   allowNewUploads?: boolean;
+  /** Hides the file-picker form; its OS file dialog would let students open desktop files. */
+  lockdownBrowser?: boolean;
   csrfToken: string;
   context: 'question' | 'assessment';
 }) {
@@ -77,7 +80,7 @@ export function PersonalNotesPanel({
                       </div>
                     `
                   : html`
-                      ${AttachFileForm({ variantId, csrfToken })}
+                      ${lockdownBrowser ? '' : AttachFileForm({ variantId, csrfToken })}
                       ${UploadTextForm({ variantId, csrfToken })}
                     `}
             </div>

--- a/apps/prairielearn/src/ee/auth/prairietestCallback.ts
+++ b/apps/prairielearn/src/ee/auth/prairietestCallback.ts
@@ -17,6 +17,7 @@ const PrairieTestJwtPayloadSchema = z.object({
   user_id: z.string(),
   course_instance_id: z.string().optional(),
   assessment_id: z.string().optional(),
+  lockdown_browser: z.boolean().optional(),
 });
 
 router.post(
@@ -55,7 +56,7 @@ router.post(
         cause: err,
       });
     }
-    const { user_id, course_instance_id, assessment_id } =
+    const { user_id, course_instance_id, assessment_id, lockdown_browser } =
       PrairieTestJwtPayloadSchema.parse(payload);
 
     if ((course_instance_id === undefined) !== (assessment_id === undefined)) {
@@ -74,6 +75,10 @@ router.post(
       course_instance_id !== undefined && assessment_id !== undefined
         ? `${getStudentAssessmentUrl(course_instance_id, assessment_id)}?rldbsp=1`
         : undefined;
+
+    // Record whether the student authenticated through the LockDown Browser
+    // flow so PrairieLearn pages can conditionally hide navigation elements.
+    req.session.lockdown_browser = lockdown_browser ?? false;
 
     await authnLib.loadUser(
       req,

--- a/apps/prairielearn/src/lib/authn.types.ts
+++ b/apps/prairielearn/src/lib/authn.types.ts
@@ -28,4 +28,5 @@ export interface ResLocalsAuthnUser {
   access_as_administrator: boolean;
   is_administrator: boolean;
   is_institution_administrator: boolean;
+  lockdown_browser: boolean;
 }

--- a/apps/prairielearn/src/lib/client/page-context.test.ts
+++ b/apps/prairielearn/src/lib/client/page-context.test.ts
@@ -29,6 +29,7 @@ const createBaseContext = (overrides: Record<string, any> = {}) => ({
   authn_is_administrator: false,
   is_administrator: false,
   is_institution_administrator: false,
+  lockdown_browser: false,
   navPage: 'home' as const,
   access_as_administrator: false,
   authn_user: TEST_USER,

--- a/apps/prairielearn/src/lib/client/page-context.ts
+++ b/apps/prairielearn/src/lib/client/page-context.ts
@@ -31,6 +31,7 @@ const BasePageContextSchema = z.object({
   access_as_administrator: z.boolean(),
   is_administrator: z.boolean(),
   is_institution_administrator: z.boolean(),
+  lockdown_browser: z.boolean(),
   navPage: NavPageSchema,
   /** You should prefer to set the navbarType instead of using this value. */
   navbarType: NavbarTypeSchema,

--- a/apps/prairielearn/src/middlewares/authn.ts
+++ b/apps/prairielearn/src/middlewares/authn.ts
@@ -16,6 +16,7 @@ const UUID_REGEXP = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4
 
 export default asyncHandler(async (req, res, next) => {
   res.locals.is_administrator = false;
+  res.locals.lockdown_browser = false;
 
   if (req.method === 'OPTIONS') {
     // don't authenticate for OPTIONS requests, as these are just for CORS
@@ -176,6 +177,10 @@ export default asyncHandler(async (req, res, next) => {
   await authnLib.loadUser(req, res, authnParams, {
     redirect: false,
   });
+
+  // Surface the LockDown Browser flag recorded on the session at PT->PL
+  // login so pages can conditionally hide navigation elements.
+  res.locals.lockdown_browser = req.session.lockdown_browser ?? false;
 
   next();
 });

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -20,6 +20,7 @@ export function Home({
   unreadNewsItems,
   blogUrl,
   now,
+  lockdownBrowser,
 }: {
   canAddCourses: boolean;
   csrfToken: string;
@@ -32,6 +33,7 @@ export function Home({
   unreadNewsItems: NewsItem[];
   blogUrl: string | null;
   now: Date;
+  lockdownBrowser: boolean;
 }) {
   const listedStudentCourses = studentCourses.filter((ci) => {
     if (ci.enrollment.status === 'joined') return true;
@@ -55,7 +57,11 @@ export function Home({
       <DevModeCard isDevMode={isDevMode} />
       <AdminInstitutionsCard adminInstitutions={adminInstitutions} />
       <NewsAlert newsItems={unreadNewsItems} csrfToken={csrfToken} blogUrl={blogUrl} now={now} />
-      <InstructorCoursesCard instructorCourses={instructorCourses} urlPrefix={urlPrefix} />
+      <InstructorCoursesCard
+        instructorCourses={instructorCourses}
+        urlPrefix={urlPrefix}
+        lockdownBrowser={lockdownBrowser}
+      />
       <Hydrate>
         <HomeCards
           studentCourses={listedStudentCourses}
@@ -130,24 +136,31 @@ function AdminInstitutionsCard({ adminInstitutions }: AdminInstitutionsCardProps
 interface InstructorCoursesCardProps {
   instructorCourses: InstructorHomePageCourse[];
   urlPrefix: string;
+  lockdownBrowser: boolean;
 }
 
-function InstructorCoursesCard({ instructorCourses, urlPrefix }: InstructorCoursesCardProps) {
+function InstructorCoursesCard({
+  instructorCourses,
+  urlPrefix,
+  lockdownBrowser,
+}: InstructorCoursesCardProps) {
   if (instructorCourses.length === 0) return null;
 
   return (
     <div className="card mb-4">
       <div className="card-header bg-primary text-white d-flex align-items-center">
         <h2>Courses with instructor access</h2>
-        <a
-          href="https://docs.prairielearn.com"
-          className="btn btn-light btn-sm ms-auto"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <i className="bi bi-journal-text me-sm-1" aria-hidden="true" />
-          <span className="d-none d-sm-inline">View docs</span>
-        </a>
+        {!lockdownBrowser && (
+          <a
+            href="https://docs.prairielearn.com"
+            className="btn btn-light btn-sm ms-auto"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <i className="bi bi-journal-text me-sm-1" aria-hidden="true" />
+            <span className="d-none d-sm-inline">View docs</span>
+          </a>
+        )}
       </div>
 
       <div className="table-responsive">

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -165,6 +165,7 @@ router.get(
             unreadNewsItems={unreadNewsItems}
             blogUrl={config.newsFeedBlogUrl}
             now={res.locals.req_date}
+            lockdownBrowser={res.locals.lockdown_browser}
           />
         ),
       }),

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
@@ -423,6 +423,7 @@ export function StudentAssessmentInstance({
             assessment_instance: resLocals.assessment_instance,
             csrfToken: resLocals.__csrf_token,
             authz_result: resLocals.authz_result,
+            lockdownBrowser: resLocals.lockdown_browser,
           })
         : ''}
       ${InstructorInfoPanel({

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.html.ts
@@ -222,6 +222,7 @@ export function StudentInstanceQuestion({
                 authz_result: resLocals.authz_result,
                 variantId: renderState?.variant.id,
                 csrfToken: resLocals.__csrf_token,
+                lockdownBrowser: resLocals.lockdown_browser,
               })
             : ''}
           ${hasCalculator ? CalculatorDrawerToggle() : ''}


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

This PR addresses the following suggestions from the Respondus team:

- [x] On the initial landing page and during the exam you should remove any active links that appear, otherwise students can navigate away while still being inside LockDown Browser. The black toolbar at the top should be suppressed as it provides too many ways for students to navigate away from the start page.
- [x] There shouldn't be a way for students to open the Attach File dialog as they can easily access and open a cheat sheet found on their desktop.

This PR covers the **PrairieLearn** side, which is what a student sees while taking the exam inside LockDown Browser. The PrairieTest landing-page side is a companion PR.

PrairieTest passes a `lockdown_browser` flag in the auth JWT at handoff; PrairieLearn stores it on the session and exposes it on `res.locals` and the page context, so pages can branch on it.

- **Attach File dialog** — the "Attach a file" form in the Personal Notes panel is hidden inside LDB. Its file picker opens the OS file dialog, which would let a student browse to and open a cheat sheet on their desktop. The "Add text note" option stays, since it cannot reach the filesystem.
- **Navigate-away links** — the page footer (external Company / GitHub links) is removed inside LDB, as is the "View docs" link on the "Courses with instructor access" card (in case a student has instructor access to some other courses, and manages to view them even while in exam mode)

The PrairieLearn navbar is not separately suppressed: in exam mode PrairieLearn already hides non-exam navigation, so the remaining navbar has no navigate-away vectors.

All of these elements remain visible in a normal browser.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

This was tested manually by accessing the pages in PT and verifying if the elements rendered inside the LDB.
