### PR TITLE
Refine question preview button test coverage

### DIFF
--- a/apps/prairielearn/src/tests/exampleCourseQuestions.test.ts
+++ b/apps/prairielearn/src/tests/exampleCourseQuestions.test.ts
@@ -5,21 +5,11 @@ import * as path from 'node:path';
 import fg from 'fast-glob';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 
-import { config } from '../lib/config.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 
 import * as helperQuestion from './helperQuestion.js';
 import * as helperServer from './helperServer.js';
 import { withConfig } from './utils/config.js';
-
-const locals: Record<string, any> = { siteUrl: 'http://localhost:' + config.serverPort };
-
-locals.baseUrl = locals.siteUrl + '/pl';
-locals.courseInstanceBaseUrl = locals.baseUrl + '/course_instance/1/instructor';
-locals.questionBaseUrl = locals.courseInstanceBaseUrl + '/question';
-locals.questionPreviewTabUrl = '/preview';
-locals.questionsUrl = locals.courseInstanceBaseUrl + '/questions';
-locals.isStudentPage = false;
 
 const qidsExampleCourse = [
   'demo/calculation',
@@ -93,11 +83,7 @@ describe('Auto-test questions in exampleCourse', () => {
 
     [...qidsExampleCourse, ...templateQuestionQids].forEach((qid) => {
       it.concurrent(`auto-test ${qid}`, async () => {
-        await helperQuestion.autoTestQuestion({
-          questionBaseUrl: locals.questionBaseUrl,
-          questionPreviewTabUrl: locals.questionPreviewTabUrl,
-          qid,
-        });
+        await helperQuestion.autoTestQuestion({ qid });
       });
     });
   });

--- a/apps/prairielearn/src/tests/gradingMethods.test.ts
+++ b/apps/prairielearn/src/tests/gradingMethods.test.ts
@@ -90,6 +90,14 @@ function getLatestSubmissionStatus($: cheerio.CheerioAPI): string {
   return $('[data-testid="submission-status"] .badge').first().text().trim();
 }
 
+function assertQuestionActionButtons(
+  $: cheerio.CheerioAPI,
+  expected: { grade: boolean; save: boolean },
+): void {
+  assert.lengthOf($('button[name="__action"][value="grade"]'), expected.grade ? 1 : 0);
+  assert.lengthOf($('button[name="__action"][value="save"]'), expected.save ? 1 : 0);
+}
+
 describe('Grading method(s)', { timeout: 80_000 }, function () {
   let $hm1Body: cheerio.CheerioAPI;
   let iqUrl: string;
@@ -116,7 +124,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           // open page to produce variant because we want to get the correct answer
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 1);
+          assertQuestionActionButtons($questionsPage, { grade: true, save: true });
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
         });
@@ -190,7 +198,8 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
             $hm1Body('a:contains("Manual Grading: Fibonacci function, file upload")').attr('href');
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 0);
+          assertQuestionActionButtons($questionsPage, { grade: false, save: true });
+          iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should be possible to submit a grade action to "Manual" type question', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'grade', [
@@ -223,6 +232,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           iqUrl =
             siteUrl +
             $hm1Body('a:contains("Manual Grading: Fibonacci function, file upload")').attr('href');
+          iqId = parseInstanceQuestionId(iqUrl);
         });
         it('should be possible to submit a save action to "Manual" type question', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'save', [
@@ -259,7 +269,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
             $hm1Body('a:contains("External Grading: Alpine Linux smoke test")').attr('href');
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 1);
+          assertQuestionActionButtons($questionsPage, { grade: true, save: true });
         });
         it('should submit "grade" action', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'grade', [
@@ -352,7 +362,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
             $hm1Body('a:contains("External Grading: Alpine Linux with arguments")').attr('href');
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 1);
+          assertQuestionActionButtons($questionsPage, { grade: true, save: true });
         });
         it('should submit "grade" action', async () => {
           gradeRes = await saveOrGrade(iqUrl, {}, 'grade', [
@@ -420,7 +430,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           // open page to produce variant because we want to get the correct answer
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 1);
+          assertQuestionActionButtons($questionsPage, { grade: true, save: true });
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
         });
@@ -501,7 +511,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           // open page to produce variant because we want to get the correct answer
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 0);
+          assertQuestionActionButtons($questionsPage, { grade: false, save: true });
 
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
@@ -582,7 +592,7 @@ describe('Grading method(s)', { timeout: 80_000 }, function () {
           // open page to produce variant because we want to get the correct answer
           questionsPage = await (await fetch(iqUrl)).text();
           $questionsPage = cheerio.load(questionsPage);
-          assert.lengthOf($questionsPage('button[value="grade"]'), 1);
+          assertQuestionActionButtons($questionsPage, { grade: true, save: true });
           // get variant params
           iqId = parseInstanceQuestionId(iqUrl);
         });

