### PR TITLE
Rewrite `infoAssessment.json` when deleting questions; scope rewrites to current course

### DIFF
--- a/apps/prairielearn/src/api/trpc/routers/course-files/batchDeleteQuestions.sql
+++ b/apps/prairielearn/src/api/trpc/routers/course-files/batchDeleteQuestions.sql
@@ -1,8 +1,0 @@
--- BLOCK select_questions_by_ids_and_course_id
-SELECT
-  *
-FROM
-  questions AS q
-WHERE
-  q.id = ANY ($question_ids::bigint[])
-  AND q.course_id = $course_id;

--- a/apps/prairielearn/src/api/trpc/routers/course-files/batchDeleteQuestions.ts
+++ b/apps/prairielearn/src/api/trpc/routers/course-files/batchDeleteQuestions.ts
@@ -3,9 +3,21 @@ import { z } from 'zod';
 import { IdSchema } from '@prairielearn/zod';
 
 import { QuestionDeleteEditor } from '../../../../lib/editors.js';
+import {
+  formatBlockedAssessments,
+  selectAssessmentsBlockingDeletion,
+} from '../../../../lib/question-deletion-validation.js';
+import { type ServerJobExecutor } from '../../../../lib/server-jobs.js';
 import { selectCourseById } from '../../../../models/course.js';
-import { selectQuestionsByIdsAndCourseId } from '../../../../models/question.js';
+import {
+  selectQuestionsByIdsAndCourseId,
+  selectQuestionsUsedInOtherCourses,
+} from '../../../../models/question.js';
 import { privateProcedure, selectUsers } from '../../trpc.js';
+
+async function failServerJob(serverJob: ServerJobExecutor, message: string) {
+  await serverJob.execute(async (job) => job.fail(message));
+}
 
 export const batchDeleteQuestions = privateProcedure
   .input(
@@ -57,6 +69,40 @@ export const batchDeleteQuestions = privateProcedure
     });
 
     const serverJob = await editor.prepareServerJob();
+
+    const blockedByOtherCourses = await selectQuestionsUsedInOtherCourses({
+      question_ids: questions.map((question) => question.id),
+      course_id: course.id,
+    });
+    if (blockedByOtherCourses.length > 0) {
+      await failServerJob(
+        serverJob,
+        'One or more questions are used by another course and cannot be deleted. Unshare them or remove them from those assessments first.',
+      );
+      return {
+        status: 'error',
+        job_sequence_id: serverJob.jobSequenceId,
+      };
+    }
+
+    const qidsToRemove = new Set(
+      questions.flatMap((question) => (question.qid !== null ? [question.qid] : [])),
+    );
+    const blockedAssessments = await selectAssessmentsBlockingDeletion({
+      course,
+      questionIds: questions.map((question) => question.id),
+      qidsToRemove,
+    });
+    if (blockedAssessments.length > 0) {
+      await failServerJob(
+        serverJob,
+        `Deleting these questions would leave the following assessments in an invalid state: ${formatBlockedAssessments(blockedAssessments)}. Remove the questions from these assessments first.`,
+      );
+      return {
+        status: 'error',
+        job_sequence_id: serverJob.jobSequenceId,
+      };
+    }
 
     try {
       await editor.executeWithServerJob(serverJob);

--- a/apps/prairielearn/src/api/trpc/routers/course-files/batchDeleteQuestions.ts
+++ b/apps/prairielearn/src/api/trpc/routers/course-files/batchDeleteQuestions.ts
@@ -1,14 +1,11 @@
 import { z } from 'zod';
 
-import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
-import { QuestionSchema } from '../../../../lib/db-types.js';
 import { QuestionDeleteEditor } from '../../../../lib/editors.js';
 import { selectCourseById } from '../../../../models/course.js';
+import { selectQuestionsByIdsAndCourseId } from '../../../../models/question.js';
 import { privateProcedure, selectUsers } from '../../trpc.js';
-
-const sql = loadSqlEquiv(import.meta.url);
 
 export const batchDeleteQuestions = privateProcedure
   .input(
@@ -42,14 +39,10 @@ export const batchDeleteQuestions = privateProcedure
       authn_user_id: opts.input.authn_user_id,
     });
 
