### PR TITLE
Remove placeholder values from the course instance and assessment copy modals

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
@@ -249,8 +249,6 @@ function CopyAssessmentModal({
   const copyMutation = useMutation(trpc.assessmentSettings.copyAssessment.mutationOptions());
   const copyError = getAppError<AssessmentSettingsError['CopyAssessment']>(copyMutation.error);
 
-  const placeholderAid = assessment.tid ?? '';
-  const placeholderTitle = assessment.title ?? '';
   const placeholderNumber = assessment.number;
   const defaultSet = assessmentSet.name;
 
@@ -306,7 +304,6 @@ function CopyAssessmentModal({
               className={clsx('form-control', errors.title && 'is-invalid')}
               aria-invalid={errors.title ? 'true' : 'false'}
               {...(errors.title ? { 'aria-errormessage': 'copy-assessment-title-error' } : {})}
-              placeholder={placeholderTitle}
               defaultValue=""
               {...register('title', {
                 validate: (value) => (value.trim() === '' ? 'Title is required' : true),
@@ -329,7 +326,6 @@ function CopyAssessmentModal({
               aria-describedby="copy-assessment-aid-help"
               aria-invalid={errors.aid ? 'true' : 'false'}
               {...(errors.aid ? { 'aria-errormessage': 'copy-assessment-aid-error' } : {})}
-              placeholder={placeholderAid}
               defaultValue=""
               {...register('aid', {
                 validate: (value) => {

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -269,7 +269,7 @@ function SettingsStep({
           aria-describedby="copy-long-name-help"
           aria-invalid={!!errors.long_name}
           aria-errormessage={errors.long_name ? 'copy-long-name-error' : undefined}
-          placeholder={courseInstance.long_name ?? undefined}
+          defaultValue=""
           {...register('long_name', {
             required: 'Long name is required',
           })}
@@ -297,7 +297,7 @@ function SettingsStep({
           aria-describedby="copy-short-name-help"
           aria-invalid={!!errors.short_name}
           aria-errormessage={errors.short_name ? 'copy-short-name-error' : undefined}
-          placeholder={courseInstance.short_name}
+          defaultValue=""
           {...register('short_name', {
             required: 'Short name is required',
             validate: (value) => {


### PR DESCRIPTION


<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

The course instance and assessment copy modals use the short name and long name values of the course instance/assessment being copied as placeholders. Having these values as placeholders not only has confused users, but also are not good suggestions.

This PR removes these placeholders. The field is required, and given that an existing assessment/course instance is being copied, suggesting a default value does not make sense.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): none.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Manually tested, change is very small