### PR TITLE
Fix access control override ordering and PrairieTest visibility

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/authz.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/authz.test.ts
@@ -177,6 +177,36 @@ describe('resolverResultToAuthzAssessmentForInstance', () => {
     expect(result.password).toBeNull();
   });
 
+  it('keeps unmatched Exam-mode denies hidden for closed instances', () => {
+    const result = resolverResultToAuthzAssessmentForInstance({
+      result: {
+        ...baseResolverResult,
+        authorized: false,
+        submittable: false,
+        credit: 0,
+        creditDateString: 'None',
+        visibility: {
+          showQuestions: false,
+          showScore: false,
+        },
+        afterCompleteVisibility: {
+          showQuestions: false,
+          showScore: false,
+        },
+        complete: true,
+      },
+      authzMode: 'Exam',
+      displayTimezone: 'America/Chicago',
+      assessmentInstance: { open: false, date_limit: null },
+      reqDate: new Date('2025-03-15T00:00:00Z'),
+    });
+
+    expect(result.authorized).toBe(false);
+    expect(result.active).toBe(false);
+    expect(result.show_closed_assessment).toBe(false);
+    expect(result.show_closed_assessment_score).toBe(false);
+  });
+
   it('applies afterComplete score visibility when the time limit has expired', () => {
     const result = resolverResultToAuthzAssessmentForInstance({
       result: {

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -922,14 +922,24 @@ describe('resolveAccessControl', () => {
         rules: [ptDefaultRule],
         authzMode: 'Exam',
         reservations: [{ examUuid: 'wrong-uuid', accessEnd: new Date('2025-03-15T14:00:00Z') }],
-        expect: { authorized: false, submittable: false },
+        expect: {
+          authorized: false,
+          submittable: false,
+          visibility: { showQuestions: false, showScore: false },
+          afterCompleteVisibility: { showQuestions: false, showScore: false },
+        },
       },
       {
         name: 'no reservation: denied',
         rules: [ptDefaultRule],
         authzMode: 'Exam',
         reservations: [],
-        expect: { authorized: false, submittable: false },
+        expect: {
+          authorized: false,
+          submittable: false,
+          visibility: { showQuestions: false, showScore: false },
+          afterCompleteVisibility: { showQuestions: false, showScore: false },
+        },
       },
       {
         name: 'matching reservation among multiple: granted',
@@ -954,7 +964,12 @@ describe('resolveAccessControl', () => {
         name: 'non-PT rule in Exam mode: denied',
         rules: [makeDefaultRule()],
         authzMode: 'Exam',
-        expect: { authorized: false, submittable: false },
+        expect: {
+          authorized: false,
+          submittable: false,
+          visibility: { showQuestions: false, showScore: false },
+          afterCompleteVisibility: { showQuestions: false, showScore: false },
+        },
       },
       {
         name: 'readOnly flag from matched exam when multiple exams configured',
@@ -1279,15 +1294,11 @@ describe('resolveAccessControl', () => {
             },
           },
           {
-            // Regression test for
-            // https://github.com/PrairieLearn/PrairieLearn/issues/12579: after a
-            // student finishes and their PT reservation ends, PrairieLearn keeps
-            // them in Exam for a short grace period (~30 min). The rule-matching
-            // path denies access (no active reservation), but the gradebook still
-            // renders rows, so the deny path must propagate the configured
-            // top-level afterComplete visibility rather than falling back to
-            // defaults that would reveal scores while they should still be hidden.
-            name: 'grace-period Exam mode after reservation ended: afterComplete propagates on deny',
+            // During the post-reservation Exam-mode grace period, hide review
+            // visibility unless there is still a matching active PT reservation.
+            // Otherwise a student taking one PT exam could review other
+            // released assessments while still in Exam mode.
+            name: 'grace-period Exam mode after reservation ended: hides review visibility',
             rules: [ruleWithDeferredRelease],
             authzMode: 'Exam',
             date: new Date('2025-03-15T14:15:00Z'),
@@ -1296,6 +1307,7 @@ describe('resolveAccessControl', () => {
               authorized: false,
               submittable: false,
               visibility: { showQuestions: false, showScore: false },
+              afterCompleteVisibility: { showQuestions: false, showScore: false },
             },
           },
         ])('$name', (c) => {
@@ -1539,7 +1551,12 @@ describe('resolveAccessControl', () => {
             ),
           ],
           authzMode: 'Exam',
-          expect: { authorized: false, showBeforeRelease: false, submittable: false },
+          expect: {
+            authorized: false,
+            showBeforeRelease: false,
+            submittable: false,
+            visibility: { showQuestions: false, showScore: false },
+          },
         },
         {
           // Review-only access wins over `beforeRelease.listed`: a student
@@ -2361,7 +2378,7 @@ describe('resolveAccessControl', () => {
       });
     });
 
-    it('preserves accessTimeline on Exam-mode deny without matching reservation', () => {
+    it('suppresses accessTimeline on Exam-mode deny without matching reservation', () => {
       const result = runCase({
         name: 'Exam-mode deny',
         rules: [
@@ -2381,7 +2398,7 @@ describe('resolveAccessControl', () => {
         expect: { authorized: false, submittable: false },
       });
       expect(result.authorized).toBe(false);
-      expect(result.accessTimeline.length).toBeGreaterThan(0);
+      expect(result.accessTimeline).toEqual([]);
     });
   });
 

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.test.ts
@@ -1294,10 +1294,16 @@ describe('resolveAccessControl', () => {
             },
           },
           {
-            // During the post-reservation Exam-mode grace period, hide review
-            // visibility unless there is still a matching active PT reservation.
-            // Otherwise a student taking one PT exam could review other
-            // released assessments while still in Exam mode.
+            // Regression test for this issue:
+            // https://github.com/PrairieLearn/PrairieLearn/issues/12579
+            //
+            // After a student finishes a PT exam and the reservation is explicitly
+            // ended, PrairieLearn keeps them in Exam mode for a short grace period
+            // (~30 min). There is no active matching reservation, so access is
+            // denied, but the gradebook still renders the completed assessment row.
+            // The deny path must keep completed-work visibility hidden instead of
+            // falling back to defaults that would reveal the score for that
+            // just-finished assessment.
             name: 'grace-period Exam mode after reservation ended: hides review visibility',
             rules: [ruleWithDeferredRelease],
             authzMode: 'Exam',

--- a/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/resolver.ts
@@ -162,6 +162,11 @@ const VISIBLE = Object.freeze({
   showScore: true,
 } satisfies Readonly<Visibility>);
 
+const HIDDEN = Object.freeze({
+  showQuestions: false,
+  showScore: false,
+} satisfies Readonly<Visibility>);
+
 const EMPTY_ACCESS_TIMELINE: readonly Readonly<AccessTimelineEntry>[] = Object.freeze([]);
 
 const UNAUTHORIZED_RESULT = Object.freeze({
@@ -445,10 +450,10 @@ export function resolveAccessControl(
   const accessTimeline = buildAccessTimeline(rule.dateControl, date);
 
   // In Exam mode, the only access path is a matching PrairieTest reservation;
-  // `dateControl` is intentionally ignored for the access decision (still
-  // consulted for the timeline). Without a match, we deny but propagate
-  // top-level visibility so the gradebook renders correctly during the post-
-  // reservation grace period (issue #12579).
+  // `dateControl` is intentionally ignored for the access decision. Without a
+  // match, hide completed-work visibility too: a student taking one PT exam
+  // should not be able to review other released assessments. This also keeps
+  // #12579 fixed during the post-reservation Exam-mode grace period.
   if (authzMode === 'Exam') {
     const matched = rule.prairieTestExams.find((exam) =>
       prairieTestReservations.some((r) => r.examUuid === exam.uuid),
@@ -456,11 +461,9 @@ export function resolveAccessControl(
     if (!matched) {
       return {
         ...UNAUTHORIZED_RESULT,
-        visibility: afterCompleteVisibility,
-        afterCompleteVisibility,
-        visibilitySource: 'afterComplete',
+        visibility: HIDDEN,
+        afterCompleteVisibility: HIDDEN,
         complete: true,
-        accessTimeline,
       };
     }
 

--- a/apps/prairielearn/src/models/assessment-access-control-rules.sql
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.sql
@@ -129,3 +129,12 @@ WHERE
   id = ANY ($ids::bigint[])
   AND target_type = 'enrollment'
   AND assessment_id = $assessment_id;
+
+-- BLOCK move_enrollment_rules_to_temporary_numbers
+UPDATE assessment_access_control_rules
+SET
+  number = - number
+WHERE
+  assessment_id = $assessment_id
+  AND target_type = 'enrollment'
+  AND number > 0;

--- a/apps/prairielearn/src/models/assessment-access-control-rules.ts
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.ts
@@ -35,6 +35,7 @@ type AccessControlJsonWithRequiredId = Required<Pick<AccessControlJsonWithId, 'i
 
 export interface EnrollmentAccessControlRuleData {
   id?: string;
+  number?: number;
   beforeReleaseListed: boolean | null;
   releaseDate: string | null;
   dueOverridden: boolean;
@@ -101,7 +102,7 @@ function dbBaseRowToAccessControlJson(
     z.infer<typeof RuleRowSchema>,
     'access_control_rule' | 'early_deadlines' | 'late_deadlines'
   >,
-): AccessControlJson & { id: string } {
+): AccessControlJsonWithRequiredId {
   const rule = row.access_control_rule;
   const dateControl: AccessControlJson['dateControl'] = {};
 
@@ -200,6 +201,7 @@ function dbBaseRowToAccessControlJson(
 
   return {
     id: rule.id,
+    number: rule.number,
     ...(beforeReleaseListed != null ? { beforeRelease: { listed: beforeReleaseListed } } : {}),
     dateControl: Object.keys(dateControl).length > 0 ? dateControl : undefined,
     afterComplete: Object.keys(afterComplete).length > 0 ? afterComplete : undefined,
@@ -304,6 +306,7 @@ export async function syncEnrollmentAccessControl(
 ): Promise<string> {
   const ruleJson = JSON.stringify({
     id: ruleData.id ?? null,
+    number: ruleData.number ?? null,
     before_release_listed: ruleData.beforeReleaseListed,
     date_control_release_date: ruleData.releaseDate,
     date_control_due_overridden: ruleData.dueOverridden,
@@ -348,6 +351,14 @@ export async function syncEnrollmentAccessControl(
     ],
     IdSchema,
   );
+}
+
+export async function moveEnrollmentAccessControlsToTemporaryNumbers(
+  assessment: Assessment,
+): Promise<void> {
+  await execute(sql.move_enrollment_rules_to_temporary_numbers, {
+    assessment_id: assessment.id,
+  });
 }
 
 export async function deleteEnrollmentAccessControlsByIds(

--- a/apps/prairielearn/src/models/assessment-access-control-rules.ts
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.ts
@@ -367,14 +367,6 @@ async function syncEnrollmentAccessControlRule(
   );
 }
 
-async function moveEnrollmentAccessControlsToTemporaryNumbers(
-  assessment: Assessment,
-): Promise<void> {
-  await execute(sql.move_enrollment_rules_to_temporary_numbers, {
-    assessment_id: assessment.id,
-  });
-}
-
 export async function replaceEnrollmentAccessControlRules(
   assessment: Assessment,
   rules: EnrollmentAccessControlRuleInput[],
@@ -386,14 +378,21 @@ export async function replaceEnrollmentAccessControlRules(
     const existingIds = new Set(currentRules.map((rule) => rule.id));
     const submittedIds = new Set(rules.map((rule) => rule.ruleData.id).filter((id) => id != null));
     const idsToDelete = [...existingIds].filter((id) => !submittedIds.has(id));
-    await deleteEnrollmentAccessControlsByIds(idsToDelete, assessment);
+    if (idsToDelete.length > 0) {
+      await execute(sql.delete_enrollment_rules_by_ids, {
+        ids: idsToDelete,
+        assessment_id: assessment.id,
+      });
+    }
 
     if (rules.length === 0) return;
 
     // Reordering can swap existing rule numbers, which would otherwise violate
     // the unique constraint before the batch finishes. These temporary values
     // stay inside this transaction and are replaced by the loop below.
-    await moveEnrollmentAccessControlsToTemporaryNumbers(assessment);
+    await execute(sql.move_enrollment_rules_to_temporary_numbers, {
+      assessment_id: assessment.id,
+    });
     for (const [index, rule] of rules.entries()) {
       await syncEnrollmentAccessControlRule(
         assessment,
@@ -402,16 +401,5 @@ export async function replaceEnrollmentAccessControlRules(
         rule.enrollmentIds,
       );
     }
-  });
-}
-
-async function deleteEnrollmentAccessControlsByIds(
-  ids: string[],
-  assessment: Assessment,
-): Promise<void> {
-  if (ids.length === 0) return;
-  await execute(sql.delete_enrollment_rules_by_ids, {
-    ids,
-    assessment_id: assessment.id,
   });
 }

--- a/apps/prairielearn/src/models/assessment-access-control-rules.ts
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.ts
@@ -371,12 +371,21 @@ export async function replaceEnrollmentAccessControlRules(
   assessment: Assessment,
   rules: EnrollmentAccessControlRuleInput[],
 ): Promise<void> {
+  const submittedIds = new Set<string>();
+  for (const rule of rules) {
+    const id = rule.ruleData.id;
+    if (id == null) continue;
+    if (submittedIds.has(id)) {
+      throw new Error(`Duplicate enrollment access control rule ID: ${id}`);
+    }
+    submittedIds.add(id);
+  }
+
   await runInTransactionAsync(async () => {
     await lockAssessment(assessment);
 
     const currentRules = await selectAccessControlRules(assessment, ['enrollment']);
     const existingIds = new Set(currentRules.map((rule) => rule.id));
-    const submittedIds = new Set(rules.map((rule) => rule.ruleData.id).filter((id) => id != null));
     const idsToDelete = [...existingIds].filter((id) => !submittedIds.has(id));
     if (idsToDelete.length > 0) {
       await execute(sql.delete_enrollment_rules_by_ids, {

--- a/apps/prairielearn/src/models/assessment-access-control-rules.ts
+++ b/apps/prairielearn/src/models/assessment-access-control-rules.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 
-import { callScalar, execute, loadSqlEquiv, queryRows, queryScalar } from '@prairielearn/postgres';
+import {
+  callScalar,
+  execute,
+  loadSqlEquiv,
+  queryRows,
+  queryScalar,
+  runInTransactionAsync,
+} from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
 import {
@@ -9,6 +16,8 @@ import {
   AssessmentAccessControlRuleSchema,
 } from '../lib/db-types.js';
 import type { AccessControlJson } from '../schemas/accessControl.js';
+
+import { lockAssessment } from './assessment.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
@@ -35,7 +44,6 @@ type AccessControlJsonWithRequiredId = Required<Pick<AccessControlJsonWithId, 'i
 
 export interface EnrollmentAccessControlRuleData {
   id?: string;
-  number?: number;
   beforeReleaseListed: boolean | null;
   releaseDate: string | null;
   dueOverridden: boolean;
@@ -57,6 +65,11 @@ export interface EnrollmentAccessControlRuleData {
   scoreVisibleFromDate: string | null;
   earlyDeadlines: { date: string; credit: number }[];
   lateDeadlines: { date: string; credit: number }[];
+}
+
+export interface EnrollmentAccessControlRuleInput {
+  ruleData: EnrollmentAccessControlRuleData;
+  enrollmentIds: string[];
 }
 
 type AccessControlTargetType = 'none' | 'student_label' | 'enrollment';
@@ -299,14 +312,15 @@ export async function selectPrairieTestExamMetadataByUuids(
  * Creates or updates an enrollment-based access control rule (targeting individual students).
  * These rules are stored in the database with target_type = 'enrollment'.
  */
-export async function syncEnrollmentAccessControl(
+async function syncEnrollmentAccessControlRule(
   assessment: Assessment,
   ruleData: EnrollmentAccessControlRuleData,
+  ruleNumber: number,
   enrollmentIds: string[],
 ): Promise<string> {
   const ruleJson = JSON.stringify({
     id: ruleData.id ?? null,
-    number: ruleData.number ?? null,
+    number: ruleNumber,
     before_release_listed: ruleData.beforeReleaseListed,
     date_control_release_date: ruleData.releaseDate,
     date_control_due_overridden: ruleData.dueOverridden,
@@ -353,7 +367,7 @@ export async function syncEnrollmentAccessControl(
   );
 }
 
-export async function moveEnrollmentAccessControlsToTemporaryNumbers(
+async function moveEnrollmentAccessControlsToTemporaryNumbers(
   assessment: Assessment,
 ): Promise<void> {
   await execute(sql.move_enrollment_rules_to_temporary_numbers, {
@@ -361,7 +375,37 @@ export async function moveEnrollmentAccessControlsToTemporaryNumbers(
   });
 }
 
-export async function deleteEnrollmentAccessControlsByIds(
+export async function replaceEnrollmentAccessControlRules(
+  assessment: Assessment,
+  rules: EnrollmentAccessControlRuleInput[],
+): Promise<void> {
+  await runInTransactionAsync(async () => {
+    await lockAssessment(assessment);
+
+    const currentRules = await selectAccessControlRules(assessment, ['enrollment']);
+    const existingIds = new Set(currentRules.map((rule) => rule.id));
+    const submittedIds = new Set(rules.map((rule) => rule.ruleData.id).filter((id) => id != null));
+    const idsToDelete = [...existingIds].filter((id) => !submittedIds.has(id));
+    await deleteEnrollmentAccessControlsByIds(idsToDelete, assessment);
+
+    if (rules.length === 0) return;
+
+    // Reordering can swap existing rule numbers, which would otherwise violate
+    // the unique constraint before the batch finishes. These temporary values
+    // stay inside this transaction and are replaced by the loop below.
+    await moveEnrollmentAccessControlsToTemporaryNumbers(assessment);
+    for (const [index, rule] of rules.entries()) {
+      await syncEnrollmentAccessControlRule(
+        assessment,
+        rule.ruleData,
+        index + 1,
+        rule.enrollmentIds,
+      );
+    }
+  });
+}
+
+async function deleteEnrollmentAccessControlsByIds(
   ids: string[],
   assessment: Assessment,
 ): Promise<void> {

--- a/apps/prairielearn/src/sprocs/sync_enrollment_access_control.sql
+++ b/apps/prairielearn/src/sprocs/sync_enrollment_access_control.sql
@@ -12,6 +12,7 @@ AS $$
 DECLARE
     existing_rule_id bigint;
     new_rule_id bigint;
+    desired_number integer;
     next_number integer;
     ci_timezone text;
 BEGIN
@@ -22,10 +23,16 @@ BEGIN
 
     -- Check if updating an existing rule (rule_data contains 'id')
     existing_rule_id := (rule_data ->> 'id')::bigint;
+    desired_number := (rule_data ->> 'number')::integer;
+
+    IF desired_number IS NOT NULL AND desired_number <= 0 THEN
+        RAISE EXCEPTION 'Enrollment access control rule number must be positive, got %', desired_number;
+    END IF;
 
     IF existing_rule_id IS NOT NULL THEN
         -- Update existing enrollment rule
         UPDATE assessment_access_control_rules SET
+            number = COALESCE(desired_number, assessment_access_control_rules.number),
             before_release_listed = (rule_data ->> 'before_release_listed')::boolean,
             date_control_release_date = input_date(rule_data ->> 'date_control_release_date', ci_timezone),
             date_control_due_overridden = (rule_data ->> 'date_control_due_overridden')::boolean,
@@ -69,9 +76,13 @@ BEGIN
     ELSE
         -- Get next available number for enrollment rules. Starts at 1 (not 0)
         -- because check_first_rule_is_none requires number=0 ⟺ target_type='none'.
-        SELECT COALESCE(MAX(number), 0) + 1 INTO next_number
-        FROM assessment_access_control_rules
-        WHERE assessment_id = syncing_assessment_id AND target_type = 'enrollment';
+        IF desired_number IS NULL THEN
+            SELECT COALESCE(MAX(number), 0) + 1 INTO next_number
+            FROM assessment_access_control_rules
+            WHERE assessment_id = syncing_assessment_id AND target_type = 'enrollment' AND number > 0;
+        ELSE
+            next_number := desired_number;
+        END IF;
 
         -- Insert new enrollment rule
         INSERT INTO assessment_access_control_rules (

--- a/apps/prairielearn/src/sprocs/sync_enrollment_access_control.sql
+++ b/apps/prairielearn/src/sprocs/sync_enrollment_access_control.sql
@@ -12,8 +12,6 @@ AS $$
 DECLARE
     existing_rule_id bigint;
     new_rule_id bigint;
-    desired_number integer;
-    next_number integer;
     ci_timezone text;
 BEGIN
     -- Lock the assessment row to serialize concurrent access control modifications.
@@ -23,16 +21,11 @@ BEGIN
 
     -- Check if updating an existing rule (rule_data contains 'id')
     existing_rule_id := (rule_data ->> 'id')::bigint;
-    desired_number := (rule_data ->> 'number')::integer;
-
-    IF desired_number IS NOT NULL AND desired_number <= 0 THEN
-        RAISE EXCEPTION 'Enrollment access control rule number must be positive, got %', desired_number;
-    END IF;
 
     IF existing_rule_id IS NOT NULL THEN
         -- Update existing enrollment rule
         UPDATE assessment_access_control_rules SET
-            number = COALESCE(desired_number, assessment_access_control_rules.number),
+            number = (rule_data ->> 'number')::integer,
             before_release_listed = (rule_data ->> 'before_release_listed')::boolean,
             date_control_release_date = input_date(rule_data ->> 'date_control_release_date', ci_timezone),
             date_control_due_overridden = (rule_data ->> 'date_control_due_overridden')::boolean,
@@ -74,16 +67,6 @@ BEGIN
         DELETE FROM assessment_access_control_late_deadlines
         WHERE assessment_access_control_rule_id = new_rule_id;
     ELSE
-        -- Get next available number for enrollment rules. Starts at 1 (not 0)
-        -- because check_first_rule_is_none requires number=0 ⟺ target_type='none'.
-        IF desired_number IS NULL THEN
-            SELECT COALESCE(MAX(number), 0) + 1 INTO next_number
-            FROM assessment_access_control_rules
-            WHERE assessment_id = syncing_assessment_id AND target_type = 'enrollment' AND number > 0;
-        ELSE
-            next_number := desired_number;
-        END IF;
-
         -- Insert new enrollment rule
         INSERT INTO assessment_access_control_rules (
             assessment_id,
@@ -111,7 +94,7 @@ BEGIN
             after_complete_score_visible_from_date
         ) VALUES (
             syncing_assessment_id,
-            next_number,
+            (rule_data ->> 'number')::integer,
             'enrollment',
             (rule_data ->> 'before_release_listed')::boolean,
             input_date(rule_data ->> 'date_control_release_date', ci_timezone),

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -371,6 +371,46 @@ describe('Access control save via tRPC', () => {
     assert.equal(reorderedRuleA.number, 2);
   });
 
+  test.sequential('rejects duplicate student-specific override ids', async () => {
+    const assessment = await selectAssessmentByTid({
+      course_instance_id: '1',
+      tid: 'hw19-accessControlUi',
+    });
+    const existingRules = await selectAccessControlRules(assessment, ['enrollment']);
+    const existingRule = existingRules[0];
+    assert.isOk(existingRule);
+    const enrollmentIds = existingRule.enrollments!.map((enrollment) => enrollment.enrollmentId);
+
+    await expect(
+      replaceEnrollmentAccessControlRules(assessment, [
+        {
+          ruleData: {
+            ...formJsonToEnrollmentRuleData({
+              dateControl: { due: { date: '2024-04-01T23:59:00' } },
+            }),
+            id: existingRule.id,
+          },
+          enrollmentIds,
+        },
+        {
+          ruleData: {
+            ...formJsonToEnrollmentRuleData({
+              dateControl: { due: { date: '2024-04-08T23:59:00' } },
+            }),
+            id: existingRule.id,
+          },
+          enrollmentIds,
+        },
+      ]),
+    ).rejects.toThrow(`Duplicate enrollment access control rule ID: ${existingRule.id}`);
+
+    const rulesAfterRejection = await selectAccessControlRules(assessment, ['enrollment']);
+    assert.deepEqual(
+      rulesAfterRejection.map((rule) => rule.id),
+      existingRules.map((rule) => rule.id),
+    );
+  });
+
   test.sequential('rejects save with stale origHash', async () => {
     const client = await createClient();
     const staleHash = await getOrigHash();

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -376,10 +376,11 @@ describe('Access control save via tRPC', () => {
     const staleHash = await getOrigHash();
 
     // First save succeeds and changes the hash.
-    await client.accessControl.saveAllRules.mutate({
-      rules: [makeRule()],
+    const firstSave = await client.accessControl.saveAllRules.mutate({
+      rules: [makeRule({ beforeRelease: { listed: true } })],
       origHash: staleHash,
     });
+    assert.notEqual(firstSave.newHash, staleHash);
 
     // Second save with the same (now stale) hash must fail.
     await expect(

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -13,8 +13,8 @@ import { computeScopedJsonHash } from '../lib/editorUtil.js';
 import { features } from '../lib/features/index.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
 import {
+  replaceEnrollmentAccessControlRules,
   selectAccessControlRules,
-  syncEnrollmentAccessControl,
 } from '../models/assessment-access-control-rules.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
@@ -100,13 +100,14 @@ describe('Access control save via tRPC', () => {
       requiredRole: ['System'],
       authzData: dangerousFullSystemAuthz(),
     });
-    await syncEnrollmentAccessControl(
-      assessment,
-      formJsonToEnrollmentRuleData({
-        dateControl: { due: { date: '2024-04-18T23:59:00' } },
-      }),
-      [enrollment.id],
-    );
+    await replaceEnrollmentAccessControlRules(assessment, [
+      {
+        ruleData: formJsonToEnrollmentRuleData({
+          dateControl: { due: { date: '2024-04-18T23:59:00' } },
+        }),
+        enrollmentIds: [enrollment.id],
+      },
+    ]);
   });
 
   afterAll(helperServer.after);

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -12,7 +12,10 @@ import { config } from '../lib/config.js';
 import { computeScopedJsonHash } from '../lib/editorUtil.js';
 import { features } from '../lib/features/index.js';
 import { TEST_COURSE_PATH } from '../lib/paths.js';
-import { syncEnrollmentAccessControl } from '../models/assessment-access-control-rules.js';
+import {
+  selectAccessControlRules,
+  syncEnrollmentAccessControl,
+} from '../models/assessment-access-control-rules.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -287,6 +290,84 @@ describe('Access control save via tRPC', () => {
     const html = await response.text();
     assert.include(html, enrollmentOverrideStudentUid);
     assert.include(html, '"hiddenEnrollmentRuleCount":0');
+  });
+
+  test.sequential('persists student-specific override order', async () => {
+    const client = await createClient();
+    const assessment = await selectAssessmentByTid({
+      course_instance_id: '1',
+      tid: 'hw19-accessControlUi',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const [studentA, studentB] = await generateAndEnrollUsers({
+      count: 2,
+      course_instance_id: '1',
+    });
+    const enrollmentRows = await selectUsersAndEnrollmentsByUidsInCourseInstance({
+      uids: [studentA.uid, studentB.uid],
+      courseInstance,
+      requiredRole: ['System'],
+      authzData: dangerousFullSystemAuthz(),
+    });
+    const enrollmentByUid = new Map(enrollmentRows.map((row) => [row.user.uid, row.enrollment]));
+    const enrollmentA = enrollmentByUid.get(studentA.uid)!;
+    const enrollmentB = enrollmentByUid.get(studentB.uid)!;
+
+    const firstSave = await client.accessControl.saveAllRules.mutate({
+      rules: [makeRule()],
+      enrollmentRules: [
+        {
+          enrollmentIds: [enrollmentA.id],
+          ruleJson: { dateControl: { due: { date: '2024-04-01T23:59:00' } } },
+        },
+        {
+          enrollmentIds: [enrollmentB.id],
+          ruleJson: { dateControl: { due: { date: '2024-04-08T23:59:00' } } },
+        },
+      ],
+      origHash: await getOrigHash(),
+    });
+
+    let enrollmentRules = await selectAccessControlRules(assessment, ['enrollment']);
+    const ruleA = enrollmentRules.find((rule) =>
+      rule.enrollments?.some((enrollment) => enrollment.enrollmentId === enrollmentA.id),
+    );
+    const ruleB = enrollmentRules.find((rule) =>
+      rule.enrollments?.some((enrollment) => enrollment.enrollmentId === enrollmentB.id),
+    );
+    assert.isOk(ruleA);
+    assert.isOk(ruleB);
+    assert.equal(ruleA.number, 1);
+    assert.equal(ruleB.number, 2);
+
+    await client.accessControl.saveAllRules.mutate({
+      rules: [makeRule()],
+      enrollmentRules: [
+        {
+          id: ruleB.id,
+          enrollmentIds: [enrollmentB.id],
+          ruleJson: { dateControl: { due: { date: '2024-04-08T23:59:00' } } },
+        },
+        {
+          id: ruleA.id,
+          enrollmentIds: [enrollmentA.id],
+          ruleJson: { dateControl: { due: { date: '2024-04-01T23:59:00' } } },
+        },
+      ],
+      origHash: firstSave.newHash,
+    });
+
+    enrollmentRules = await selectAccessControlRules(assessment, ['enrollment']);
+    const reorderedRuleA = enrollmentRules.find((rule) =>
+      rule.enrollments?.some((enrollment) => enrollment.enrollmentId === enrollmentA.id),
+    );
+    const reorderedRuleB = enrollmentRules.find((rule) =>
+      rule.enrollments?.some((enrollment) => enrollment.enrollmentId === enrollmentB.id),
+    );
+    assert.isOk(reorderedRuleA);
+    assert.isOk(reorderedRuleB);
+    assert.equal(reorderedRuleB.number, 1);
+    assert.equal(reorderedRuleA.number, 2);
   });
 
   test.sequential('rejects save with stale origHash', async () => {

--- a/apps/prairielearn/src/tests/e2e/captureAccessControlScreenshots.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/captureAccessControlScreenshots.spec.ts
@@ -19,7 +19,7 @@ import { dangerousFullSystemAuthz } from '../../lib/authz-data-lib.js';
 import type { Assessment, CourseInstance } from '../../lib/db-types.js';
 import { features } from '../../lib/features/index.js';
 import { REPOSITORY_ROOT_PATH } from '../../lib/paths.js';
-import { syncEnrollmentAccessControl } from '../../models/assessment-access-control-rules.js';
+import { replaceEnrollmentAccessControlRules } from '../../models/assessment-access-control-rules.js';
 import { selectAssessmentByTid } from '../../models/assessment.js';
 import {
   generateAndEnrollUsers,
@@ -233,26 +233,26 @@ async function seedRealisticOverrides({
     authzData,
   });
 
-  await syncEnrollmentAccessControl(
-    assessment,
-    formJsonToEnrollmentRuleData({
-      dateControl: {
-        release: { date: screenshotDate(displayTimezone, 2, '09:00:00') },
-        durationMinutes: 90,
-      },
-    }),
-    enrollments.slice(4, 7).map((e) => e.id),
-  );
-  await syncEnrollmentAccessControl(
-    assessment,
-    formJsonToEnrollmentRuleData({
-      dateControl: {
-        due: { date: screenshotDate(displayTimezone, 21, '23:59:59') },
-        durationMinutes: 75,
-      },
-    }),
-    enrollments.slice(7, 10).map((e) => e.id),
-  );
+  await replaceEnrollmentAccessControlRules(assessment, [
+    {
+      ruleData: formJsonToEnrollmentRuleData({
+        dateControl: {
+          release: { date: screenshotDate(displayTimezone, 2, '09:00:00') },
+          durationMinutes: 90,
+        },
+      }),
+      enrollmentIds: enrollments.slice(4, 7).map((e) => e.id),
+    },
+    {
+      ruleData: formJsonToEnrollmentRuleData({
+        dateControl: {
+          due: { date: screenshotDate(displayTimezone, 21, '23:59:59') },
+          durationMinutes: 75,
+        },
+      }),
+      enrollmentIds: enrollments.slice(7, 10).map((e) => e.id),
+    },
+  ]);
 
   // Sort by UID before zipping with display names so the override card lists
   // the same names in the same order as the UI, which renders enrollment

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -22,17 +22,10 @@ import {
 } from '../../lib/db-types.js';
 import { features } from '../../lib/features/index.js';
 import { idsEqual } from '../../lib/id.js';
-import {
-  moveEnrollmentAccessControlsToTemporaryNumbers,
-  syncEnrollmentAccessControl,
-} from '../../models/assessment-access-control-rules.js';
 import { selectOrInsertUserByUid } from '../../models/user.js';
 import { plainDateTimeStringToDate } from '../../pages/instructorInstanceAdminPublishing/utils/dateUtils.js';
 import { type AccessControlJsonInput } from '../../schemas/accessControl.js';
-import {
-  cleanAccessControlRulesForDisk,
-  formJsonToEnrollmentRuleData,
-} from '../../trpc/assessment/access-control.js';
+import { cleanAccessControlRulesForDisk } from '../../trpc/assessment/access-control.js';
 import * as helperDb from '../helperDb.js';
 import { runInTransactionAndRollback } from '../helperDb.js';
 import { withConfig } from '../utils/config.js';
@@ -969,85 +962,6 @@ describe('Access control syncing', () => {
           idsEqual(e.assessment_access_control_rule_id, allRules[1].id),
         );
         assert.isOk(enrollmentTarget);
-      }));
-
-    it('renumbers enrollment rules from requested order', () =>
-      runInTransactionAndRollback(async () => {
-        const courseData = util.getCourseData();
-        const assignmentRule = makeAccessControlRule({
-          dateControl: { durationMinutes: 60 },
-        });
-        courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
-          util.ASSESSMENT_ID
-        ].accessControl = [assignmentRule];
-
-        const courseDir = await util.writeCourseToTempDirectory(courseData);
-        await util.syncCourseData(courseDir);
-
-        const syncedAssessments = await util.dumpTableWithSchema('assessments', AssessmentSchema);
-        const assessment = syncedAssessments.find(
-          (a) => a.tid === util.ASSESSMENT_ID && a.deleted_at == null,
-        );
-        assert.isOk(assessment);
-
-        const user1 = await selectOrInsertUserByUid('renumber-user1@example.com');
-        const user2 = await selectOrInsertUserByUid('renumber-user2@example.com');
-
-        const enrollment1Id = await sqldb.queryScalar(
-          sql.insert_enrollment,
-          {
-            user_id: user1.id,
-            course_instance_id: assessment.course_instance_id,
-            status: 'joined',
-          },
-          IdSchema,
-        );
-        const enrollment2Id = await sqldb.queryScalar(
-          sql.insert_enrollment,
-          {
-            user_id: user2.id,
-            course_instance_id: assessment.course_instance_id,
-            status: 'joined',
-          },
-          IdSchema,
-        );
-
-        const rule1Data = formJsonToEnrollmentRuleData({
-          dateControl: { durationMinutes: 150 },
-        });
-        rule1Data.number = 1;
-        const rule1Id = await syncEnrollmentAccessControl(assessment, rule1Data, [enrollment1Id]);
-
-        const rule2Data = formJsonToEnrollmentRuleData({
-          dateControl: { durationMinutes: 180 },
-        });
-        rule2Data.number = 2;
-        const rule2Id = await syncEnrollmentAccessControl(assessment, rule2Data, [enrollment2Id]);
-
-        await moveEnrollmentAccessControlsToTemporaryNumbers(assessment);
-
-        const reorderedRule2Data = formJsonToEnrollmentRuleData({
-          dateControl: { durationMinutes: 180 },
-        });
-        reorderedRule2Data.id = rule2Id;
-        reorderedRule2Data.number = 1;
-        await syncEnrollmentAccessControl(assessment, reorderedRule2Data, [enrollment2Id]);
-
-        const reorderedRule1Data = formJsonToEnrollmentRuleData({
-          dateControl: { durationMinutes: 150 },
-        });
-        reorderedRule1Data.id = rule1Id;
-        reorderedRule1Data.number = 2;
-        await syncEnrollmentAccessControl(assessment, reorderedRule1Data, [enrollment1Id]);
-
-        const allRules = await findSyncedAccessControlRules(util.ASSESSMENT_ID);
-        assert.equal(allRules.length, 3);
-        assert.equal(allRules[1].target_type, 'enrollment');
-        assert.equal(allRules[1].number, 1);
-        assert.equal(allRules[1].date_control_duration_minutes, 180);
-        assert.equal(allRules[2].target_type, 'enrollment');
-        assert.equal(allRules[2].number, 2);
-        assert.equal(allRules[2].date_control_duration_minutes, 150);
       }));
   });
 

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -22,10 +22,17 @@ import {
 } from '../../lib/db-types.js';
 import { features } from '../../lib/features/index.js';
 import { idsEqual } from '../../lib/id.js';
+import {
+  moveEnrollmentAccessControlsToTemporaryNumbers,
+  syncEnrollmentAccessControl,
+} from '../../models/assessment-access-control-rules.js';
 import { selectOrInsertUserByUid } from '../../models/user.js';
 import { plainDateTimeStringToDate } from '../../pages/instructorInstanceAdminPublishing/utils/dateUtils.js';
 import { type AccessControlJsonInput } from '../../schemas/accessControl.js';
-import { cleanAccessControlRulesForDisk } from '../../trpc/assessment/access-control.js';
+import {
+  cleanAccessControlRulesForDisk,
+  formJsonToEnrollmentRuleData,
+} from '../../trpc/assessment/access-control.js';
 import * as helperDb from '../helperDb.js';
 import { runInTransactionAndRollback } from '../helperDb.js';
 import { withConfig } from '../utils/config.js';
@@ -962,6 +969,85 @@ describe('Access control syncing', () => {
           idsEqual(e.assessment_access_control_rule_id, allRules[1].id),
         );
         assert.isOk(enrollmentTarget);
+      }));
+
+    it('renumbers enrollment rules from requested order', () =>
+      runInTransactionAndRollback(async () => {
+        const courseData = util.getCourseData();
+        const assignmentRule = makeAccessControlRule({
+          dateControl: { durationMinutes: 60 },
+        });
+        courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments[
+          util.ASSESSMENT_ID
+        ].accessControl = [assignmentRule];
+
+        const courseDir = await util.writeCourseToTempDirectory(courseData);
+        await util.syncCourseData(courseDir);
+
+        const syncedAssessments = await util.dumpTableWithSchema('assessments', AssessmentSchema);
+        const assessment = syncedAssessments.find(
+          (a) => a.tid === util.ASSESSMENT_ID && a.deleted_at == null,
+        );
+        assert.isOk(assessment);
+
+        const user1 = await selectOrInsertUserByUid('renumber-user1@example.com');
+        const user2 = await selectOrInsertUserByUid('renumber-user2@example.com');
+
+        const enrollment1Id = await sqldb.queryScalar(
+          sql.insert_enrollment,
+          {
+            user_id: user1.id,
+            course_instance_id: assessment.course_instance_id,
+            status: 'joined',
+          },
+          IdSchema,
+        );
+        const enrollment2Id = await sqldb.queryScalar(
+          sql.insert_enrollment,
+          {
+            user_id: user2.id,
+            course_instance_id: assessment.course_instance_id,
+            status: 'joined',
+          },
+          IdSchema,
+        );
+
+        const rule1Data = formJsonToEnrollmentRuleData({
+          dateControl: { durationMinutes: 150 },
+        });
+        rule1Data.number = 1;
+        const rule1Id = await syncEnrollmentAccessControl(assessment, rule1Data, [enrollment1Id]);
+
+        const rule2Data = formJsonToEnrollmentRuleData({
+          dateControl: { durationMinutes: 180 },
+        });
+        rule2Data.number = 2;
+        const rule2Id = await syncEnrollmentAccessControl(assessment, rule2Data, [enrollment2Id]);
+
+        await moveEnrollmentAccessControlsToTemporaryNumbers(assessment);
+
+        const reorderedRule2Data = formJsonToEnrollmentRuleData({
+          dateControl: { durationMinutes: 180 },
+        });
+        reorderedRule2Data.id = rule2Id;
+        reorderedRule2Data.number = 1;
+        await syncEnrollmentAccessControl(assessment, reorderedRule2Data, [enrollment2Id]);
+
+        const reorderedRule1Data = formJsonToEnrollmentRuleData({
+          dateControl: { durationMinutes: 150 },
+        });
+        reorderedRule1Data.id = rule1Id;
+        reorderedRule1Data.number = 2;
+        await syncEnrollmentAccessControl(assessment, reorderedRule1Data, [enrollment1Id]);
+
+        const allRules = await findSyncedAccessControlRules(util.ASSESSMENT_ID);
+        assert.equal(allRules.length, 3);
+        assert.equal(allRules[1].target_type, 'enrollment');
+        assert.equal(allRules[1].number, 1);
+        assert.equal(allRules[1].date_control_duration_minutes, 180);
+        assert.equal(allRules[2].target_type, 'enrollment');
+        assert.equal(allRules[2].number, 2);
+        assert.equal(allRules[2].date_control_duration_minutes, 150);
       }));
   });
 

--- a/apps/prairielearn/src/trpc/assessment/access-control.ts
+++ b/apps/prairielearn/src/trpc/assessment/access-control.ts
@@ -15,6 +15,7 @@ import { saveJsonFile } from '../../lib/editors.js';
 import {
   type EnrollmentAccessControlRuleData,
   deleteEnrollmentAccessControlsByIds,
+  moveEnrollmentAccessControlsToTemporaryNumbers,
   selectAccessControlRules,
   selectPrairieTestExamMetadataByUuids,
   syncEnrollmentAccessControl,
@@ -301,10 +302,12 @@ const saveAllRules = t.procedure
         await deleteEnrollmentAccessControlsByIds(idsToDelete, opts.ctx.assessment);
 
         if (enrollmentRules.length > 0) {
+          await moveEnrollmentAccessControlsToTemporaryNumbers(opts.ctx.assessment);
           // TODO: Add audit logging for enrollment rule changes. Label/default rules
           // are tracked in git; only enrollment rules need separate audit logs.
-          for (const enrollmentRule of enrollmentRules) {
+          for (const [index, enrollmentRule] of enrollmentRules.entries()) {
             const ruleData = formJsonToEnrollmentRuleData(enrollmentRule.ruleJson);
+            ruleData.number = index + 1;
             if (enrollmentRule.id) {
               ruleData.id = enrollmentRule.id;
             }

--- a/apps/prairielearn/src/trpc/assessment/access-control.ts
+++ b/apps/prairielearn/src/trpc/assessment/access-control.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
-import { runInTransactionAsync } from '@prairielearn/postgres';
-
 import {
   MAX_ACCESS_CONTROL_RULES,
   MAX_ENROLLMENT_RULES,
@@ -14,13 +12,9 @@ import { StaffStudentLabelSchema } from '../../lib/client/safe-db-types.js';
 import { saveJsonFile } from '../../lib/editors.js';
 import {
   type EnrollmentAccessControlRuleData,
-  deleteEnrollmentAccessControlsByIds,
-  moveEnrollmentAccessControlsToTemporaryNumbers,
-  selectAccessControlRules,
+  replaceEnrollmentAccessControlRules,
   selectPrairieTestExamMetadataByUuids,
-  syncEnrollmentAccessControl,
 } from '../../models/assessment-access-control-rules.js';
-import { lockAssessment } from '../../models/assessment.js';
 import {
   selectUsersAndEnrollmentsByUidsInCourseInstance,
   selectUsersAndEnrollmentsForCourseInstance,
@@ -291,34 +285,21 @@ const saveAllRules = t.procedure
     // Enrollment rules are written directly to DB (they are per-student
     // overrides, not stored in infoAssessment.json).
     if (enrollmentRules !== undefined) {
-      await runInTransactionAsync(async () => {
-        await lockAssessment(opts.ctx.assessment);
-
-        // Determine which enrollment rules to delete
-        const currentRules = await selectAccessControlRules(opts.ctx.assessment, ['enrollment']);
-        const existingIds = new Set(currentRules.map((r) => r.id));
-        const submittedIds = new Set(enrollmentRules.filter((r) => r.id).map((r) => r.id));
-        const idsToDelete = [...existingIds].filter((id) => !submittedIds.has(id));
-        await deleteEnrollmentAccessControlsByIds(idsToDelete, opts.ctx.assessment);
-
-        if (enrollmentRules.length > 0) {
-          await moveEnrollmentAccessControlsToTemporaryNumbers(opts.ctx.assessment);
-          // TODO: Add audit logging for enrollment rule changes. Label/default rules
-          // are tracked in git; only enrollment rules need separate audit logs.
-          for (const [index, enrollmentRule] of enrollmentRules.entries()) {
-            const ruleData = formJsonToEnrollmentRuleData(enrollmentRule.ruleJson);
-            ruleData.number = index + 1;
-            if (enrollmentRule.id) {
-              ruleData.id = enrollmentRule.id;
-            }
-            await syncEnrollmentAccessControl(
-              opts.ctx.assessment,
-              ruleData,
-              enrollmentRule.enrollmentIds,
-            );
+      // TODO: Add audit logging for enrollment rule changes. Label/default rules
+      // are tracked in git; only enrollment rules need separate audit logs.
+      await replaceEnrollmentAccessControlRules(
+        opts.ctx.assessment,
+        enrollmentRules.map((enrollmentRule) => {
+          const ruleData = formJsonToEnrollmentRuleData(enrollmentRule.ruleJson);
+          if (enrollmentRule.id) {
+            ruleData.id = enrollmentRule.id;
           }
-        }
-      });
+          return {
+            ruleData,
+            enrollmentIds: enrollmentRule.enrollmentIds,
+          };
+        }),
+      );
     }
 
     return { newHash: saveResult.newHash };

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -92,7 +92,7 @@ Enable **Password** to require a password to start or continue working on the as
 
 Enable **PrairieTest** to let an active PrairieTest reservation grant access to the assessment. Add the PrairieTest exam UUID from the PrairieTest exam settings.
 
-PrairieLearn shows an **Exam** badge in the navigation bar when a student is in **Exam mode**, the PrairieTest-controlled state for a checked-in reservation. While a matching reservation is active and the student is in Exam mode, PrairieTest controls the scheduled access window and time limit. Outside Exam mode, the top-level date control, before-release behavior, and after-completion visibility apply normally.
+PrairieLearn shows an **Exam** badge in the navigation bar when a student is in **Exam mode**, which means the student has a checked-in PrairieTest reservation. While a matching reservation is active and the student is in Exam mode, PrairieTest controls the scheduled access window and time limit. Outside Exam mode, the top-level date control, before-release behavior, and after-completion visibility apply normally.
 
 For each PrairieTest exam, configure what students see after they finish **while the reservation is still active**:
 
@@ -106,7 +106,7 @@ You can also enable **Read-only mode**. During a read-only reservation, students
 
 #### PrairieTest precedence
 
-When PrairieTest is configured, PrairieLearn resolves access in this order:
+When a PrairieTest exam is associated with the assessment, PrairieLearn resolves access in this order:
 
 - **During an active matching reservation (Exam mode)**, PrairieTest grants access. Date-control scheduling, time limits, and passwords are **not** enforced — PrairieTest enforces its own scheduling, time limit, and access controls. For non-read-only reservations, the per-exam **After completion** visibility setting controls what students see after they finish, until the reservation ends.
 - **In Exam mode without an active matching reservation**, date control is not used as a fallback access path. PrairieLearn denies access, omits the assessment from the student assessment list, and hides completed-work visibility such as gradebook scores.
@@ -178,7 +178,7 @@ When an override field is active, the detail panel shows **Remove override** for
 
 ## Override priority
 
-Specific-student overrides take priority over student-label overrides. Within each section, overrides lower in the list take priority over overrides higher in the list; use the drag handle to reorder overrides when priority matters.
+Specific-student overrides take priority over student-label overrides. Within each section, overrides lower in the list take priority over those higher in the list; use the drag handle to reorder overrides when priority matters.
 
 For example, suppose a student has both the "Section A" and "Extended time" labels:
 
@@ -587,7 +587,7 @@ The visibility fields follow a toggle pattern. For example, if `questions.hidden
 
 ### JSON override inheritance
 
-JSON overrides only target student labels. They store the fields they change; unset fields inherit through the same priority order used by the UI:
+JSON overrides only target student labels. They store the fields they change; omitted fields inherit through the same priority order used by the UI:
 
 1. Start with the defaults rule.
 2. Apply matching overrides with `labels` in the order they appear in the `accessControl` array.
@@ -597,7 +597,7 @@ Later matching label overrides replace fields from earlier matching label overri
 
 | Field                        | Defaults to override merge                                        | Override to override cascade                            |
 | ---------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
-| `dateControl.*` sub-fields   | Override replaces individual sub-fields; unset sub-fields inherit | Later override replaces; unset fields kept from earlier |
+| `dateControl.*` sub-fields   | Override replaces individual sub-fields; omitted sub-fields inherit | Later override replaces; omitted fields kept from earlier |
 | `afterComplete.questions`    | Replaced as a whole object when set                               | Replaced as a whole object; otherwise inherited         |
 | `afterComplete.score`        | Replaced as a whole object when set                               | Replaced as a whole object; otherwise inherited         |
 | `beforeRelease`              | Cannot be overridden                                              | Not applicable                                          |

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -78,7 +78,7 @@ Enable **Time limit** to give each student a fixed amount of working time after 
 
 Timed attempts can span early deadlines, the due date, and late deadlines that still allow submissions, so the credit a student earns can shift as those deadlines pass during the attempt. If an assessment has a due date, a late deadline, and a 60-minute time limit, a student who starts 1 minute before the due date works for the full 60 minutes: the first minute earns the on-time credit, and the remainder earns the late-deadline credit.
 
-However, the timer is capped by the last submittable deadline. If submissions stop entirely at some point (for example, **After due date** is set to **No submissions allowed** with no late deadlines), a student who starts shortly before that deadline receives only the remaining time until then, not the full configured time limit.
+However, a timed attempt cannot continue past the point where submissions stop entirely. For example, if **After due date** is set to **No submissions allowed** with no late deadlines, a student who starts shortly before the due date receives only the remaining time until then, not the full configured time limit.
 
 #### Passwords
 
@@ -86,7 +86,7 @@ Enable **Password** to require a password to start or continue working on the as
 
 !!! info
 
-    Time limits and passwords apply only when a student gains access through **date control**. They are not enforced inside an active PrairieTest reservation — PrairieTest enforces its own scheduled time limit, and PrairieTest exams do not support a separate password.
+    Time limits and passwords apply only when a student gains access through **date control**. They are not enforced inside an active PrairieTest reservation — PrairieTest enforces its own scheduled time limit and access controls, including any PrairieTest session password.
 
 ### PrairieTest
 
@@ -108,15 +108,15 @@ You can also enable **Read-only mode**. During a read-only reservation, students
 
 When PrairieTest is configured, PrairieLearn resolves access in this order:
 
-- **During an active matching reservation (Exam mode)**, PrairieTest grants access. Date-control scheduling, time limits, and passwords are **not** enforced — PrairieTest enforces its own scheduling and time limit, and there is no password prompt. The per-exam **After completion** visibility setting controls what students see after they finish, until the reservation ends.
+- **During an active matching reservation (Exam mode)**, PrairieTest grants access. Date-control scheduling, time limits, and passwords are **not** enforced — PrairieTest enforces its own scheduling, time limit, and access controls. For non-read-only reservations, the per-exam **After completion** visibility setting controls what students see after they finish, until the reservation ends.
 - **In Exam mode without an active matching reservation**, date control is not used as a fallback access path. PrairieLearn denies access, omits the assessment from the student assessment list, and hides completed-work visibility such as gradebook scores.
 - **Outside Exam mode**, the top-level date control rules apply normally when a date-control release exists. Top-level **After completion** visibility also takes over for completed instances once the reservation ends.
 
-To restrict submission access to PrairieTest only, leave date control disabled. If students should also be unable to review the assessment outside the reservation, keep top-level **Question visibility** hidden.
+To restrict submission access to PrairieTest only, leave date control disabled. If students should also be unable to review questions or scores outside the reservation, keep top-level **Question visibility** and **Score visibility** hidden.
 
 ### Before release
 
-Enable **List before release** when students should see the assessment title before they can open it. With date control, this is the period before the release date. With PrairieTest only (no date control), the assessment can be listed outside Exam mode when students cannot open it yet. In Exam mode, only an active matching reservation can list or open it. If neither date control nor PrairieTest is enabled, the assessment is listed but students cannot start it.
+Enable **List before release** when students should see the assessment title before they can open it. With date control, this is the period before the release date. With PrairieTest only (no date control), this controls whether students can see the assessment title outside Exam mode even though they cannot open it. In Exam mode, only assessments with an active matching reservation are listed or accessible. If neither date control nor PrairieTest is enabled, the assessment is listed but students cannot start it.
 
 Disable it when the assessment should be completely hidden until release.
 
@@ -178,7 +178,7 @@ When an override field is active, the detail panel shows **Remove override** for
 
 ## Override priority
 
-Specific-student overrides take priority over student-label overrides. Within each section, lower overrides take priority over higher overrides; use the drag handle to reorder overrides when priority matters.
+Specific-student overrides take priority over student-label overrides. Within each section, overrides lower in the list take priority over overrides higher in the list; use the drag handle to reorder overrides when priority matters.
 
 For example, suppose a student has both the "Section A" and "Extended time" labels:
 
@@ -587,14 +587,13 @@ The visibility fields follow a toggle pattern. For example, if `questions.hidden
 
 ### JSON override inheritance
 
-JSON overrides only target student labels. They store the fields they change; unset fields inherit from the defaults and from earlier matching label overrides.
-
-The file-backed cascade is:
+JSON overrides only target student labels. They store the fields they change; unset fields inherit through the same priority order used by the UI:
 
 1. Start with the defaults rule.
-2. Apply matching `student_label` overrides in the order they appear in the array.
+2. Apply matching overrides with `labels` in the order they appear in the `accessControl` array.
+3. Apply any individual-student overrides configured through the UI.
 
-Later matching label overrides replace fields from earlier matching label overrides. Individual-student overrides are managed through the UI and take priority over the resolved file-backed rule.
+Later matching label overrides replace fields from earlier matching label overrides. Individual-student overrides are managed through the UI and take priority over label overrides.
 
 | Field                        | Defaults to override merge                                        | Override to override cascade                            |
 | ---------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -595,13 +595,13 @@ JSON overrides only target student labels. They store the fields they change; om
 
 Later matching label overrides replace fields from earlier matching label overrides. Individual-student overrides are managed through the UI and take priority over label overrides.
 
-| Field                        | Defaults to override merge                                        | Override to override cascade                            |
-| ---------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
+| Field                        | Defaults to override merge                                          | Override to override cascade                              |
+| ---------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------- |
 | `dateControl.*` sub-fields   | Override replaces individual sub-fields; omitted sub-fields inherit | Later override replaces; omitted fields kept from earlier |
-| `afterComplete.questions`    | Replaced as a whole object when set                               | Replaced as a whole object; otherwise inherited         |
-| `afterComplete.score`        | Replaced as a whole object when set                               | Replaced as a whole object; otherwise inherited         |
-| `beforeRelease`              | Cannot be overridden                                              | Not applicable                                          |
-| `integrations.prairieTest.*` | Cannot be overridden                                              | Not applicable                                          |
+| `afterComplete.questions`    | Replaced as a whole object when set                                 | Replaced as a whole object; otherwise inherited           |
+| `afterComplete.score`        | Replaced as a whole object when set                                 | Replaced as a whole object; otherwise inherited           |
+| `beforeRelease`              | Cannot be overridden                                                | Not applicable                                            |
+| `integrations.prairieTest.*` | Cannot be overridden                                                | Not applicable                                            |
 
 There are a few important details:
 

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -72,11 +72,17 @@ Configure what happens after all deadlines have passed. The setting is labeled *
 - **Allow practice submissions**: students can submit for feedback, but receive 0% credit.
 - **Allow submissions for partial credit**: students can submit for the credit percentage you choose.
 
-#### Time limits and passwords
+#### Time limits
 
-Enable **Time limit** to give each student a fixed amount of working time after they start the assessment. The timer is independent of deadlines: a student who starts close to a deadline gets the full time limit, but the credit they earn shifts as each deadline passes during the attempt. For example, a student with a 60-minute time limit who starts 1 minute before the due date works for the full 60 minutes — the first minute earns the on-time credit, and the remainder earns the next late-deadline credit.
+Enable **Time limit** to give each student a fixed amount of working time after they start the assessment. The timer spans deadlines that still allow submissions, so the credit a student earns can shift as each deadline passes during the attempt.
 
-Enable **Password** to require a password to start or continue working on the assessment. This is typically used for proctored exams. Students do not need to re-enter the password to review their work once submissions are no longer allowed (for example, in **No submissions allowed** mode after the last deadline).
+Consider an assessment with a due date and a late deadline. If it has a 60-minute time limit and a student starts 1 minute before the due date, the student works for the full 60 minutes: the first minute earns the on-time credit, and the remainder earns the next late-deadline credit.
+
+However, the timer is capped by the last submittable deadline. If submissions stop entirely at some point (for example, **After due date** is set to **No submissions allowed** with no late deadlines), a student who starts shortly before that deadline receives only the remaining time until then, not the full configured time limit. To guarantee every student the full time limit regardless of start time, configure **Allow practice submissions** or **Allow submissions for partial credit** after the last deadline, or remove the final submission cutoff entirely.
+
+#### Passwords
+
+Enable **Password** to require a password to start or continue working on the assessment. This is typically used for proctored exams. The password gates active, submittable work; students do not need to re-enter the password to review their work once submissions are no longer allowed (for example, in **No submissions allowed** mode after the last deadline).
 
 !!! info
 
@@ -86,7 +92,7 @@ Enable **Password** to require a password to start or continue working on the as
 
 Enable **PrairieTest** to let an active PrairieTest reservation grant access to the assessment. Add the PrairieTest exam UUID from the PrairieTest exam settings.
 
-While a matching reservation is active, PrairieTest controls the scheduled access window and time limit. The top-level date control, before-release behavior, and after-completion visibility apply outside the active reservation.
+While a matching reservation is active and the student is in PrairieTest **Exam mode**, PrairieTest controls the scheduled access window and time limit. Outside Exam mode, the top-level date control, before-release behavior, and after-completion visibility apply normally.
 
 For each PrairieTest exam, configure what students see after they finish **while the reservation is still active**:
 
@@ -96,13 +102,22 @@ For each PrairieTest exam, configure what students see after they finish **while
 
 These per-exam settings do not support reveal dates. Use the top-level **After completion** settings for visibility after the active reservation ends.
 
-You can also enable **Read-only mode**. During a read-only reservation, students can view previous submissions but cannot submit new answers or start the assessment if they have not already started. Questions and scores are always shown during read-only reservations.
+You can also enable **Read-only mode**. During a read-only reservation, students can view previous submissions but cannot submit new answers or start the assessment if they have not already started. Questions and scores are always shown during read-only reservations, regardless of the per-exam visibility settings.
 
-When both PrairieTest and date control are configured, an active matching reservation **takes precedence**: access is granted through PrairieTest using its own scheduling and time limit. Outside the reservation, date control determines access. To restrict an exam to PrairieTest only, leave date control disabled so students cannot open the assessment outside the reservation.
+#### PrairieTest precedence
+
+When PrairieTest is configured, PrairieLearn resolves access in this order:
+
+- **During an active matching reservation (Exam mode)**, PrairieTest grants access. Date-control scheduling, time limits, and passwords are **not** enforced — PrairieTest enforces its own scheduling and time limit, and there is no password prompt. The per-exam **After completion** visibility setting controls what students see after they finish, until the reservation ends.
+- **In Exam mode without an active matching reservation**, date control is not used as a fallback access path. PrairieLearn denies access, omits the assessment from the student assessment list, and hides completed-work visibility such as gradebook scores.
+- **Outside Exam mode**, the top-level date control rules apply normally when a date-control release exists. Top-level **After completion** visibility also takes over for completed instances once the reservation ends.
+- **Outside Exam mode without a date-control release**, a PrairieTest-gated assessment has no ordinary submission path. Students can open it only if top-level **Question visibility** has unlocked review access; even then, they cannot submit.
+
+To restrict submission access to PrairieTest only, leave date control disabled. If students should also be unable to review the assessment outside the reservation, keep top-level **Question visibility** hidden.
 
 ### Before release
 
-Enable **List before release** when students should see the assessment title before they can open it. With date control, this is the period before the release date. With PrairieTest only (no date control), the assessment is listed any time the student is not in an active reservation. If neither date control nor PrairieTest is enabled, the assessment is listed but students cannot start it.
+Enable **List before release** when students should see the assessment title before they can open it. With date control, this is the period before the release date. With PrairieTest only (no date control), the assessment can be listed outside Exam mode when students cannot open it yet. In Exam mode, only an active matching reservation can list or open it. If neither date control nor PrairieTest is enabled, the assessment is listed but students cannot start it.
 
 Disable it when the assessment should be completely hidden until release.
 
@@ -137,8 +152,8 @@ Click **Add override** in the **Overrides** section.
 
 Choose who the override applies to:
 
-- **Specific students**: select individual enrolled students.
-- **Students by label**: select one or more student labels, such as "Section A" or "Extra time". The override applies to students with _any_ of the selected labels (not all of them).
+- **Specific students**: select individual enrolled students. Specific-student overrides are stored in the database, not in `infoAssessment.json`, which keeps one-off accommodations and makeup windows out of the course's git history.
+- **Students by label**: select one or more student labels, such as "Section A" or "Extra time". The override applies to students with _any_ of the selected labels (not all of them). Label-targeted overrides are stored in `infoAssessment.json` alongside the rest of the assessment configuration.
 
 [Student labels](../courseInstance/index.md#student-labels) are managed on the course instance **Students** page. They are the recommended way to handle repeated accommodations, sections, or cohort-specific deadlines.
 
@@ -164,13 +179,7 @@ When an override field is active, the detail panel shows **Remove override** for
 
 ## Override priority
 
-If a student matches more than one override, PrairieLearn resolves the rules in this order:
-
-1. Start with the defaults.
-2. Apply matching student-label overrides.
-3. Apply matching specific-student overrides.
-
-Specific-student overrides take priority over student-label overrides. Within each section, overrides lower in the list take priority over overrides higher in the list. Use the drag handle to reorder overrides when priority matters.
+Specific-student overrides take priority over student-label overrides. Within each section, lower overrides take priority over higher overrides; use the drag handle to reorder overrides when priority matters.
 
 For example, suppose a student has both the "Section A" and "Extended time" labels:
 
@@ -420,8 +429,6 @@ In the UI:
 4. Click **Override** next to only the fields that should differ, such as **Release**, **Due date**, or **Time limit**.
 5. Save the changes.
 
-Individual-student overrides are stored in the database and are not represented in `infoAssessment.json`.
-
 ## Limitations
 
 Modern access control models credit as a single contiguous timeline from the release date through deadlines to the final close. It cannot represent non-contiguous credit ranges where credit is available, then unavailable, then available again.
@@ -581,20 +588,30 @@ The visibility fields follow a toggle pattern. For example, if `questions.hidden
 
 ### JSON override inheritance
 
-Overrides only store fields they change. Unset fields inherit from the defaults and from earlier matching overrides. The UI's **Override** and **Remove override** buttons are the safest way to control whether a field is explicitly set or inherited.
+JSON overrides only target student labels. They store the fields they change; unset fields inherit from the defaults and from earlier matching label overrides.
+
+The file-backed cascade is:
+
+1. Start with the defaults rule.
+2. Apply matching `student_label` overrides in the order they appear in the array.
+
+Later matching label overrides replace fields from earlier matching label overrides. Individual-student overrides are managed through the UI and take priority over the resolved file-backed rule.
 
 | Field                        | Defaults to override merge                                        | Override to override cascade                            |
 | ---------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
 | `dateControl.*` sub-fields   | Override replaces individual sub-fields; unset sub-fields inherit | Later override replaces; unset fields kept from earlier |
-| `afterComplete.*` sub-fields | Same as `dateControl`                                             | Same as `dateControl`                                   |
+| `afterComplete.questions`    | Replaced as a whole object when set                               | Replaced as a whole object; otherwise inherited         |
+| `afterComplete.score`        | Replaced as a whole object when set                               | Replaced as a whole object; otherwise inherited         |
 | `beforeRelease`              | Cannot be overridden                                              | Not applicable                                          |
+| `integrations.prairieTest.*` | Cannot be overridden                                              | Not applicable                                          |
 
 There are a few important details:
 
-- `due` is one atomic setting. Overriding the due date also overrides the due-date credit choice.
-- Early and late deadline arrays can be overridden with an empty list, which clears inherited deadlines.
-- Time limits and passwords can be overridden to no value, which clears an inherited time limit or password.
-- Individual-student overrides are not written to `infoAssessment.json`; they are stored in the database.
+- `due` is one atomic setting. Overriding the due date also overrides the due-date credit choice — they cannot be cascaded independently.
+- `earlyDeadlines` and `lateDeadlines` are each replaced as a whole array. Setting either to `[]` in an override **clears** the inherited deadlines for that override's students.
+- `durationMinutes: null` and `password: null` in an override **clear** the inherited time limit or password. Omitting the field entirely keeps the inherited value.
+- `afterComplete.questions` and `afterComplete.score` inherit independently of each other, but each is replaced as a whole object: an override that sets `afterComplete.questions` without dates does not retain the default's `visibleFromDate`/`visibleUntilDate`.
+- `beforeRelease.listed` and PrairieTest integrations (`integrations.prairieTest`) are **defaults-only**. Overrides cannot enable, disable, or change them.
 
 ### Legacy migration examples
 

--- a/docs/assessment/accessControlModern.md
+++ b/docs/assessment/accessControlModern.md
@@ -74,11 +74,11 @@ Configure what happens after all deadlines have passed. The setting is labeled *
 
 #### Time limits
 
-Enable **Time limit** to give each student a fixed amount of working time after they start the assessment. The timer spans deadlines that still allow submissions, so the credit a student earns can shift as each deadline passes during the attempt.
+Enable **Time limit** to give each student a fixed amount of working time after they start the assessment.
 
-Consider an assessment with a due date and a late deadline. If it has a 60-minute time limit and a student starts 1 minute before the due date, the student works for the full 60 minutes: the first minute earns the on-time credit, and the remainder earns the next late-deadline credit.
+Timed attempts can span early deadlines, the due date, and late deadlines that still allow submissions, so the credit a student earns can shift as those deadlines pass during the attempt. If an assessment has a due date, a late deadline, and a 60-minute time limit, a student who starts 1 minute before the due date works for the full 60 minutes: the first minute earns the on-time credit, and the remainder earns the late-deadline credit.
 
-However, the timer is capped by the last submittable deadline. If submissions stop entirely at some point (for example, **After due date** is set to **No submissions allowed** with no late deadlines), a student who starts shortly before that deadline receives only the remaining time until then, not the full configured time limit. To guarantee every student the full time limit regardless of start time, configure **Allow practice submissions** or **Allow submissions for partial credit** after the last deadline, or remove the final submission cutoff entirely.
+However, the timer is capped by the last submittable deadline. If submissions stop entirely at some point (for example, **After due date** is set to **No submissions allowed** with no late deadlines), a student who starts shortly before that deadline receives only the remaining time until then, not the full configured time limit.
 
 #### Passwords
 
@@ -92,7 +92,7 @@ Enable **Password** to require a password to start or continue working on the as
 
 Enable **PrairieTest** to let an active PrairieTest reservation grant access to the assessment. Add the PrairieTest exam UUID from the PrairieTest exam settings.
 
-While a matching reservation is active and the student is in PrairieTest **Exam mode**, PrairieTest controls the scheduled access window and time limit. Outside Exam mode, the top-level date control, before-release behavior, and after-completion visibility apply normally.
+PrairieLearn shows an **Exam** badge in the navigation bar when a student is in **Exam mode**, the PrairieTest-controlled state for a checked-in reservation. While a matching reservation is active and the student is in Exam mode, PrairieTest controls the scheduled access window and time limit. Outside Exam mode, the top-level date control, before-release behavior, and after-completion visibility apply normally.
 
 For each PrairieTest exam, configure what students see after they finish **while the reservation is still active**:
 
@@ -111,7 +111,6 @@ When PrairieTest is configured, PrairieLearn resolves access in this order:
 - **During an active matching reservation (Exam mode)**, PrairieTest grants access. Date-control scheduling, time limits, and passwords are **not** enforced — PrairieTest enforces its own scheduling and time limit, and there is no password prompt. The per-exam **After completion** visibility setting controls what students see after they finish, until the reservation ends.
 - **In Exam mode without an active matching reservation**, date control is not used as a fallback access path. PrairieLearn denies access, omits the assessment from the student assessment list, and hides completed-work visibility such as gradebook scores.
 - **Outside Exam mode**, the top-level date control rules apply normally when a date-control release exists. Top-level **After completion** visibility also takes over for completed instances once the reservation ends.
-- **Outside Exam mode without a date-control release**, a PrairieTest-gated assessment has no ordinary submission path. Students can open it only if top-level **Question visibility** has unlocked review access; even then, they cannot submit.
 
 To restrict submission access to PrairieTest only, leave date control disabled. If students should also be unable to review the assessment outside the reservation, keep top-level **Question visibility** hidden.
 


### PR DESCRIPTION
# Description

This updates the modern access control docs for time limits, passwords, PrairieTest precedence, and override inheritance, and clarifies that unmatched PrairieTest Exam-mode access is denied without exposing assessment-list or gradebook visibility.

It also fixes student-specific override ordering by persisting enrollment-rule numbers from the submitted UI order, using temporary renumbering to avoid unique-key conflicts when existing rules are reordered, while keeping PrairieLearn/PrairieLearn#12579 fixed.

Majority of implementation done with Codex.

# Testing

New tests were added, and now pass!