### PR TITLE
Use permitted copy for group controls

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -212,7 +212,7 @@ function InstructorAssessmentGroupsInner({
           if (permissions.isExampleCourse) {
             return {
               status: 'denied',
-              reason: 'Enabling group work is not available for the example course.',
+              reason: 'Enabling group work is not permitted for the example course.',
             };
           }
           return {
@@ -252,7 +252,7 @@ function InstructorAssessmentGroupsInner({
             if (permissions.isExampleCourse) {
               return {
                 status: 'denied',
-                reason: 'Editing group settings is not available for the example course.',
+                reason: 'Editing group settings is not permitted for the example course.',
               };
             }
             return {
@@ -284,7 +284,7 @@ function InstructorAssessmentGroupsInner({
               if (permissions.isExampleCourse) {
                 return {
                   status: 'denied',
-                  reason: 'Editing group memberships is not available for the example course.',
+                  reason: 'Editing group memberships is not permitted for the example course.',
                 };
               }
               return {


### PR DESCRIPTION
# Description

Updates the remaining instructor assessment group example-course messages to say actions are "not permitted" rather than "not available" for enabling group work, editing group settings, and editing group memberships. This keeps policy-denial copy consistent with the existing disable group work message and reserves "not available" for capability or availability limitations. AI assistance: majority of implementation and validation by Codex.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Verified the instructor assessment groups integration test still passes, covering the affected group controls page and permission-copy rendering.