### PR TITLE
Limit student labels per course instance

### DIFF
--- a/apps/prairielearn/src/pages/instructorStudentsLabels/instructorStudentsLabels.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentsLabels/instructorStudentsLabels.html.tsx
@@ -94,19 +94,14 @@ function StudentLabelsCard({
         <div className="d-flex align-items-center justify-content-between mb-2">
           <h2 className="h5 mb-0">Student labels</h2>
           {canEdit && (
-            <div className="d-flex align-items-center gap-2">
-              <small className="text-muted text-nowrap">
-                {labels.length} of {MAX_STUDENT_LABELS} labels
-              </small>
-              <button
-                type="button"
-                className="btn btn-outline-primary btn-sm text-nowrap"
-                disabled={origHash === null || atStudentLabelLimit}
-                onClick={() => editModal.showWithData({ type: 'add', origHash })}
-              >
-                Add label
-              </button>
-            </div>
+            <button
+              type="button"
+              className="btn btn-outline-primary btn-sm text-nowrap"
+              disabled={origHash === null || atStudentLabelLimit}
+              onClick={() => editModal.showWithData({ type: 'add', origHash })}
+            >
+              Add label
+            </button>
           )}
         </div>
         <small className="text-muted">

--- a/apps/prairielearn/src/pages/instructorStudentsLabels/instructorStudentsLabels.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentsLabels/instructorStudentsLabels.html.tsx
@@ -5,6 +5,7 @@ import { Alert } from 'react-bootstrap';
 import { useModalState } from '@prairielearn/ui';
 
 import { QueryClientProviderDebug } from '../../lib/client/tanstackQuery.js';
+import { MAX_STUDENT_LABELS } from '../../schemas/infoCourseInstance.js';
 import { createCourseInstanceTrpcClient } from '../../trpc/courseInstance/client.js';
 import { TRPCProvider, useTRPC } from '../../trpc/courseInstance/context.js';
 
@@ -48,6 +49,7 @@ function StudentLabelsCard({
   });
 
   const labels = data.labels;
+  const atStudentLabelLimit = labels.length >= MAX_STUDENT_LABELS;
   const [origHashOverride, setOrigHashOverride] = useState<string | null>(null);
   const origHash = origHashOverride ?? data.origHash ?? initialOrigHash;
 
@@ -92,14 +94,19 @@ function StudentLabelsCard({
         <div className="d-flex align-items-center justify-content-between mb-2">
           <h2 className="h5 mb-0">Student labels</h2>
           {canEdit && (
-            <button
-              type="button"
-              className="btn btn-outline-primary btn-sm text-nowrap"
-              disabled={origHash === null}
-              onClick={() => editModal.showWithData({ type: 'add', origHash })}
-            >
-              Add label
-            </button>
+            <div className="d-flex align-items-center gap-2">
+              <small className="text-muted text-nowrap">
+                {labels.length} of {MAX_STUDENT_LABELS} labels
+              </small>
+              <button
+                type="button"
+                className="btn btn-outline-primary btn-sm text-nowrap"
+                disabled={origHash === null || atStudentLabelLimit}
+                onClick={() => editModal.showWithData({ type: 'add', origHash })}
+              >
+                Add label
+              </button>
+            </div>
           )}
         </div>
         <small className="text-muted">
@@ -127,6 +134,13 @@ function StudentLabelsCard({
           You cannot edit student labels because the <code>infoCourseInstance.json</code> file does
           not exist.
         </div>
+      )}
+
+      {canEdit && atStudentLabelLimit && (
+        <Alert variant="info">
+          This course instance has reached the limit of {MAX_STUDENT_LABELS} student labels.
+          Existing labels can still be edited or deleted.
+        </Alert>
       )}
 
       {labels.length === 0 ? (

--- a/apps/prairielearn/src/pages/instructorStudentsLabels/instructorStudentsLabels.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentsLabels/instructorStudentsLabels.html.tsx
@@ -5,7 +5,7 @@ import { Alert } from 'react-bootstrap';
 import { useModalState } from '@prairielearn/ui';
 
 import { QueryClientProviderDebug } from '../../lib/client/tanstackQuery.js';
-import { MAX_STUDENT_LABELS } from '../../schemas/infoCourseInstance.js';
+import { MAX_STUDENT_LABELS_PER_COURSE_INSTANCE } from '../../schemas/infoCourseInstance.js';
 import { createCourseInstanceTrpcClient } from '../../trpc/courseInstance/client.js';
 import { TRPCProvider, useTRPC } from '../../trpc/courseInstance/context.js';
 
@@ -49,7 +49,7 @@ function StudentLabelsCard({
   });
 
   const labels = data.labels;
-  const atStudentLabelLimit = labels.length >= MAX_STUDENT_LABELS;
+  const atStudentLabelLimit = labels.length >= MAX_STUDENT_LABELS_PER_COURSE_INSTANCE;
   const [origHashOverride, setOrigHashOverride] = useState<string | null>(null);
   const origHash = origHashOverride ?? data.origHash ?? initialOrigHash;
 
@@ -133,8 +133,8 @@ function StudentLabelsCard({
 
       {canEdit && atStudentLabelLimit && (
         <Alert variant="info">
-          This course instance has reached the limit of {MAX_STUDENT_LABELS} student labels.
-          Existing labels can still be edited or deleted.
+          This course instance has reached the limit of {MAX_STUDENT_LABELS_PER_COURSE_INSTANCE}{' '}
+          student labels. Existing labels can still be edited or deleted.
         </Alert>
       )}
 

--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { CommentJsonSchema } from './comment.js';
 import { ColorJsonSchema } from './infoCourse.js';
 
-export const MAX_STUDENT_LABELS = 25;
+export const MAX_STUDENT_LABELS_PER_COURSE_INSTANCE = 25;
 
 const AccessRuleJsonSchema = z
   .object({
@@ -135,7 +135,7 @@ export const CourseInstanceJsonSchema = z
       .default(false),
     studentLabels: z
       .array(StudentLabelJsonSchema)
-      .max(MAX_STUDENT_LABELS)
+      .max(MAX_STUDENT_LABELS_PER_COURSE_INSTANCE)
       .describe('Student labels.')
       .optional(),
   })

--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { CommentJsonSchema } from './comment.js';
 import { ColorJsonSchema } from './infoCourse.js';
 
+export const MAX_STUDENT_LABELS = 25;
+
 const AccessRuleJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
@@ -131,7 +133,11 @@ export const CourseInstanceJsonSchema = z
       )
       .optional()
       .default(false),
-    studentLabels: z.array(StudentLabelJsonSchema).describe('Student labels.').optional(),
+    studentLabels: z
+      .array(StudentLabelJsonSchema)
+      .max(MAX_STUDENT_LABELS)
+      .describe('Student labels.')
+      .optional(),
   })
   .strict()
   .describe('The specification file for a course instance.');

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -158,7 +158,8 @@
             "$ref": "#/definitions/ColorJsonSchema"
           }
         }
-      }
+      },
+      "maxItems": 25
     }
   },
   "definitions": {

--- a/apps/prairielearn/src/tests/instructorStudentsLabels.test.ts
+++ b/apps/prairielearn/src/tests/instructorStudentsLabels.test.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import * as path from 'path';
 
 import fs from 'fs-extra';
@@ -27,13 +28,14 @@ import {
 } from '../models/student-label.js';
 import { getStudentLabelsWithUserData } from '../pages/instructorStudentsLabels/queries.js';
 import type { AssessmentJsonInput } from '../schemas/infoAssessment.js';
-import type { CourseInstanceJsonInput } from '../schemas/infoCourseInstance.js';
+import { type CourseInstanceJsonInput, MAX_STUDENT_LABELS } from '../schemas/infoCourseInstance.js';
 import { createCourseInstanceTrpcClient } from '../trpc/courseInstance/client.js';
 import type { StudentLabelError } from '../trpc/courseInstance/student-labels.js';
 
 import * as helperClient from './helperClient.js';
 import {
   type CourseRepoFixture,
+  commitOriginAndSync,
   createCourseRepoFixture,
   updateCourseRepository,
 } from './helperCourse.js';
@@ -63,6 +65,14 @@ function createTrpcClient() {
     courseInstanceId: '1',
     urlBase: siteUrl,
   });
