### PR TITLE
Alt text is required for pl-figure and img

### DIFF
--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -87,7 +87,8 @@
     {
       "id": "pl-require-img-alt",
       "selector": "img:not([alt]):not([aria-hidden='true'])",
-      "message": "Images must have alt-text in order to be WCAG 2.1 AA compliant"
+      "message": "Images must have alt-text in order to be WCAG 2.1 AA compliant",
+      "severity": "warning"
     },
     {
       "id": "pl-prefer-pl-figure",

--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -85,6 +85,11 @@
       "exclude": ["apps/prairielearn/elements/**/*.mustache"]
     },
     {
+      "id": "pl-require-img-alt",
+      "selector": "img:not([alt]),img[alt='']",
+      "message": "Images must have alt-text in order to be ADA compliant"
+    },
+    {
       "id": "pl-prefer-pl-figure",
       "selector": "img:not([style]):not([class]):not(pl-overlay img)",
       "message": "Prefer pl-figure over raw <img> tags. See https://docs.prairielearn.com/elements/pl-figure/.",
@@ -253,7 +258,20 @@
         }
       ]
     },
-    { "name": "pl-figure" },
+    {
+      "name": "pl-figure",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "type": "object",
+        "required": ["alt"],
+        "properties": {
+          "alt": {
+            "type": "string",
+            "minLength": 10
+          }
+        }
+      }
+    },
     { "name": "pl-file-download" },
     { "name": "pl-file-preview" },
     { "name": "pl-matrix-latex" },

--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -86,7 +86,7 @@
     },
     {
       "id": "pl-require-img-alt",
-      "selector": "img:not([alt]):not([aria-hidden='true']), pl-figure:not([alt])",
+      "selector": "img:not([alt]):not([aria-hidden='true']):not(pl-overlay *), pl-figure:not([alt]):not(pl-overlay *)",
       "message": "Images must have alt-text in order to be WCAG 2.1 AA compliant",
       "severity": "warning"
     },
@@ -259,6 +259,7 @@
         }
       ]
     },
+    { "name": "pl-figure" },
     { "name": "pl-file-download" },
     { "name": "pl-file-preview" },
     { "name": "pl-matrix-latex" },

--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -86,7 +86,7 @@
     },
     {
       "id": "pl-require-img-alt",
-      "selector": "img:not([alt]):not([aria-hidden='true'])",
+      "selector": "img:not([alt]):not([aria-hidden='true']), pl-figure:not([alt])",
       "message": "Images must have alt-text in order to be WCAG 2.1 AA compliant",
       "severity": "warning"
     },
@@ -258,20 +258,6 @@
           "name": "pl-variable"
         }
       ]
-    },
-    {
-      "name": "pl-figure",
-      "schema": {
-        "$schema": "http://json-schema.org/draft-06/schema#",
-        "type": "object",
-        "required": ["alt"],
-        "properties": {
-          "alt": {
-            "type": "string",
-            "minLength": 10
-          }
-        }
-      }
     },
     { "name": "pl-file-download" },
     { "name": "pl-file-preview" },

