### PR TITLE
Update React effect lint plugin

### DIFF
--- a/.changeset/update-react-effect-eslint-plugin.md
+++ b/.changeset/update-react-effect-eslint-plugin.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/eslint-config': patch
+---
+
+Update eslint-plugin-react-you-might-not-need-an-effect to 0.10.2.

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/components/AiQuestionGenerationChat.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/components/AiQuestionGenerationChat.tsx
@@ -587,14 +587,12 @@ export function AiQuestionGenerationChat({
       prevIsGeneratingRef.current = isGenerating;
       // If we're already generating on mount (e.g., resuming a stream), notify parent
 
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (isGenerating) {
         onGeneratingChange?.(true);
       }
       return;
     }
 
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (prevIsGeneratingRef.current !== isGenerating) {
       prevIsGeneratingRef.current = isGenerating;
       // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent, react-you-might-not-need-an-effect/no-pass-live-state-to-parent
@@ -602,7 +600,6 @@ export function AiQuestionGenerationChat({
 
       // If generation just finished, call the completion callback
 
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
       if (!isGenerating) {
         onGenerationComplete?.();
       }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-no-floating-promise": "^2.0.0",
     "eslint-plugin-perfectionist": "^5.9.0",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.0",
+    "eslint-plugin-react-you-might-not-need-an-effect": "^0.10.2",
     "eslint-plugin-unicorn": "^64.0.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.14.0",
     "globals": "^17.6.0",

--- a/packages/eslint-config/src/configs/react.ts
+++ b/packages/eslint-config/src/configs/react.ts
@@ -37,6 +37,9 @@ export function reactConfig(): TSESLint.FlatConfig.ConfigArray {
             (ruleName: string) => [ruleName, 'error'],
           ),
         ),
+        // This rule flags many legitimate effect-based synchronizations with
+        // third-party libraries, DOM APIs, and form state.
+        'react-you-might-not-need-an-effect/no-event-handler': 'off',
 
         // eslint-react recommended rules as errors
         ...Object.fromEntries(

--- a/packages/ui/src/components/ColumnManager.tsx
+++ b/packages/ui/src/components/ColumnManager.tsx
@@ -268,7 +268,6 @@ export function ColumnManager<RowDataModel>({
     // When we use the pin or reset button, we want to refocus to another element.
     // We want this in a useEffect so that this code runs after the component re-renders.
 
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-event-handler
     if (activeElementId) {
       document.getElementById(activeElementId)?.focus();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4889,7 +4889,7 @@ __metadata:
     eslint-plugin-no-floating-promise: "npm:^2.0.0"
     eslint-plugin-perfectionist: "npm:^5.9.0"
     eslint-plugin-react-hooks: "npm:^7.1.1"
-    eslint-plugin-react-you-might-not-need-an-effect: "npm:^0.10.0"
+    eslint-plugin-react-you-might-not-need-an-effect: "npm:^0.10.2"
     eslint-plugin-unicorn: "npm:^64.0.0"
     eslint-plugin-you-dont-need-lodash-underscore: "npm:^6.14.0"
     globals: "npm:^17.6.0"
@@ -12243,14 +12243,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-you-might-not-need-an-effect@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "eslint-plugin-react-you-might-not-need-an-effect@npm:0.10.0"
+"eslint-plugin-react-you-might-not-need-an-effect@npm:^0.10.2":
+  version: 0.10.2
+  resolution: "eslint-plugin-react-you-might-not-need-an-effect@npm:0.10.2"
   dependencies:
     globals: "npm:^16.2.0"
   peerDependencies:
     eslint: ">=8.40.0"
-  checksum: 10c0/04573515d6a43bd96c0e8e6b35ebd632ecd01d2114feafa941bdc93afc1b37ce850272eae68768347c99f073e072806d3dec03c61f246d8961cf865dd1abc0c2
+  checksum: 10c0/82373ff9c3015b92665a6d3c14e202ba78cfb6ff03ad75ac0178cede9d636c26593ae9df984d084efa35fbdcce6ae19d805ab9592bb2f35334132ff0492fd055
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Updates `eslint-plugin-react-you-might-not-need-an-effect` to 0.10.2 and adds a patch changeset for `@prairielearn/eslint-config`. The newer plugin broadens `no-event-handler` enough to flag common synchronization effects in PrairieLearn, so this disables that one rule while keeping the rest of the plugin enabled and removes stale local disables.

AI assistance: majority of implementation by Codex.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Validated the lint-config change with `yarn workspace @prairielearn/eslint-config build` and `make lint-js`.