+}
+
+function makeStudentLabelsAtLimit(): NonNullable<CourseInstanceJsonInput['studentLabels']> {
+  return Array.from({ length: MAX_STUDENT_LABELS }, (_, index) => ({
+    uuid: crypto.randomUUID(),
+    name: index === 0 ? 'Section A' : `Limit Label ${String(index + 1).padStart(2, '0')}`,
+    color: 'blue1' as const,
+  }));
 }
 
 describe('Instructor student labels page', () => {
@@ -502,5 +512,62 @@ describe('Instructor student labels page', () => {
       assert.deepEqual(after.accessControl?.[1].labels, []);
       assert.isDefined(after.accessControl?.[1].dateControl);
     });
+  });
+
+  test.sequential('should enforce the student label limit only for new labels', async () => {
+    const trpcClient = createTrpcClient();
+    const originInfoPath = getCourseInstanceJsonPath(
+      courseRepo.courseOriginDir,
+      courseInstanceShortName,
+    );
+    const originJson = (await fs.readJson(originInfoPath)) as CourseInstanceJsonInput;
+    originJson.studentLabels = makeStudentLabelsAtLimit();
+    await fs.writeJson(originInfoPath, originJson, { spaces: 2 });
+
+    await commitOriginAndSync(courseRepo, 'Fill student labels to limit', [
+      path.relative(courseRepo.courseOriginDir, originInfoPath),
+    ]);
+
+    let labels = await selectStudentLabelsInCourseInstance(await selectCourseInstanceById('1'));
+    assert.lengthOf(labels, MAX_STUDENT_LABELS);
+
+    const labelToEdit = labels.find((l) => l.name === 'Limit Label 02');
+    assert.isDefined(labelToEdit);
+
+    let origHash = await computeScopedJsonHash<CourseInstanceJsonInput>(
+      getCourseInstanceJsonPath(courseRepo.courseLiveDir, courseInstanceShortName),
+      (json) => json.studentLabels ?? [],
+    );
+
+    await trpcClient.studentLabels.upsert.mutate({
+      labelId: labelToEdit.id,
+      name: 'Limit Label 02 Renamed',
+      color: 'green1',
+      uids: [],
+      origHash,
+    });
+
+    labels = await selectStudentLabelsInCourseInstance(await selectCourseInstanceById('1'));
+    assert.lengthOf(labels, MAX_STUDENT_LABELS);
+    assert.isDefined(labels.find((l) => l.name === 'Limit Label 02 Renamed'));
+
+    origHash = await computeScopedJsonHash<CourseInstanceJsonInput>(
+      getCourseInstanceJsonPath(courseRepo.courseLiveDir, courseInstanceShortName),
+      (json) => json.studentLabels ?? [],
+    );
+
+    try {
+      await trpcClient.studentLabels.upsert.mutate({
+        name: 'Overflow Label',
+        color: 'red1',
+        uids: [],
+        origHash,
+      });
+      assert.fail('Expected error for student label limit');
+    } catch (err) {
+      const appError = getAppError<StudentLabelError['Upsert']>(err);
+      assert.isNotNull(appError);
+      assert.include(appError.message, `at most ${MAX_STUDENT_LABELS} student labels`);
+    }
   });
 });

