### PR TITLE
Ignore top level ./ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ docker-compose.override.yml
 ## Config
 /config.json
 /apps/*/config.json
+/ssl/
 
 ## Generated HTML
 


### PR DESCRIPTION
Simply adds `/ssl/` to .gitignore.


- [X] I have disclosed the level of AI assistance used: none

# Testing
N/A