### PR TITLE
Make copy access-control analysis lazy

### DIFF
--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -49,7 +49,7 @@ export function CopyCourseInstanceModal({
   courseInstance,
   courseShortName,
   isAdministrator,
-  enhancedAccessControlEnabled,
+  accessControlMigrationNeeded,
 }: {
   show: boolean;
   onHide: () => void;
@@ -57,7 +57,7 @@ export function CopyCourseInstanceModal({
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   courseShortName: string;
   isAdministrator: boolean;
-  enhancedAccessControlEnabled: boolean;
+  accessControlMigrationNeeded: boolean;
 }) {
   const [step, setStep] = useState<Step>('settings');
 
@@ -71,7 +71,7 @@ export function CopyCourseInstanceModal({
       self_enrollment_enabled: courseInstance.self_enrollment_enabled,
       self_enrollment_use_enrollment_code: courseInstance.self_enrollment_use_enrollment_code,
       course_instance_permission: isAdministrator ? 'None' : 'Student Data Editor',
-      access_control_strategy: enhancedAccessControlEnabled ? 'migrate' : 'keep',
+      access_control_strategy: accessControlMigrationNeeded ? 'migrate' : 'keep',
       clear_incompatible: true,
     },
     mode: 'onSubmit',
@@ -92,7 +92,7 @@ export function CopyCourseInstanceModal({
     trpc.instanceAdminSettings.analyzeAccessControl.queryOptions(
       { publishingStartDate: publishingStartDate || null },
       {
-        enabled: enhancedAccessControlEnabled,
+        enabled: show && step === 'access-control',
       },
     ),
   );
@@ -153,10 +153,10 @@ export function CopyCourseInstanceModal({
   };
 
   const handleSettingsNext = async () => {
-    const valid = await trigger(['short_name', 'long_name']);
+    const valid = await trigger(['short_name', 'long_name', 'start_date', 'end_date']);
     if (!valid) return;
 
-    if (enhancedAccessControlEnabled && (analysisAppError || analysisQuery.data?.hasLegacyRules)) {
+    if (accessControlMigrationNeeded) {
       setStep('access-control');
     } else {
       void handleSubmit((data) => copyMutation.mutate(data))();
@@ -226,18 +226,15 @@ export function CopyCourseInstanceModal({
             <button
               type="submit"
               className="btn btn-primary"
-              disabled={
-                isPending ||
-                (enhancedAccessControlEnabled && step === 'settings' && analysisQuery.isLoading)
-              }
+              disabled={isPending || (step === 'access-control' && analysisQuery.isFetching)}
             >
               {isPending
                 ? 'Copying...'
-                : enhancedAccessControlEnabled &&
-                    step === 'settings' &&
-                    (analysisAppError || analysisQuery.data?.hasLegacyRules)
-                  ? 'Next'
-                  : 'Copy course instance'}
+                : step === 'access-control' && analysisQuery.isFetching
+                  ? 'Analyzing...'
+                  : step === 'settings' && accessControlMigrationNeeded
+                    ? 'Review access control'
+                    : 'Copy course instance'}
             </button>
           </Modal.Footer>
         </form>
@@ -370,7 +367,7 @@ function AccessControlStep({
 }) {
   const analysis = analysisQuery.data;
 
-  if (analysisQuery.isLoading) {
+  if (analysisQuery.isFetching) {
     return (
       <Modal.Body className="text-center py-5">
         <Spinner animation="border" role="status">
@@ -388,6 +385,16 @@ function AccessControlStep({
   );
   const blockedAssessments = assessments.filter((a) => a.errors.length > 0);
   const showPreserveOption = accessControlStrategy === 'migrate' && (appError || !allCanMigrate);
+
+  if (!appError && assessments.length === 0) {
+    return (
+      <Modal.Body>
+        <Alert variant="info" className="mb-0">
+          No legacy access control rules were found. You can continue copying this course instance.
+        </Alert>
+      </Modal.Body>
+    );
+  }
 
   return (
     <Modal.Body>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -40,7 +40,7 @@ interface InstructorInstanceAdminSettingsProps {
   isAdministrator: boolean;
   nonPublicAssessmentsInCourseInstance: { id: string; tid: string }[];
   questionSharingEnabled: boolean;
-  enhancedAccessControlEnabled: boolean;
+  accessControlMigrationNeeded: boolean;
 }
 
 export function InstructorInstanceAdminSettings({
@@ -84,7 +84,7 @@ function InstructorInstanceAdminSettingsInner({
   isAdministrator,
   nonPublicAssessmentsInCourseInstance,
   questionSharingEnabled,
-  enhancedAccessControlEnabled,
+  accessControlMigrationNeeded,
 }: Omit<InstructorInstanceAdminSettingsProps, 'trpcCsrfToken' | 'isDevMode'>) {
   const [showCopyModal, setShowCopyModal] = useState(false);
 
@@ -130,7 +130,7 @@ function InstructorInstanceAdminSettingsInner({
         courseShortName={course.short_name}
         courseInstance={courseInstance}
         isAdministrator={isAdministrator}
-        enhancedAccessControlEnabled={enhancedAccessControlEnabled}
+        accessControlMigrationNeeded={accessControlMigrationNeeded}
         onHide={() => setShowCopyModal(false)}
       />
       <form

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.sql
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.sql
@@ -17,6 +17,19 @@ WHERE
   e.course_instance_id = $course_instance_id
   AND NOT users_is_instructor_in_course_instance (e.user_id, e.course_instance_id);
 
+-- BLOCK select_access_control_migration_needed
+SELECT
+  EXISTS (
+    SELECT
+      1
+    FROM
+      assessments AS a
+      JOIN assessment_access_rules AS aar ON aar.assessment_id = a.id
+    WHERE
+      a.course_instance_id = $course_instance_id
+      AND a.deleted_at IS NULL
+  ) AS migration_needed;
+
 -- BLOCK update_enrollment_code
 UPDATE course_instances
 SET

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -120,6 +120,14 @@ router.get(
       'enhanced-access-control',
       res.locals,
     );
+    const accessControlMigrationNeeded =
+      canEdit && enhancedAccessControlEnabled
+        ? await sqldb.queryScalar(
+            sql.select_access_control_migration_needed,
+            { course_instance_id: courseInstance.id },
+            z.boolean(),
+          )
+        : false;
 
     const trpcCsrfToken = generatePrefixCsrfToken(
       {
@@ -164,7 +172,7 @@ router.get(
                 isAdministrator={isAdministrator}
                 nonPublicAssessmentsInCourseInstance={nonPublicAssessmentsInCourseInstance}
                 questionSharingEnabled={questionSharingEnabled}
-                enhancedAccessControlEnabled={enhancedAccessControlEnabled}
+                accessControlMigrationNeeded={accessControlMigrationNeeded}
               />
             </Hydrate>
             <Hydrate>


### PR DESCRIPTION
# Description

This makes the copy course instance modal use a cheap settings-page query to decide whether access-control migration review is needed, instead of running full migration analysis while the hidden modal is mounted.
When legacy assessment access rules are present, the modal shows a Review access control step and runs detailed tRPC analysis only while that step is visible; modern-only copies go straight to copy.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Tested in the browser:

- I opened the copy modal for the `Sp15` course in the test course. The footer button showed "Review access control". Upon clicking it, a loading indicator showed briefly, then showed the results. I copied the course instance with the default settings.
- I then opened the copy modal for the new course instance I just copied. As expected, the footer button just prompted to copy because no migration was needed.
