### PR TITLE
Clarify in AI grading docs that submissions are not used for training

### DIFF
--- a/docs/aiGrading/index.md
+++ b/docs/aiGrading/index.md
@@ -136,7 +136,7 @@ For transparency and debugging, the exact prompt sent to the model is available 
 
 **Concurrency:** AI grading keeps up to 20 submissions in progress at any time. When one finishes, the next begins automatically.
 
-**Privacy:** Student identifying information (name, email, UIN) is not sent to LLM providers, as long as it is not in the submission, question, or correct answer. Student submissions are not used for model training.
+**Privacy:** Student identifying information (name, email, UIN) is not sent to LLM providers, as long as it is not in the submission, question, or correct answer. Student submissions are not used for model training when using PrairieLearn AI grading credits.
 
 ## Billing
 

--- a/docs/aiGrading/index.md
+++ b/docs/aiGrading/index.md
@@ -136,7 +136,7 @@ For transparency and debugging, the exact prompt sent to the model is available 
 
 **Concurrency:** AI grading keeps up to 20 submissions in progress at any time. When one finishes, the next begins automatically.
 
-**Privacy:** Student identifying information (name, email, UIN) is not sent to LLM providers, as long as it is not in the submission, question, or correct answer.
+**Privacy:** Student identifying information (name, email, UIN) is not sent to LLM providers, as long as it is not in the submission, question, or correct answer. Student submissions are not used for model training.
 
 ## Billing
 


### PR DESCRIPTION
# Description

Adds a sentence to the Privacy note in the AI grading docs clarifying that student submissions are not used for model training.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation.

# Testing

Docs-only change.