### PR TITLE
Fix handling of pl-drawing objects with numeric labels

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -162,6 +162,7 @@ window.PLDrawingApi = {
 
       // Parse any numerical options from string to floating point
       for (const key in opts) {
+        if (/^type$|^label|color|^plist$/.test(key)) continue; // skip parsing for string-only options
         const parsed = Number(opts[key]);
         if (!Number.isNaN(parsed)) {
           opts[key] = parsed;


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Noticed while testing something else. When a pl-drawing element includes a button to create objects, and that button contains a label that can be interpreted as numeric, that label was failing to appear. For example:

```html
<pl-drawing-button type="pl-point" label="0"></pl-drawing-button>
```

This was caused by an over-eager parsing function that was converting any argument that could be interpreted as numeric to a number, even if it was not supposed to be a number. This caused elements that expected it to be a string to fail to show the label.

This PR changes the parsing functionality to skip the numeric check if the argument key is "label". Given there are other attributes that are also string only and could potentially have the same issue (e.g., label-x, label-y, label1, color, stroke-color, etc.), this enforcement was done with a regex that matches all string-only object attributes.

<img width="236" height="121" alt="image" src="https://github.com/user-attachments/assets/d5dae573-c145-48bd-803e-de9455b21144" />

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: I asked copilot to double-check that the regex I used matched all arguments. Implementation itself did not use AI.

# Testing

Add the drawing button above to any pl-drawing construct in example course. In master, the label is not shown. In this branch, it is shown as expected. I tested both "0" (which is falsey) and "2" (which is truey) to ensure that tests based on the content of the label are still working as expected.