--- a/apps/prairielearn/src/tests/instructorStudentsLabels.test.ts
+++ b/apps/prairielearn/src/tests/instructorStudentsLabels.test.ts
@@ -28,7 +28,10 @@ import {
 } from '../models/student-label.js';
 import { getStudentLabelsWithUserData } from '../pages/instructorStudentsLabels/queries.js';
 import type { AssessmentJsonInput } from '../schemas/infoAssessment.js';
-import { type CourseInstanceJsonInput, MAX_STUDENT_LABELS } from '../schemas/infoCourseInstance.js';
+import {
+  type CourseInstanceJsonInput,
+  MAX_STUDENT_LABELS_PER_COURSE_INSTANCE,
+} from '../schemas/infoCourseInstance.js';
 import { createCourseInstanceTrpcClient } from '../trpc/courseInstance/client.js';
 import type { StudentLabelError } from '../trpc/courseInstance/student-labels.js';
 
@@ -513,11 +516,14 @@ describe('Instructor student labels page', () => {
       courseInstanceShortName,
     );
     const originJson = (await fs.readJson(originInfoPath)) as CourseInstanceJsonInput;
-    originJson.studentLabels = Array.from({ length: MAX_STUDENT_LABELS }, (_, index) => ({
-      uuid: crypto.randomUUID(),
-      name: index === 0 ? 'Section A' : `Limit Label ${String(index + 1).padStart(2, '0')}`,
-      color: 'blue1' as const,
-    }));
+    originJson.studentLabels = Array.from(
+      { length: MAX_STUDENT_LABELS_PER_COURSE_INSTANCE },
+      (_, index) => ({
+        uuid: crypto.randomUUID(),
+        name: index === 0 ? 'Section A' : `Limit Label ${String(index + 1).padStart(2, '0')}`,
+        color: 'blue1' as const,
+      }),
+    );
     await fs.writeJson(originInfoPath, originJson, { spaces: 2 });
 
     await commitOriginAndSync(courseRepo, 'Fill student labels to limit', [
@@ -525,7 +531,7 @@ describe('Instructor student labels page', () => {
     ]);
 
     let labels = await selectStudentLabelsInCourseInstance(await selectCourseInstanceById('1'));
-    assert.lengthOf(labels, MAX_STUDENT_LABELS);
+    assert.lengthOf(labels, MAX_STUDENT_LABELS_PER_COURSE_INSTANCE);
 
     const labelToEdit = labels.find((l) => l.name === 'Limit Label 02');
     assert.isDefined(labelToEdit);
@@ -544,7 +550,7 @@ describe('Instructor student labels page', () => {
     });
 
     labels = await selectStudentLabelsInCourseInstance(await selectCourseInstanceById('1'));
-    assert.lengthOf(labels, MAX_STUDENT_LABELS);
+    assert.lengthOf(labels, MAX_STUDENT_LABELS_PER_COURSE_INSTANCE);
     assert.isDefined(labels.find((l) => l.name === 'Limit Label 02 Renamed'));
 
     origHash = await computeScopedJsonHash<CourseInstanceJsonInput>(
@@ -559,6 +565,6 @@ describe('Instructor student labels page', () => {
         uids: [],
         origHash,
       }),
-    ).rejects.toThrow(`at most ${MAX_STUDENT_LABELS} student labels`);
+    ).rejects.toThrow(`at most ${MAX_STUDENT_LABELS_PER_COURSE_INSTANCE} student labels`);
   });
 });

