### PR TITLE
Add link to AI image grading paper in AI grading docs

### DIFF
--- a/docs/aiGrading/index.md
+++ b/docs/aiGrading/index.md
@@ -190,7 +190,7 @@ Across a range of open-ended questions and frontier models, rubric-item accuracy
 For more detail, see our published research:
 
 - **Text grading** — Zhao, C., Fowler, M., Gertner, Y., Poulsen, S., West, M., & Silva, M. (2026). [AI-Supported Grading and Rubric Refinement for Free Response Questions](https://dl.acm.org/doi/10.1145/3770762.3772545). In _Proceedings of the 57th ACM Technical Symposium on Computer Science Education_ (SIGCSE TS 2026).
-- **Image grading** — Levine, J., Aenlle, M., Zilles, C., West, M., & Silva, M. (forthcoming). Automated grading of handwritten mathematics using vision-capable LLMs. In _Proceedings of the 27th International Conference on Artificial Intelligence in Education_ (AIED 2026). Springer.
+- **Image grading** — Levine, J., Aenlle, M., Zilles, C., West, M., & Silva, M. (forthcoming). [Automated grading of handwritten mathematics using vision-capable LLMs](https://arxiv.org/abs/2605.19043). In _Proceedings of the 27th International Conference on Artificial Intelligence in Education_ (AIED 2026). Springer.
 
 ## Cost and runtime
 


### PR DESCRIPTION
# Description

Add link to AI image grading paper in the docs.

# Testing

Navigate to the AI grading page in the docs, go to the Accuracy section, and make sure the image grading paper link works.