-    const questions = await queryRows(
-      sql.select_questions_by_ids_and_course_id,
-      {
-        question_ids: opts.input.question_ids,
-        course_id: opts.input.course_id,
-      },
-      QuestionSchema,
-    );
+    const questions = await selectQuestionsByIdsAndCourseId({
+      question_ids: opts.input.question_ids,
+      course_id: opts.input.course_id,
+    });
 
     const editor = new QuestionDeleteEditor({
       locals: {

--- a/apps/prairielearn/src/lib/editors.sql
+++ b/apps/prairielearn/src/lib/editors.sql
@@ -1,18 +1,3 @@
--- BLOCK select_assessments_with_questions
-SELECT DISTINCT
-  ci.short_name AS course_instance_directory,
-  a.tid AS assessment_directory
-FROM
-  assessment_questions AS aq
-  JOIN assessments AS a ON (a.id = aq.assessment_id)
-  JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
-WHERE
-  aq.question_id = ANY ($question_ids::bigint[])
-  AND ci.course_id = $course_id
-  AND aq.deleted_at IS NULL
-  AND a.deleted_at IS NULL
-  AND ci.deleted_at IS NULL;
-
 -- BLOCK select_course_instances_with_course
 SELECT
   ci.long_name

--- a/apps/prairielearn/src/lib/editors.sql
+++ b/apps/prairielearn/src/lib/editors.sql
@@ -1,5 +1,5 @@
--- BLOCK select_assessments_with_question
-SELECT
+-- BLOCK select_assessments_with_questions
+SELECT DISTINCT
   ci.short_name AS course_instance_directory,
   a.tid AS assessment_directory
 FROM
@@ -7,7 +7,8 @@ FROM
   JOIN assessments AS a ON (a.id = aq.assessment_id)
   JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
 WHERE
-  aq.question_id = $question_id
+  aq.question_id = ANY ($question_ids::bigint[])
+  AND ci.course_id = $course_id
   AND aq.deleted_at IS NULL
   AND a.deleted_at IS NULL
   AND ci.deleted_at IS NULL;

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -46,6 +46,7 @@ import { discoverInfoDirs } from './discover-info-dirs.js';
 import { computeFileContentHash } from './editorUtil.js';
 import { getNamesForCopy, getUniqueNames } from './editorUtil.shared.js';
 import { idsEqual } from './id.js';
+import { removeQidsFromAssessment } from './infoAssessment-edits.js';
 import { computeStableHash } from './json.js';
 import { EXAMPLE_COURSE_PATH, REPOSITORY_ROOT_PATH } from './paths.js';
 import { formatJsonWithPrettier } from './prettier.js';
@@ -1538,21 +1539,54 @@ export class QuestionDeleteEditor extends Editor {
   async write() {
     debug('QuestionDeleteEditor: write()');
 
+    const pathsToAdd: string[] = [];
+    const qidsToRemove = new Set(
+      this.questions.flatMap((question) => (question.qid !== null ? [question.qid] : [])),
+    );
+
+    // Assessment files are rewritten under this course's repository path, so
+    // shared-question references from other courses must be ignored here.
+    const referencingAssessments = await sqldb.queryRows(
+      sql.select_assessments_with_questions,
+      { course_id: this.course.id, question_ids: this.questions.map((q) => q.id) },
+      z.object({
+        course_instance_directory: CourseInstanceSchema.shape.short_name,
+        assessment_directory: AssessmentSchema.shape.tid,
+      }),
+    );
+
+    for (const referenced of referencingAssessments) {
+      assert(referenced.assessment_directory !== null, 'assessment_directory is required');
+      const infoPath = path.join(
+        this.course.path,
+        'courseInstances',
+        referenced.course_instance_directory,
+        'assessments',
+        referenced.assessment_directory,
+        'infoAssessment.json',
+      );
+      const infoJson = await fs.readJson(infoPath);
+      const { assessment: updatedInfoJson } = removeQidsFromAssessment(infoJson, qidsToRemove);
+      const formattedJson = await formatJsonWithPrettier(JSON.stringify(updatedInfoJson));
+      await fs.writeFile(infoPath, formattedJson);
+      pathsToAdd.push(infoPath);
+    }
+
     for (const question of this.questions) {
       // This shouldn't happen in practice; this is just to satisfy TypeScript.
       assert(question.qid, 'question.qid is required');
 
-      await fs.remove(path.join(this.course.path, 'questions', question.qid));
+      const questionPath = path.join(this.course.path, 'questions', question.qid);
+      await fs.remove(questionPath);
       await this.removeEmptyPrecedingSubfolders(
         path.join(this.course.path, 'questions'),
         question.qid,
       );
+      pathsToAdd.push(questionPath);
     }
 
     return {
-      pathsToAdd: this.questions.flatMap((question) =>
-        question.qid !== null ? path.join(this.course.path, 'questions', question.qid) : [],
-      ),
+      pathsToAdd,
       commitMessage:
         this.questions.length === 1
           ? `delete question ${this.questions[0].qid}`
@@ -1604,10 +1638,12 @@ export class QuestionRenameEditor extends Editor {
 
     pathsToAdd.push(oldPath, newPath);
 
-    debug(`Find all assessments (in all course instances) that contain ${this.question.qid}`);
+    debug(
+      `Find all assessments (in this course's course instances) that contain ${this.question.qid}`,
+    );
     const assessments = await sqldb.queryRows(
-      sql.select_assessments_with_question,
-      { question_id: this.question.id },
+      sql.select_assessments_with_questions,
+      { course_id: this.course.id, question_ids: [this.question.id] },
       z.object({
         course_instance_directory: CourseInstanceSchema.shape.short_name,
         assessment_directory: AssessmentSchema.shape.tid,

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -15,7 +15,10 @@ import { contains } from '@prairielearn/path-utils';
 import * as sqldb from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 
-import { selectAssessments } from '../models/assessment.js';
+import {
+  selectAssessmentDirectoriesForQuestions,
+  selectAssessments,
+} from '../models/assessment.js';
 import {
   getCourseCommitHash,
   getLockNameForCoursePath,
@@ -1546,17 +1549,12 @@ export class QuestionDeleteEditor extends Editor {
 
     // Assessment files are rewritten under this course's repository path, so
     // shared-question references from other courses must be ignored here.
-    const referencingAssessments = await sqldb.queryRows(
-      sql.select_assessments_with_questions,
-      { course_id: this.course.id, question_ids: this.questions.map((q) => q.id) },
-      z.object({
-        course_instance_directory: CourseInstanceSchema.shape.short_name,
-        assessment_directory: AssessmentSchema.shape.tid,
-      }),
-    );
+    const referencingAssessments = await selectAssessmentDirectoriesForQuestions({
+      course_id: this.course.id,
+      question_ids: this.questions.map((q) => q.id),
+    });
 
     for (const referenced of referencingAssessments) {
-      assert(referenced.assessment_directory !== null, 'assessment_directory is required');
       const infoPath = path.join(
         this.course.path,
         'courseInstances',
@@ -1641,20 +1639,15 @@ export class QuestionRenameEditor extends Editor {
     debug(
       `Find all assessments (in this course's course instances) that contain ${this.question.qid}`,
     );
-    const assessments = await sqldb.queryRows(
-      sql.select_assessments_with_questions,
-      { course_id: this.course.id, question_ids: [this.question.id] },
-      z.object({
-        course_instance_directory: CourseInstanceSchema.shape.short_name,
-        assessment_directory: AssessmentSchema.shape.tid,
-      }),
-    );
+    const assessments = await selectAssessmentDirectoriesForQuestions({
+      course_id: this.course.id,
+      question_ids: [this.question.id],
+    });
 
     debug(
       `For each assessment, read/write infoAssessment.json to replace ${this.question.qid} with ${this.qid_new}`,
     );
     for (const assessment of assessments) {
-      assert(assessment.assessment_directory !== null, 'assessment_directory is required');
       const infoPath = path.join(
         this.course.path,
         'courseInstances',

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -49,7 +49,7 @@ import { discoverInfoDirs } from './discover-info-dirs.js';
 import { computeFileContentHash } from './editorUtil.js';
 import { getNamesForCopy, getUniqueNames } from './editorUtil.shared.js';
 import { idsEqual } from './id.js';
-import { removeQidsFromAssessment } from './infoAssessment-edits.js';
+import { blockerDescription, removeQidsFromAssessment } from './infoAssessment-edits.js';
 import { computeStableHash } from './json.js';
 import { EXAMPLE_COURSE_PATH, REPOSITORY_ROOT_PATH } from './paths.js';
 import { formatJsonWithPrettier } from './prettier.js';
@@ -1563,9 +1563,37 @@ export class QuestionDeleteEditor extends Editor {
         referenced.assessment_directory,
         'infoAssessment.json',
       );
-      const infoJson = await fs.readJson(infoPath);
-      const { assessment: updatedInfoJson } = removeQidsFromAssessment(infoJson, qidsToRemove);
-      const formattedJson = await formatJsonWithPrettier(JSON.stringify(updatedInfoJson));
+      let formattedJson: string;
+      try {
+        const infoJson = (await fs.readJson(infoPath)) as AssessmentJsonInput;
+        const { assessment: updatedInfoJson, blockers } = removeQidsFromAssessment(
+          infoJson,
+          qidsToRemove,
+        );
+        if (blockers.length > 0) {
+          const reasons = blockers.map(blockerDescription).join('; ');
+          throw new AugmentedError(
+            `Deleting these questions would leave assessment ${referenced.course_instance_directory}/${referenced.assessment_directory} in an invalid state: ${reasons}.`,
+            {
+              info: html`
+                <p>
+                  Remove the questions from assessment
+                  <code
+                    >${referenced.course_instance_directory}/${referenced.assessment_directory}</code
+                  >
+                  first.
+                </p>
+              `,
+            },
+          );
+        }
+        formattedJson = await formatJsonWithPrettier(JSON.stringify(updatedInfoJson));
+      } catch (err) {
+        if (err instanceof AugmentedError) throw err;
+        throw new AugmentedError(`Unable to rewrite ${infoPath} while deleting questions.`, {
+          cause: err,
+        });
+      }
       await fs.writeFile(infoPath, formattedJson);
       pathsToAdd.push(infoPath);
     }

--- a/apps/prairielearn/src/lib/infoAssessment-edits.ts
+++ b/apps/prairielearn/src/lib/infoAssessment-edits.ts
@@ -60,9 +60,7 @@ interface EmptiedZone {
  * fail sync validation. Detected only when the deletion *introduces* the
  * problem (i.e. the pre-deletion file was syncable in this respect).
  */
-type DeletionBlocker =
-  | { code: 'NEW_FIRST_ZONE_HAS_LOCKPOINT' }
-  | { code: 'NO_ZONES_REMAINING' };
+type DeletionBlocker = { code: 'NEW_FIRST_ZONE_HAS_LOCKPOINT' } | { code: 'NO_ZONES_REMAINING' };
 
 export function blockerDescription(blocker: DeletionBlocker): string {
   switch (blocker.code) {

--- a/apps/prairielearn/src/lib/infoAssessment-edits.ts
+++ b/apps/prairielearn/src/lib/infoAssessment-edits.ts
@@ -60,7 +60,7 @@ interface EmptiedZone {
  * fail sync validation. Detected only when the deletion *introduces* the
  * problem (i.e. the pre-deletion file was syncable in this respect).
  */
-export type DeletionBlocker =
+type DeletionBlocker =
   | { code: 'NEW_FIRST_ZONE_HAS_LOCKPOINT' }
   | { code: 'NO_ZONES_REMAINING' };
 

--- a/apps/prairielearn/src/lib/infoAssessment-edits.ts
+++ b/apps/prairielearn/src/lib/infoAssessment-edits.ts
@@ -1,0 +1,96 @@
+import type {
+  AssessmentJsonInput,
+  ZoneAssessmentJsonInput,
+  ZoneQuestionBlockJsonInput,
+} from '../schemas/infoAssessment.js';
+
+/**
+ * Removes any references to `qidsToRemove` from a single zone-question block.
+ * For alternative groups, filters the alternatives list; the block itself is
+ * dropped only when all alternatives are removed. For direct QID references,
+ * the block is dropped when its QID matches.
+ */
+export function removeQidsFromBlock(
+  block: ZoneQuestionBlockJsonInput,
+  qidsToRemove: Set<string>,
+): { block: ZoneQuestionBlockJsonInput | null; removedCount: number } {
+  if (block.alternatives) {
+    const alternatives = block.alternatives.filter(
+      (alternative) => !qidsToRemove.has(alternative.id),
+    );
+    return {
+      block: alternatives.length > 0 ? { ...block, alternatives } : null,
+      removedCount: block.alternatives.length - alternatives.length,
+    };
+  }
+
+  if (block.id && qidsToRemove.has(block.id)) {
+    return { block: null, removedCount: 1 };
+  }
+  return { block, removedCount: 0 };
+}
+
+/**
+ * Removes any references to `qidsToRemove` from a single zone's question
+ * blocks, returning the surviving blocks alongside a count of removed
+ * references. Does not mutate the input.
+ */
+export function removeQidsFromZone(
+  zone: ZoneAssessmentJsonInput,
+  qidsToRemove: Set<string>,
+): { questions: ZoneQuestionBlockJsonInput[]; removedCount: number } {
+  let removedCount = 0;
+  const questions: ZoneQuestionBlockJsonInput[] = [];
+  for (const block of zone.questions) {
+    const result = removeQidsFromBlock(block, qidsToRemove);
+    removedCount += result.removedCount;
+    if (result.block) questions.push(result.block);
+  }
+  return { questions, removedCount };
+}
+
+export interface EmptiedZone {
+  /** Zero-based index of the zone in the original `assessment.zones`. */
+  zoneIndex: number;
+  zoneTitle: string | null;
+}
+
+export interface RemoveQidsFromAssessmentResult {
+  assessment: AssessmentJsonInput;
+  removedCount: number;
+  /**
+   * Zones that were non-empty before the removal and would be empty after.
+   * These zones are dropped from `assessment`; callers that want to refuse
+   * the operation rather than silently discard zone metadata should inspect
+   * this list before persisting.
+   */
+  emptiedZones: EmptiedZone[];
+}
+
+/**
+ * Returns a copy of `assessment` with any references to `qidsToRemove`
+ * filtered out, alongside the list of zones that became empty as a result.
+ * Empty zones are dropped from the returned assessment.
+ */
+export function removeQidsFromAssessment(
+  assessment: AssessmentJsonInput,
+  qidsToRemove: Set<string>,
+): RemoveQidsFromAssessmentResult {
+  let removedCount = 0;
+  const emptiedZones: EmptiedZone[] = [];
+  const zones: ZoneAssessmentJsonInput[] = [];
+  for (const [zoneIndex, zone] of (assessment.zones ?? []).entries()) {
+    const { questions, removedCount: zoneRemovedCount } = removeQidsFromZone(zone, qidsToRemove);
+    removedCount += zoneRemovedCount;
+    if (zone.questions.length > 0 && questions.length === 0) {
+      emptiedZones.push({ zoneIndex, zoneTitle: zone.title ?? null });
+      continue;
+    }
+    zones.push({ ...zone, questions });
+  }
+  return {
+    assessment: { ...assessment, zones },
+    removedCount,
+    emptiedZones,
+  };
+}

--- a/apps/prairielearn/src/lib/infoAssessment-edits.ts
+++ b/apps/prairielearn/src/lib/infoAssessment-edits.ts
@@ -10,7 +10,7 @@ import type {
  * dropped only when all alternatives are removed. For direct QID references,
  * the block is dropped when its QID matches.
  */
-export function removeQidsFromBlock(
+function removeQidsFromBlock(
   block: ZoneQuestionBlockJsonInput,
   qidsToRemove: Set<string>,
 ): { block: ZoneQuestionBlockJsonInput | null; removedCount: number } {
@@ -35,7 +35,7 @@ export function removeQidsFromBlock(
  * blocks, returning the surviving blocks alongside a count of removed
  * references. Does not mutate the input.
  */
-export function removeQidsFromZone(
+function removeQidsFromZone(
   zone: ZoneAssessmentJsonInput,
   qidsToRemove: Set<string>,
 ): { questions: ZoneQuestionBlockJsonInput[]; removedCount: number } {
@@ -49,13 +49,13 @@ export function removeQidsFromZone(
   return { questions, removedCount };
 }
 
-export interface EmptiedZone {
+interface EmptiedZone {
   /** Zero-based index of the zone in the original `assessment.zones`. */
   zoneIndex: number;
   zoneTitle: string | null;
 }
 
-export interface RemoveQidsFromAssessmentResult {
+interface RemoveQidsFromAssessmentResult {
   assessment: AssessmentJsonInput;
   removedCount: number;
   /**

--- a/apps/prairielearn/src/lib/infoAssessment-edits.ts
+++ b/apps/prairielearn/src/lib/infoAssessment-edits.ts
@@ -55,6 +55,30 @@ interface EmptiedZone {
   zoneTitle: string | null;
 }
 
+/**
+ * A reason the deletion cannot proceed because the resulting assessment would
+ * fail sync validation. Detected only when the deletion *introduces* the
+ * problem (i.e. the pre-deletion file was syncable in this respect).
+ */
+export type DeletionBlocker =
+  | { code: 'NEW_FIRST_ZONE_HAS_LOCKPOINT' }
+  | { code: 'NO_ZONES_REMAINING' };
+
+export function blockerDescription(blocker: DeletionBlocker): string {
+  switch (blocker.code) {
+    case 'NO_ZONES_REMAINING':
+      return 'all zones would be empty';
+    case 'NEW_FIRST_ZONE_HAS_LOCKPOINT':
+      return 'the new first zone has lockpoint: true';
+  }
+}
+
+export interface BlockedAssessment {
+  assessmentLabel: string;
+  courseInstanceShortName: string;
+  blockers: DeletionBlocker[];
+}
+
 interface RemoveQidsFromAssessmentResult {
   assessment: AssessmentJsonInput;
   removedCount: number;
@@ -65,6 +89,11 @@ interface RemoveQidsFromAssessmentResult {
    * this list before persisting.
    */
   emptiedZones: EmptiedZone[];
+  /**
+   * Sync-validation problems newly introduced by the deletion. Callers should
+   * refuse to persist when this is non-empty.
+   */
+  blockers: DeletionBlocker[];
 }
 
 /**
@@ -88,9 +117,20 @@ export function removeQidsFromAssessment(
     }
     zones.push({ ...zone, questions });
   }
+
+  const originalZones = assessment.zones ?? [];
+  const blockers: DeletionBlocker[] = [];
+  if (zones.length === 0 && originalZones.length > 0) {
+    blockers.push({ code: 'NO_ZONES_REMAINING' });
+  }
+  if (zones[0]?.lockpoint && !originalZones[0]?.lockpoint) {
+    blockers.push({ code: 'NEW_FIRST_ZONE_HAS_LOCKPOINT' });
+  }
+
   return {
     assessment: { ...assessment, zones },
     removedCount,
     emptiedZones,
+    blockers,
   };
 }

--- a/apps/prairielearn/src/lib/question-deletion-validation.ts
+++ b/apps/prairielearn/src/lib/question-deletion-validation.ts
@@ -1,0 +1,72 @@
+import * as path from 'path';
+
+import fs from 'fs-extra';
+
+import { type Course } from './db-types.js';
+import {
+  type BlockedAssessment,
+  blockerDescription,
+  removeQidsFromAssessment,
+} from './infoAssessment-edits.js';
+import { selectAssessmentDirectoriesForQuestions } from '../models/assessment.js';
+import type { AssessmentJsonInput } from '../schemas/infoAssessment.js';
+
+/**
+ * For each assessment in `course` that references one of `questionIds`, returns
+ * the assessments whose `infoAssessment.json` would become invalid after the
+ * deletion (e.g. losing all zones, or promoting a lockpoint zone to first).
+ * Assessments whose files are unreadable are skipped — sync will surface that
+ * error separately if the deletion proceeds.
+ */
+export async function selectAssessmentsBlockingDeletion({
+  course,
+  questionIds,
+  qidsToRemove,
+}: {
+  course: Pick<Course, 'id' | 'path'>;
+  questionIds: string[];
+  qidsToRemove: Set<string>;
+}): Promise<BlockedAssessment[]> {
+  if (qidsToRemove.size === 0) return [];
+
+  const refs = await selectAssessmentDirectoriesForQuestions({
+    course_id: course.id,
+    question_ids: questionIds,
+  });
+
+  const blocked: BlockedAssessment[] = [];
+  for (const ref of refs) {
+    const jsonPath = path.join(
+      course.path,
+      'courseInstances',
+      ref.course_instance_directory,
+      'assessments',
+      ref.assessment_directory,
+      'infoAssessment.json',
+    );
+    let parsed: AssessmentJsonInput;
+    try {
+      parsed = (await fs.readJson(jsonPath)) as AssessmentJsonInput;
+    } catch {
+      continue;
+    }
+    const { blockers } = removeQidsFromAssessment(parsed, qidsToRemove);
+    if (blockers.length > 0) {
+      blocked.push({
+        assessmentLabel: ref.assessment_directory,
+        courseInstanceShortName: ref.course_instance_directory,
+        blockers,
+      });
+    }
+  }
+  return blocked;
+}
+
+export function formatBlockedAssessments(blocked: BlockedAssessment[]): string {
+  return blocked
+    .map((a) => {
+      const reasons = a.blockers.map(blockerDescription).join('; ');
+      return `${a.courseInstanceShortName}/${a.assessmentLabel} (${reasons})`;
+    })
+    .join(', ');
+}

--- a/apps/prairielearn/src/lib/question-deletion-validation.ts
+++ b/apps/prairielearn/src/lib/question-deletion-validation.ts
@@ -2,14 +2,15 @@ import * as path from 'path';
 
 import fs from 'fs-extra';
 
+import { selectAssessmentDirectoriesForQuestions } from '../models/assessment.js';
+import type { AssessmentJsonInput } from '../schemas/infoAssessment.js';
+
 import { type Course } from './db-types.js';
 import {
   type BlockedAssessment,
   blockerDescription,
   removeQidsFromAssessment,
 } from './infoAssessment-edits.js';
-import { selectAssessmentDirectoriesForQuestions } from '../models/assessment.js';
-import type { AssessmentJsonInput } from '../schemas/infoAssessment.js';
 
 /**
  * For each assessment in `course` that references one of `questionIds`, returns
@@ -44,13 +45,13 @@ export async function selectAssessmentsBlockingDeletion({
       ref.assessment_directory,
       'infoAssessment.json',
     );
-    let parsed: AssessmentJsonInput;
+    let blockers: BlockedAssessment['blockers'];
     try {
-      parsed = (await fs.readJson(jsonPath)) as AssessmentJsonInput;
+      const parsed = (await fs.readJson(jsonPath)) as AssessmentJsonInput;
+      ({ blockers } = removeQidsFromAssessment(parsed, qidsToRemove));
     } catch {
       continue;
     }
-    const { blockers } = removeQidsFromAssessment(parsed, qidsToRemove);
     if (blockers.length > 0) {
       blocked.push({
         assessmentLabel: ref.assessment_directory,

--- a/apps/prairielearn/src/models/assessment.sql
+++ b/apps/prairielearn/src/models/assessment.sql
@@ -279,3 +279,18 @@ SELECT
   ) AS min_total
 FROM
   zone_totals;
+
+-- BLOCK select_assessment_directories_for_questions
+SELECT DISTINCT
+  ci.short_name AS course_instance_directory,
+  a.tid AS assessment_directory
+FROM
+  assessment_questions AS aq
+  JOIN assessments AS a ON (a.id = aq.assessment_id)
+  JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+  aq.question_id = ANY ($question_ids::bigint[])
+  AND ci.course_id = $course_id
+  AND aq.deleted_at IS NULL
+  AND a.deleted_at IS NULL
+  AND ci.deleted_at IS NULL;

--- a/apps/prairielearn/src/models/assessment.ts
+++ b/apps/prairielearn/src/models/assessment.ts
@@ -19,6 +19,7 @@ import {
   AssessmentSetSchema,
   type AssessmentTool,
   AssessmentToolSchema,
+  CourseInstanceSchema,
 } from '../lib/db-types.js';
 import { EnumAssessmentToolSchema } from '../schemas/infoAssessment.js';
 
@@ -185,6 +186,28 @@ export function selectAssessmentsCursor({
     sql.select_assessments_for_course_instance,
     { course_instance_id },
     AssessmentRowSchema,
+  );
+}
+
+/**
+ * Returns the directory names of assessments (in `course_id`) that reference
+ * any of `question_ids` via their synced `assessment_questions`. Used to
+ * locate each assessment's `infoAssessment.json` on disk.
+ */
+export async function selectAssessmentDirectoriesForQuestions({
+  course_id,
+  question_ids,
+}: {
+  course_id: string;
+  question_ids: string[];
+}) {
+  return await queryRows(
+    sql.select_assessment_directories_for_questions,
+    { course_id, question_ids },
+    z.object({
+      course_instance_directory: CourseInstanceSchema.shape.short_name,
+      assessment_directory: AssessmentSchema.shape.tid.unwrap(),
+    }),
   );
 }
 

--- a/apps/prairielearn/src/models/question.sql
+++ b/apps/prairielearn/src/models/question.sql
@@ -6,6 +6,15 @@ FROM
 WHERE
   id = $question_id;
 
+-- BLOCK select_questions_by_ids_and_course_id
+SELECT
+  *
+FROM
+  questions
+WHERE
+  id = ANY ($question_ids::bigint[])
+  AND course_id = $course_id;
+
 -- BLOCK select_question_by_qid
 SELECT
   *
@@ -53,6 +62,23 @@ FROM
   JOIN questions AS q ON (q.id = aq.question_id)
 WHERE
   iq.id = $instance_question_id;
+
+-- BLOCK select_questions_used_in_other_courses
+SELECT DISTINCT
+  q.id,
+  q.qid
+FROM
+  questions AS q
+  JOIN assessment_questions AS aq ON aq.question_id = q.id
+  JOIN assessments AS a ON a.id = aq.assessment_id
+  JOIN course_instances AS ci ON ci.id = a.course_instance_id
+WHERE
+  q.id = ANY ($question_ids::bigint[])
+  AND ci.course_id != $course_id
+  AND q.deleted_at IS NULL
+  AND aq.deleted_at IS NULL
+  AND a.deleted_at IS NULL
+  AND ci.deleted_at IS NULL;
 
 -- BLOCK select_questions_for_course_instance_copy
 SELECT DISTINCT

--- a/apps/prairielearn/src/models/question.sql
+++ b/apps/prairielearn/src/models/question.sql
@@ -74,6 +74,7 @@ FROM
   JOIN course_instances AS ci ON ci.id = a.course_instance_id
 WHERE
   q.id = ANY ($question_ids::bigint[])
+  AND q.course_id = $course_id
   AND ci.course_id != $course_id
   AND q.deleted_at IS NULL
   AND aq.deleted_at IS NULL

--- a/apps/prairielearn/src/models/question.ts
+++ b/apps/prairielearn/src/models/question.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
 
+import { z } from 'zod';
+
 import {
   execute,
   loadSqlEquiv,
@@ -7,6 +9,7 @@ import {
   queryRow,
   queryRows,
 } from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import { type Question, QuestionSchema } from '../lib/db-types.js';
 
@@ -18,6 +21,40 @@ export async function selectQuestionById(question_id: string): Promise<Question>
 
 export async function selectOptionalQuestionById(question_id: string): Promise<Question | null> {
   return await queryOptionalRow(sql.select_question_by_id, { question_id }, QuestionSchema);
+}
+
+export async function selectQuestionsByIdsAndCourseId({
+  question_ids,
+  course_id,
+}: {
+  question_ids: string[];
+  course_id: string;
+}): Promise<Question[]> {
+  return await queryRows(
+    sql.select_questions_by_ids_and_course_id,
+    { question_ids, course_id },
+    QuestionSchema,
+  );
+}
+
+/**
+ * Returns the subset of `question_ids` (belonging to `course_id`) that are
+ * referenced by assessments in other courses. Used to block destructive
+ * mutations on shared questions whose deletion would break a consumer course's
+ * sync.
+ */
+export async function selectQuestionsUsedInOtherCourses({
+  question_ids,
+  course_id,
+}: {
+  question_ids: string[];
+  course_id: string;
+}): Promise<{ id: string; qid: string }[]> {
+  return await queryRows(
+    sql.select_questions_used_in_other_courses,
+    { question_ids, course_id },
+    z.object({ id: IdSchema, qid: z.string() }),
+  );
 }
 
 export async function selectQuestionByQid({

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/components/QuestionSettingsCardFooter.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/components/QuestionSettingsCardFooter.tsx
@@ -78,7 +78,7 @@ function DeleteQuestionModal({
         </p>
         {assessmentsWithQuestion.length > 0 && (
           <>
-            <p>It is included by these assessments:</p>
+            <p>It will also be removed from these assessments:</p>
             <ul className="list-group my-4">
               {assessmentsWithQuestion.map((aWithQ) => (
                 <li key={aWithQ.course_instance_id} className="list-group-item">
@@ -95,11 +95,6 @@ function DeleteQuestionModal({
                 </li>
               ))}
             </ul>
-            <p>
-              So, if you delete it, you will be unable to sync your course content to the database
-              until you either remove the question from these assessments or create a new question
-              with the same QID.
-            </p>
           </>
         )}
       </Modal.Body>

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
@@ -43,6 +43,10 @@ import { idsEqual } from '../../lib/id.js';
 import { getPaths } from '../../lib/instructorFiles.js';
 import { applyKeyOrder } from '../../lib/json.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
+import {
+  formatBlockedAssessments,
+  selectAssessmentsBlockingDeletion,
+} from '../../lib/question-deletion-validation.js';
 import { validatePreferencesSchema } from '../../lib/question-settings/validation.js';
 import { startTestQuestion } from '../../lib/question-testing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
@@ -570,6 +574,21 @@ router.post(
           'This question is used by another course and cannot be deleted. Unshare it or remove it from those assessments first.',
         );
         return res.redirect(req.originalUrl);
+      }
+
+      if (res.locals.question.qid) {
+        const blockedAssessments = await selectAssessmentsBlockingDeletion({
+          course: res.locals.course,
+          questionIds: [res.locals.question.id],
+          qidsToRemove: new Set([res.locals.question.qid]),
+        });
+        if (blockedAssessments.length > 0) {
+          flash(
+            'error',
+            `Deleting this question would leave the following assessments in an invalid state: ${formatBlockedAssessments(blockedAssessments)}. Remove the question from these assessments first.`,
+          );
+          return res.redirect(req.originalUrl);
+        }
       }
 
       const editor = new QuestionDeleteEditor({

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
@@ -50,7 +50,7 @@ import { validateShortName } from '../../lib/short-name.js';
 import { getCanonicalHost } from '../../lib/url.js';
 import { generateCsrfToken } from '../../middlewares/csrfToken.js';
 import { selectCoursesWithEditAccess } from '../../models/course.js';
-import { selectQuestionByUuid } from '../../models/question.js';
+import { selectQuestionByUuid, selectQuestionsUsedInOtherCourses } from '../../models/question.js';
 import {
   type QuestionSharingSetRow,
   selectQuestionSharingConstraints,
@@ -560,6 +560,18 @@ router.post(
         });
       }
     } else if (req.body.__action === 'delete_question') {
+      const blockedByOtherCourses = await selectQuestionsUsedInOtherCourses({
+        question_ids: [res.locals.question.id],
+        course_id: res.locals.course.id,
+      });
+      if (blockedByOtherCourses.length > 0) {
+        flash(
+          'error',
+          'This question is used by another course and cannot be deleted. Unshare it or remove it from those assessments first.',
+        );
+        return res.redirect(req.originalUrl);
+      }
+
       const editor = new QuestionDeleteEditor({
         locals: res.locals,
         questions: res.locals.question,

--- a/apps/prairielearn/src/sync/sharing.sql
+++ b/apps/prairielearn/src/sync/sharing.sql
@@ -46,22 +46,6 @@ WHERE
     )
   );
 
--- BLOCK select_renames_used_in_other_courses
-SELECT DISTINCT
-  q.qid
-FROM
-  questions AS q
-  JOIN assessment_questions AS aq ON aq.question_id = q.id
-  JOIN assessments AS a ON a.id = aq.assessment_id
-  JOIN course_instances AS ci ON ci.id = a.course_instance_id
-WHERE
-  q.id = ANY ($question_ids::bigint[])
-  AND ci.course_id != $course_id
-  AND q.deleted_at IS NULL
-  AND aq.deleted_at IS NULL
-  AND a.deleted_at IS NULL
-  AND ci.deleted_at IS NULL;
-
 -- BLOCK select_in_use_question_sharing_set_removals
 SELECT DISTINCT
   q.qid,

--- a/apps/prairielearn/src/sync/sharing.ts
+++ b/apps/prairielearn/src/sync/sharing.ts
@@ -4,6 +4,7 @@ import * as sqldb from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
 import { type ServerJobLogger } from '../lib/server-jobs.js';
+import { selectQuestionsUsedInOtherCourses } from '../models/question.js';
 
 import { type CourseData } from './course-db.js';
 
@@ -39,11 +40,10 @@ export async function getInvalidRenames(
 
   if (renamedQuestions.length === 0) return false;
 
-  const blockedQuestions = await sqldb.queryRows(
-    sql.select_renames_used_in_other_courses,
-    { course_id: courseId, question_ids: renamedQuestions.map((q) => q.id) },
-    z.object({ qid: z.string() }),
-  );
+  const blockedQuestions = await selectQuestionsUsedInOtherCourses({
+    course_id: courseId,
+    question_ids: renamedQuestions.map((q) => q.id),
+  });
 
   if (blockedQuestions.length === 0) return false;
 

--- a/apps/prairielearn/src/tests/e2e/questionSettings.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/questionSettings.spec.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import type { Page } from '@playwright/test';
 
 import { selectQuestionByQid } from '../../models/question.js';
+import { syncCourse } from '../helperCourse.js';
 
 import { expect, test } from './fixtures.js';
 
@@ -134,5 +136,67 @@ test.describe('Question settings', () => {
 
     const updatedInfo = JSON.parse(await fs.readFile(infoJsonPath, 'utf8'));
     expect(updatedInfo.gradingMethod).toBe('Manual');
+  });
+});
+
+test.describe('Question deletion blockers', () => {
+  test('blocks deletion when it would leave an assessment with no zones', async ({
+    page,
+    testCoursePath,
+  }) => {
+    const suffix = randomUUID().replaceAll('-', '').slice(0, 8);
+    const qid = `singleblock${suffix}`;
+
+    const sourcePath = path.join(testCoursePath, 'questions', 'addNumbers');
+    const targetPath = path.join(testCoursePath, 'questions', qid);
+    await fs.cp(sourcePath, targetPath, { recursive: true });
+    const infoPath = path.join(targetPath, 'info.json');
+    const infoJson = JSON.parse(await fs.readFile(infoPath, 'utf-8'));
+    infoJson.uuid = randomUUID();
+    infoJson.title = 'Single delete blocker';
+    await fs.writeFile(infoPath, `${JSON.stringify(infoJson, null, 2)}\n`);
+
+    const assessmentTid = `singleblock${suffix}`;
+    const assessmentDir = path.join(
+      testCoursePath,
+      'courseInstances',
+      'Sp15',
+      'assessments',
+      assessmentTid,
+    );
+    await fs.mkdir(assessmentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(assessmentDir, 'infoAssessment.json'),
+      `${JSON.stringify(
+        {
+          uuid: randomUUID(),
+          type: 'Homework',
+          title: 'Single delete blocker target',
+          set: 'Homework',
+          number: `5${suffix.slice(0, 4)}`,
+          allowAccess: [
+            { credit: 100, startDate: '2014-07-07T00:00:01', endDate: '2034-07-10T23:59:59' },
+          ],
+          zones: [{ title: 'Only zone', questions: [{ id: qid, autoPoints: 1 }] }],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    await syncCourse(testCoursePath);
+
+    const question = await selectQuestionByQid({ qid, course_id: '1' });
+    await page.goto(`/pl/course/1/question/${question.id}/settings`);
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+    const modal = page.getByRole('dialog').filter({ hasText: qid });
+    await expect(modal).toBeVisible();
+    await modal.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await expect(
+      page.getByText(
+        `Deleting this question would leave the following assessments in an invalid state: Sp15/${assessmentTid} (all zones would be empty). Remove the question from these assessments first.`,
+      ),
+    ).toBeVisible();
+    await expect(fs.access(path.join(testCoursePath, 'questions', qid))).resolves.toBeUndefined();
   });
 });

--- a/apps/prairielearn/src/tests/questionDeleteRewrite.test.ts
+++ b/apps/prairielearn/src/tests/questionDeleteRewrite.test.ts
@@ -1,0 +1,193 @@
+import * as path from 'path';
+
+import { execa } from 'execa';
+import fs from 'fs-extra';
+import fetch from 'node-fetch';
+import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+
+import { config } from '../lib/config.js';
+import { generateCsrfToken } from '../middlewares/csrfToken.js';
+import { selectQuestionByQid } from '../models/question.js';
+
+import {
+  type CourseRepoFixture,
+  createCourseRepoFixture,
+  updateCourseRepository,
+} from './helperCourse.js';
+import * as helperServer from './helperServer.js';
+
+const siteUrl = 'http://localhost:' + config.serverPort;
+const baseUrl = siteUrl + '/pl';
+const courseInstanceUrl = baseUrl + '/course_instance/1/instructor';
+
+const COURSE_ID = '1';
+const COURSE_INSTANCE_SHORT_NAME = 'Fa18';
+const QUESTION_HTML = 'This is a test question.\n';
+
+const TARGET_QID = 'target';
+const OTHER_QID = 'other';
+
+const DIRECT_AID = 'direct';
+const MIXED_ALT_AID = 'mixed-alt';
+const ONLY_ALT_AID = 'only-alt';
+
+async function populateOrigin(originDir: string) {
+  await fs.ensureDir(originDir);
+  await fs.writeJSON(path.join(originDir, 'infoCourse.json'), {
+    uuid: '01234567-89ab-cdef-0123-456789abcdef',
+    name: 'TEST 101',
+    title: 'Test Course',
+    topics: [{ name: 'Test', color: 'gray3', description: 'Test topic' }],
+  });
+
+  for (const [qid, uuid] of [
+    [TARGET_QID, '11111111-1111-1111-1111-111111111111'],
+    [OTHER_QID, '22222222-2222-2222-2222-222222222222'],
+  ] as const) {
+    const qDir = path.join(originDir, 'questions', qid);
+    await fs.ensureDir(qDir);
+    await fs.writeJSON(path.join(qDir, 'info.json'), {
+      uuid,
+      title: qid,
+      topic: 'Test',
+      type: 'v3',
+    });
+    await fs.writeFile(path.join(qDir, 'question.html'), QUESTION_HTML);
+  }
+
+  const ciDir = path.join(originDir, 'courseInstances', COURSE_INSTANCE_SHORT_NAME);
+  await fs.ensureDir(ciDir);
+  await fs.writeJSON(path.join(ciDir, 'infoCourseInstance.json'), {
+    uuid: '6d65eff5-b7c6-4b8f-bc18-ab5e7cbea2fa',
+    longName: 'Fall 2018',
+    allowAccess: [
+      { institution: 'Any', startDate: '1900-01-19T00:00:01', endDate: '2400-05-13T23:59:59' },
+    ],
+  });
+
+  const assessments: Record<string, object> = {
+    [DIRECT_AID]: {
+      uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1',
+      type: 'Homework',
+      title: 'Direct reference assessment',
+      set: 'Homework',
+      number: '1',
+      allowAccess: [{ credit: 100 }],
+      zones: [
+        {
+          title: 'zone',
+          questions: [
+            { id: TARGET_QID, points: 10 },
+            { id: OTHER_QID, points: 5 },
+          ],
+        },
+      ],
+    },
+    [MIXED_ALT_AID]: {
+      uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2',
+      type: 'Homework',
+      title: 'Alternative group assessment (mixed)',
+      set: 'Homework',
+      number: '2',
+      allowAccess: [{ credit: 100 }],
+      zones: [
+        {
+          title: 'zone',
+          questions: [
+            {
+              points: 10,
+              alternatives: [{ id: TARGET_QID }, { id: OTHER_QID }],
+            },
+          ],
+        },
+      ],
+    },
+    [ONLY_ALT_AID]: {
+      uuid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3',
+      type: 'Homework',
+      title: 'Alternative group assessment (target only)',
+      set: 'Homework',
+      number: '3',
+      allowAccess: [{ credit: 100 }],
+      zones: [
+        {
+          title: 'zone-target',
+          questions: [{ points: 10, alternatives: [{ id: TARGET_QID }] }],
+        },
+        {
+          title: 'zone-other',
+          questions: [{ id: OTHER_QID, points: 5 }],
+        },
+      ],
+    },
+  };
+
+  for (const [aid, body] of Object.entries(assessments)) {
+    const aDir = path.join(ciDir, 'assessments', aid);
+    await fs.ensureDir(aDir);
+    await fs.writeJSON(path.join(aDir, 'infoAssessment.json'), body);
+  }
+}
+
+let courseRepo: CourseRepoFixture;
+
+describe('QuestionDeleteEditor rewrites infoAssessment.json', { timeout: 20_000 }, () => {
+  beforeAll(async () => {
+    courseRepo = await createCourseRepoFixture({ populateOrigin });
+    await helperServer.before(courseRepo.courseLiveDir)();
+    await updateCourseRepository({ courseId: COURSE_ID, repository: courseRepo.courseOriginDir });
+  });
+
+  afterAll(helperServer.after);
+
+  it('removes the deleted qid from every referencing assessment', async () => {
+    const targetQuestion = await selectQuestionByQid({ qid: TARGET_QID, course_id: COURSE_ID });
+
+    const settingsPath = `/pl/course_instance/1/instructor/question/${targetQuestion.id}/settings`;
+    const csrfToken = generateCsrfToken({ url: settingsPath, authnUserId: '1' });
+
+    const postUrl = `${courseInstanceUrl}/question/${targetQuestion.id}/settings`;
+    const res = await fetch(postUrl, {
+      method: 'POST',
+      body: new URLSearchParams({ __csrf_token: csrfToken, __action: 'delete_question' }),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+    assert.isOk(res.ok);
+    assert.notInclude(res.url, '/edit_error/');
+
+    await execa('git', ['pull'], { cwd: courseRepo.courseDevDir, env: process.env });
+
+    const assessmentsDir = path.join(
+      courseRepo.courseDevDir,
+      'courseInstances',
+      COURSE_INSTANCE_SHORT_NAME,
+      'assessments',
+    );
+
+    const directJson = await fs.readJson(
+      path.join(assessmentsDir, DIRECT_AID, 'infoAssessment.json'),
+    );
+    assert.deepEqual(directJson.zones, [
+      { title: 'zone', questions: [{ id: OTHER_QID, points: 5 }] },
+    ]);
+
+    const mixedJson = await fs.readJson(
+      path.join(assessmentsDir, MIXED_ALT_AID, 'infoAssessment.json'),
+    );
+    assert.deepEqual(mixedJson.zones, [
+      { title: 'zone', questions: [{ points: 10, alternatives: [{ id: OTHER_QID }] }] },
+    ]);
+
+    const onlyAltJson = await fs.readJson(
+      path.join(assessmentsDir, ONLY_ALT_AID, 'infoAssessment.json'),
+    );
+    assert.deepEqual(onlyAltJson.zones, [
+      { title: 'zone-other', questions: [{ id: OTHER_QID, points: 5 }] },
+    ]);
+
+    assert.isFalse(
+      await fs.pathExists(path.join(courseRepo.courseDevDir, 'questions', TARGET_QID)),
+    );
+    assert.isTrue(await fs.pathExists(path.join(courseRepo.courseDevDir, 'questions', OTHER_QID)));
+  });
+});

--- a/apps/prairielearn/src/tests/questionDeleteRewrite.test.ts
+++ b/apps/prairielearn/src/tests/questionDeleteRewrite.test.ts
@@ -6,6 +6,7 @@ import fetch from 'node-fetch';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
 import { config } from '../lib/config.js';
+import { getCourseFilesClient } from '../lib/course-files-api.js';
 import { generateCsrfToken } from '../middlewares/csrfToken.js';
 import { selectQuestionByQid } from '../models/question.js';
 
@@ -139,6 +140,23 @@ describe('QuestionDeleteEditor rewrites infoAssessment.json', { timeout: 20_000 
   });
 
   afterAll(helperServer.after);
+
+  it('blocks bulk deletion when it would invalidate referencing assessments', async () => {
+    const targetQuestion = await selectQuestionByQid({ qid: TARGET_QID, course_id: COURSE_ID });
+    const otherQuestion = await selectQuestionByQid({ qid: OTHER_QID, course_id: COURSE_ID });
+
+    const result = await getCourseFilesClient().batchDeleteQuestions.mutate({
+      course_id: COURSE_ID,
+      user_id: '1',
+      authn_user_id: '1',
+      has_course_permission_edit: true,
+      question_ids: [targetQuestion.id, otherQuestion.id],
+    });
+
+    assert.equal(result.status, 'error');
+    assert.isTrue(await fs.pathExists(path.join(courseRepo.courseDevDir, 'questions', TARGET_QID)));
+    assert.isTrue(await fs.pathExists(path.join(courseRepo.courseDevDir, 'questions', OTHER_QID)));
+  });
 
   it('removes the deleted qid from every referencing assessment', async () => {
     const targetQuestion = await selectQuestionByQid({ qid: TARGET_QID, course_id: COURSE_ID });


### PR DESCRIPTION
# Description

Parent of #15085 

- Fix `QuestionRenameEditor` to only rewrite assessments in the current course, not other courses assessments
- Fix `QuestionDeleteEditor` to rewrite assessments and delete empty zones when needed. In certain cases, deletion cannot happen easily. We try to detect these cases and catch the error ahead of sync problems.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation

# Testing

Unit test added for deletion.
