### PR TITLE
Make fileStoreS3Bucket nullable

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -177,7 +177,10 @@ export const ConfigSchema = z.object({
   sslCAFile: z.string().default('/etc/pki/tls/certs/server-chain.crt'),
   fileUploadMaxBytes: z.number().default(1e7),
   fileUploadMaxParts: z.number().default(1000),
-  fileStoreS3Bucket: z.string().default('file-store'),
+  fileStoreS3Bucket: z
+    .string()
+    .nullable()
+    .default(DEV_MODE ? 'file-store' : null),
   fileStoreStorageTypeDefault: z.enum(['S3', 'FileSystem']).default('S3'),
   cronActive: z.boolean().default(true),
   /**

--- a/apps/prairielearn/src/lib/file-store.ts
+++ b/apps/prairielearn/src/lib/file-store.ts
@@ -21,6 +21,14 @@ const StorageTypes = Object.freeze({
   FileSystem: 'FileSystem',
 });
 
+function getFileStoreS3Bucket(): string {
+  if (config.fileStoreS3Bucket === null) {
+    throw new Error('fileStoreS3Bucket must be configured to use S3 file storage');
+  }
+
+  return config.fileStoreS3Bucket;
+}
+
 interface UploadFileOptions {
   /** The display_filename of the file. */
   display_filename: string;
@@ -76,7 +84,7 @@ export async function uploadFile({
     // use a UUIDv4 as the filename for S3
     storage_filename = crypto.randomUUID();
 
-    const res = await uploadToS3(config.fileStoreS3Bucket, storage_filename, null, false, contents);
+    const res = await uploadToS3(getFileStoreS3Bucket(), storage_filename, null, false, contents);
     debug('upload() : uploaded to ' + res.Location);
   } else if (storage_type === StorageTypes.FileSystem) {
     // Make a filename to store the file. We use a UUIDv4 as the filename,
@@ -193,10 +201,11 @@ export async function getFile(
       };
     }
     case StorageTypes.S3: {
+      const fileStoreS3Bucket = getFileStoreS3Bucket();
       const contents =
         data_type === 'buffer'
-          ? await getFromS3(config.fileStoreS3Bucket, file.storage_filename, true)
-          : await getFromS3(config.fileStoreS3Bucket, file.storage_filename, false);
+          ? await getFromS3(fileStoreS3Bucket, file.storage_filename, true)
+          : await getFromS3(fileStoreS3Bucket, file.storage_filename, false);
 
       return {
         contents,

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -209,7 +209,7 @@
       "default": 1000
     },
     "fileStoreS3Bucket": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": "file-store"
     },
     "fileStoreStorageTypeDefault": {

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -462,7 +462,7 @@
       "default": 1000
     },
     "fileStoreS3Bucket": {
-      "type": "string",
+      "type": ["string", "null"],
       "default": "file-store"
     },
     "fileStoreStorageTypeDefault": {


### PR DESCRIPTION
# Description

Make `fileStoreS3Bucket` nullable and keep the local default as `file-store` while defaulting to `null` in production-like `NODE_ENV=production` runs. S3 file-store operations now fail with a clear configuration error when S3 storage is selected without a configured bucket, and the generated config schemas now permit `null`.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Confirmed the production default resolves to `null`, the non-production default remains `file-store`, and the config JSON schema check passes.