--- a/apps/prairielearn/src/tests/instructorStudentsLabels.test.ts
+++ b/apps/prairielearn/src/tests/instructorStudentsLabels.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import fs from 'fs-extra';
 import fetch from 'node-fetch';
-import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, assert, beforeAll, describe, expect, test } from 'vitest';
 
 import { queryOptionalRow } from '@prairielearn/postgres';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
@@ -65,14 +65,6 @@ function createTrpcClient() {
     courseInstanceId: '1',
     urlBase: siteUrl,
   });
-}
-
-function makeStudentLabelsAtLimit(): NonNullable<CourseInstanceJsonInput['studentLabels']> {
-  return Array.from({ length: MAX_STUDENT_LABELS }, (_, index) => ({
-    uuid: crypto.randomUUID(),
-    name: index === 0 ? 'Section A' : `Limit Label ${String(index + 1).padStart(2, '0')}`,
-    color: 'blue1' as const,
-  }));
 }
 
 describe('Instructor student labels page', () => {
@@ -521,7 +513,11 @@ describe('Instructor student labels page', () => {
       courseInstanceShortName,
     );
     const originJson = (await fs.readJson(originInfoPath)) as CourseInstanceJsonInput;
-    originJson.studentLabels = makeStudentLabelsAtLimit();
+    originJson.studentLabels = Array.from({ length: MAX_STUDENT_LABELS }, (_, index) => ({
+      uuid: crypto.randomUUID(),
+      name: index === 0 ? 'Section A' : `Limit Label ${String(index + 1).padStart(2, '0')}`,
+      color: 'blue1' as const,
+    }));
     await fs.writeJson(originInfoPath, originJson, { spaces: 2 });
 
     await commitOriginAndSync(courseRepo, 'Fill student labels to limit', [
@@ -556,18 +552,13 @@ describe('Instructor student labels page', () => {
       (json) => json.studentLabels ?? [],
     );
 
-    try {
-      await trpcClient.studentLabels.upsert.mutate({
+    await expect(
+      trpcClient.studentLabels.upsert.mutate({
         name: 'Overflow Label',
         color: 'red1',
         uids: [],
         origHash,
-      });
-      assert.fail('Expected error for student label limit');
-    } catch (err) {
-      const appError = getAppError<StudentLabelError['Upsert']>(err);
-      assert.isNotNull(appError);
-      assert.include(appError.message, `at most ${MAX_STUDENT_LABELS} student labels`);
-    }
+      }),
+    ).rejects.toThrow(`at most ${MAX_STUDENT_LABELS} student labels`);
   });
 });

--- a/apps/prairielearn/src/trpc/courseInstance/student-labels.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/student-labels.ts
@@ -31,7 +31,10 @@ import {
 } from '../../pages/instructorStudentsLabels/instructorStudentsLabels.types.js';
 import { getStudentLabelsWithUserData } from '../../pages/instructorStudentsLabels/queries.js';
 import { ColorJsonSchema } from '../../schemas/infoCourse.js';
-import { type CourseInstanceJsonInput } from '../../schemas/infoCourseInstance.js';
+import {
+  type CourseInstanceJsonInput,
+  MAX_STUDENT_LABELS,
+} from '../../schemas/infoCourseInstance.js';
 import { throwAppError } from '../app-errors.js';
 
 import {
@@ -184,6 +187,12 @@ const upsert = t.procedure
             throw new TRPCError({
               code: 'BAD_REQUEST',
               message: 'A label with this name already exists',
+            });
+          }
+          if (studentLabels.length >= MAX_STUDENT_LABELS) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: `A course instance can have at most ${MAX_STUDENT_LABELS} student labels. Edit or delete an existing label before adding another.`,
             });
           }
           studentLabels.push({ uuid: labelUuid, name, color });