--- a/apps/prairielearn/src/tests/helperQuestion.ts
+++ b/apps/prairielearn/src/tests/helperQuestion.ts
@@ -196,6 +196,9 @@ export function getInstanceQuestion(
       const elemList = locals.$('a:contains(New variant)');
       if (locals.shouldHaveButtons?.includes('newVariant')) {
         assert.lengthOf(elemList, 1);
+        const href = elemList.attr('href');
+        assert.isString(href);
+        assert.match(href, /\/preview\/$/);
       } else {
         assert.lengthOf(elemList, 0);
       }
@@ -607,68 +610,9 @@ export function uploadAssessmentInstanceScores(locals: Record<string, any>) {
   waitForJobSequence(locals);
 }
 
-export async function autoTestQuestion({
-  questionBaseUrl,
-  questionPreviewTabUrl = '',
-  qid,
-}: {
-  questionBaseUrl: string;
-  questionPreviewTabUrl?: string;
-  qid: string;
-}): Promise<void> {
+export async function autoTestQuestion({ qid }: { qid: string }): Promise<void> {
   const question = await selectQuestionByQid({ qid, course_id: '1' });
   assert.equal(question.type, 'Freeform');
-
-  const shouldHaveButtons =
-    question.grading_method === 'Manual' ? ['save', 'newVariant'] : ['grade', 'save', 'newVariant'];
-  const hasGradeOrSave = shouldHaveButtons.includes('grade') || shouldHaveButtons.includes('save');
-
-  const previewUrl = questionBaseUrl + '/' + question.id + questionPreviewTabUrl;
-  const previewResponse = await fetch(previewUrl);
-  assert.equal(previewResponse.status, 200);
-  const preview$ = cheerio.load(await previewResponse.text());
-
-  if (hasGradeOrSave) {
-    const variantIdElems = preview$('.question-form input[name="__variant_id"]');
-    assert.lengthOf(variantIdElems, 1);
-    assert.nestedProperty(variantIdElems[0], 'attribs.value');
-    const variantId = variantIdElems[0].attribs.value;
-
-    const variant = await sqldb.queryRow(
-      sql.select_variant,
-      { variant_id: variantId },
-      VariantSchema,
-    );
-    assert.equal(variant.question_id, question.id);
-    assert.equal(variant.broken, false);
-    assert.isNull(variant.broken_at);
-
-    const previewCsrfElems = preview$('.question-form input[name="__csrf_token"]');
-    assert.lengthOf(previewCsrfElems, 1);
-    assert.nestedProperty(previewCsrfElems[0], 'attribs.value');
-    assert.isString(previewCsrfElems[0].attribs.value);
-  }
-
-  const gradeButtons = preview$('button[name="__action"][value="grade"]');
-  assert.lengthOf(gradeButtons, shouldHaveButtons.includes('grade') ? 1 : 0);
-  const saveButtons = preview$('button[name="__action"][value="save"]');
-  assert.lengthOf(saveButtons, shouldHaveButtons.includes('save') ? 1 : 0);
-  const newVariantButtons = preview$('a:contains(New variant)');
-  assert.lengthOf(newVariantButtons, shouldHaveButtons.includes('newVariant') ? 1 : 0);
-  const tryAgainButtons = preview$('a:contains(Try a new variant)');
-  assert.lengthOf(tryAgainButtons, shouldHaveButtons.includes('tryAgain') ? 1 : 0);
-
-  const previewIssues = await sqldb.queryRows(
-    sql.select_issues_for_question,
-    { question_id: question.id },
-    IssueSchema,
-  );
-  assert.lengthOf(
-    previewIssues,
-    0,
-    `[${qid}] preview generated ${previewIssues.length} issues:\n` +
-      JSON.stringify(previewIssues, null, '    '),
-  );
 
   const course = await selectCourseById('1');
   const jobSequenceId = await startTestQuestion({

--- a/apps/prairielearn/src/tests/testCourseQuestions.test.ts
+++ b/apps/prairielearn/src/tests/testCourseQuestions.test.ts
@@ -2,20 +2,9 @@ import * as os from 'node:os';
 
 import { afterAll, beforeAll, describe, it } from 'vitest';
 
-import { config } from '../lib/config.js';
-
 import * as helperQuestion from './helperQuestion.js';
 import * as helperServer from './helperServer.js';
 import { withConfig } from './utils/config.js';
-
-const locals: Record<string, any> = { siteUrl: 'http://localhost:' + config.serverPort };
-
-locals.baseUrl = locals.siteUrl + '/pl';
-locals.courseInstanceBaseUrl = locals.baseUrl + '/course_instance/1/instructor';
-locals.questionBaseUrl = locals.courseInstanceBaseUrl + '/question';
-locals.questionPreviewTabUrl = '/preview';
-locals.questionsUrl = locals.courseInstanceBaseUrl + '/questions';
-locals.isStudentPage = false;
 
 const qidsTestCourse = [
   'addNumbers',
@@ -37,11 +26,7 @@ describe('Auto-test questions in testCourse', { timeout: 60_000 }, function () {
 
   qidsTestCourse.forEach((qid) => {
     it.concurrent(`auto-test ${qid}`, async () => {
-      await helperQuestion.autoTestQuestion({
-        questionBaseUrl: locals.questionBaseUrl,
-        questionPreviewTabUrl: locals.questionPreviewTabUrl,
-        qid,
-      });
+      await helperQuestion.autoTestQuestion({ qid });
     });
   });
 });


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Simplifies `autoTestQuestion` to focus on `startTestQuestion` results rather than performing its own HTTP preview and button checks. Moves grading-method button expectations into `gradingMethods.test.ts`, adds save-button expectations there, and ensures the manual grading assertions use the instance question they just loaded. Keeps preview-page coverage for `New variant` links in the shared question helper.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Targeted integration tests were run for the affected grading-method, question auto-test, instructor preview, and shared preview paths.