### PR TITLE
Standardize student data permission copy

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
@@ -828,8 +828,8 @@ export function AssessmentQuestionTable({
                       tooltip={{
                         body: (
                           <>
-                            Only staff with <strong>Student Data Editor</strong> permissions or
-                            higher can be assigned as graders
+                            Only staff with student data editor permissions can be assigned as
+                            graders
                           </>
                         ),
                         props: { id: 'assign-for-grading-tooltip' },

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -708,7 +708,7 @@ router.post(
         if (!courseStaff.some((staff) => idsEqual(staff.id, assigned_grader))) {
           throw new error.HttpStatusError(
             400,
-            'Assigned grader does not have Student Data Editor permission',
+            'The assigned grader does not have student data editor permissions.',
           );
         }
       }

--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/PublishingExtensions.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/PublishingExtensions.tsx
@@ -106,7 +106,7 @@ export function PublishingExtensions({
 
       {!canView ? (
         <div className="alert alert-info" role="alert">
-          You must have student data permission to view and edit extensions.
+          You must have student data viewer permissions to view extensions.
         </div>
       ) : extensionsQuery.isError ? (
         <Alert variant="danger" dismissible onClose={() => void extensionsQuery.refetch()}>

--- a/apps/prairielearn/src/tests/permissions/publishingAccess.test.ts
+++ b/apps/prairielearn/src/tests/permissions/publishingAccess.test.ts
@@ -267,7 +267,7 @@ describe('publishing page access', { timeout: 60_000 }, function () {
         assert.isTrue(response.ok);
         assert.lengthOf(
           response.$(
-            '.alert:contains("You must have student data permission to view and edit extensions.")',
+            '.alert:contains("You must have student data viewer permissions to view extensions.")',
           ),
           1,
         );
@@ -285,7 +285,7 @@ describe('publishing page access', { timeout: 60_000 }, function () {
         assert.isTrue(response.ok);
         assert.lengthOf(
           response.$(
-            '.alert:contains("You must have student data permission to view and edit extensions.")',
+            '.alert:contains("You must have student data viewer permissions to view extensions.")',
           ),
           0,
         );

--- a/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
+++ b/apps/prairielearn/src/trpc/assessmentQuestion/manual-grading.ts
@@ -224,7 +224,7 @@ const setAssignedGraderMutation = t.procedure
       if (!courseStaff.some((staff) => idsEqual(staff.id, assigned_grader))) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
-          message: 'The assigned grader does not have Student Data Editor permission.',
+          message: 'The assigned grader does not have student data editor permissions.',
         });
       }
     }

--- a/docs/lmsIntegrationInstructor.md
+++ b/docs/lmsIntegrationInstructor.md
@@ -15,7 +15,7 @@ Linking a PrairieLearn course instance with a Canvas course requires the followi
 - PrairieLearn Course Instance
   - [Student Data Editor](course/index.md#course-staff)
 
-To check this, in PrairieLearn go to the "Staff" tab and make sure that the "Student data access" column has an "Editor" badge for the appropriate course instance, in the row corresponding to your name. If you don't have Student Data Editor permission, add this or ask the course owner to do so.
+To check this, in PrairieLearn go to the "Staff" tab and make sure that the "Student data access" column has an "Editor" badge for the appropriate course instance, in the row corresponding to your name. If you don't have student data editor permissions, add them or ask the course owner to do so.
 
 ## Setting up your Canvas course for PrairieLearn
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Standardizes user-facing copy around student data permissions to use lowercase/plural descriptors for explanatory text, while preserving exact role names when listing roles. This updates publishing extensions, LMS instructor documentation, and manual grading assigned-grader messages so they consistently refer to student data viewer/editor permissions.

- [x] I have disclosed the level of AI assistance used (majority of implementation completed by Codex).

# Testing

- Updated and ran `yarn test apps/prairielearn/src/tests/permissions/publishingAccess.test.ts` for the exact publishing alert assertion.