--- a/apps/prairielearn/src/trpc/courseInstance/student-labels.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/student-labels.ts
@@ -33,7 +33,7 @@ import { getStudentLabelsWithUserData } from '../../pages/instructorStudentsLabe
 import { ColorJsonSchema } from '../../schemas/infoCourse.js';
 import {
   type CourseInstanceJsonInput,
-  MAX_STUDENT_LABELS,
+  MAX_STUDENT_LABELS_PER_COURSE_INSTANCE,
 } from '../../schemas/infoCourseInstance.js';
 import { throwAppError } from '../app-errors.js';
 
@@ -189,10 +189,10 @@ const upsert = t.procedure
               message: 'A label with this name already exists',
             });
           }
-          if (studentLabels.length >= MAX_STUDENT_LABELS) {
+          if (studentLabels.length >= MAX_STUDENT_LABELS_PER_COURSE_INSTANCE) {
             throw new TRPCError({
               code: 'BAD_REQUEST',
-              message: `A course instance can have at most ${MAX_STUDENT_LABELS} student labels. Delete an existing label before adding another.`,
+              message: `A course instance can have at most ${MAX_STUDENT_LABELS_PER_COURSE_INSTANCE} student labels. Delete an existing label before adding another.`,
             });
           }
           studentLabels.push({ uuid: labelUuid, name, color });

--- a/apps/prairielearn/src/trpc/courseInstance/student-labels.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/student-labels.ts
@@ -192,7 +192,7 @@ const upsert = t.procedure
           if (studentLabels.length >= MAX_STUDENT_LABELS) {
             throw new TRPCError({
               code: 'BAD_REQUEST',
-              message: `A course instance can have at most ${MAX_STUDENT_LABELS} student labels. Edit or delete an existing label before adding another.`,
+              message: `A course instance can have at most ${MAX_STUDENT_LABELS} student labels. Delete an existing label before adding another.`,
             });
           }
           studentLabels.push({ uuid: labelUuid, name, color });

--- a/docs/courseInstance/index.md
+++ b/docs/courseInstance/index.md
@@ -270,9 +270,7 @@ Allowable timezones are those in the TZ column in the [list of tz database time 
 
 ## Student labels
 
-Student labels let you organize students with colored badges. Use them for sections, TA assignments, accommodations, or any other grouping.
-
-Each course instance can have up to 25 student labels.
+Student labels let you organize students with colored badges. Use them for sections, TA assignments, accommodations, or any other grouping. Each course instance can have up to 25 student labels.
 
 To review configured labels and their assigned students, go to **Students → Labels**. Users with student data viewer access can view that page. Users who have both course editor and student data editor access can create, rename, delete, and assign labels there by entering UIDs. Student data editors can also apply existing labels from the main Students page using batch actions, or from an individual student's page.
 

--- a/docs/courseInstance/index.md
+++ b/docs/courseInstance/index.md
@@ -272,6 +272,8 @@ Allowable timezones are those in the TZ column in the [list of tz database time 
 
 Student labels let you organize students with colored badges. Use them for sections, TA assignments, accommodations, or any other grouping.
 
+Each course instance can have up to 25 student labels.
+
 To review configured labels and their assigned students, go to **Students → Labels**. Users with student data viewer access can view that page. Users who have both course editor and student data editor access can create, rename, delete, and assign labels there by entering UIDs. Student data editors can also apply existing labels from the main Students page using batch actions, or from an individual student's page.
 
 Labels appear in the student roster, gradebook, and student detail pages.


### PR DESCRIPTION
# Description

Adds a 25-label cap to course-instance student labels in the course instance schema and the instructor student-label creation flow. The student-label management page now shows the current label count and disables creating labels at the cap. The course instance documentation now calls out the limit. I checked prod, currently the max number of labels in a given course instance is 6.

This limit is intentionally pretty conservative. If people end up with a compelling use case for more, we can pretty easily increase it.

- [x] I have disclosed the level of AI assistance used: majority of implementation and PR preparation used AI assistance.

# Testing

- Added and ran focused student-label integration coverage for editing at the cap and rejecting a new label above it.
- Ran `make check-jsonschema` after regenerating the course instance JSON schema.
