### PR TITLE
Fix concurrent assessment question stats queries

### DIFF
--- a/apps/prairielearn/src/lib/assessment.ts
+++ b/apps/prairielearn/src/lib/assessment.ts
@@ -609,10 +609,6 @@ export async function selectAssessmentInstanceLogCursor(
   );
 }
 
-async function updateAssessmentQuestionStats(assessment_question_id: string): Promise<void> {
-  await sqldb.execute(sql.calculate_stats_for_assessment_question, { assessment_question_id });
-}
-
 export async function updateAssessmentQuestionStatsForAssessment(
   assessment_id: string,
 ): Promise<void> {
@@ -622,7 +618,9 @@ export async function updateAssessmentQuestionStatsForAssessment(
       { assessment_id },
       IdSchema,
     );
-    await async.eachLimit(assessment_questions, 3, updateAssessmentQuestionStats);
+    await async.eachSeries(assessment_questions, async (assessment_question_id) => {
+      await sqldb.execute(sql.calculate_stats_for_assessment_question, { assessment_question_id });
+    });
     await sqldb.execute(sql.update_assessment_stats_last_updated, { assessment_id });
   });
 }


### PR DESCRIPTION
# Description

Serialize assessment question stats recalculation inside the existing transaction so the transaction-bound pg client is not asked to execute multiple queries concurrently. This fixes the pg deprecation warning emitted when `updateAssessmentQuestionStatsForAssessment()` used `async.eachLimit(..., 3, ...)` in `runInTransactionAsync`. The previous single-use helper is inlined into the serial loop.

Closes #15142.

Codex investigated and fixed; I did some manual cleanup.

# Testing

Ran an AST audit for parallel constructs inside `runInTransactionAsync` callbacks; it reports `TOTAL 0`.
