### PR TITLE
Remove stale process questions server flag

### DIFF
--- a/apps/prairielearn/src/tests/exampleCourseQuestionsComplete.test.ts
+++ b/apps/prairielearn/src/tests/exampleCourseQuestionsComplete.test.ts
@@ -8,7 +8,6 @@ import { HtmlValidate } from 'html-validate';
 import { JSDOM, VirtualConsole } from 'jsdom';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
-import { config } from '../lib/config.js';
 import type { Course, Question, Submission, Variant } from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { extractDefaultPreferences } from '../lib/question-preferences.js';
@@ -280,16 +279,12 @@ const accessibilitySkip = new Set([
 ]);
 
 describe('Internally graded question lifecycle tests', { timeout: 60_000 }, function () {
-  const originalProcessQuestionsInServer = config.features['process-questions-in-server'];
-
   beforeAll(async function () {
-    config.features['process-questions-in-server'] = false;
     await helperServer.before()();
   });
 
   afterAll(async function () {
     await helperServer.after();
-    config.features['process-questions-in-server'] = originalProcessQuestionsInServer;
   });
 
   internallyGradedQuestions.forEach(({ relativePath, info }) => {


### PR DESCRIPTION
# Description

Removes the last source reference to the retired `process-questions-in-server` feature flag, which only remained as a stale override in the example course question lifecycle test setup. The test now uses the normal server configuration path instead of mutating an unused config entry.

- [x] I have disclosed the level of AI assistance used (majority of implementation by Codex).

# Testing

Ran the example course question lifecycle test for the affected setup path: `yarn test apps/prairielearn/src/tests/exampleCourseQuestionsComplete.test.ts`.
