### PR TITLE
Return unparsed expression for input copy button in calculator

### DIFF
--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -4,7 +4,7 @@ import {
   type MathJsonExpression,
   isTensor,
 } from '@cortex-js/compute-engine';
-import { MathfieldElement } from 'mathlive';
+import { type Mathfield, MathfieldElement } from 'mathlive';
 
 import { onDocumentReady } from '@prairielearn/browser-utils';
 
@@ -110,10 +110,13 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   const displayModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#displayModeSwitch'));
   const angleModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#angleModeSwitch'));
 
-  const onExport = (_mf: unknown, latex: string) =>
+  const parseLatexForClipboard = (_mf: Mathfield | null, latex: string) =>
+    // The starting = sign is handled separately to avoid ce introducing a "missing operand" error.
+    (latex.startsWith('=') ? '=' : '') +
     ce.parse(latex.replace(/^=/, ''), { form: 'raw' }).toString();
-  calculatorInputElement.onExport = onExport;
-  calculatorOutput.onExport = onExport;
+
+  calculatorInputElement.onExport = parseLatexForClipboard;
+  calculatorOutput.onExport = parseLatexForClipboard;
 
   MathfieldElement.soundsDirectory = null;
   calculatorInputElement.menuItems = [];
@@ -693,11 +696,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       updateModeBadge(modeBadge, angleMode);
     }
 
-    const normalizeLatex = (latex: string) =>
-      ce.parse(latex.replace(/^=/, ''), { form: 'raw' }).toString();
-    const historyOnExport: MathfieldElement['onExport'] = (_mf, latex) => normalizeLatex(latex);
-    inputField.onExport = historyOnExport;
-    outputField.onExport = historyOnExport;
+    inputField.onExport = parseLatexForClipboard;
+    outputField.onExport = parseLatexForClipboard;
 
     // Copy buttons
     const inputCopyBtn = ensureElement(
@@ -706,8 +706,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     const outputCopyBtn = ensureElement(
       clone.querySelector<HTMLElement>('.history-output .history-copy-btn'),
     );
-    inputCopyBtn.dataset.clipboardText = normalizeLatex(input);
-    outputCopyBtn.dataset.clipboardText = normalizeLatex(outputField.value);
+    inputCopyBtn.dataset.clipboardText = parseLatexForClipboard(null, input);
+    outputCopyBtn.dataset.clipboardText = parseLatexForClipboard(null, outputField.value);
 
     // Insert buttons
     const inputInsertBtn = ensureElement(

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -4,7 +4,7 @@ import {
   type MathJsonExpression,
   isTensor,
 } from '@cortex-js/compute-engine';
-import { type Mathfield, MathfieldElement } from 'mathlive';
+import { type Mathfield, MathfieldElement, convertLatexToAsciiMath } from 'mathlive';
 
 import { onDocumentReady } from '@prairielearn/browser-utils';
 
@@ -110,13 +110,10 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   const displayModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#displayModeSwitch'));
   const angleModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#angleModeSwitch'));
 
-  const parseLatexForClipboard = (_mf: Mathfield | null, latex: string) =>
-    // The starting = sign is handled separately to avoid ce introducing a "missing operand" error.
-    (latex.startsWith('=') ? '=' : '') +
-    ce.parse(latex.replace(/^=/, ''), { form: 'raw' }).toString();
+  const latexFieldOnExport = (_mf: Mathfield, latex: string) => convertLatexToAsciiMath(latex);
 
-  calculatorInputElement.onExport = parseLatexForClipboard;
-  calculatorOutput.onExport = parseLatexForClipboard;
+  calculatorInputElement.onExport = latexFieldOnExport;
+  calculatorOutput.onExport = latexFieldOnExport;
 
   MathfieldElement.soundsDirectory = null;
   calculatorInputElement.menuItems = [];
@@ -696,8 +693,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       updateModeBadge(modeBadge, angleMode);
     }
 
-    inputField.onExport = parseLatexForClipboard;
-    outputField.onExport = parseLatexForClipboard;
+    inputField.onExport = latexFieldOnExport;
+    outputField.onExport = latexFieldOnExport;
 
     // Copy buttons
     const inputCopyBtn = ensureElement(
@@ -706,8 +703,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     const outputCopyBtn = ensureElement(
       clone.querySelector<HTMLElement>('.history-output .history-copy-btn'),
     );
-    inputCopyBtn.dataset.clipboardText = parseLatexForClipboard(null, input);
-    outputCopyBtn.dataset.clipboardText = parseLatexForClipboard(null, outputField.value);
+    inputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(input);
+    outputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(outputField.value);
 
     // Insert buttons
     const inputInsertBtn = ensureElement(

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -352,7 +352,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     calculatorInputGroup.classList.remove('error');
     calculatorOutput.value = `=${displayed}`;
 
-    copyButton.dataset.clipboardText = ce.parse(displayed).toString();
+    copyButton.dataset.clipboardText = convertLatexToAsciiMath(displayed);
 
     // Add to history
     if (addToHistory) {
@@ -704,7 +704,9 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       clone.querySelector<HTMLElement>('.history-output .history-copy-btn'),
     );
     inputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(input);
-    outputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(outputField.value);
+    outputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(
+      outputField.value.replace(/^=/, ''),
+    );
 
     // Insert buttons
     const inputInsertBtn = ensureElement(

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -110,7 +110,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   const displayModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#displayModeSwitch'));
   const angleModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#angleModeSwitch'));
 
-  const onExport = (_mf: unknown, latex: string) => ce.parse(latex, { form: 'raw' }).toString();
+  const onExport = (_mf: unknown, latex: string) =>
+    ce.parse(latex.replace(/^=/, ''), { form: 'raw' }).toString();
   calculatorInputElement.onExport = onExport;
   calculatorOutput.onExport = onExport;
 
@@ -692,7 +693,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       updateModeBadge(modeBadge, angleMode);
     }
 
-    const normalizeLatex = (latex: string) => ce.parse(latex, { form: 'raw' }).toString();
+    const normalizeLatex = (latex: string) =>
+      ce.parse(latex.replace(/^=/, ''), { form: 'raw' }).toString();
     const historyOnExport: MathfieldElement['onExport'] = (_mf, latex) => normalizeLatex(latex);
     inputField.onExport = historyOnExport;
     outputField.onExport = historyOnExport;
@@ -705,7 +707,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       clone.querySelector<HTMLElement>('.history-output .history-copy-btn'),
     );
     inputCopyBtn.dataset.clipboardText = normalizeLatex(input);
-    outputCopyBtn.dataset.clipboardText = normalizeLatex(outputField.value.replace(/^=/, ''));
+    outputCopyBtn.dataset.clipboardText = normalizeLatex(outputField.value);
 
     // Insert buttons
     const inputInsertBtn = ensureElement(

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -694,7 +694,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       updateModeBadge(modeBadge, angleMode);
     }
 
-    const normalizeLatex = (latex: string) => ce.parse(latex).toString();
+    const normalizeLatex = (latex: string) => ce.parse(latex, { form: 'raw' }).toString();
     const historyOnExport: MathfieldElement['onExport'] = (_mf, latex) => normalizeLatex(latex);
     inputField.onExport = historyOnExport;
     outputField.onExport = historyOnExport;

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -110,9 +110,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   const displayModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#displayModeSwitch'));
   const angleModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#angleModeSwitch'));
 
-  const onExport = (_mf: unknown, latex: string) => {
-    return ce.parse(latex).toString();
-  };
+  const onExport = (_mf: unknown, latex: string) => ce.parse(latex, { form: 'raw' }).toString();
   calculatorInputElement.onExport = onExport;
   calculatorOutput.onExport = onExport;
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes #14895. In the calculator tool, the "copy" button for expressions was parsing the expression to its [canonical form](https://mathlive.io/compute-engine/guides/canonical-form/), which in some cases caused the copy text to correspond to the result instead of the original expression. This PR changes it to return [the raw, non-canonical expression instead](https://mathlive.io/compute-engine/guides/latex-syntax/).

I can't tag @zojize for review, but I think you'd like to double-check that this works for you.

This also updates the `onExport` value, which affects what is copied if a user selects a portion of the expression and hits Ctrl-C/Cmd-C. This is done both for the history inputs and the main input. The main input doesn't have a dedicated copy button.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

In the calculator, try a simple expression like "2*3", and enter. The expression and results are added to history. Now use the copy button next to the input (expression), and paste to an element text input field. In master, this would paste "6". In this PR, this pastes "2 * 3".

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
