### PR TITLE
Refactor access control migration analysis

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -21,7 +21,7 @@ import { validateAccessControlRules } from './validation.js';
 // file-level helpers are exercised the same way production calls them.
 // Cases whose legacy rules don't supply a startDate (always-open, password-only)
 // get this fallback as their release date in `expected`.
-const FALLBACK_RELEASE = '1900-01-01T00:00:00';
+const FALLBACK_RELEASE = '2000-01-01T00:00:00';
 
 describe('migrateAllowAccess', () => {
   const cases: {
@@ -198,6 +198,23 @@ describe('migrateAllowAccess', () => {
       expected: {
         accessControl: null,
         errors: ['Open-ended credit windows without a 100% credit rule cannot be migrated.'],
+        notes: [],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'fallback release date after due date fails final validation',
+      rules: [
+        // This end date is before FALLBACK_RELEASE, forcing the fallback
+        // release date through final date-ordering validation.
+        { credit: 0, endDate: '1999-12-31T00:00:00' },
+      ],
+      expected: {
+        accessControl: null,
+        errors: [
+          'Release date must be before due date.',
+          'Due date must be after the earliest possible release date.',
+        ],
         notes: [],
         hasUidRules: false,
       },
@@ -1689,33 +1706,6 @@ describe('analyzeAssessmentFile', () => {
         assert.deepEqual(result.notes, [
           'An empty accessControl list signifies that no access is granted.',
         ]);
-      },
-      { unsafeCleanup: true },
-    );
-  });
-
-  it('uses the fallback release date for final validation', async () => {
-    await tmp.withDir(
-      async ({ path: tmpDir }) => {
-        const filePath = path.join(tmpDir, 'infoAssessment.json');
-        const allowAccess: AssessmentAccessRuleJson[] = [
-          { credit: 0, endDate: '2024-06-01T00:00:00' },
-        ];
-        await fs.writeFile(
-          filePath,
-          JSON.stringify({
-            type: 'Homework',
-            title: 'HW1',
-            allowAccess,
-          }),
-        );
-
-        const fallbackReleaseDate = '2025-01-01T00:00:00';
-        const migration = migrateAllowAccess(allowAccess, fallbackReleaseDate);
-        const result = await analyzeAssessmentFile(filePath, 'hw01', fallbackReleaseDate);
-        assert.isNotNull(result);
-        assert.isAbove(migration.errors.length, 0);
-        assert.deepEqual(result.errors, migration.errors);
       },
       { unsafeCleanup: true },
     );

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -1549,7 +1549,7 @@ describe('analyzeAssessmentFile', () => {
       async ({ path: tmpDir }) => {
         const filePath = path.join(tmpDir, 'infoAssessment.json');
         await fs.writeFile(filePath, JSON.stringify({ type: 'Exam', title: 'Test' }));
-        const result = await analyzeAssessmentFile(filePath, 'test');
+        const result = await analyzeAssessmentFile(filePath, 'test', FALLBACK_RELEASE);
         assert.isNull(result);
       },
       { unsafeCleanup: true },
@@ -1568,7 +1568,7 @@ describe('analyzeAssessmentFile', () => {
             accessControl: [{ dateControl: { release: { date: '2024-01-01T00:00:00' } } }],
           }),
         );
-        const result = await analyzeAssessmentFile(filePath, 'test');
+        const result = await analyzeAssessmentFile(filePath, 'test', FALLBACK_RELEASE);
         assert.isNull(result);
       },
       { unsafeCleanup: true },
@@ -1589,7 +1589,7 @@ describe('analyzeAssessmentFile', () => {
             ],
           }),
         );
-        const result = await analyzeAssessmentFile(filePath, 'hw01');
+        const result = await analyzeAssessmentFile(filePath, 'hw01', FALLBACK_RELEASE);
         assert.isNotNull(result);
         assert.equal(result.tid, 'hw01');
         assert.equal(result.errors.length, 0);
@@ -1626,7 +1626,7 @@ describe('analyzeAssessmentFile', () => {
             ],
           }),
         );
-        const result = await analyzeAssessmentFile(filePath, 'hw01');
+        const result = await analyzeAssessmentFile(filePath, 'hw01', FALLBACK_RELEASE);
         assert.isNotNull(result);
         assert.deepEqual(result.errors, []);
         assert.deepEqual(result.notes, [
@@ -1649,7 +1649,7 @@ describe('analyzeAssessmentFile', () => {
             allowAccess: [],
           }),
         );
-        const result = await analyzeAssessmentFile(filePath, 'e01');
+        const result = await analyzeAssessmentFile(filePath, 'e01', FALLBACK_RELEASE);
         assert.isNull(result);
       },
       { unsafeCleanup: true },
@@ -1661,7 +1661,7 @@ describe('analyzeAssessmentFile', () => {
       async ({ path: tmpDir }) => {
         const filePath = path.join(tmpDir, 'infoAssessment.json');
         await fs.writeFile(filePath, 'not valid json {{{');
-        const result = await analyzeAssessmentFile(filePath, 'e01');
+        const result = await analyzeAssessmentFile(filePath, 'e01', FALLBACK_RELEASE);
         assert.isNull(result);
       },
       { unsafeCleanup: true },
@@ -1680,12 +1680,39 @@ describe('analyzeAssessmentFile', () => {
             allowAccess: [{}],
           }),
         );
-        const result = await analyzeAssessmentFile(filePath, 'hw01');
+        const result = await analyzeAssessmentFile(filePath, 'hw01', FALLBACK_RELEASE);
         assert.isNotNull(result);
         assert.deepEqual(result.errors, []);
         assert.deepEqual(result.notes, [
           'An empty accessControl list signifies that no access is granted.',
         ]);
+      },
+      { unsafeCleanup: true },
+    );
+  });
+
+  it('uses the fallback release date for final validation', async () => {
+    await tmp.withDir(
+      async ({ path: tmpDir }) => {
+        const filePath = path.join(tmpDir, 'infoAssessment.json');
+        const allowAccess: AssessmentAccessRuleJson[] = [
+          { credit: 0, endDate: '2024-06-01T00:00:00' },
+        ];
+        await fs.writeFile(
+          filePath,
+          JSON.stringify({
+            type: 'Homework',
+            title: 'HW1',
+            allowAccess,
+          }),
+        );
+
+        const fallbackReleaseDate = '2025-01-01T00:00:00';
+        const migration = migrateAllowAccess(allowAccess, fallbackReleaseDate);
+        const result = await analyzeAssessmentFile(filePath, 'hw01', fallbackReleaseDate);
+        assert.isNotNull(result);
+        assert.isAbove(migration.errors.length, 0);
+        assert.deepEqual(result.errors, migration.errors);
       },
       { unsafeCleanup: true },
     );
@@ -1696,7 +1723,7 @@ describe('analyzeCourseInstanceAssessments', () => {
   it('returns empty analysis when no assessments directory exists', async () => {
     await tmp.withDir(
       async ({ path: tmpDir }) => {
-        const result = await analyzeCourseInstanceAssessments(tmpDir);
+        const result = await analyzeCourseInstanceAssessments(tmpDir, FALLBACK_RELEASE);
         assert.equal(result.hasLegacyRules, false);
         assert.lengthOf(result.assessments, 0);
       },
@@ -1729,7 +1756,7 @@ describe('analyzeCourseInstanceAssessments', () => {
           }),
         );
 
-        const result = await analyzeCourseInstanceAssessments(tmpDir);
+        const result = await analyzeCourseInstanceAssessments(tmpDir, FALLBACK_RELEASE);
         assert.equal(result.hasLegacyRules, true);
         assert.lengthOf(result.assessments, 1);
         assert.equal(result.assessments[0].tid, 'hw01');

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -196,7 +196,7 @@ describe('migrateAllowAccess', () => {
       name: 'always-open with non-standard credit',
       rules: [{ credit: 120 }],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Open-ended credit windows without a 100% credit rule cannot be migrated.'],
         notes: [],
         hasUidRules: false,
@@ -276,7 +276,7 @@ describe('migrateAllowAccess', () => {
       name: 'open-ended reduced credit (startDate, no endDate)',
       rules: [{ credit: 50, startDate: '2024-01-01T00:00:00' }],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Open-ended credit windows without a 100% credit rule cannot be migrated.'],
         notes: [],
         hasUidRules: false,
@@ -362,7 +362,7 @@ describe('migrateAllowAccess', () => {
         { credit: 100, startDate: '2024-04-01T00:00:00' },
       ],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Credit must be non-increasing over time.'],
         notes: [],
         hasUidRules: false,
@@ -375,7 +375,7 @@ describe('migrateAllowAccess', () => {
         { credit: 100, startDate: '2024-03-01T00:00:00' },
       ],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Credit must be non-increasing over time.'],
         notes: [],
         hasUidRules: false,
@@ -1289,7 +1289,7 @@ describe('migrateAllowAccess', () => {
         { credit: 100, startDate: '2024-02-01T00:00:00', endDate: '2024-06-01T00:00:00' },
       ],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: [
           'Practice windows before the assessment opens are not supported. Practice is only allowed after the assessment closes.',
         ],
@@ -1322,7 +1322,7 @@ describe('migrateAllowAccess', () => {
         { credit: 100, startDate: '2024-03-01T00:00:00', endDate: '2024-04-01T00:00:00' },
       ],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Non-contiguous access windows are not supported.'],
         notes: [],
         hasUidRules: false,
@@ -1335,7 +1335,7 @@ describe('migrateAllowAccess', () => {
         { credit: 100, startDate: '2024-03-01T00:00:00' },
       ],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Non-contiguous access windows are not supported.'],
         notes: [],
         hasUidRules: false,
@@ -1348,7 +1348,7 @@ describe('migrateAllowAccess', () => {
         { credit: 0, startDate: '2024-04-01T00:00:00', endDate: '2024-04-30T00:00:00' },
       ],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Non-contiguous access windows are not supported.'],
         notes: [],
         hasUidRules: false,
@@ -1375,7 +1375,7 @@ describe('migrateAllowAccess', () => {
       name: 'mode-gated only',
       rules: [{ mode: 'Exam' }],
       expected: {
-        accessControl: {},
+        accessControl: null,
         errors: ['Mode-only access rules are not supported.'],
         notes: [],
         hasUidRules: false,
@@ -1528,9 +1528,12 @@ describe('migrateAllowAccess', () => {
     const result = migrateAllowAccess(rules, FALLBACK_RELEASE);
     assert.deepEqual(result, expected);
 
-    // Skip validation for migrations that errored out — the result is `{}` and
-    // the migration is rejecting the input, so there's nothing to validate.
+    // Skip validation for migrations that errored out; there is no migrated
+    // accessControl to validate.
     if (result.errors.length > 0) return;
+    if (result.accessControl == null) {
+      assert.fail('Expected migrated access control');
+    }
 
     const zodResult = AccessControlJsonSchema.safeParse(result.accessControl);
     assert.isTrue(

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -820,157 +820,28 @@ function extractPrairieTest(rules: AssessmentAccessRuleJson[]): {
 // Main migration pipeline
 // ---------------------------------------------------------------------------
 
-interface AnalysisResults {
+interface Analysis {
+  errors: string[];
+  notes: string[];
+  hasUidRules: boolean;
+  accessControl: AccessControlJsonInput | null;
+}
+
+function assembleAccessControl({
+  schedulingRules,
+  ptExtract,
+  pwExtract,
+  dateControl,
+  visibilityMigration,
+  fallbackReleaseDate,
+}: {
   schedulingRules: AssessmentAccessRuleJson[];
   ptExtract: ReturnType<typeof extractPrairieTest>;
   pwExtract: ReturnType<typeof extractPassword>;
   dateControl: AccessControlJsonInput['dateControl'];
   visibilityMigration: VisibilityMigration;
-}
-
-interface Analysis {
-  errors: string[];
-  notes: string[];
-  hasUidRules: boolean;
-  /**
-   * Intermediate state used by `migrateAllowAccess` to assemble the final
-   * `AccessControlJsonInput`. `null` when the analysis failed (errors is
-   * non-empty). Callers that only need diagnostics can ignore this field.
-   */
-  results: AnalysisResults | null;
-}
-
-/**
- * Runs the diagnostic phase of the migration: normalization, orthogonal-concern
- * extraction, precondition checks, and credit-timeline construction. Use this
- * when the caller wants to know whether the migration would succeed (and what
- * notes/UID-rule warnings to surface) without producing a final
- * `AccessControlJsonInput`.
- */
-function analyzeAllowAccess(rules: AssessmentAccessRuleJson[]): Analysis {
-  const hasUidRules = rules.some((r) => r.uids);
-  rules = normalizeRules(rules);
-
-  const notes: string[] = [];
-  if (hasUidRules) {
-    notes.push(
-      'UID-based rules are excluded from the migrated JSON and must be recreated as enrollment overrides if needed.',
-    );
-  }
-
-  let schedulingRules = rules;
-
-  const ptExtract = extractPrairieTest(schedulingRules);
-  if (ptExtract) {
-    schedulingRules = ptExtract.remainingRules;
-    notes.push(...ptExtract.notes);
-  }
-
-  const pwExtract = extractPassword(schedulingRules);
-  if (pwExtract) {
-    schedulingRules = pwExtract.remainingRules;
-    notes.push(...pwExtract.notes);
-  }
-
-  if (hasAccessGaps(schedulingRules)) {
-    return {
-      errors: ['Non-contiguous access windows are not supported.'],
-      notes,
-      hasUidRules,
-      results: null,
-    };
-  }
-
-  if (hasNonMonotonicCredit(schedulingRules)) {
-    return {
-      errors: ['Credit must be non-increasing over time.'],
-      notes,
-      hasUidRules,
-      results: null,
-    };
-  }
-
-  if (hasPracticeBeforeRelease(schedulingRules)) {
-    return {
-      errors: [
-        'Practice windows before the assessment opens are not supported. Practice is only allowed after the assessment closes.',
-      ],
-      notes,
-      hasUidRules,
-      results: null,
-    };
-  }
-
-  const hasCreditRules = schedulingRules.some((r) => (r.credit ?? 0) > 0);
-  const hasModeOnly =
-    !hasCreditRules &&
-    schedulingRules.some((r) => r.mode) &&
-    schedulingRules.every(
-      (r) =>
-        (r.credit ?? 0) === 0 &&
-        (r.active ?? true) &&
-        !r.startDate &&
-        !r.endDate &&
-        !r.showClosedAssessment &&
-        !r.showClosedAssessmentScore,
-    );
-  if (hasModeOnly && !ptExtract) {
-    return {
-      errors: ['Mode-only access rules are not supported.'],
-      notes,
-      hasUidRules,
-      results: null,
-    };
-  }
-
-  const { dateControl, errors, notes: builderNotes } = buildCreditTimeline(schedulingRules);
-  notes.push(...builderNotes);
-
-  if (errors.length > 0) {
-    return { errors, notes, hasUidRules, results: null };
-  }
-
-  const questionReviewWindowCount = getQuestionReviewWindows(schedulingRules).length;
-  if (questionReviewWindowCount > 1) {
-    notes.push(
-      `${questionReviewWindowCount} completed-question review windows collapsed into a single visibility window.`,
-    );
-  }
-
-  // No-op detection: when nothing produced a dateControl, password, or
-  // PrairieTest config, the rules collapse to a no-op. Suppress the note if
-  // the rules were intentionally hidden via `active: false`.
-  if (!dateControl && !ptExtract && !pwExtract) {
-    const isHidden = schedulingRules.some((r) => (r.active ?? true) === false);
-    if (!isHidden) {
-      notes.push('An empty accessControl list signifies that no access is granted.');
-    }
-  }
-
-  const visibilityMigration = buildVisibilityMigration(schedulingRules);
-  notes.push(...visibilityMigration.notes);
-
-  return {
-    errors: [],
-    notes,
-    hasUidRules,
-    results: { schedulingRules, ptExtract, pwExtract, dateControl, visibilityMigration },
-  };
-}
-
-export function migrateAllowAccess(
-  rules: AssessmentAccessRuleJson[],
-  fallbackReleaseDate: string,
-): Migration {
-  const analysis = analyzeAllowAccess(rules);
-  if (analysis.results === null) {
-    const { errors, notes, hasUidRules } = analysis;
-    return { accessControl: {}, errors, notes, hasUidRules };
-  }
-
-  const { schedulingRules, ptExtract, pwExtract, dateControl, visibilityMigration } =
-    analysis.results;
-  const { notes, hasUidRules } = analysis;
+  fallbackReleaseDate: string;
+}): AccessControlJsonInput {
   const accessControl: AccessControlJsonInput = {};
 
   if (dateControl) {
@@ -1002,27 +873,165 @@ export function migrateAllowAccess(
     accessControl.dateControl.release = { date: fallbackReleaseDate };
   }
 
-  // Run the assembled config through the same validators that sync uses.
-  // We shouldn't be creating invalid configurations, so this acts as a safety check.
+  return accessControl;
+}
+
+function validateMigratedAccessControl(accessControl: AccessControlJsonInput): string[] {
   const schemaResult = AccessControlJsonSchema.safeParse(accessControl);
   if (!schemaResult.success) {
-    return {
-      accessControl: {},
-      errors: schemaResult.error.issues.map((issue) =>
-        issue.path.length > 0 ? `${issue.path.join('.')}: ${issue.message}` : issue.message,
-      ),
-      notes,
-      hasUidRules,
-    };
-  }
-  const { errors: validationErrors } = validateAccessControlRules({
-    rules: [accessControl],
-  });
-  if (validationErrors.length > 0) {
-    return { accessControl: {}, errors: validationErrors, notes, hasUidRules };
+    return schemaResult.error.issues.map((issue) =>
+      issue.path.length > 0 ? `${issue.path.join('.')}: ${issue.message}` : issue.message,
+    );
   }
 
-  return { accessControl, errors: [], notes, hasUidRules };
+  const { errors } = validateAccessControlRules({
+    rules: [accessControl],
+  });
+  return errors;
+}
+
+/**
+ * Runs the diagnostic phase of the migration: normalization, orthogonal-concern
+ * extraction, precondition checks, credit-timeline construction, and final
+ * accessControl validation. Use this when the caller wants to know whether the
+ * migration would succeed and what notes/UID-rule warnings to surface.
+ */
+function analyzeAllowAccess(
+  rules: AssessmentAccessRuleJson[],
+  fallbackReleaseDate: string,
+): Analysis {
+  const hasUidRules = rules.some((r) => r.uids);
+  rules = normalizeRules(rules);
+
+  const notes: string[] = [];
+  if (hasUidRules) {
+    notes.push(
+      'UID-based rules are excluded from the migrated JSON and must be recreated as enrollment overrides if needed.',
+    );
+  }
+
+  let schedulingRules = rules;
+
+  const ptExtract = extractPrairieTest(schedulingRules);
+  if (ptExtract) {
+    schedulingRules = ptExtract.remainingRules;
+    notes.push(...ptExtract.notes);
+  }
+
+  const pwExtract = extractPassword(schedulingRules);
+  if (pwExtract) {
+    schedulingRules = pwExtract.remainingRules;
+    notes.push(...pwExtract.notes);
+  }
+
+  if (hasAccessGaps(schedulingRules)) {
+    return {
+      errors: ['Non-contiguous access windows are not supported.'],
+      notes,
+      hasUidRules,
+      accessControl: null,
+    };
+  }
+
+  if (hasNonMonotonicCredit(schedulingRules)) {
+    return {
+      errors: ['Credit must be non-increasing over time.'],
+      notes,
+      hasUidRules,
+      accessControl: null,
+    };
+  }
+
+  if (hasPracticeBeforeRelease(schedulingRules)) {
+    return {
+      errors: [
+        'Practice windows before the assessment opens are not supported. Practice is only allowed after the assessment closes.',
+      ],
+      notes,
+      hasUidRules,
+      accessControl: null,
+    };
+  }
+
+  const hasCreditRules = schedulingRules.some((r) => (r.credit ?? 0) > 0);
+  const hasModeOnly =
+    !hasCreditRules &&
+    schedulingRules.some((r) => r.mode) &&
+    schedulingRules.every(
+      (r) =>
+        (r.credit ?? 0) === 0 &&
+        (r.active ?? true) &&
+        !r.startDate &&
+        !r.endDate &&
+        !r.showClosedAssessment &&
+        !r.showClosedAssessmentScore,
+    );
+  if (hasModeOnly && !ptExtract) {
+    return {
+      errors: ['Mode-only access rules are not supported.'],
+      notes,
+      hasUidRules,
+      accessControl: null,
+    };
+  }
+
+  const { dateControl, errors, notes: builderNotes } = buildCreditTimeline(schedulingRules);
+  notes.push(...builderNotes);
+
+  if (errors.length > 0) {
+    return { errors, notes, hasUidRules, accessControl: null };
+  }
+
+  const questionReviewWindowCount = getQuestionReviewWindows(schedulingRules).length;
+  if (questionReviewWindowCount > 1) {
+    notes.push(
+      `${questionReviewWindowCount} completed-question review windows collapsed into a single visibility window.`,
+    );
+  }
+
+  // No-op detection: when nothing produced a dateControl, password, or
+  // PrairieTest config, the rules collapse to a no-op. Suppress the note if
+  // the rules were intentionally hidden via `active: false`.
+  if (!dateControl && !ptExtract && !pwExtract) {
+    const isHidden = schedulingRules.some((r) => (r.active ?? true) === false);
+    if (!isHidden) {
+      notes.push('An empty accessControl list signifies that no access is granted.');
+    }
+  }
+
+  const visibilityMigration = buildVisibilityMigration(schedulingRules);
+  notes.push(...visibilityMigration.notes);
+
+  const accessControl = assembleAccessControl({
+    schedulingRules,
+    ptExtract,
+    pwExtract,
+    dateControl,
+    visibilityMigration,
+    fallbackReleaseDate,
+  });
+  const validationErrors = validateMigratedAccessControl(accessControl);
+  if (validationErrors.length > 0) {
+    return { errors: validationErrors, notes, hasUidRules, accessControl: null };
+  }
+
+  return {
+    errors: [],
+    notes,
+    hasUidRules,
+    accessControl,
+  };
+}
+
+export function migrateAllowAccess(
+  rules: AssessmentAccessRuleJson[],
+  fallbackReleaseDate: string,
+): Migration {
+  const { accessControl, errors, notes, hasUidRules } = analyzeAllowAccess(
+    rules,
+    fallbackReleaseDate,
+  );
+  return { accessControl: accessControl ?? {}, errors, notes, hasUidRules };
 }
 
 // ---------------------------------------------------------------------------
@@ -1050,6 +1059,7 @@ export function migrateAssessmentJson(
 export async function analyzeAssessmentFile(
   filePath: string,
   tid: string,
+  fallbackReleaseDate: string,
 ): Promise<AssessmentMigrationAnalysis | null> {
   let data: Record<string, unknown>;
   try {
@@ -1068,7 +1078,7 @@ export async function analyzeAssessmentFile(
     return null;
   }
 
-  const { errors, notes, hasUidRules } = analyzeAllowAccess(allowAccess);
+  const { errors, notes, hasUidRules } = analyzeAllowAccess(allowAccess, fallbackReleaseDate);
 
   return {
     tid,
@@ -1083,6 +1093,7 @@ export async function analyzeAssessmentFile(
 
 export async function analyzeCourseInstanceAssessments(
   courseInstancePath: string,
+  fallbackReleaseDate: string,
 ): Promise<CourseInstanceMigrationAnalysis> {
   const assessmentsPath = path.join(courseInstancePath, 'assessments');
   const assessments: AssessmentMigrationAnalysis[] = [];
@@ -1090,7 +1101,7 @@ export async function analyzeCourseInstanceAssessments(
   const assessmentDirs = await discoverInfoDirs(assessmentsPath, 'infoAssessment.json');
   for (const dir of assessmentDirs) {
     const infoPath = path.join(assessmentsPath, dir, 'infoAssessment.json');
-    const analysis = await analyzeAssessmentFile(infoPath, dir);
+    const analysis = await analyzeAssessmentFile(infoPath, dir, fallbackReleaseDate);
     if (analysis) {
       assessments.push(analysis);
     }

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -32,7 +32,11 @@ import { getAfterCompleteCrossFieldIssue, validateAccessControlRules } from './v
 // ---------------------------------------------------------------------------
 
 export interface Migration {
-  accessControl: AccessControlJsonInput;
+  /**
+   * Fully assembled migrated access control. `null` when the migration failed
+   * (errors is non-empty).
+   */
+  accessControl: AccessControlJsonInput | null;
   errors: string[];
   notes: string[];
   hasUidRules: boolean;
@@ -820,13 +824,6 @@ function extractPrairieTest(rules: AssessmentAccessRuleJson[]): {
 // Main migration pipeline
 // ---------------------------------------------------------------------------
 
-interface Analysis {
-  errors: string[];
-  notes: string[];
-  hasUidRules: boolean;
-  accessControl: AccessControlJsonInput | null;
-}
-
 function assembleAccessControl({
   schedulingRules,
   ptExtract,
@@ -891,15 +888,14 @@ function validateMigratedAccessControl(accessControl: AccessControlJsonInput): s
 }
 
 /**
- * Runs the diagnostic phase of the migration: normalization, orthogonal-concern
- * extraction, precondition checks, credit-timeline construction, and final
- * accessControl validation. Use this when the caller wants to know whether the
- * migration would succeed and what notes/UID-rule warnings to surface.
+ * Runs the allowAccess migration pipeline: normalization, orthogonal-concern
+ * extraction, precondition checks, credit-timeline construction, final
+ * accessControl assembly, and final accessControl validation.
  */
-function analyzeAllowAccess(
+export function migrateAllowAccess(
   rules: AssessmentAccessRuleJson[],
   fallbackReleaseDate: string,
-): Analysis {
+): Migration {
   const hasUidRules = rules.some((r) => r.uids);
   rules = normalizeRules(rules);
 
@@ -1011,27 +1007,13 @@ function analyzeAllowAccess(
     fallbackReleaseDate,
   });
   const validationErrors = validateMigratedAccessControl(accessControl);
-  if (validationErrors.length > 0) {
-    return { errors: validationErrors, notes, hasUidRules, accessControl: null };
-  }
 
   return {
-    errors: [],
+    errors: validationErrors,
     notes,
     hasUidRules,
-    accessControl,
+    accessControl: validationErrors.length > 0 ? null : accessControl,
   };
-}
-
-export function migrateAllowAccess(
-  rules: AssessmentAccessRuleJson[],
-  fallbackReleaseDate: string,
-): Migration {
-  const { accessControl, errors, notes, hasUidRules } = analyzeAllowAccess(
-    rules,
-    fallbackReleaseDate,
-  );
-  return { accessControl: accessControl ?? {}, errors, notes, hasUidRules };
 }
 
 // ---------------------------------------------------------------------------
@@ -1049,7 +1031,7 @@ export function migrateAssessmentJson(
 
   const { accessControl, errors, notes } = migrateAllowAccess(allowAccess, fallbackReleaseDate);
 
-  if (errors.length > 0) return null;
+  if (errors.length > 0 || accessControl == null) return null;
 
   data.accessControl = [accessControl];
   delete data.allowAccess;
@@ -1078,7 +1060,7 @@ export async function analyzeAssessmentFile(
     return null;
   }
 
-  const { errors, notes, hasUidRules } = analyzeAllowAccess(allowAccess, fallbackReleaseDate);
+  const { errors, notes, hasUidRules } = migrateAllowAccess(allowAccess, fallbackReleaseDate);
 
   return {
     tid,
@@ -1144,7 +1126,7 @@ export async function applyMigrationToAssessmentFile(
       break;
     case 'migrate': {
       const { accessControl, errors } = migrateAllowAccess(allowAccess, fallbackReleaseDate);
-      if (errors.length === 0) {
+      if (errors.length === 0 && accessControl != null) {
         data.accessControl = [accessControl];
         delete data.allowAccess;
       } else if (clearIncompatible) {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.ts
@@ -140,9 +140,12 @@ router.get(
     } | null = null;
 
     if (enhancedAccessControlEnabled) {
-      migrationAnalysis = await analyzeAssessmentFile(assessmentPath, res.locals.assessment.tid!);
-
       const fallbackReleaseDate = todayAsDatetimeLocal(res.locals.course_instance.display_timezone);
+      migrationAnalysis = await analyzeAssessmentFile(
+        assessmentPath,
+        res.locals.assessment.tid!,
+        fallbackReleaseDate,
+      );
 
       if (migrationAnalysis?.errors.length === 0) {
         const content = await fs.readFile(assessmentPath, 'utf-8');

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -62,12 +62,6 @@ export function CopyCourseInstanceModal({
   const [step, setStep] = useState<Step>('settings');
 
   const trpc = useTRPC();
-  const analysisQuery = useQuery(
-    trpc.instanceAdminSettings.analyzeAccessControl.queryOptions(undefined, {
-      enabled: enhancedAccessControlEnabled,
-    }),
-  );
-
   const methods = useForm<CopyFormValues>({
     defaultValues: {
       short_name: '',
@@ -93,6 +87,15 @@ export function CopyCourseInstanceModal({
   } = methods;
 
   const accessControlStrategy = useWatch({ control, name: 'access_control_strategy' });
+  const publishingStartDate = useWatch({ control, name: 'start_date' });
+  const analysisQuery = useQuery(
+    trpc.instanceAdminSettings.analyzeAccessControl.queryOptions(
+      { publishingStartDate: publishingStartDate || null },
+      {
+        enabled: enhancedAccessControlEnabled,
+      },
+    ),
+  );
 
   const analysisAppError = analysisQuery.isError
     ? getAppError<InstanceAdminSettingsError['AnalyzeAccessControl']>(analysisQuery.error)

--- a/apps/prairielearn/src/trpc/courseInstance/instance-admin-settings.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/instance-admin-settings.ts
@@ -1,6 +1,10 @@
 import * as path from 'path';
 
+import { Temporal } from '@js-temporal/polyfill';
 import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { DatetimeLocalStringSchema } from '@prairielearn/zod';
 
 import { analyzeCourseInstanceAssessments } from '../../lib/assessment-access-control/migration.js';
 
@@ -10,9 +14,15 @@ export interface InstanceAdminSettingsError {
   AnalyzeAccessControl: never;
 }
 
+function todayAsDatetimeLocal(timezone: string): string {
+  const today = Temporal.Now.plainDateISO(timezone);
+  return `${today.toString()}T00:00:00`;
+}
+
 const analyzeAccessControl = t.procedure
   .use(requireEnhancedAccessControl)
   .use(requireCoursePermissionEdit)
+  .input(z.object({ publishingStartDate: DatetimeLocalStringSchema.nullable() }))
   .query(async (opts) => {
     const shortName = opts.ctx.course_instance.short_name;
     if (!shortName) {
@@ -23,7 +33,11 @@ const analyzeAccessControl = t.procedure
       });
     }
     const courseInstancePath = path.join(opts.ctx.course.path, 'courseInstances', shortName);
-    return analyzeCourseInstanceAssessments(courseInstancePath);
+    return analyzeCourseInstanceAssessments(
+      courseInstancePath,
+      opts.input.publishingStartDate ??
+        todayAsDatetimeLocal(opts.ctx.course_instance.display_timezone),
+    );
   });
 
 export const instanceAdminSettingsRouter = t.router({


### PR DESCRIPTION
# Description

Refactors legacy allowAccess migration analysis so analysis and migration share the same assembled and validated accessControl path, removing the AnalysisResults intermediate and making migrateAllowAccess a thin wrapper.

Threads fallback release dates through assessment and course-instance analysis, with copy-course analysis accepting a pending publishing start date rather than a generic fallback date so diagnostics match real migration behavior.

- [x] I have disclosed the level of AI assistance used (majority of implementation by Codex at Nathan's request).

# Testing

Added focused migration coverage for fallback-date-sensitive final validation and preserved the existing migrateAllowAccess output cases.