### PR TITLE
Improve instructor group work management

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
@@ -404,7 +404,7 @@ export function GroupSettingsCard({
               </div>
             </div>
 
-            <div className="mb-4">
+            <div>
               <div className="d-flex justify-content-between align-items-center gap-2">
                 <h5 className="mb-0">Roles</h5>
                 <button

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -1,4 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
+import { type UseQueryResult, useMutation } from '@tanstack/react-query';
+import type { TRPCClientErrorLike } from '@trpc/client';
+import type { inferRouterOutputs } from '@trpc/server';
 import clsx from 'clsx';
 import { formatDistance } from 'date-fns';
 import { useEffect, useState } from 'react';
@@ -25,7 +27,10 @@ import {
 import type { GroupUsersRow } from '../../../models/group.js';
 import type { AssessmentGroupsError } from '../../../trpc/assessment/assessment-groups.js';
 import { useTRPC } from '../../../trpc/assessment/context.js';
+import type { AssessmentRouter } from '../../../trpc/assessment/trpc.js';
 import type { ActionAccess } from '../types.js';
+
+type MembershipData = inferRouterOutputs<AssessmentRouter>['assessmentGroups']['membership'];
 
 function EditGroupModal({
   row,
@@ -669,8 +674,7 @@ function GroupRow({
 
 export function GroupsCard({
   groupsCsvFilename,
-  groups,
-  notAssigned,
+  membershipQuery,
   assessment,
   assessmentSet,
   courseInstanceId,
@@ -678,14 +682,10 @@ export function GroupsCard({
   editAccess,
   minGroupSize,
   maxGroupSize,
-  lastRefreshedAt,
-  isRefreshingGroups,
-  membershipErrorMessage,
-  onRefreshGroups,
+  onRefresh,
 }: {
   groupsCsvFilename: string;
-  groups: GroupUsersRow[];
-  notAssigned: string[];
+  membershipQuery: UseQueryResult<MembershipData, TRPCClientErrorLike<AssessmentRouter>>;
   assessment: StaffAssessment;
   assessmentSet: StaffAssessmentSet;
   courseInstanceId: string;
@@ -693,14 +693,11 @@ export function GroupsCard({
   editAccess: ActionAccess;
   minGroupSize: number;
   maxGroupSize: number;
-  lastRefreshedAt: number;
-  isRefreshingGroups: boolean;
-  membershipErrorMessage: string | null;
-  onRefreshGroups: () => void;
+  onRefresh: () => void;
 }) {
+  const { groups, notAssigned } = membershipQuery.data ?? { groups: [], notAssigned: [] };
   const [now, setNow] = useState(() => Date.now());
   const canEdit = editAccess.status === 'allowed';
-  const relativeNow = Math.max(now, lastRefreshedAt);
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 30_000);
@@ -745,14 +742,14 @@ export function GroupsCard({
           <AddGroupModal
             show={addModal.show}
             onHide={addModal.hide}
-            onGroupMembershipChanged={onRefreshGroups}
+            onGroupMembershipChanged={onRefresh}
           />
           <DeleteAllGroupsModal
             assessmentSetName={assessmentSet.name}
             assessmentNumber={assessment.number}
             show={deleteAllModal.show}
             onHide={deleteAllModal.hide}
-            onGroupMembershipChanged={onRefreshGroups}
+            onGroupMembershipChanged={onRefresh}
           />
           {editModal.data && (
             <EditGroupModal
@@ -760,7 +757,7 @@ export function GroupsCard({
               row={editModal.data}
               show={editModal.show}
               onHide={editModal.hide}
-              onGroupMembershipChanged={onRefreshGroups}
+              onGroupMembershipChanged={onRefresh}
             />
           )}
           {deleteModal.data && (
@@ -769,7 +766,7 @@ export function GroupsCard({
               row={deleteModal.data}
               show={deleteModal.show}
               onHide={deleteModal.hide}
-              onGroupMembershipChanged={onRefreshGroups}
+              onGroupMembershipChanged={onRefresh}
             />
           )}
         </>
@@ -787,8 +784,18 @@ export function GroupsCard({
                     {assignmentSummary}
                   </>
                 )}
-                {' · Updated '}
-                {formatDistance(lastRefreshedAt, relativeNow, { addSuffix: true })}
+                {membershipQuery.data ? (
+                  <>
+                    {' · Updated '}
+                    {formatDistance(
+                      membershipQuery.dataUpdatedAt,
+                      Math.max(now, membershipQuery.dataUpdatedAt),
+                      { addSuffix: true },
+                    )}
+                  </>
+                ) : (
+                  membershipQuery.isFetching && <> · Refreshing...</>
+                )}
               </div>
             </div>
             <div className="d-flex gap-2">
@@ -841,10 +848,10 @@ export function GroupsCard({
               <Button
                 variant="outline-secondary"
                 aria-label="Refresh groups"
-                disabled={isRefreshingGroups}
-                onClick={onRefreshGroups}
+                disabled={membershipQuery.isFetching}
+                onClick={onRefresh}
               >
-                {isRefreshingGroups ? (
+                {membershipQuery.isFetching ? (
                   <Spinner as="span" size="sm" animation="border" aria-hidden="true" />
                 ) : (
                   <i className="bi bi-arrow-clockwise" aria-hidden="true" />
@@ -859,9 +866,9 @@ export function GroupsCard({
             </Alert>
           )}
 
-          {membershipErrorMessage && (
-            <Alert variant="danger">
-              Could not refresh group membership: {membershipErrorMessage}
+          {membershipQuery.isError && (
+            <Alert variant="danger" className="mb-3">
+              Could not refresh group memberships. {membershipQuery.error.message}
             </Alert>
           )}
 

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -31,12 +31,12 @@ function EditGroupModal({
   row,
   show,
   onHide,
-  onGroupEdited,
+  onGroupMembershipChanged,
 }: {
   row: GroupUsersRow;
   show: boolean;
   onHide: () => void;
-  onGroupEdited: (group: GroupUsersRow, notAssigned: string[]) => void;
+  onGroupMembershipChanged: () => void;
 }) {
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.editGroup.mutationOptions());
@@ -56,8 +56,8 @@ function EditGroupModal({
     mutation.mutate(
       { groupId: row.group_id, uids: data.uids },
       {
-        onSuccess: ({ group, notAssigned, failures }) => {
-          onGroupEdited(group, notAssigned);
+        onSuccess: ({ failures }) => {
+          onGroupMembershipChanged();
           if (failures.length === 0) {
             reset();
             mutation.reset();
@@ -158,12 +158,12 @@ function DeleteGroupModal({
   row,
   show,
   onHide,
-  onGroupDeleted,
+  onGroupMembershipChanged,
 }: {
   row: GroupUsersRow;
   show: boolean;
   onHide: () => void;
-  onGroupDeleted: (groupId: string, notAssigned: string[]) => void;
+  onGroupMembershipChanged: () => void;
 }) {
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.deleteGroup.mutationOptions());
@@ -182,9 +182,10 @@ function DeleteGroupModal({
           mutation.mutate(
             { groupId: row.group_id },
             {
-              onSuccess: ({ notAssigned }) => {
-                onGroupDeleted(row.group_id, notAssigned);
+              onSuccess: () => {
+                onGroupMembershipChanged();
                 mutation.reset();
+                onHide();
               },
             },
           );
@@ -421,11 +422,11 @@ function RandomAssessmentGroupsModal({
 function AddGroupModal({
   show,
   onHide,
-  onGroupAdded,
+  onGroupMembershipChanged,
 }: {
   show: boolean;
   onHide: () => void;
-  onGroupAdded: (group: GroupUsersRow, notAssigned: string[]) => void;
+  onGroupMembershipChanged: () => void;
 }) {
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.addGroup.mutationOptions());
@@ -442,10 +443,11 @@ function AddGroupModal({
 
   const onSubmit = (data: { groupName: string; uids: string }) => {
     mutation.mutate(data, {
-      onSuccess: ({ group, notAssigned }) => {
-        onGroupAdded(group, notAssigned);
+      onSuccess: () => {
+        onGroupMembershipChanged();
         reset();
         mutation.reset();
+        onHide();
       },
     });
   };
@@ -546,13 +548,13 @@ function DeleteAllGroupsModal({
   assessmentNumber,
   show,
   onHide,
-  onAllGroupsDeleted,
+  onGroupMembershipChanged,
 }: {
   assessmentSetName: string;
   assessmentNumber: string;
   show: boolean;
   onHide: () => void;
-  onAllGroupsDeleted: (notAssigned: string[]) => void;
+  onGroupMembershipChanged: () => void;
 }) {
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.deleteAll.mutationOptions());
@@ -569,9 +571,10 @@ function DeleteAllGroupsModal({
         onSubmit={(e) => {
           e.preventDefault();
           mutation.mutate(undefined, {
-            onSuccess: ({ notAssigned }) => {
-              onAllGroupsDeleted(notAssigned);
+            onSuccess: () => {
+              onGroupMembershipChanged();
               mutation.reset();
+              onHide();
             },
           });
         }}
@@ -666,8 +669,8 @@ function GroupRow({
 
 export function GroupsCard({
   groupsCsvFilename,
-  initialGroups,
-  initialNotAssigned,
+  groups,
+  notAssigned,
   assessment,
   assessmentSet,
   courseInstanceId,
@@ -675,10 +678,15 @@ export function GroupsCard({
   editAccess,
   minGroupSize,
   maxGroupSize,
+  lastRefreshedAt,
+  isRefreshingGroups,
+  membershipErrorMessage,
+  onRefreshGroups,
+  onGroupMembershipChanged,
 }: {
   groupsCsvFilename: string;
-  initialGroups?: GroupUsersRow[];
-  initialNotAssigned?: string[];
+  groups: GroupUsersRow[];
+  notAssigned: string[];
   assessment: StaffAssessment;
   assessmentSet: StaffAssessmentSet;
   courseInstanceId: string;
@@ -686,24 +694,15 @@ export function GroupsCard({
   editAccess: ActionAccess;
   minGroupSize: number;
   maxGroupSize: number;
+  lastRefreshedAt: number;
+  isRefreshingGroups: boolean;
+  membershipErrorMessage: string | null;
+  onRefreshGroups: () => void;
+  onGroupMembershipChanged: () => void;
 }) {
-  const [groups, setGroups] = useState(initialGroups);
-  const [notAssigned, setNotAssigned] = useState(initialNotAssigned);
-  const [lastRefreshedAt, setLastRefreshedAt] = useState(() => Date.now());
   const [now, setNow] = useState(() => Date.now());
   const canEdit = editAccess.status === 'allowed';
-  const trpc = useTRPC();
-  const refreshMutation = useMutation(
-    trpc.assessmentGroups.refreshGroups.mutationOptions({
-      onSuccess: ({ groups: newGroups, notAssigned: newNotAssigned }) => {
-        const refreshedAt = Date.now();
-        setGroups(newGroups);
-        setNotAssigned(newNotAssigned);
-        setLastRefreshedAt(refreshedAt);
-        setNow(refreshedAt);
-      },
-    }),
-  );
+  const relativeNow = Math.max(now, lastRefreshedAt);
 
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 30_000);
@@ -716,25 +715,18 @@ export function GroupsCard({
   const editModal = useModalState<GroupUsersRow>();
   const deleteModal = useModalState<GroupUsersRow>();
 
-  const handleGroupAdded = (group: GroupUsersRow, newNotAssigned: string[]) => {
-    setGroups((prev) => [...(prev ?? []), group]);
-    setNotAssigned(newNotAssigned);
-  };
-
-  const handleGroupUpdated = (group: GroupUsersRow, newNotAssigned: string[]) => {
-    setGroups((prev) => prev?.map((g) => (g.group_id === group.group_id ? group : g)));
-    setNotAssigned(newNotAssigned);
-  };
-
-  const handleGroupDeleted = (groupId: string, newNotAssigned: string[]) => {
-    setGroups((prev) => prev?.filter((g) => g.group_id !== groupId));
-    setNotAssigned(newNotAssigned);
-  };
-
-  const handleAllGroupsDeleted = (newNotAssigned: string[]) => {
-    setGroups([]);
-    setNotAssigned(newNotAssigned);
-  };
+  const groupCount = groups.length;
+  const assignmentSummary = run(() => {
+    const unassignedCount = notAssigned.length;
+    const assignedCount = groups.reduce((sum, g) => sum + g.size, 0);
+    const totalStudents = unassignedCount + assignedCount;
+    if (totalStudents === 0) return null;
+    if (unassignedCount === 0) return 'All students are assigned';
+    if (assignedCount === 0) {
+      return `${unassignedCount} student${unassignedCount === 1 ? '' : 's'} unassigned`;
+    }
+    return `${assignedCount} assigned · ${unassignedCount} unassigned`;
+  });
 
   return (
     <>
@@ -755,20 +747,14 @@ export function GroupsCard({
           <AddGroupModal
             show={addModal.show}
             onHide={addModal.hide}
-            onGroupAdded={(group, notAssigned) => {
-              handleGroupAdded(group, notAssigned);
-              addModal.hide();
-            }}
+            onGroupMembershipChanged={onGroupMembershipChanged}
           />
           <DeleteAllGroupsModal
             assessmentSetName={assessmentSet.name}
             assessmentNumber={assessment.number}
             show={deleteAllModal.show}
             onHide={deleteAllModal.hide}
-            onAllGroupsDeleted={(notAssigned) => {
-              handleAllGroupsDeleted(notAssigned);
-              deleteAllModal.hide();
-            }}
+            onGroupMembershipChanged={onGroupMembershipChanged}
           />
           {editModal.data && (
             <EditGroupModal
@@ -776,7 +762,7 @@ export function GroupsCard({
               row={editModal.data}
               show={editModal.show}
               onHide={editModal.hide}
-              onGroupEdited={handleGroupUpdated}
+              onGroupMembershipChanged={onGroupMembershipChanged}
             />
           )}
           {deleteModal.data && (
@@ -785,10 +771,7 @@ export function GroupsCard({
               row={deleteModal.data}
               show={deleteModal.show}
               onHide={deleteModal.hide}
-              onGroupDeleted={(groupId, newNotAssigned) => {
-                handleGroupDeleted(groupId, newNotAssigned);
-                deleteModal.hide();
-              }}
+              onGroupMembershipChanged={onGroupMembershipChanged}
             />
           )}
         </>
@@ -799,21 +782,15 @@ export function GroupsCard({
             <div>
               <h5 className="mb-1">Groups</h5>
               <div className="text-muted small">
-                {groups?.length ?? 0} group{(groups?.length ?? 0) === 1 ? '' : 's'}
-                {' · '}
-                {run(() => {
-                  const unassignedCount = notAssigned?.length ?? 0;
-                  const assignedCount = groups?.reduce((sum, g) => sum + g.size, 0) ?? 0;
-                  const totalStudents = unassignedCount + assignedCount;
-                  if (totalStudents === 0) return 'No students enrolled';
-                  if (unassignedCount === 0) return 'All students are assigned';
-                  if (assignedCount === 0) {
-                    return `${unassignedCount} student${unassignedCount === 1 ? '' : 's'} unassigned`;
-                  }
-                  return `${assignedCount} assigned · ${unassignedCount} unassigned`;
-                })}
+                {groupCount} group{groupCount === 1 ? '' : 's'}
+                {assignmentSummary && (
+                  <>
+                    {' · '}
+                    {assignmentSummary}
+                  </>
+                )}
                 {' · Updated '}
-                {formatDistance(lastRefreshedAt, now, { addSuffix: true })}
+                {formatDistance(lastRefreshedAt, relativeNow, { addSuffix: true })}
               </div>
             </div>
             <div className="d-flex gap-2">
@@ -866,10 +843,10 @@ export function GroupsCard({
               <Button
                 variant="outline-secondary"
                 aria-label="Refresh groups"
-                disabled={refreshMutation.isPending}
-                onClick={() => refreshMutation.mutate()}
+                disabled={isRefreshingGroups}
+                onClick={onRefreshGroups}
               >
-                {refreshMutation.isPending ? (
+                {isRefreshingGroups ? (
                   <Spinner as="span" size="sm" animation="border" aria-hidden="true" />
                 ) : (
                   <i className="bi bi-arrow-clockwise" aria-hidden="true" />
@@ -884,7 +861,13 @@ export function GroupsCard({
             </Alert>
           )}
 
-          {notAssigned && notAssigned.length > 0 && (
+          {membershipErrorMessage && (
+            <Alert variant="danger">
+              Could not refresh group membership: {membershipErrorMessage}
+            </Alert>
+          )}
+
+          {notAssigned.length > 0 && (
             <Alert
               variant="warning"
               className="d-flex flex-column flex-md-row justify-content-md-between align-items-md-baseline gap-3"
@@ -925,7 +908,7 @@ export function GroupsCard({
                 </tr>
               </thead>
               <tbody>
-                {groups && groups.length > 0 ? (
+                {groups.length > 0 ? (
                   groups.map((row) => (
                     <GroupRow
                       key={row.group_id}

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupsCard.tsx
@@ -682,7 +682,6 @@ export function GroupsCard({
   isRefreshingGroups,
   membershipErrorMessage,
   onRefreshGroups,
-  onGroupMembershipChanged,
 }: {
   groupsCsvFilename: string;
   groups: GroupUsersRow[];
@@ -698,7 +697,6 @@ export function GroupsCard({
   isRefreshingGroups: boolean;
   membershipErrorMessage: string | null;
   onRefreshGroups: () => void;
-  onGroupMembershipChanged: () => void;
 }) {
   const [now, setNow] = useState(() => Date.now());
   const canEdit = editAccess.status === 'allowed';
@@ -747,14 +745,14 @@ export function GroupsCard({
           <AddGroupModal
             show={addModal.show}
             onHide={addModal.hide}
-            onGroupMembershipChanged={onGroupMembershipChanged}
+            onGroupMembershipChanged={onRefreshGroups}
           />
           <DeleteAllGroupsModal
             assessmentSetName={assessmentSet.name}
             assessmentNumber={assessment.number}
             show={deleteAllModal.show}
             onHide={deleteAllModal.hide}
-            onGroupMembershipChanged={onGroupMembershipChanged}
+            onGroupMembershipChanged={onRefreshGroups}
           />
           {editModal.data && (
             <EditGroupModal
@@ -762,7 +760,7 @@ export function GroupsCard({
               row={editModal.data}
               show={editModal.show}
               onHide={editModal.hide}
-              onGroupMembershipChanged={onGroupMembershipChanged}
+              onGroupMembershipChanged={onRefreshGroups}
             />
           )}
           {deleteModal.data && (
@@ -771,7 +769,7 @@ export function GroupsCard({
               row={deleteModal.data}
               show={deleteModal.show}
               onHide={deleteModal.hide}
-              onGroupMembershipChanged={onGroupMembershipChanged}
+              onGroupMembershipChanged={onRefreshGroups}
             />
           )}
         </>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
@@ -36,8 +36,8 @@ function DisableGroupWorkModal({
           All group configuration for this assessment, including groups and their memberships, will
           be permanently removed.
         </p>
-        <p className="mb-0 text-muted small">
-          Students will need to be re-grouped if you enable group work again later.
+        <p className="mb-0">
+          If you enable group work again later, students will need to be assigned to groups again.
         </p>
         {hasAssessmentInstances && (
           <GroupWorkInstancesWarning
@@ -66,6 +66,7 @@ export function ManageGroupWorkCard({
   courseInstanceId,
   assessmentId,
   disableAccess,
+  membershipSummary,
   onDisable,
 }: {
   origHash: string | null;
@@ -73,6 +74,7 @@ export function ManageGroupWorkCard({
   courseInstanceId: string;
   assessmentId: string;
   disableAccess: ActionAccess;
+  membershipSummary?: { groupCount: number; unassignedStudentCount: number };
   onDisable: (result: { origHash: string }) => void;
 }) {
   const [showDisableModal, setShowDisableModal] = useState(false);
@@ -102,28 +104,37 @@ export function ManageGroupWorkCard({
           )
         }
       />
-      <div className="card-body">
-        <h5 className="mb-3">Manage group work</h5>
+      <div className="card-body py-2">
         {appError && (
-          <Alert variant="danger" dismissible onClose={() => mutation.reset()}>
+          <Alert variant="danger" className="mb-2" dismissible onClose={() => mutation.reset()}>
             {appError.message}
           </Alert>
         )}
-        {disableAccess.status === 'denied' && <Alert variant="info">{disableAccess.reason}</Alert>}
-        <div className="d-flex align-items-center gap-3">
-          <div className="flex-grow-1">
-            <div className="fw-bold">Disable group work</div>
-            <div className="text-muted small">
-              All group configuration for this assessment, including groups and their memberships,
-              will be permanently removed.
+        {disableAccess.status === 'denied' && (
+          <Alert variant="info" className="mb-2">
+            {disableAccess.reason}
+          </Alert>
+        )}
+        <div className="d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-2">
+          <div className="d-flex flex-column flex-sm-row align-items-sm-center gap-1 gap-sm-3">
+            <div className="d-flex align-items-center gap-2">
+              <i className="bi bi-check-circle-fill text-success" aria-hidden="true" />
+              <span className="fw-semibold">Group work is enabled</span>
             </div>
+            {membershipSummary && (
+              <div className="text-muted small">
+                {`${membershipSummary.groupCount} group${membershipSummary.groupCount === 1 ? '' : 's'} · ${membershipSummary.unassignedStudentCount} student${membershipSummary.unassignedStudentCount === 1 ? '' : 's'} unassigned`}
+              </div>
+            )}
           </div>
           <Button
+            size="sm"
             variant="outline-danger"
+            className="text-nowrap align-self-start align-self-lg-center"
             disabled={mutation.isPending || !canDisable}
             onClick={() => setShowDisableModal(true)}
           >
-            Disable
+            Disable group work
           </Button>
         </div>
       </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
@@ -2,7 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Alert, Button, Modal } from 'react-bootstrap';
 
-import { getAppError } from '../../../lib/client/errors.js';
+import { type AppError, AppErrorAlert, getAppError } from '../../../lib/client/errors.js';
+import { getCourseInstanceJobSequenceUrl } from '../../../lib/client/url.js';
 import type { AssessmentGroupsError } from '../../../trpc/assessment/assessment-groups.js';
 import { useTRPC } from '../../../trpc/assessment/context.js';
 import type { ActionAccess } from '../types.js';
@@ -17,6 +18,8 @@ function DisableGroupWorkModal({
   hasAssessmentInstances,
   courseInstanceId,
   assessmentId,
+  error,
+  onDismissError,
 }: {
   show: boolean;
   onHide: () => void;
@@ -25,6 +28,8 @@ function DisableGroupWorkModal({
   hasAssessmentInstances: boolean;
   courseInstanceId: string;
   assessmentId: string;
+  error: AppError<AssessmentGroupsError['DisableGroupWork']> | null;
+  onDismissError: () => void;
 }) {
   return (
     <Modal show={show} onHide={onHide}>
@@ -32,6 +37,22 @@ function DisableGroupWorkModal({
         <Modal.Title>Disable group work</Modal.Title>
       </Modal.Header>
       <Modal.Body>
+        <AppErrorAlert
+          error={error}
+          className="mb-3"
+          render={{
+            SYNC_JOB_FAILED: ({ message, jobSequenceId }) => (
+              <>
+                {message}{' '}
+                <a href={getCourseInstanceJobSequenceUrl(courseInstanceId, jobSequenceId)}>
+                  View job logs
+                </a>
+              </>
+            ),
+            UNKNOWN: ({ message }) => message,
+          }}
+          onDismiss={onDismissError}
+        />
         <p className="mb-2">
           All group configuration for this assessment, including groups and their memberships, will
           be permanently removed.
@@ -82,6 +103,10 @@ export function ManageGroupWorkCard({
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.disableGroupWork.mutationOptions());
   const appError = getAppError<AssessmentGroupsError['DisableGroupWork']>(mutation.error);
+  const hideDisableModal = () => {
+    mutation.reset();
+    setShowDisableModal(false);
+  };
 
   return (
     <div className="card">
@@ -91,13 +116,15 @@ export function ManageGroupWorkCard({
         hasAssessmentInstances={hasAssessmentInstances}
         courseInstanceId={courseInstanceId}
         assessmentId={assessmentId}
-        onHide={() => setShowDisableModal(false)}
+        error={appError}
+        onDismissError={() => mutation.reset()}
+        onHide={hideDisableModal}
         onConfirm={() =>
           mutation.mutate(
             { origHash },
             {
               onSuccess: (result) => {
-                setShowDisableModal(false);
+                hideDisableModal();
                 onDisable(result);
               },
             },
@@ -105,11 +132,6 @@ export function ManageGroupWorkCard({
         }
       />
       <div className="card-body py-2">
-        {appError && (
-          <Alert variant="danger" className="mb-2" dismissible onClose={() => mutation.reset()}>
-            {appError.message}
-          </Alert>
-        )}
         {disableAccess.status === 'denied' && (
           <Alert variant="info" className="mb-2">
             {disableAccess.reason}

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/ManageGroupWorkCard.tsx
@@ -87,19 +87,19 @@ export function ManageGroupWorkCard({
   courseInstanceId,
   assessmentId,
   disableAccess,
-  membershipSummary,
+  assignmentSummary,
   onDisable,
 }: {
   origHash: string | null;
   hasAssessmentInstances: boolean;
   courseInstanceId: string;
   assessmentId: string;
-  disableAccess: ActionAccess;
-  membershipSummary?: { groupCount: number; unassignedStudentCount: number };
+  disableAccess?: ActionAccess;
+  assignmentSummary?: { totalStudentCount: number; unassignedStudentCount: number };
   onDisable: (result: { origHash: string }) => void;
 }) {
   const [showDisableModal, setShowDisableModal] = useState(false);
-  const canDisable = disableAccess.status === 'allowed';
+  const canDisable = disableAccess?.status === 'allowed';
   const trpc = useTRPC();
   const mutation = useMutation(trpc.assessmentGroups.disableGroupWork.mutationOptions());
   const appError = getAppError<AssessmentGroupsError['DisableGroupWork']>(mutation.error);
@@ -110,29 +110,31 @@ export function ManageGroupWorkCard({
 
   return (
     <div className="card">
-      <DisableGroupWorkModal
-        show={showDisableModal}
-        isPending={mutation.isPending}
-        hasAssessmentInstances={hasAssessmentInstances}
-        courseInstanceId={courseInstanceId}
-        assessmentId={assessmentId}
-        error={appError}
-        onDismissError={() => mutation.reset()}
-        onHide={hideDisableModal}
-        onConfirm={() =>
-          mutation.mutate(
-            { origHash },
-            {
-              onSuccess: (result) => {
-                hideDisableModal();
-                onDisable(result);
+      {disableAccess && (
+        <DisableGroupWorkModal
+          show={showDisableModal}
+          isPending={mutation.isPending}
+          hasAssessmentInstances={hasAssessmentInstances}
+          courseInstanceId={courseInstanceId}
+          assessmentId={assessmentId}
+          error={appError}
+          onDismissError={() => mutation.reset()}
+          onHide={hideDisableModal}
+          onConfirm={() =>
+            mutation.mutate(
+              { origHash },
+              {
+                onSuccess: (result) => {
+                  hideDisableModal();
+                  onDisable(result);
+                },
               },
-            },
-          )
-        }
-      />
+            )
+          }
+        />
+      )}
       <div className="card-body py-2">
-        {disableAccess.status === 'denied' && (
+        {disableAccess?.status === 'denied' && (
           <Alert variant="info" className="mb-2">
             {disableAccess.reason}
           </Alert>
@@ -143,21 +145,25 @@ export function ManageGroupWorkCard({
               <i className="bi bi-check-circle-fill text-success" aria-hidden="true" />
               <span className="fw-semibold">Group work is enabled</span>
             </div>
-            {membershipSummary && (
+            {assignmentSummary && assignmentSummary.totalStudentCount > 0 && (
               <div className="text-muted small">
-                {`${membershipSummary.groupCount} group${membershipSummary.groupCount === 1 ? '' : 's'} · ${membershipSummary.unassignedStudentCount} student${membershipSummary.unassignedStudentCount === 1 ? '' : 's'} unassigned`}
+                {assignmentSummary.unassignedStudentCount === 0
+                  ? 'All students assigned'
+                  : `${assignmentSummary.unassignedStudentCount} student${assignmentSummary.unassignedStudentCount === 1 ? '' : 's'} unassigned`}
               </div>
             )}
           </div>
-          <Button
-            size="sm"
-            variant="outline-danger"
-            className="text-nowrap align-self-start align-self-lg-center"
-            disabled={mutation.isPending || !canDisable}
-            onClick={() => setShowDisableModal(true)}
-          >
-            Disable group work
-          </Button>
+          {disableAccess && (
+            <Button
+              size="sm"
+              variant="outline-danger"
+              className="text-nowrap align-self-start align-self-lg-center"
+              disabled={mutation.isPending || !canDisable}
+              onClick={() => setShowDisableModal(true)}
+            >
+              Disable group work
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -42,8 +42,6 @@ function NoGroupConfigCard({
     origHash: string;
     groupConfig: StaffGroupConfig;
     groupSettingsDefaults: GroupSettingsFormValues | null;
-    groups?: GroupUsersRow[];
-    notAssigned?: string[];
   }) => void;
 }) {
   const trpc = useTRPC();
@@ -206,11 +204,11 @@ function InstructorAssessmentGroupsInner({
   const groupMembershipQueryKey = trpc.assessmentGroups.membership.queryKey();
   const groupMembershipQuery = useQuery({
     ...trpc.assessmentGroups.membership.queryOptions(),
-    enabled: !!groupConfigInfo && canViewStudentData,
-    initialData: {
-      groups: initialGroups ?? [],
-      notAssigned: initialNotAssigned ?? [],
-    },
+    enabled: groupConfigInfo != null && canViewStudentData,
+    initialData:
+      groupConfigInfo === initialGroupConfigInfo && initialGroups && initialNotAssigned
+        ? { groups: initialGroups, notAssigned: initialNotAssigned }
+        : undefined,
     staleTime: Infinity,
   });
 
@@ -238,34 +236,16 @@ function InstructorAssessmentGroupsInner({
         hasAssessmentInstances={hasAssessmentInstances}
         courseInstanceId={courseInstanceId}
         assessment={assessment}
-        onEnable={({
-          origHash: newHash,
-          groupConfig,
-          groupSettingsDefaults: newDefaults,
-          groups: newGroups,
-          notAssigned: newNotAssigned,
-        }) => {
+        onEnable={({ origHash: newHash, groupConfig, groupSettingsDefaults: newDefaults }) => {
           setOrigHash(newHash);
+          // Setting `groupConfigInfo` flips the membership query's `enabled`
+          // from false to true, which triggers an auto-fetch on the next render.
           setGroupConfigInfo(groupConfig);
           setGroupSettingsDefaults(newDefaults);
-          if (canViewStudentData) {
-            queryClient.setQueryData(groupMembershipQueryKey, {
-              groups: newGroups ?? [],
-              notAssigned: newNotAssigned ?? [],
-            });
-          }
         }}
       />
     );
   }
-
-  const groupMembership = groupMembershipQuery.data;
-  const unassignedStudentCount = groupMembership.notAssigned.length;
-  const groupMembershipError =
-    groupMembershipQuery.error == null
-      ? null
-      : (getAppError<AssessmentGroupsError['Membership']>(groupMembershipQuery.error)?.message ??
-        'An unknown error occurred.');
 
   return (
     <>
@@ -277,10 +257,10 @@ function InstructorAssessmentGroupsInner({
             courseInstanceId={courseInstanceId}
             assessmentId={assessment.id}
             membershipSummary={
-              canViewStudentData
+              canViewStudentData && groupMembershipQuery.data
                 ? {
-                    groupCount: groupMembership.groups.length,
-                    unassignedStudentCount,
+                    groupCount: groupMembershipQuery.data.groups.length,
+                    unassignedStudentCount: groupMembershipQuery.data.notAssigned.length,
                   }
                 : undefined
             }
@@ -319,7 +299,7 @@ function InstructorAssessmentGroupsInner({
               setOrigHash(newHash);
               setGroupSettingsDefaults(null);
               setGroupConfigInfo(undefined);
-              queryClient.setQueryData(groupMembershipQueryKey, { groups: [], notAssigned: [] });
+              queryClient.removeQueries({ queryKey: groupMembershipQueryKey });
             }}
           />
         )}
@@ -353,8 +333,7 @@ function InstructorAssessmentGroupsInner({
         {canViewStudentData ? (
           <GroupsCard
             groupsCsvFilename={groupsCsvFilename}
-            groups={groupMembership.groups}
-            notAssigned={groupMembership.notAssigned}
+            membershipQuery={groupMembershipQuery}
             assessment={assessment}
             assessmentSet={assessmentSet}
             courseInstanceId={courseInstanceId}
@@ -374,10 +353,7 @@ function InstructorAssessmentGroupsInner({
             })}
             minGroupSize={minGroupSize}
             maxGroupSize={maxGroupSize}
-            lastRefreshedAt={groupMembershipQuery.dataUpdatedAt}
-            isRefreshingGroups={groupMembershipQuery.isFetching}
-            membershipErrorMessage={groupMembershipError}
-            onRefreshGroups={refreshGroupMembership}
+            onRefresh={refreshGroupMembership}
           />
         ) : (
           <div className="card">

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -197,7 +197,7 @@ function InstructorAssessmentGroupsInner({
   const canViewStudentData = permissions.hasCourseInstancePermissionView;
   const canEditStudentData =
     permissions.hasCourseInstancePermissionEdit && !permissions.isExampleCourse;
-  const showManageGroupWork =
+  const showDisableGroupWorkAction =
     permissions.hasCoursePermissionEdit || permissions.hasCourseInstancePermissionEdit;
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -215,6 +215,18 @@ function InstructorAssessmentGroupsInner({
   const refreshGroupMembership = () => {
     void queryClient.invalidateQueries({ queryKey: groupMembershipQueryKey });
   };
+  const assignmentSummary = run(() => {
+    if (!canViewStudentData || !groupMembershipQuery.data) return undefined;
+    const unassignedStudentCount = groupMembershipQuery.data.notAssigned.length;
+    const assignedStudentCount = groupMembershipQuery.data.groups.reduce(
+      (sum, group) => sum + group.size,
+      0,
+    );
+    return {
+      totalStudentCount: assignedStudentCount + unassignedStudentCount,
+      unassignedStudentCount,
+    };
+  });
 
   if (!groupConfigInfo) {
     return (
@@ -250,59 +262,44 @@ function InstructorAssessmentGroupsInner({
   return (
     <>
       <div className="container d-flex flex-column gap-3 py-3">
-        {showManageGroupWork && (
-          <ManageGroupWorkCard
-            origHash={origHash}
-            hasAssessmentInstances={hasAssessmentInstances}
-            courseInstanceId={courseInstanceId}
-            assessmentId={assessment.id}
-            membershipSummary={
-              canViewStudentData && groupMembershipQuery.data
-                ? {
-                    groupCount: groupMembershipQuery.data.groups.length,
-                    unassignedStudentCount: groupMembershipQuery.data.notAssigned.length,
+        <ManageGroupWorkCard
+          origHash={origHash}
+          hasAssessmentInstances={hasAssessmentInstances}
+          courseInstanceId={courseInstanceId}
+          assessmentId={assessment.id}
+          assignmentSummary={assignmentSummary}
+          disableAccess={
+            showDisableGroupWorkAction
+              ? run<ActionAccess>(() => {
+                  if (canEditGroupSettings && canEditStudentData) return ALLOWED_ACCESS;
+                  if (permissions.isExampleCourse) {
+                    return {
+                      status: 'denied',
+                      reason: 'Disabling group work is not permitted for the example course.',
+                    };
                   }
-                : undefined
-            }
-            disableAccess={run<ActionAccess>(() => {
-              if (canEditGroupSettings && canEditStudentData) return ALLOWED_ACCESS;
-              if (permissions.isExampleCourse) {
-                return {
-                  status: 'denied',
-                  reason: 'Disabling group work is not permitted for the example course.',
-                };
-              }
-              if (
-                !permissions.hasCoursePermissionEdit &&
-                !permissions.hasCourseInstancePermissionEdit
-              ) {
-                return {
-                  status: 'denied',
-                  reason:
-                    'Disabling group work requires both course editor and student data editor permissions because it changes group settings and permanently removes group memberships.',
-                };
-              }
-              if (!permissions.hasCoursePermissionEdit) {
-                return {
-                  status: 'denied',
-                  reason:
-                    'Disabling group work requires course editor permissions because it changes group settings.',
-                };
-              }
-              return {
-                status: 'denied',
-                reason:
-                  'Disabling group work requires student data editor permissions because it permanently removes group memberships.',
-              };
-            })}
-            onDisable={({ origHash: newHash }) => {
-              setOrigHash(newHash);
-              setGroupSettingsDefaults(null);
-              setGroupConfigInfo(undefined);
-              queryClient.removeQueries({ queryKey: groupMembershipQueryKey });
-            }}
-          />
-        )}
+                  if (!permissions.hasCoursePermissionEdit) {
+                    return {
+                      status: 'denied',
+                      reason:
+                        'Disabling group work requires course editor permissions because it changes group settings.',
+                    };
+                  }
+                  return {
+                    status: 'denied',
+                    reason:
+                      'Disabling group work requires student data editor permissions because it permanently removes group memberships.',
+                  };
+                })
+              : undefined
+          }
+          onDisable={({ origHash: newHash }) => {
+            setOrigHash(newHash);
+            setGroupSettingsDefaults(null);
+            setGroupConfigInfo(undefined);
+            queryClient.removeQueries({ queryKey: groupMembershipQueryKey });
+          }}
+        />
         <GroupSettingsCard
           groupConfigInfo={groupConfigInfo}
           groupSettingsDefaults={groupSettingsDefaults}

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -215,8 +215,7 @@ function InstructorAssessmentGroupsInner({
   });
 
   const refreshGroupMembership = () => {
-    // Refetch errors surface via the membership query's `error` state; swallow here.
-    void queryClient.invalidateQueries({ queryKey: groupMembershipQueryKey }).catch(() => {});
+    void queryClient.invalidateQueries({ queryKey: groupMembershipQueryKey });
   };
 
   if (!groupConfigInfo) {
@@ -379,7 +378,6 @@ function InstructorAssessmentGroupsInner({
             isRefreshingGroups={groupMembershipQuery.isFetching}
             membershipErrorMessage={groupMembershipError}
             onRefreshGroups={refreshGroupMembership}
-            onGroupMembershipChanged={refreshGroupMembership}
           />
         ) : (
           <div className="card">

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/instructorAssessmentGroups.html.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, useMutation } from '@tanstack/react-query';
+import { QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Alert } from 'react-bootstrap';
 
@@ -186,8 +186,6 @@ function InstructorAssessmentGroupsInner({
   const [groupConfigInfo, setGroupConfigInfo] = useState(initialGroupConfigInfo);
   const [groupSettingsDefaults, setGroupSettingsDefaults] = useState(initialGroupSettingsDefaults);
   const [origHash, setOrigHash] = useState(initialOrigHash);
-  const [groups, setGroups] = useState(initialGroups);
-  const [notAssigned, setNotAssigned] = useState(initialNotAssigned);
   const [minGroupSize, setMinGroupSize] = useState(
     groupSettingsDefaults?.minMembers ?? groupConfigInfo?.minimum ?? 2,
   );
@@ -198,10 +196,28 @@ function InstructorAssessmentGroupsInner({
     { kind: 'success' } | { kind: 'error'; message: string } | null
   >(null);
   const canEditGroupSettings = permissions.hasCoursePermissionEdit && !permissions.isExampleCourse;
+  const canViewStudentData = permissions.hasCourseInstancePermissionView;
   const canEditStudentData =
     permissions.hasCourseInstancePermissionEdit && !permissions.isExampleCourse;
   const showManageGroupWork =
     permissions.hasCoursePermissionEdit || permissions.hasCourseInstancePermissionEdit;
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const groupMembershipQueryKey = trpc.assessmentGroups.membership.queryKey();
+  const groupMembershipQuery = useQuery({
+    ...trpc.assessmentGroups.membership.queryOptions(),
+    enabled: !!groupConfigInfo && canViewStudentData,
+    initialData: {
+      groups: initialGroups ?? [],
+      notAssigned: initialNotAssigned ?? [],
+    },
+    staleTime: Infinity,
+  });
+
+  const refreshGroupMembership = () => {
+    // Refetch errors surface via the membership query's `error` state; swallow here.
+    void queryClient.invalidateQueries({ queryKey: groupMembershipQueryKey }).catch(() => {});
+  };
 
   if (!groupConfigInfo) {
     return (
@@ -233,88 +249,42 @@ function InstructorAssessmentGroupsInner({
           setOrigHash(newHash);
           setGroupConfigInfo(groupConfig);
           setGroupSettingsDefaults(newDefaults);
-          setGroups(newGroups);
-          setNotAssigned(newNotAssigned);
+          if (canViewStudentData) {
+            queryClient.setQueryData(groupMembershipQueryKey, {
+              groups: newGroups ?? [],
+              notAssigned: newNotAssigned ?? [],
+            });
+          }
         }}
       />
     );
   }
 
+  const groupMembership = groupMembershipQuery.data;
+  const unassignedStudentCount = groupMembership.notAssigned.length;
+  const groupMembershipError =
+    groupMembershipQuery.error == null
+      ? null
+      : (getAppError<AssessmentGroupsError['Membership']>(groupMembershipQuery.error)?.message ??
+        'An unknown error occurred.');
+
   return (
     <>
       <div className="container d-flex flex-column gap-3 py-3">
-        <GroupSettingsCard
-          groupConfigInfo={groupConfigInfo}
-          groupSettingsDefaults={groupSettingsDefaults}
-          origHash={origHash}
-          editAccess={run<ActionAccess>(() => {
-            if (canEditGroupSettings) return ALLOWED_ACCESS;
-            if (permissions.isExampleCourse) {
-              return {
-                status: 'denied',
-                reason: 'Editing group settings is not available for the example course.',
-              };
-            }
-            return {
-              status: 'denied',
-              reason: 'Editing group settings requires course editor permissions.',
-            };
-          })}
-          onOrigHashChange={setOrigHash}
-          onGroupSizeSaved={(min, max) => {
-            setMinGroupSize(min ?? 2);
-            setMaxGroupSize(max ?? 4);
-          }}
-          onSaved={() => setSaveStatus({ kind: 'success' })}
-          onSaveError={(message) => setSaveStatus({ kind: 'error', message })}
-          onClearSaveStatus={() => setSaveStatus(null)}
-        />
-
-        {permissions.hasCourseInstancePermissionView ? (
-          <GroupsCard
-            groupsCsvFilename={groupsCsvFilename}
-            initialGroups={groups}
-            initialNotAssigned={notAssigned}
-            assessment={assessment}
-            assessmentSet={assessmentSet}
-            courseInstanceId={courseInstanceId}
-            csrfToken={csrfToken}
-            editAccess={run<ActionAccess>(() => {
-              if (canEditStudentData) return ALLOWED_ACCESS;
-              if (permissions.isExampleCourse) {
-                return {
-                  status: 'denied',
-                  reason: 'Editing group memberships is not available for the example course.',
-                };
-              }
-              return {
-                status: 'denied',
-                reason: 'Editing group memberships requires student data editor permissions.',
-              };
-            })}
-            minGroupSize={minGroupSize}
-            maxGroupSize={maxGroupSize}
-          />
-        ) : (
-          <div className="card">
-            <div className="card-body">
-              <h5 className="mb-1">Groups</h5>
-              <div className="text-muted small mb-3">
-                View and manage student group memberships for this assessment.
-              </div>
-              <Alert variant="info" className="mb-0">
-                You must have student data viewer permissions to view student group memberships.
-              </Alert>
-            </div>
-          </div>
-        )}
-
         {showManageGroupWork && (
           <ManageGroupWorkCard
             origHash={origHash}
             hasAssessmentInstances={hasAssessmentInstances}
             courseInstanceId={courseInstanceId}
             assessmentId={assessment.id}
+            membershipSummary={
+              canViewStudentData
+                ? {
+                    groupCount: groupMembership.groups.length,
+                    unassignedStudentCount,
+                  }
+                : undefined
+            }
             disableAccess={run<ActionAccess>(() => {
               if (canEditGroupSettings && canEditStudentData) return ALLOWED_ACCESS;
               if (permissions.isExampleCourse) {
@@ -350,10 +320,79 @@ function InstructorAssessmentGroupsInner({
               setOrigHash(newHash);
               setGroupSettingsDefaults(null);
               setGroupConfigInfo(undefined);
-              setGroups([]);
-              setNotAssigned([]);
+              queryClient.setQueryData(groupMembershipQueryKey, { groups: [], notAssigned: [] });
             }}
           />
+        )}
+        <GroupSettingsCard
+          groupConfigInfo={groupConfigInfo}
+          groupSettingsDefaults={groupSettingsDefaults}
+          origHash={origHash}
+          editAccess={run<ActionAccess>(() => {
+            if (canEditGroupSettings) return ALLOWED_ACCESS;
+            if (permissions.isExampleCourse) {
+              return {
+                status: 'denied',
+                reason: 'Editing group settings is not available for the example course.',
+              };
+            }
+            return {
+              status: 'denied',
+              reason: 'Editing group settings requires course editor permissions.',
+            };
+          })}
+          onOrigHashChange={setOrigHash}
+          onGroupSizeSaved={(min, max) => {
+            setMinGroupSize(min ?? 2);
+            setMaxGroupSize(max ?? 4);
+          }}
+          onSaved={() => setSaveStatus({ kind: 'success' })}
+          onSaveError={(message) => setSaveStatus({ kind: 'error', message })}
+          onClearSaveStatus={() => setSaveStatus(null)}
+        />
+
+        {canViewStudentData ? (
+          <GroupsCard
+            groupsCsvFilename={groupsCsvFilename}
+            groups={groupMembership.groups}
+            notAssigned={groupMembership.notAssigned}
+            assessment={assessment}
+            assessmentSet={assessmentSet}
+            courseInstanceId={courseInstanceId}
+            csrfToken={csrfToken}
+            editAccess={run<ActionAccess>(() => {
+              if (canEditStudentData) return ALLOWED_ACCESS;
+              if (permissions.isExampleCourse) {
+                return {
+                  status: 'denied',
+                  reason: 'Editing group memberships is not available for the example course.',
+                };
+              }
+              return {
+                status: 'denied',
+                reason: 'Editing group memberships requires student data editor permissions.',
+              };
+            })}
+            minGroupSize={minGroupSize}
+            maxGroupSize={maxGroupSize}
+            lastRefreshedAt={groupMembershipQuery.dataUpdatedAt}
+            isRefreshingGroups={groupMembershipQuery.isFetching}
+            membershipErrorMessage={groupMembershipError}
+            onRefreshGroups={refreshGroupMembership}
+            onGroupMembershipChanged={refreshGroupMembership}
+          />
+        ) : (
+          <div className="card">
+            <div className="card-body">
+              <h5 className="mb-1">Groups</h5>
+              <div className="text-muted small mb-3">
+                View and manage student group memberships for this assessment.
+              </div>
+              <Alert variant="info" className="mb-0">
+                You must have student data viewer permissions to view student group memberships.
+              </Alert>
+            </div>
+          </div>
         )}
       </div>
 

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -269,4 +269,19 @@ describe('Instructor group controls', () => {
     assert.match(failures[0].message, /in another group/);
     assert.notOk(group.users.some((u) => u.uid === users[4].uid));
   });
+
+  test.sequential('can fetch current group membership', async () => {
+    assert.isDefined(group1RowId);
+    assert.isDefined(group2RowId);
+
+    const membership = await trpcClient.assessmentGroups.membership.query();
+
+    assert.includeMembers(
+      membership.groups.map((group) => group.group_id),
+      [group1RowId, group2RowId],
+    );
+    for (const user of users) {
+      assert.notInclude(membership.notAssigned, user.uid);
+    }
+  });
 });

--- a/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentGroups.test.ts
@@ -106,13 +106,16 @@ describe('Instructor group controls', () => {
   });
 
   test.sequential('can create a new group', async () => {
-    const { group } = await trpcClient.assessmentGroups.addGroup.mutate({
+    await trpcClient.assessmentGroups.addGroup.mutate({
       groupName: 'TestGroup',
       uids: users
         .slice(0, 2)
         .map((u) => u.uid)
         .join(','),
     });
+    const membership = await trpcClient.assessmentGroups.membership.query();
+    const group = membership.groups.find((group) => group.name === 'TestGroup');
+    assert.isDefined(group);
     assert.equal(group.name, 'TestGroup');
     assert.deepEqual(group.users.map((u) => u.uid).sort(), [users[0].uid, users[1].uid].sort());
     group1RowId = group.group_id;
@@ -227,46 +230,58 @@ describe('Instructor group controls', () => {
   });
 
   test.sequential('can create a second group', async () => {
-    const { group } = await trpcClient.assessmentGroups.addGroup.mutate({
+    await trpcClient.assessmentGroups.addGroup.mutate({
       groupName: 'TestGroup2',
       uids: users
         .slice(2, 4)
         .map((u) => u.uid)
         .join(','),
     });
+    const membership = await trpcClient.assessmentGroups.membership.query();
+    const group = membership.groups.find((group) => group.name === 'TestGroup2');
+    assert.isDefined(group);
     assert.equal(group.name, 'TestGroup2');
     assert.deepEqual(group.users.map((u) => u.uid).sort(), [users[2].uid, users[3].uid].sort());
     group2RowId = group.group_id;
   });
 
   test.sequential('can create a group with an instructor', async () => {
-    const { group } = await trpcClient.assessmentGroups.addGroup.mutate({
+    await trpcClient.assessmentGroups.addGroup.mutate({
       groupName: 'TestGroupWithInstructor',
       uids: 'dev@example.com',
     });
+    const membership = await trpcClient.assessmentGroups.membership.query();
+    const group = membership.groups.find((group) => group.name === 'TestGroupWithInstructor');
+    assert.isDefined(group);
     assert.equal(group.name, 'TestGroupWithInstructor');
     assert.ok(group.users.some((u) => u.uid === 'dev@example.com'));
   });
 
   test.sequential('can add a user to an existing group', async () => {
     assert.isDefined(group1RowId);
-    const { group, failures } = await trpcClient.assessmentGroups.editGroup.mutate({
+    const { failures } = await trpcClient.assessmentGroups.editGroup.mutate({
       groupId: group1RowId,
       uids: [users[0].uid, users[1].uid, users[4].uid].join(','),
     });
     assert.lengthOf(failures, 0);
+    const membership = await trpcClient.assessmentGroups.membership.query();
+    const group = membership.groups.find((group) => group.group_id === group1RowId);
+    assert.isDefined(group);
     assert.ok(group.users.some((u) => u.uid === users[4].uid));
   });
 
   test.sequential('cannot add a user to a group if they are already in another group', async () => {
     assert.isDefined(group2RowId);
-    const { group, failures } = await trpcClient.assessmentGroups.editGroup.mutate({
+    const { failures } = await trpcClient.assessmentGroups.editGroup.mutate({
       groupId: group2RowId,
       uids: [users[2].uid, users[3].uid, users[4].uid].join(','),
     });
     assert.lengthOf(failures, 1);
     assert.equal(failures[0].uid, users[4].uid);
     assert.match(failures[0].message, /in another group/);
+    const membership = await trpcClient.assessmentGroups.membership.query();
+    const group = membership.groups.find((group) => group.group_id === group2RowId);
+    assert.isDefined(group);
     assert.notOk(group.users.some((u) => u.uid === users[4].uid));
   });
 

--- a/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
+++ b/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
@@ -57,6 +57,7 @@ export interface AssessmentGroupsError {
   DisableGroupWork: { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   UpdateGroupConfig: { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   RandomizeGroups: never;
+  Membership: never;
   RefreshGroups: never;
 }
 
@@ -455,22 +456,32 @@ const disableGroupWork = t.procedure
     return { origHash: newHash };
   });
 
+async function selectGroupMembership(ctx: AssessmentTrpcCtx) {
+  const groupConfig = await selectGroupConfigForAssessment(ctx.assessment.id);
+  if (!groupConfig) {
+    return { groups: [], notAssigned: [] };
+  }
+
+  const [groups, notAssigned] = await Promise.all([
+    selectGroupsForConfig(groupConfig.id),
+    selectUidsNotInGroup({
+      group_config_id: groupConfig.id,
+      course_instance_id: groupConfig.course_instance_id,
+    }),
+  ]);
+  return { groups, notAssigned };
+}
+
+const membership = t.procedure
+  .use(requireCourseInstancePermissionView)
+  .query(async ({ ctx }) => await selectGroupMembership(ctx));
+
+// Deploy-window compatibility shim: in-flight browser tabs loaded against the
+// previous bundle still call `refreshGroups`. Keep through one release cycle,
+// then delete in a follow-up PR once the new bundle has fully rolled out.
 const refreshGroups = t.procedure
   .use(requireCourseInstancePermissionView)
-  .mutation(async ({ ctx }) => {
-    const groupConfig = await selectGroupConfigForAssessment(ctx.assessment.id);
-    if (!groupConfig) {
-      return { groups: [], notAssigned: [] };
-    }
-    const [groups, notAssigned] = await Promise.all([
-      selectGroupsForConfig(groupConfig.id),
-      selectUidsNotInGroup({
-        group_config_id: groupConfig.id,
-        course_instance_id: groupConfig.course_instance_id,
-      }),
-    ]);
-    return { groups, notAssigned };
-  });
+  .mutation(async ({ ctx }) => await selectGroupMembership(ctx));
 
 const randomizeGroups = t.procedure
   .use(requireCourseInstancePermissionEdit)
@@ -508,6 +519,7 @@ export const assessmentGroupsRouter = t.router({
   enableGroupWork,
   disableGroupWork,
   updateGroupConfig,
+  membership,
   randomizeGroups,
   refreshGroups,
 });

--- a/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
+++ b/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
@@ -90,6 +90,8 @@ const addGroup = t.procedure
       throw err;
     }
 
+    // TODO: Drop this compatibility payload once old Groups UI bundles no
+    // longer consume it; new clients refetch `membership` after this mutation.
     const [group, notAssigned] = await Promise.all([
       selectGroupById({ group_id: createdGroupId, assessment_id: assessment.id }),
       selectNotAssignedForAssessment({
@@ -158,6 +160,8 @@ const editGroup = t.procedure
       }
     });
 
+    // TODO: Return only `failures` once old Groups UI bundles no longer consume
+    // `group` and `notAssigned`.
     const [group, notAssigned] = await Promise.all([
       selectGroupById({ group_id: input.groupId, assessment_id: assessment.id }),
       selectNotAssignedForAssessment({
@@ -187,6 +191,8 @@ const deleteGroupProcedure = t.procedure
       throw err;
     }
 
+    // TODO: Stop returning `notAssigned` once old Groups UI bundles no longer
+    // consume it; new clients refetch `membership` after this mutation.
     const notAssigned = await selectNotAssignedForAssessment({
       assessment_id: assessment.id,
       course_instance_id: course_instance.id,
@@ -199,6 +205,8 @@ const deleteAll = t.procedure.use(requireCourseInstancePermissionEdit).mutation(
 
   await deleteAllGroups(assessment.id, authn_user.id);
 
+  // TODO: Stop returning `notAssigned` once old Groups UI bundles no longer
+  // consume it; new clients refetch `membership` after this mutation.
   const notAssigned = await selectNotAssignedForAssessment({
     assessment_id: assessment.id,
     course_instance_id: course_instance.id,
@@ -476,9 +484,8 @@ const membership = t.procedure
   .use(requireCourseInstancePermissionView)
   .query(async ({ ctx }) => await selectGroupMembership(ctx));
 
-// Deploy-window compatibility shim: in-flight browser tabs loaded against the
-// previous bundle still call `refreshGroups`. Keep through one release cycle,
-// then delete in a follow-up PR once the new bundle has fully rolled out.
+// TODO: Delete `refreshGroups` after one release cycle; it only supports
+// in-flight browser tabs loaded against the previous bundle.
 const refreshGroups = t.procedure
   .use(requireCourseInstancePermissionView)
   .mutation(async ({ ctx }) => await selectGroupMembership(ctx));

--- a/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
+++ b/apps/prairielearn/src/trpc/assessment/assessment-groups.ts
@@ -316,6 +316,8 @@ const enableGroupWork = t.procedure
       });
     }
 
+    // TODO: Drop this compatibility payload once old Groups UI bundles no
+    // longer consume it; new clients fetch `membership` after enabling.
     const [groups, notAssigned] = ctx.authz_data.has_course_instance_permission_view
       ? await Promise.all([
           selectGroupsForConfig(groupConfig.id),

--- a/docs/assessment/configuration.md
+++ b/docs/assessment/configuration.md
@@ -508,9 +508,9 @@ groupB,three@example.com
 groupB,four@example.com
 ```
 
-The assessment's "Downloads" tab has an `<assessment>_groups.csv` file that contains the current group memberships. This can be used to copy group memberships from one assessment to another. The same file is also listed at the bottom of the groups page.
+The assessment's "Downloads" tab has an `<assessment>_groups.csv` file that contains the current group memberships. This can be used to copy group memberships from one assessment to another. The same file can also be exported from the "Groups" tab by using "Actions" > "Export CSV".
 
-Alternatively, the "Random" button can be used to randomly assign students to groups based on a desired minimum/maximum group size.
+Alternatively, the "Assign randomly" button can be used to randomly assign students to groups based on a desired minimum/maximum group size.
 
 ### Student options for group work
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

This updates the instructor assessment Groups tab so group-work enablement is surfaced at the top with membership counts and a nearby disable action, instead of burying disable after the groups table. It centralizes group membership fetching in a parent-owned tRPC query, invalidates/refetches that query after membership mutations, and keeps `refreshGroups` as a temporary compatibility shim. It also updates the groups documentation for the current CSV export and random assignment UI.

<img width="1682" height="1029" alt="Screenshot 2026-05-22 at 16 36 32" src="https://github.com/user-attachments/assets/b0e43214-26bd-4206-a047-75be42645176" />

- [x] I have disclosed the level of AI assistance used (majority of implementation by AI with human review and direction).

# Testing

Tested manually in the browser, things are looking good.