--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -86,8 +86,8 @@
     },
     {
       "id": "pl-require-img-alt",
-      "selector": "img:not([alt]),img[alt='']",
-      "message": "Images must have alt-text in order to be ADA compliant"
+      "selector": "img:not([alt]):not([aria-hidden='true'])",
+      "message": "Images must have alt-text in order to be WCAG 2.1 AA compliant"
     },
     {
       "id": "pl-prefer-pl-figure",

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.mustache
@@ -1,5 +1,5 @@
 {{#render_button}}
-<button type="button" name="{{button_class}}" class="btn btn-primary pl-drawing-button" opts="{{{ options }}}" title="{{button_class}}"><img src=""></button>
+<button type="button" name="{{button_class}}" class="btn btn-primary pl-drawing-button" opts="{{{ options }}}" title="{{button_class}}"><img src="" alt=""></button>
 {{/render_button}}
 
 {{#render_element}}

--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
@@ -1,3 +1,4 @@
+{{! htmlmustache-disable pl-require-img-alt }}
 {{#graded}}
 <div class="pl-external-grader-results">
   {{^grading_succeeded}}
@@ -52,7 +53,7 @@
                 {{#images}}
                   <figure class="figure">
                     <figcaption><strong>{{label}}{{^label}}Figure{{/label}}</strong></figcaption>
-                    <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}" alt="{{alt}}"/>
+                    <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}"{{#alt}} alt="{{alt}}"{{/alt}}/>
                   </figure>
                 {{/images}}
               </li>
@@ -105,7 +106,7 @@
                       {{#images}}
                       <figure class="figure">
                         <figcaption><strong>{{label}}{{^label}}Figure{{/label}}</strong></figcaption>
-                        <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}" alt="{{alt}}"/>
+                        <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}"{{#alt}} alt="{{alt}}"{{/alt}}/>
                       </figure>
                       {{/images}}
                   </li>

--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.mustache
@@ -52,7 +52,7 @@
                 {{#images}}
                   <figure class="figure">
                     <figcaption><strong>{{label}}{{^label}}Figure{{/label}}</strong></figcaption>
-                    <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}"/>
+                    <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}" alt="{{alt}}"/>
                   </figure>
                 {{/images}}
               </li>
@@ -105,7 +105,7 @@
                       {{#images}}
                       <figure class="figure">
                         <figcaption><strong>{{label}}{{^label}}Figure{{/label}}</strong></figcaption>
-                        <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}"/>
+                        <img class="figure-img img-fluid" src="{{url}}{{^url}}{{.}}{{/url}}" alt="{{alt}}"/>
                       </figure>
                       {{/images}}
                   </li>

--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -33,8 +33,6 @@ ansi2html_style.SCHEME["iterm"] = (
 
 conv: Ansi2HTMLConverter = Ansi2HTMLConverter(inline=True, scheme="iterm")
 
-_DEFAULT_ALT_TEXT = "Report missing alt-text using the report an issue button"
-
 
 def ansi_to_html(output: str | None) -> str | None:
     if output is None:
@@ -73,7 +71,6 @@ def normalize_images(images: list[Any]) -> list[dict[str, Any]]:
         else:
             normalized_image = dict(image)
 
-        normalized_image.setdefault("alt", _DEFAULT_ALT_TEXT)
         normalized_images.append(normalized_image)
 
     return normalized_images

--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -33,6 +33,8 @@ ansi2html_style.SCHEME["iterm"] = (
 
 conv: Ansi2HTMLConverter = Ansi2HTMLConverter(inline=True, scheme="iterm")
 
+_DEFAULT_ALT_TEXT = "Report missing alt-text using the report an issue button"
+
 
 def ansi_to_html(output: str | None) -> str | None:
     if output is None:
@@ -60,6 +62,21 @@ def round_value(value: float, digits: int = 2) -> str:
         The value rounded to the specified precision
     """
     return f"{value:.{digits}f}".rstrip("0").rstrip(".")
+
+
+def normalize_images(images: list[Any]) -> list[dict[str, Any]]:
+    normalized_images: list[dict[str, Any]] = []
+
+    for image in images:
+        if isinstance(image, str):
+            normalized_image = {"url": image}
+        else:
+            normalized_image = dict(image)
+
+        normalized_image.setdefault("alt", _DEFAULT_ALT_TEXT)
+        normalized_images.append(normalized_image)
+
+    return normalized_images
 
 
 def render(element_html: str, data: pl.QuestionData) -> str:
@@ -106,7 +123,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         html_params["output"] = ansi_to_html(output)
         html_params["has_output"] = bool(output)
 
-        images = results.get("images", [])
+        images = normalize_images(results.get("images", []))
         html_params["images"] = images
         html_params["has_images"] = bool(images)
 
@@ -142,7 +159,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
                 message = results_test.get("message", None)
                 output = results_test.get("output", None)
                 description = results_test.get("description", None)
-                images = results_test.get("images", [])
+                images = normalize_images(results_test.get("images", []))
 
                 test: dict[str, Any] = {
                     "index": index,

--- a/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
+++ b/apps/prairielearn/elements/pl-external-grader-results/pl-external-grader-results.py
@@ -68,8 +68,10 @@ def normalize_images(images: list[Any]) -> list[dict[str, Any]]:
     for image in images:
         if isinstance(image, str):
             normalized_image = {"url": image}
-        else:
+        elif isinstance(image, dict):
             normalized_image = dict(image)
+        else:
+            continue
 
         normalized_images.append(normalized_image)
 

--- a/apps/prairielearn/elements/pl-figure/pl-figure.mustache
+++ b/apps/prairielearn/elements/pl-figure/pl-figure.mustache
@@ -1,3 +1,4 @@
+{{! htmlmustache-disable pl-require-img-alt }}
 {{^inline}}
 <div class="container-fluid mb-3">
     <img src="{{src}}" {{#width}}width="{{width}}"{{/width}} {{#alt}}alt="{{alt}}"{{/alt}} class="img-fluid mx-auto d-block" />

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.js
@@ -167,11 +167,13 @@
                 }
               } else if (type.startsWith('image/')) {
                 const url = URL.createObjectURL(blob);
-                img.src = url;
                 img.onload = () => {
                   URL.revokeObjectURL(url);
+                  img.alt = `Preview of ${file}`;
+                  img.removeAttribute('aria-hidden');
+                  img.classList.remove('d-none');
                 };
-                img.classList.remove('d-none');
+                img.src = url;
               } else if (type === 'application/pdf') {
                 const url = URL.createObjectURL(blob);
                 iframe.src = url;

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.mustache
@@ -27,12 +27,12 @@
         <div class="alert alert-danger mt-2 d-none js-error-alert" role="alert"></div>
         <div class="alert alert-info mt-2 d-none js-info-alert" role="alert"></div>
         <div class="file-preview collapse" id="file-preview-contents-{{uuid}}-{{index}}">
-          <img class="d-none mw-100 mt-2">
-          <div class="d-none ratio ratio-4x3 mt-2 js-file-preview-pdf-container"> 
+          <img aria-hidden="true" class="d-none mw-100 mt-2">
+          <div class="d-none ratio ratio-4x3 mt-2 js-file-preview-pdf-container">
             <iframe title="PDF file preview">
-              This PDF cannot be displayed. 
+              This PDF cannot be displayed.
             </iframe>
-          </div> 
+          </div>
           <div class="file-preview-container mt-2">
             <pre class="d-none bg-dark text-white rounded p-3 mb-0"><code></code></pre>
             <div class="d-none js-notebook-preview"></div>

--- a/apps/prairielearn/src/lib/htmlMustacheConfig.ts
+++ b/apps/prairielearn/src/lib/htmlMustacheConfig.ts
@@ -139,7 +139,7 @@ export const htmlMustacheConfig: Config = {
     },
     {
       id: 'pl-require-img-alt',
-      selector: "img:not([alt]):not([aria-hidden='true']), pl-figure:not([alt])",
+      selector: "img:not([alt]):not([aria-hidden='true']):not(pl-overlay *), pl-figure:not([alt]):not(pl-overlay *)",
       message: 'Images must have alt-text in order to be WCAG 2.1 AA compliant',
       severity: 'warning',
     },

--- a/apps/prairielearn/src/lib/htmlMustacheConfig.ts
+++ b/apps/prairielearn/src/lib/htmlMustacheConfig.ts
@@ -138,6 +138,12 @@ export const htmlMustacheConfig: Config = {
       severity: 'warning',
     },
     {
+      id: 'pl-require-img-alt',
+      selector: "img:not([alt]):not([aria-hidden='true']), pl-figure:not([alt])",
+      message: 'Images must have alt-text in order to be WCAG 2.1 AA compliant',
+      severity: 'warning',
+    },
+    {
       id: 'pl-prefer-pl-figure',
       selector: 'img:not([style]):not([class]):not(pl-overlay img)',
       message:

--- a/apps/prairielearn/src/lib/htmlMustacheConfig.ts
+++ b/apps/prairielearn/src/lib/htmlMustacheConfig.ts
@@ -139,7 +139,8 @@ export const htmlMustacheConfig: Config = {
     },
     {
       id: 'pl-require-img-alt',
-      selector: "img:not([alt]):not([aria-hidden='true']):not(pl-overlay *), pl-figure:not([alt]):not(pl-overlay *)",
+      selector:
+        "img:not([alt]):not([aria-hidden='true']):not(pl-overlay *), pl-figure:not([alt]):not(pl-overlay *)",
       message: 'Images must have alt-text in order to be WCAG 2.1 AA compliant',
       severity: 'warning',
     },

--- a/docs/elements/pl-external-grader-results.md
+++ b/docs/elements/pl-external-grader-results.md
@@ -10,7 +10,7 @@ Displays results from externally-graded questions.
 
 ## Details
 
-It expects results to follow [the reference schema for external grading results](../externalGrading.md#grading-results). Image entries may include an optional `alt` field for alternative text; if omitted, PrairieLearn falls back to the image label or "Figure".
+It expects results to follow [the reference schema for external grading results](../externalGrading.md#grading-results).
 
 ## Example Implementations
 

--- a/docs/elements/pl-external-grader-results.md
+++ b/docs/elements/pl-external-grader-results.md
@@ -10,7 +10,7 @@ Displays results from externally-graded questions.
 
 ## Details
 
-It expects results to follow [the reference schema for external grading results](../externalGrading.md#grading-results).
+It expects results to follow [the reference schema for external grading results](../externalGrading.md#grading-results). Image entries may include an optional `alt` field for alternative text; if omitted, PrairieLearn falls back to the image label or "Figure".
 
 ## Example Implementations
 

--- a/docs/externalGrading.md
+++ b/docs/externalGrading.md
@@ -159,10 +159,12 @@ The [`<pl-external-grader-results>` element](./elements/pl-external-grader-resul
   "images": [
     {
       "label": "First Image",
+      "alt": "A plot of the first result",
       "url": "data:image/png;base64,..."
     },
     {
       "label": "Second Image",
+      "alt": "A plot of the second result",
       "url": "data:image/jpeg;base64,..."
     }
   ],
@@ -185,10 +187,12 @@ The [`<pl-external-grader-results>` element](./elements/pl-external-grader-resul
       "images": [
         {
           "label": "First Image",
+          "alt": "A plot of the first test result",
           "url": "data:image/gif;base64,..."
         },
         {
           "label": "First Image",
+          "alt": "A plot of the second test result",
           "url": "data:image/png;base64,..."
         }
       ]
@@ -201,6 +205,7 @@ Plots or images can be added to either individual test cases or to the main outp
 
 - `url`: The source of the image, typically formatted as standard data URL like `"data:[mimetype];base64,[contents]"`.
 - `label`: An optional label for the image (defaults to "Figure").
+- `alt`: Optional alternative text for the image. If omitted, PrairieLearn uses the label for the image's `alt` text, or "Figure" if no label was provided.
 
 For compatibility with older versions of external graders, the object may be replaced with a string containing only the URL.
 

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/question.html
@@ -17,7 +17,7 @@ $$v_a = \frac{f(a+h) - f(a)}{h}$$
 
 <p> How is the average rate of change of a function connected to its graph? Take a look at the graph below:</p>
 
-<pl-figure file-name="figure1.png" type="dynamic" width="400"></pl-figure>
+<pl-figure file-name="figure1.png" type="dynamic" width="400" alt="Graph of f(x) with a secant line connecting point a at {{params.p_a}} to point b at {{params.p_b}}."></pl-figure>
 
 <p> Construct a right triangle in which the hypotenuse connects the points $a$ and $b$. What are the lengths of the legs
 of this triangle?</p>

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/server.py
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/server.py
@@ -17,7 +17,10 @@ def generate(data):
     b = int(max(points))
     a = int(min(points))
     data["params"]["a"] = a
+    data["params"]["p_a"] = repr((a, round(f(a))))
+
     data["params"]["b"] = b
+    data["params"]["p_b"] = repr((b, round(f(b))))
 
     h = abs(f(b) - f(a))
     base = abs(b - a)

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
@@ -22,7 +22,7 @@ $$ s(t) = {{params.f_tex}} $$
 
 <pl-overlay width="550" height="450" clip="false">
     <pl-background>
-      <pl-figure file-name="figure1.png" type="dynamic" alt="-- if you're reading this, report an issue with the question --"></pl-figure>
+      <pl-figure file-name="figure1.png" type="dynamic"></pl-figure>
     </pl-background>
 
     <pl-location left="20" top="0" valign="top" halign="left">

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
@@ -2,7 +2,7 @@
 
 <p>A cannon ball is fired from the top of a cliff and its trajectory is described by the following function:</p>
 
-$$ s(t) = - {{params.a}} t^2 + {{params.b}} t + 30 $$
+$$ s(t) = {{params.f_tex}} $$
 
 <h5> Part 1 </h5>
 
@@ -22,7 +22,7 @@ $$ s(t) = - {{params.a}} t^2 + {{params.b}} t + 30 $$
 
 <pl-overlay width="550" height="450" clip="false">
     <pl-background>
-      <pl-figure file-name="figure1.png" type="dynamic"></pl-figure>
+      <pl-figure file-name="figure1.png" type="dynamic" alt="-- this is hidden by pl-background --"></pl-figure>
     </pl-background>
 
     <pl-location left="20" top="0" valign="top" halign="left">

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
@@ -22,7 +22,7 @@ $$ s(t) = {{params.f_tex}} $$
 
 <pl-overlay width="550" height="450" clip="false">
     <pl-background>
-      <pl-figure file-name="figure1.png" type="dynamic" alt="-- this is hidden by pl-background --"></pl-figure>
+      <pl-figure file-name="figure1.png" type="dynamic" alt="-- if you're reading this, report an issue with the question --"></pl-figure>
     </pl-background>
 
     <pl-location left="20" top="0" valign="top" halign="left">

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/server.py
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/server.py
@@ -4,6 +4,8 @@ import random
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+import sympy as sp
+import sympy.abc as spabc
 
 mpl.rcParams["text.usetex"] = True
 plt.rcParams.update({"font.size": 14})
@@ -29,6 +31,7 @@ def generate(data):
     data["params"]["a"] = a
     data["params"]["b"] = b
     data["params"]["c"] = c
+    data["params"]["f_tex"] = sp.latex(f(spabc.t, a, b, c))
 
     # interval and given points
     t0 = random.choice([0.125, 0.25, 0.375, 0.5])

--- a/exampleCourse/questions/demo/annotated/engMarkovBrewing/question.html
+++ b/exampleCourse/questions/demo/annotated/engMarkovBrewing/question.html
@@ -5,7 +5,7 @@
          each other: sugar water, acid, carbon dioxide, and the {{params.beverage}} culture itself.
     </p>
 
-    <pl-figure file-name="drink.png" width="450"></pl-figure>
+    <pl-figure file-name="drink.png" width="450" alt="Mason-jar drink with strawberries, mint, and a striped straw."></pl-figure>
     <br>
 
     <p> You know how each ingredient of the solution changes in one hour: </p>

--- a/exampleCourse/questions/demo/fixedCheckbox/question.html
+++ b/exampleCourse/questions/demo/fixedCheckbox/question.html
@@ -1,7 +1,7 @@
 <pl-question-panel>
   <p>An object's motion is described by the position-time graph below.</p>
 
-  <pl-figure file-name="graph.png"></pl-figure>
+  <pl-figure file-name="graph.png" alt="Position-time graph x(m) with points A through G on a curve that rises, dips, and then falls. In left to right order: at A the value of f is -2, the curve moves linearly to f(B) at 0, then again to f(C) at 3, then to f(D) at 2, then to f(E) at 4, then to f(F) at 3, then stops at f(G) at 0"></pl-figure>
 </pl-question-panel>
 
 <pl-question-panel><hr></pl-question-panel>
@@ -17,5 +17,3 @@
   <pl-answer>               E-F</pl-answer>
   <pl-answer>               F-G</pl-answer>
 </pl-checkbox>
-
-

--- a/exampleCourse/questions/demo/overlayMap/question.html
+++ b/exampleCourse/questions/demo/overlayMap/question.html
@@ -31,6 +31,6 @@
         <pl-figure file-name="us_states_blank.png" directory="clientFilesQuestion" alt="Color-coded map of the United States with state borders and insets for distant states."></pl-figure>
     </pl-background>
     <pl-location left="{{params.x}}" top="{{params.y}}" halign="left">
-        <pl-string-input aria-label="nothern-most US State, in an inset" answers-name="state" show-help-text="false" size="1" ignore-case="True"></pl-string-input>
+        <pl-string-input aria-label="Northern-most US State, in an inset" answers-name="state" show-help-text="false" size="1" ignore-case="True"></pl-string-input>
     </pl-location>
 </pl-overlay>

--- a/exampleCourse/questions/demo/overlayMap/question.html
+++ b/exampleCourse/questions/demo/overlayMap/question.html
@@ -28,9 +28,9 @@
 
 <pl-overlay width="773" clip="false">
     <pl-background>
-        <pl-figure file-name="us_states_blank.png" directory="clientFilesQuestion"></pl-figure>
+        <pl-figure file-name="us_states_blank.png" directory="clientFilesQuestion" alt="Color-coded map of the United States with state borders and insets for distant states."></pl-figure>
     </pl-background>
     <pl-location left="{{params.x}}" top="{{params.y}}" halign="left">
-        <pl-string-input aria-label="US State" answers-name="state" show-help-text="false" size="1" ignore-case="True"></pl-string-input>
+        <pl-string-input aria-label="nothern-most US State, in an inset" answers-name="state" show-help-text="false" size="1" ignore-case="True"></pl-string-input>
     </pl-location>
 </pl-overlay>

--- a/exampleCourse/questions/demo/randomMultipleChoice/question.html
+++ b/exampleCourse/questions/demo/randomMultipleChoice/question.html
@@ -3,7 +3,7 @@
 A ball with mass $m ={{params.m}}\rm\ kg$ is thrown downward from the top of a building with height $h = {{params.h}}\rm\ m$ and initial speed $v_0$ at an angle $\theta$ with respect to the horizontal as shown in the figure. The $x$-component of the initial velocity $v_{x0} = {{params.v0x}}\rm\ m/s$, and the ball hits the ground a distance $d = {{params.d}}\rm\ m$ from the building as shown in the figure.
 </p>
 
-<pl-figure file-name="BallToss2.png" width="250"></pl-figure>
+<pl-figure file-name="BallToss2.png" width="250" alt="A ball is rolled off a cliff at initial angle theta with initial speed v0 from a height h off the ground and travels a distance d before impact"></pl-figure>
 </pl-question-panel>
 
 <pl-question-panel>

--- a/exampleCourse/questions/demo/randomPlot/question.html
+++ b/exampleCourse/questions/demo/randomPlot/question.html
@@ -1,6 +1,6 @@
 <pl-question-panel>
     {{! "figure.png" here is not a physical file. Since this pl-figure is the "dynamic" type, the figure is generated via server.py's `file()`. }}
-    <pl-figure file-name="figure.png" type="dynamic" width="500"></pl-figure>
+    <pl-figure file-name="figure.png" type="dynamic" width="500" alt="Graph of a linear function f(x) versus x, that enters the image at {{params.left}} and exits at {{params.right}}."></pl-figure>
     <p>
         What is $f({{params.x}})$?
     </p>

--- a/exampleCourse/questions/demo/randomPlot/server.py
+++ b/exampleCourse/questions/demo/randomPlot/server.py
@@ -4,11 +4,13 @@ import random
 import matplotlib.pyplot as plt
 import numpy as np
 
+MIN_X, MAX_X = -5, 5
+
 
 def file(data):
     if data["filename"] == "figure.png":
         # Create the figure
-        x = np.linspace(-5, 5)
+        x = np.linspace(MIN_X, MAX_X)
         f = data["params"]["m"] * x + data["params"]["b"]
         fig = plt.figure()
         plt.plot(x, f)
@@ -36,21 +38,22 @@ def file(data):
 
 def generate(data):
     # Pick a non-zero slope
-    while True:
-        m = random.randint(-2, 2)
-        if m != 0:
-            break
+    m = random.choice([-1, 1]) * random.randint(1, 2)
 
     # Pick a y-intercept
     b = random.randint(-3, 3)
 
-    # Pick x
-    x = random.randint(-5, 5)
+    def f(t):
+        return m * t + b
 
-    # Find f(x)
-    f = m * x + b
+    # Pick x that is not at the boundary of the plot
+    x = random.randint(MIN_X + 1, MAX_X - 1)
 
     data["params"]["m"] = m
     data["params"]["b"] = b
     data["params"]["x"] = x
-    data["correct_answers"]["f"] = f
+    data["correct_answers"]["f"] = f(x)
+
+    # alt label helpers for where the line enters/exits the plot
+    data["params"]["left"] = repr((MIN_X, f(MIN_X)))
+    data["params"]["right"] = repr((MAX_X, f(MAX_X)))

--- a/exampleCourse/questions/element/codeDocumentation/question.html
+++ b/exampleCourse/questions/element/codeDocumentation/question.html
@@ -179,7 +179,7 @@ def square(x):
      <p>Example of displaying an image in a question.</p>
     </pl-question-panel>
 
-    <pl-figure file-name="pl-logo.png" directory="clientFilesQuestion"></pl-figure>
+    <pl-figure file-name="pl-logo.png" directory="clientFilesQuestion" alt="PrairieLearn logo with prairie grass silhouette above the PrairieLearn wordmark."></pl-figure>
 </pl-card>
 
 <pl-card header="&lt;code&gt;pl-file-download&lt;/code&gt;">

--- a/exampleCourse/questions/element/overlay/question.html
+++ b/exampleCourse/questions/element/overlay/question.html
@@ -17,12 +17,12 @@
         {{! Use a normal img tag because pl-figure applies extra padding and scaling when the window gets small }}
         {{! htmlmustache-disable preferMustacheComments }}
         <!-- eslint-disable-next-line @html-eslint/require-img-alt -->
-        <img src="{{options.client_files_question_url}}/europe_annotated.png" width="700">
+        <img src="{{options.client_files_question_url}}/europe_annotated.png" width="700" alt="Annotated map of Europe with country labels.">
     </pl-background>
 
     {{! Input }}
     <pl-location left="460" top="290">
        <pl-string-input answers-name="string_value" show-help-text="false" size="7"
-                        correct-answer="Ukraine" aria-label="Unlabeled country" remove-leading-trailing="true" ignore-case="true"></pl-string-input>
+                        correct-answer="Ukraine" aria-label="Unlabeled country east of its neighbors Poland and Romania, and south of its neighbors Belarus and Russia" remove-leading-trailing="true" ignore-case="true"></pl-string-input>
     </pl-location>
 </pl-overlay>

--- a/exampleCourse/questions/element/overlay/question.html
+++ b/exampleCourse/questions/element/overlay/question.html
@@ -15,8 +15,6 @@
     {{! Background map image }}
     <pl-background>
         {{! Use a normal img tag because pl-figure applies extra padding and scaling when the window gets small }}
-        {{! htmlmustache-disable preferMustacheComments }}
-        <!-- eslint-disable-next-line @html-eslint/require-img-alt -->
         <img src="{{options.client_files_question_url}}/europe_annotated.png" width="700" alt="Annotated map of Europe with country labels.">
     </pl-background>
 

--- a/exampleCourse/questions/gallery/includeFigure/complex/question.html
+++ b/exampleCourse/questions/gallery/includeFigure/complex/question.html
@@ -3,7 +3,7 @@
   The function $f(x) = {{params.f}}$ is illustrated below.  Select the values of $x$
   corresponding to {{params.option}} function values.
 </p>
-<pl-figure file-name="figure.png" type="dynamic"></pl-figure>
+<pl-figure file-name="figure.png" type="dynamic" alt="Graph of the function that winds from the upper left to the bottom right, without any dips or peaks. Intercepts the x-axis at about -1."></pl-figure>
 </pl-question-panel>
 
 <pl-checkbox answers-name="select" hide-letter-keys="true" number-answers="4">

--- a/exampleCourse/questions/gallery/includeFigure/simple/question.html
+++ b/exampleCourse/questions/gallery/includeFigure/simple/question.html
@@ -3,7 +3,7 @@
   The function $f(x) = -x^3 - x^2 - 10x - 9$ is illustrated below.  Select the values of $x$
   corresponding to positive function values.
 </p>
-<pl-figure file-name="static_image.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="static_image.png" directory="clientFilesQuestion" alt="Graph of the function that winds from the upper left to the bottom right, without any dips or peaks. Intercepts the x-axis at about -1."></pl-figure>
 </pl-question-panel>
 
 <pl-checkbox answers-name="select" hide-letter-keys="true">

--- a/exampleCourse/questions/gallery/multipleChoice/complex/question.html
+++ b/exampleCourse/questions/gallery/multipleChoice/complex/question.html
@@ -1,14 +1,14 @@
 <pl-question-panel>
 <p>
-  A cannon ball with mass $m ={{params.m}}\rm\ kg$ is fired downward from a cliff at a height 
+  A cannon ball with mass $m ={{params.m}}\rm\ kg$ is fired downward from a cliff at a height
   $h = {{params.h}}\rm\ m$, at an angle  $\theta = {{params.theta}}^o$ with respect to the horizontal, and
   an initial velocity $v_0 = {{params.v0}} \rm\ m/s$, as illustrated in the figure below.
 </p>
 
-<pl-figure file-name="image.png" directory="clientFilesQuestion" width="300"></pl-figure>
+<pl-figure file-name="image.png" directory="clientFilesQuestion" width="300" alt="Projectile launched from a cliff at angle theta with initial speed v0, showing height h and having travelled horizontally a distance d."></pl-figure>
 
 <p>
-  Suppose the ball hits the ground a distance $d = {{params.d}} \rm\ m$ from the base of the cliff. 
+  Suppose the ball hits the ground a distance $d = {{params.d}} \rm\ m$ from the base of the cliff.
   How long is the ball in the air?
   Assume the acceleration due to gravity is $g=9.8 \rm\ m/s^2$.
 </p>

--- a/exampleCourse/questions/gallery/multipleChoice/simple/question.html
+++ b/exampleCourse/questions/gallery/multipleChoice/simple/question.html
@@ -1,11 +1,11 @@
 <pl-question-panel>
   <p>
-    A cannon ball with mass $m = 1.8 \rm\ kg$ is fired downward from a cliff at a height 
+    A cannon ball with mass $m = 1.8 \rm\ kg$ is fired downward from a cliff at a height
     $h = 2.67 \rm\ m$, at an angle  $\theta = 31^o$ with respect to the horizontal, and
     an initial velocity $v_0 = 20 \rm\ m/s$, as illustrated in the figure below.
   </p>
 
-  <pl-figure file-name="image.png" directory="clientFilesQuestion" width="300"></pl-figure>
+  <pl-figure file-name="image.png" directory="clientFilesQuestion" width="300" alt="Projectile launched from a cliff at angle theta with initial speed v0, showing height h and having travelled horizontally a distance d."></pl-figure>
 
   <p>
     Suppose the ball hits the ground a distance $d = 4 \rm\ m$ from the base of the cliff. How long is the ball in the air?
@@ -13,7 +13,7 @@
   </p>
 
   </pl-question-panel>
-  
+
   <pl-multiple-choice answers-name="t" none-of-the-above="random">
     <pl-answer correct="false">$t = 0.2 \rm\   s$</pl-answer>
     <pl-answer correct="false">$t = 0.388 \rm\ s$</pl-answer>
@@ -21,4 +21,3 @@
     <pl-answer correct="false">$t = 0.259 \rm\ s$</pl-answer>
     <pl-answer correct="false">$t = 0.738 \rm\ s$</pl-answer>
   </pl-multiple-choice>
-  

--- a/exampleCourse/questions/template/figure/dynamic/question.html
+++ b/exampleCourse/questions/template/figure/dynamic/question.html
@@ -1,7 +1,7 @@
 <pl-question-panel>
   <p>What is the {{params.dimension_name}} of the {{params.shape}}?</p>
 
-  <pl-figure file-name="shape.png" type="dynamic" width="400"></pl-figure>
+  <pl-figure file-name="shape.png" type="dynamic" width="400" alt="A {{params.shape}} centered at the origin with {{params.alt_label}}."></pl-figure>
 </pl-question-panel>
 
 <pl-integer-input

--- a/exampleCourse/questions/template/figure/dynamic/server.py
+++ b/exampleCourse/questions/template/figure/dynamic/server.py
@@ -18,9 +18,13 @@ def generate(data):
     if shape == "diamond":
         data["params"]["dimension_name"] = "length of the diagonal"
         data["params"]["dimension_label"] = "diamond diagonal"
+        data["params"]["alt_label"] = (
+            f"corners at (0, +/-{radius}) and (+/-{radius}, 0)"
+        )
     else:
         data["params"]["dimension_name"] = "diameter"
         data["params"]["dimension_label"] = "circle diameter"
+        data["params"]["alt_label"] = f"x-intercepts at +/-{radius}"
 
     # Compute the correct answer.
     data["correct_answers"]["dimension"] = 2 * radius

--- a/exampleCourse/questions/template/multiple-choice/images/question.html
+++ b/exampleCourse/questions/template/multiple-choice/images/question.html
@@ -4,42 +4,42 @@
 
 <pl-multiple-choice answers-name="kingfisher" number-answers="4">
   <pl-answer correct="true">
-    <pl-figure file-name="bird-a.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-a.webp" width="250" alt="A colorful blue-and-orange bird perched on a stump."></pl-figure>
   </pl-answer>
   <pl-answer correct="true">
-    <pl-figure file-name="bird-c.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-c.webp" width="250" alt="A colorful blue-and-orange bird perched on a branch."></pl-figure>
   </pl-answer>
   <pl-answer correct="true">
-    <pl-figure file-name="bird-g.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-g.webp" width="250" alt="A colorful blue-and-orange bird perched on a branch against a green background."></pl-figure>
   </pl-answer>
   <pl-answer correct="true">
-    <pl-figure file-name="bird-i.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-i.webp" width="250" alt="A colorful blue-and-orange bird perched on a branch against a green background."></pl-figure>
   </pl-answer>
   <pl-answer correct="true">
-    <pl-figure file-name="bird-j.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-j.webp" width="250" alt="A blue-and-orange bird perched on a lichen-covered branch."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-b.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-b.webp" width="250" alt="A small brown-and-white bird standing on the forest floor."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-d.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-d.webp" width="250" alt="A mottled brown bird probing mud with its bill."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-e.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-e.webp" width="250" alt="A medium-sized bird with a gray head and orange breast perched on a branch."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-f.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-f.webp" width="250" alt="A small white bird running along the beach."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-h.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-h.webp" width="250" alt="A small white bird on the beach."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-k.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-k.webp" width="250" alt="A white and green bird on a small branch."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-l.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-l.webp" width="250" alt="A small brown bird on a broken, mossy branch."></pl-figure>
   </pl-answer>
   <pl-answer correct="false">
-    <pl-figure file-name="bird-m.webp" directory="clientFilesQuestion" width="250"></pl-figure>
+    <pl-figure file-name="bird-m.webp" width="250" alt="A tiny yellow-green bird perched in foliage."></pl-figure>
   </pl-answer>
 </pl-multiple-choice>

--- a/exampleCourse/questions/workshop/Lesson1_example1_v2/question.html
+++ b/exampleCourse/questions/workshop/Lesson1_example1_v2/question.html
@@ -6,7 +6,7 @@
 
 <p>that is in the first quadrant.</p>
 
-<pl-figure file-name="figure0.png" type="dynamic" width="400"></pl-figure>
+<pl-figure file-name="figure0.png" type="dynamic" width="400" alt="Concave down plot of the curve  in the first quadrant with y-intercept {{params.a}} and x-intercept at roughly {{params.root_approx}}."></pl-figure>
 
 </pl-question-panel>
 

--- a/exampleCourse/questions/workshop/Lesson1_example1_v2/server.py
+++ b/exampleCourse/questions/workshop/Lesson1_example1_v2/server.py
@@ -16,6 +16,7 @@ def generate(data):
 
     equation = "$y = " + str(a) + " - x^{" + str(b) + "}$"
     data["params"]["equation"] = equation
+    data["params"]["root_approx"] = f"{np.power(a, 1 / b):.1f}"
 
     x2 = a ** (1 / b)
     A = a * x2 - x2 ** (b + 1) / (b + 1)

--- a/exampleCourse/questions/workshop/Lesson1_example3_v1/question.html
+++ b/exampleCourse/questions/workshop/Lesson1_example3_v1/question.html
@@ -2,7 +2,7 @@
 
 <p>Determine the equivalent resistance $ R_t $ of the circuit below:</p>
 
-<pl-figure file-name="circ1.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="circ1.png" directory="clientFilesQuestion" alt="Circuit diagram with a voltage source and three resistors in parallel: R1, R2, and R3."></pl-figure>
 
 <p> Assume $V_T = {{params.Vt}} \rm V$, $R_1 = {{params.R1}} \Omega$, $R_2 = {{params.R2}}\Omega$ and $R_3 = {{params.R3}}\Omega$. </p>
 

--- a/exampleCourse/questions/workshop/Lesson1_example3_v2/question.html
+++ b/exampleCourse/questions/workshop/Lesson1_example3_v2/question.html
@@ -2,7 +2,7 @@
 
 <p>Determine the {{params.ask}} of the circuit below:</p>
 
-<pl-figure file-name="circ1.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="circ1.png" directory="clientFilesQuestion" alt="Circuit diagram with a voltage source and three resistors in parallel: R1, R2, and R3."></pl-figure>
 <p> Assume $V_T = {{params.Vt}} \rm V$, $R_1 = {{params.R1}} \Omega$, $R_2 = {{params.R2}}\Omega$ and $R_3 = {{params.R3}}\Omega$. </p>
 
 </pl-question-panel>

--- a/exampleCourse/questions/workshop/Lesson1_example3_v3/question.html
+++ b/exampleCourse/questions/workshop/Lesson1_example3_v3/question.html
@@ -2,7 +2,7 @@
 
 <p>Determine the {{params.ask}} of the circuit below:</p>
 
-<pl-figure file-name="{{params.figname}}" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="{{params.figname}}" directory="clientFilesQuestion" alt="Circuit diagram with a voltage source and three resistors in series R1, R2, R3."></pl-figure>
 
 <p> The input variables are provided below: </p>
 <pl-variable-output digits="0" show-matlab="false" show-mathematica="false" show-r="false">

--- a/exampleCourse/questions/workshop/Lesson3_example2_v1/question.html
+++ b/exampleCourse/questions/workshop/Lesson3_example2_v1/question.html
@@ -2,12 +2,12 @@
 <p>
 Consider the Standard I-beam cross-section:
 </p>
-<pl-figure file-name="cross-section.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="cross-section.png" directory="clientFilesQuestion" alt="I-beam cross section labeled with markers: h (depth), b (flange-width), s (web-thickness), t (flange-thickness), and r (root radius)."></pl-figure>
 <hr>
 <p>
 The table below has the geometric properties for different specifications for a steel beam:
 </p>
-<pl-figure file-name="properties.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="properties.png" directory="clientFilesQuestion" alt="Table of steel I-beam properties including designation, dimensions, area, weight, and moments of inertia."></pl-figure>
 <hr>
 <p>
 For the <strong>{{params.name}}</strong> beam, what is the maximum normal stress $\sigma_x$ assuming that the maximum

--- a/exampleCourse/questions/workshop/Lesson3_example2_v2/question.html
+++ b/exampleCourse/questions/workshop/Lesson3_example2_v2/question.html
@@ -2,7 +2,7 @@
 <p>
 Consider the Standard I-beam cross-section:
 </p>
-<pl-figure file-name="cross-section.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="cross-section.png" directory="clientFilesQuestion" alt="I-beam cross section labeled with markers: h (depth), b (flange-width), s (web-thickness), t (flange-thickness), and r (root radius)."></pl-figure>
 <hr>
 <p>
 The table below has the geometric properties for different specifications for a steel beam:

--- a/exampleCourse/questions/workshop/Lesson3_example2_v3/question.html
+++ b/exampleCourse/questions/workshop/Lesson3_example2_v3/question.html
@@ -2,7 +2,7 @@
 <p>
 Consider the Standard I-beam cross-section:
 </p>
-<pl-figure file-name="cross-section.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="cross-section.png" alt="I-beam cross section labeled with markers: h (depth), b (flange-width), s (web-thickness), t (flange-thickness), and r (root radius)."></pl-figure>
 <hr>
 <p>
 The table below has the geometric properties for different specifications for a steel beam:

--- a/exampleCourse/questions/workshop/Lesson3_example4_v1/question.html
+++ b/exampleCourse/questions/workshop/Lesson3_example4_v1/question.html
@@ -2,7 +2,7 @@
 <p>
 Consider the logic diagram below:
 </p>
-<pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion"></pl-figure>
+<pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion" alt="Logic diagram with X feeding an OR gate, Y inverted and ANDed with Z, producing F."></pl-figure>
 <hr>
 <p>
 If ${\bf X} = {{params.x}}$, ${\bf Y} = {{params.y}}$ and ${\bf Z} = {{params.z}}$, what is the value of ${\bf F}$?

--- a/exampleCourse/questions/workshop/Lesson3_example4_v2/question.html
+++ b/exampleCourse/questions/workshop/Lesson3_example4_v2/question.html
@@ -6,7 +6,7 @@ Determine the output of the logic diagram below.
 
 <pl-overlay width="410" clip="true">
     <pl-background>
-      <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion"></pl-figure>
+      <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion" alt="Logic diagram with X feeding an OR gate, Y inverted and ANDed with Z, producing F."></pl-figure>
     </pl-background>
       <pl-location left="20" top="15">  <span class="bg-white p-2 border">{{params.x}}</span> </pl-location>
       <pl-location left="20" top="65">  <span class="bg-white p-2 border">{{params.y}}</span> </pl-location>

--- a/exampleCourse/questions/workshop/Lesson4_example2/question.html
+++ b/exampleCourse/questions/workshop/Lesson4_example2/question.html
@@ -7,7 +7,7 @@ Complete the empty boxes below with either $0$ or $1$ to obtain a correct logic 
 
 <pl-overlay width="500" clip="false">
     <pl-background>
-      <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion"></pl-figure>
+      <pl-figure file-name="logic-diagram.png" directory="clientFilesQuestion" alt="Logic diagram with X feeding an OR gate, Y inverted and ANDed with Z, producing F."></pl-figure>
     </pl-background>
       <pl-location left="5" top="15" halign="left">  <pl-integer-input aria-label="Top-left input value" answers-name="x" size="5" show-help-text="false"></pl-integer-input>  </pl-location>
       <pl-location left="5" top="65" halign="left">  <pl-integer-input aria-label="Middle-left input value" answers-name="y" size="5" show-help-text="false"></pl-integer-input> </pl-location>

--- a/testCourse/questions/positionTimeGraph/question.html
+++ b/testCourse/questions/positionTimeGraph/question.html
@@ -1,7 +1,7 @@
 <pl-question-panel>
   <p>An object's motion is described by the position-time graph below.</p>
 
-  <pl-figure file-name="graph.png"></pl-figure>
+  <pl-figure file-name="graph.png" alt="Position-time graph x(m) with points A through G on a curve that rises, dips, and then falls. In left to right order: at A the value of f is -2, the curve moves linearly to f(B) at 0, then peaks at f(C) at 3, then falls to f(D) at 2, then crests again at f(E) at 4, then donw to f(F) at 3, then stops at f(G) at 0"></pl-figure>
 </pl-question-panel>
 
 <pl-question-panel><hr></pl-question-panel>


### PR DESCRIPTION
# Description

*This PR should only affect internal development.*

Currently, content is allowed to be silently published in violation of ADA guidelines, specifically the WCAG 2.1 AA compliance that many public universities use. This compliance requires the use of descriptive alt-text.

This PR adds a custom rule to catch ADA-non-compliant `img` tags and a schema to the `pl-figure` tag to do the same. It additionally requires that `pl-figure` alt-text is at least 10ch long.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
  * Codex was used to draft the first version, I personally revised everything.

# Testing

It works on my machine :stuck_out_tongue_closed_eyes:
