### PR TITLE
Add cause support to HttpStatusError

### DIFF
--- a/.changeset/http-status-error-cause.md
+++ b/.changeset/http-status-error-cause.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/error': patch
+---
+
+Add `cause` support to `HttpStatusError`, matching native `Error` constructor options.

--- a/packages/error/src/index.test.ts
+++ b/packages/error/src/index.test.ts
@@ -1,6 +1,14 @@
 import { assert, describe, it } from 'vitest';
 
-import { addData, augmentError, make, makeWithData, makeWithInfo, newMessage } from './index.js';
+import {
+  HttpStatusError,
+  addData,
+  augmentError,
+  make,
+  makeWithData,
+  makeWithInfo,
+  newMessage,
+} from './index.js';
 
 describe('make', () => {
   it('makes an error without data', () => {
@@ -79,5 +87,16 @@ describe('augmentError', () => {
     assert.equal(newErr.data.foo, 'bar');
     assert.equal(newErr.cause, err);
     assert.equal((newErr.cause as any).message, 'Not Found');
+  });
+});
+
+describe('HttpStatusError', () => {
+  it('supports causes like native Error', () => {
+    const cause = new Error('Missing record');
+    const err = new HttpStatusError(404, 'Not Found', { cause });
+
+    assert.equal(err.status, 404);
+    assert.equal(err.message, 'Not Found');
+    assert.equal(err.cause, cause);
   });
 });

--- a/packages/error/src/index.ts
+++ b/packages/error/src/index.ts
@@ -108,8 +108,8 @@ export class AugmentedError extends Error {
 export class HttpStatusError extends Error {
   status: number;
 
-  constructor(status: number, message: string) {
-    super(message);
+  constructor(status: number, message: string, options?: ErrorOptions) {
+    super(message, options);
     this.status = status;
   }
 }


### PR DESCRIPTION
# Description

This updates `HttpStatusError` to accept native `ErrorOptions`. The third constructor argument now passes through to `Error`, preserving `cause` while keeping existing `(status, message)` call sites compatible. A patch changeset is included for `@prairielearn/error`.

- [x] I have disclosed the level of AI assistance used: majority of implementation by Codex.

# Testing

Added and ran unit coverage that asserts `HttpStatusError` stores the passed `cause`.
