### PR TITLE
Persist modern access-control sync errors

### DIFF
--- a/apps/prairielearn/src/sync/fromDisk/accessControl.ts
+++ b/apps/prairielearn/src/sync/fromDisk/accessControl.ts
@@ -233,7 +233,7 @@ export async function preValidateAccessControl(
  * Syncs access control rules for multiple assessments in a single sproc call.
  * Inputs must already have been checked with `preValidateAccessControl()`.
  */
-export async function syncAllAccessControl(
+export async function syncAccessControl(
   courseInstanceId: string,
   assessments: AccessControlSyncInput[],
 ): Promise<void> {

--- a/apps/prairielearn/src/sync/fromDisk/accessControl.ts
+++ b/apps/prairielearn/src/sync/fromDisk/accessControl.ts
@@ -207,7 +207,13 @@ async function selectInvalidExamUuids(
   return invalidExamUuids;
 }
 
-export async function preValidateAccessControl(
+/**
+ * Validates access-control constraints that depend on synced database rows and
+ * records any resulting errors on assessment infofiles. This must run after
+ * course instances and student labels are synced, but before assessments are
+ * synced, so `assessments.sync_errors` includes these errors.
+ */
+export async function validateAccessControl(
   courseInstanceId: string,
   assessments: CourseInstanceData['assessments'],
 ): Promise<void> {
@@ -231,7 +237,7 @@ export async function preValidateAccessControl(
 
 /**
  * Syncs access control rules for multiple assessments in a single sproc call.
- * Inputs must already have been checked with `preValidateAccessControl()`.
+ * Inputs must already have been checked with `validateAccessControl()`.
  */
 export async function syncAccessControl(
   courseInstanceId: string,

--- a/apps/prairielearn/src/sync/fromDisk/accessControl.ts
+++ b/apps/prairielearn/src/sync/fromDisk/accessControl.ts
@@ -5,6 +5,8 @@ import * as sqldb from '@prairielearn/postgres';
 import { config } from '../../lib/config.js';
 import { StudentLabelSchema } from '../../lib/db-types.js';
 import type { AccessControlJson } from '../../schemas/accessControl.js';
+import type { CourseInstanceData } from '../course-db.js';
+import * as infofile from '../infofile.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
@@ -165,71 +167,80 @@ export interface AccessControlSyncInput {
   rules: AccessControlJson[];
 }
 
-/**
- * Syncs access control rules for multiple assessments in a single sproc call.
- * Returns a map of assessmentId → error message for assessments that failed
- * validation. Assessments that fail validation are deliberately excluded from
- * the sproc call so their existing database rules are preserved. This is
- * consistent with how other sync operations handle errors: invalid new config
- * should not destroy valid existing state.
- *
- * Returns a map of assessment ID → error message for assessments that failed
- * validation. Callers should attach these to the in-memory assessment infofiles
- * via `infofile.addError()` so they appear in the sync job log (the same way
- * other late-discovered validation errors like invalid exam UUIDs are reported).
- */
-export async function syncAllAccessControl(
-  courseInstanceId: string,
-  assessments: AccessControlSyncInput[],
-): Promise<Map<string, string>> {
-  const errors = new Map<string, string>();
-  if (assessments.length === 0) return errors;
-
-  // Query student labels once for the whole course instance.
+async function selectStudentLabelIdByName(courseInstanceId: string): Promise<Map<string, string>> {
   const existingLabels = await sqldb.queryRows(
     sql.select_student_labels,
     { course_instance_id: courseInstanceId },
     StudentLabelSchema,
   );
-  const studentLabelIdByName = new Map(existingLabels.map((g) => [g.name, g.id]));
+  return new Map(existingLabels.map((g) => [g.name, g.id]));
+}
 
-  // Collect all exam UUIDs across all assessments and validate once.
+async function selectInvalidExamUuids(
+  assessments: { rules: AccessControlJson[] }[],
+): Promise<Set<string>> {
   const invalidExamUuids = new Set<string>();
-  if (config.checkAccessRulesExamUuid) {
-    const allExamUuids = new Set<string>();
-    for (const { rules } of assessments) {
-      for (const rule of rules) {
-        for (const e of rule.integrations?.prairieTest?.exams ?? []) {
-          if (UUID_REGEX.test(e.examUuid)) {
-            allExamUuids.add(e.examUuid);
-          }
+  if (!config.checkAccessRulesExamUuid) return invalidExamUuids;
+
+  const allExamUuids = new Set<string>();
+  for (const { rules } of assessments) {
+    for (const rule of rules) {
+      for (const e of rule.integrations?.prairieTest?.exams ?? []) {
+        if (UUID_REGEX.test(e.examUuid)) {
+          allExamUuids.add(e.examUuid);
         }
       }
     }
-
-    if (allExamUuids.size > 0) {
-      const examValidation = await sqldb.queryRows(
-        sql.check_exam_uuids_exist,
-        { exam_uuids: JSON.stringify([...allExamUuids]) },
-        z.object({ uuid: z.string(), uuid_exists: z.boolean() }),
-      );
-      for (const { uuid, uuid_exists } of examValidation) {
-        if (!uuid_exists) invalidExamUuids.add(uuid);
-      }
-    }
   }
 
-  // Per-assessment validation.
-  for (const { assessmentId, rules } of assessments) {
+  if (allExamUuids.size === 0) return invalidExamUuids;
+
+  const examValidation = await sqldb.queryRows(
+    sql.check_exam_uuids_exist,
+    { exam_uuids: JSON.stringify([...allExamUuids]) },
+    z.object({ uuid: z.string(), uuid_exists: z.boolean() }),
+  );
+  for (const { uuid, uuid_exists } of examValidation) {
+    if (!uuid_exists) invalidExamUuids.add(uuid);
+  }
+
+  return invalidExamUuids;
+}
+
+export async function preValidateAccessControl(
+  courseInstanceId: string,
+  assessments: CourseInstanceData['assessments'],
+): Promise<void> {
+  const validationTargets: { tid: string; rules: AccessControlJson[] }[] = [];
+  for (const [tid, assessment] of Object.entries(assessments)) {
+    if (infofile.hasErrors(assessment) || !assessment.data?.accessControl?.length) continue;
+    validationTargets.push({ tid, rules: assessment.data.accessControl });
+  }
+  if (validationTargets.length === 0) return;
+
+  const studentLabelIdByName = await selectStudentLabelIdByName(courseInstanceId);
+  const invalidExamUuids = await selectInvalidExamUuids(validationTargets);
+
+  for (const { tid, rules } of validationTargets) {
     const error = validateAssessmentRules(rules, studentLabelIdByName, invalidExamUuids);
     if (error) {
-      errors.set(assessmentId, error);
+      infofile.addError(assessments[tid], error);
     }
   }
+}
 
-  // Build batched data arrays. Assessments with validation errors are excluded
-  // entirely so their existing database rules are preserved (not cleaned up).
-  const validAssessmentIds: string[] = [];
+/**
+ * Syncs access control rules for multiple assessments in a single sproc call.
+ * Inputs must already have been checked with `preValidateAccessControl()`.
+ */
+export async function syncAllAccessControl(
+  courseInstanceId: string,
+  assessments: AccessControlSyncInput[],
+): Promise<void> {
+  if (assessments.length === 0) return;
+
+  const studentLabelIdByName = await selectStudentLabelIdByName(courseInstanceId);
+  const assessmentIds: string[] = [];
   const allRuleRows: string[] = [];
   const allStudentLabels: string[] = [];
   const allEarlyDeadlines: string[] = [];
@@ -237,8 +248,7 @@ export async function syncAllAccessControl(
   const allPrairietestExams: string[] = [];
 
   for (const { assessmentId, rules } of assessments) {
-    if (errors.has(assessmentId)) continue;
-    validAssessmentIds.push(assessmentId);
+    assessmentIds.push(assessmentId);
 
     for (let i = 0; i < rules.length; i++) {
       const { ruleRow, studentLabels, earlyDeadlines, lateDeadlines, prairietestExams } =
@@ -256,7 +266,7 @@ export async function syncAllAccessControl(
     'sync_access_control',
     [
       courseInstanceId,
-      validAssessmentIds,
+      assessmentIds,
       allRuleRows,
       allStudentLabels,
       allEarlyDeadlines,
@@ -265,6 +275,4 @@ export async function syncAllAccessControl(
     ],
     z.unknown(),
   );
-
-  return errors;
 }

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -3,7 +3,6 @@ import assert from 'node:assert';
 import async from 'async';
 
 import * as namedLocks from '@prairielearn/named-locks';
-import { runInTransactionAsync } from '@prairielearn/postgres';
 
 import { chalk } from '../lib/chalk.js';
 import { config } from '../lib/config.js';
@@ -23,7 +22,7 @@ import * as courseDB from './course-db.js';
 import {
   type AccessControlSyncInput,
   preValidateAccessControl,
-  syncAllAccessControl,
+  syncAccessControl,
 } from './fromDisk/accessControl.js';
 import * as syncAssessmentModules from './fromDisk/assessmentModules.js';
 import * as syncAssessmentSets from './fromDisk/assessmentSets.js';
@@ -253,9 +252,7 @@ export async function syncDiskToSqlWithLock(
                 inputs.push({ assessmentId, rules: assessment.data?.accessControl ?? [] });
               }
 
-              await runInTransactionAsync(async () => {
-                await syncAllAccessControl(courseInstanceId, inputs);
-              });
+              await syncAccessControl(courseInstanceId, inputs);
             });
           }
         },

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -172,10 +172,6 @@ export async function syncDiskToSqlWithLock(
     );
 
     await timed('Synced authors', () => syncAuthors.sync(courseData.questions, questionIds));
-    const enhancedAccessControlEnabled = await features.enabled('enhanced-access-control', {
-      institution_id: course.institution_id,
-      course_id: course.id,
-    });
     // We need to perform sharing validation at exactly this moment. We can only
     // do this once we have a dictionary of question IDs, as this process will also
     // populate any shared questions in that dictionary. We also need to do it before
@@ -197,7 +193,15 @@ export async function syncDiskToSqlWithLock(
         );
       });
     });
+
+    const enhancedAccessControlEnabled = await features.enabled('enhanced-access-control', {
+      institution_id: course.institution_id,
+      course_id: course.id,
+    });
     if (enhancedAccessControlEnabled) {
+      // We do this independently of the process of syncing the access control
+      // rules themselves so that this will add any relevant errors to the assessment's
+      // infofile so that they're present when we sync the assessments.
       await timed('Pre-validated access control', async () => {
         await async.eachLimit(
           Object.entries(courseData.courseInstances),

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -20,7 +20,11 @@ import {
 import { flushElementCache } from '../question-servers/freeform.js';
 
 import * as courseDB from './course-db.js';
-import { type AccessControlSyncInput, syncAllAccessControl } from './fromDisk/accessControl.js';
+import {
+  type AccessControlSyncInput,
+  preValidateAccessControl,
+  syncAllAccessControl,
+} from './fromDisk/accessControl.js';
 import * as syncAssessmentModules from './fromDisk/assessmentModules.js';
 import * as syncAssessmentSets from './fromDisk/assessmentSets.js';
 import * as syncAssessments from './fromDisk/assessments.js';
@@ -168,6 +172,10 @@ export async function syncDiskToSqlWithLock(
     );
 
     await timed('Synced authors', () => syncAuthors.sync(courseData.questions, questionIds));
+    const enhancedAccessControlEnabled = await features.enabled('enhanced-access-control', {
+      institution_id: course.institution_id,
+      course_id: course.id,
+    });
     // We need to perform sharing validation at exactly this moment. We can only
     // do this once we have a dictionary of question IDs, as this process will also
     // populate any shared questions in that dictionary. We also need to do it before
@@ -189,6 +197,17 @@ export async function syncDiskToSqlWithLock(
         );
       });
     });
+    if (enhancedAccessControlEnabled) {
+      await timed('Pre-validated access control', async () => {
+        await async.eachLimit(
+          Object.entries(courseData.courseInstances),
+          3,
+          async ([ciid, { assessments }]) => {
+            await preValidateAccessControl(courseInstanceIds[ciid], assessments);
+          },
+        );
+      });
+    }
 
     await timed('Synced sharing sets', () =>
       syncSharingSets.sync(course.id, courseData, questionIds),
@@ -198,10 +217,6 @@ export async function syncDiskToSqlWithLock(
     await timed('Synced assessment modules', () =>
       syncAssessmentModules.sync(course.id, courseData),
     );
-    const enhancedAccessControlEnabled = await features.enabled('enhanced-access-control', {
-      institution_id: course.institution_id,
-      course_id: course.id,
-    });
     await timed('Synced all assessments', async () => {
       // Ensure that a single course with a ton of course instances can't
       // monopolize the database connection pool.
@@ -228,27 +243,14 @@ export async function syncDiskToSqlWithLock(
                 const assessmentId = idMap[tid];
                 if (!assessmentId) continue;
 
-                const accessControlRules = assessment.data?.accessControl;
                 if (infofile.hasErrors(assessment)) {
                   continue;
                 }
-                if (!accessControlRules) {
-                  inputs.push({ assessmentId, rules: [] });
-                } else {
-                  inputs.push({ assessmentId, rules: accessControlRules });
-                }
+                inputs.push({ assessmentId, rules: assessment.data?.accessControl ?? [] });
               }
 
               await runInTransactionAsync(async () => {
-                const validationErrors = await syncAllAccessControl(courseInstanceId, inputs);
-                for (const [tid, assessment] of Object.entries(courseInstanceData.assessments)) {
-                  const assessmentId = idMap[tid];
-                  if (!assessmentId) continue;
-                  const error = validationErrors.get(assessmentId);
-                  if (error) {
-                    infofile.addError(assessment, error);
-                  }
-                }
+                await syncAllAccessControl(courseInstanceId, inputs);
               });
             });
           }

--- a/apps/prairielearn/src/sync/syncFromDisk.ts
+++ b/apps/prairielearn/src/sync/syncFromDisk.ts
@@ -21,8 +21,8 @@ import { flushElementCache } from '../question-servers/freeform.js';
 import * as courseDB from './course-db.js';
 import {
   type AccessControlSyncInput,
-  preValidateAccessControl,
   syncAccessControl,
+  validateAccessControl,
 } from './fromDisk/accessControl.js';
 import * as syncAssessmentModules from './fromDisk/assessmentModules.js';
 import * as syncAssessmentSets from './fromDisk/assessmentSets.js';
@@ -198,15 +198,12 @@ export async function syncDiskToSqlWithLock(
       course_id: course.id,
     });
     if (enhancedAccessControlEnabled) {
-      // We do this independently of the process of syncing the access control
-      // rules themselves so that this will add any relevant errors to the assessment's
-      // infofile so that they're present when we sync the assessments.
-      await timed('Pre-validated access control', async () => {
+      await timed('Validated access control', async () => {
         await async.eachLimit(
           Object.entries(courseData.courseInstances),
           3,
           async ([ciid, { assessments }]) => {
-            await preValidateAccessControl(courseInstanceIds[ciid], assessments);
+            await validateAccessControl(courseInstanceIds[ciid], assessments);
           },
         );
       });

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -1345,7 +1345,7 @@ describe('Access control syncing', () => {
       runInTransactionAndRollback(() =>
         withConfig({ checkAccessRulesExamUuid: true }, async () => {
           const fakeUuid = '00000000-0000-0000-0000-000000000000';
-          const { syncedRules } = await syncRulesAndRead([
+          const { syncedRules, errors } = await syncRulesAndRead([
             makeAccessControlRule({
               dateControl: undefined,
               integrations: {
@@ -1356,6 +1356,7 @@ describe('Access control syncing', () => {
             }),
           ]);
           assert.equal(syncedRules.length, 0);
+          assert.isTrue(errors.some((e) => e.includes('Invalid PrairieTest exam UUID(s)')));
 
           const assessment = await getAssessment(util.ASSESSMENT_ID);
           assert.isNotNull(assessment.sync_errors);

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -1199,6 +1199,10 @@ describe('Access control syncing', () => {
           );
         }
 
+        const assessment = await getAssessment(util.ASSESSMENT_ID);
+        assert.isNotNull(assessment.sync_errors);
+        assert.match(assessment.sync_errors, /Invalid student label\(s\): foobar/);
+
         const syncedRules = await findSyncedAccessControlRules(util.ASSESSMENT_ID);
         assert.equal(syncedRules.length, 0);
       }));
@@ -1367,6 +1371,10 @@ describe('Access control syncing', () => {
           ]);
           assert.equal(syncedRules.length, 0);
           assert.isTrue(errors.some((e) => e.includes('Invalid PrairieTest exam UUID(s)')));
+
+          const assessment = await getAssessment(util.ASSESSMENT_ID);
+          assert.isNotNull(assessment.sync_errors);
+          assert.match(assessment.sync_errors, /Invalid PrairieTest exam UUID\(s\)/);
         }),
       ));
 

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -1183,21 +1183,7 @@ describe('Access control syncing', () => {
           uuid: courseData.courseInstances[util.COURSE_INSTANCE_ID].courseInstance.uuid,
         });
 
-        const syncResults = await util.syncCourseData(courseDir);
-
-        assert.equal(syncResults.status, 'complete');
-        if (syncResults.status === 'complete') {
-          const courseInstance = syncResults.courseData.courseInstances[util.COURSE_INSTANCE_ID];
-          assert.isAbove(courseInstance.courseInstance.errors.length, 0);
-
-          const assessment = courseInstance.assessments[util.ASSESSMENT_ID];
-          assert.isTrue(
-            assessment.errors.some((error) => error.includes('Invalid student label(s): foobar')),
-          );
-          assert.isFalse(
-            assessment.errors.some((error) => error.includes('non-existent student labels')),
-          );
-        }
+        await util.syncCourseData(courseDir);
 
         const assessment = await getAssessment(util.ASSESSMENT_ID);
         assert.isNotNull(assessment.sync_errors);
@@ -1359,7 +1345,7 @@ describe('Access control syncing', () => {
       runInTransactionAndRollback(() =>
         withConfig({ checkAccessRulesExamUuid: true }, async () => {
           const fakeUuid = '00000000-0000-0000-0000-000000000000';
-          const { syncedRules, errors } = await syncRulesAndRead([
+          const { syncedRules } = await syncRulesAndRead([
             makeAccessControlRule({
               dateControl: undefined,
               integrations: {
@@ -1370,7 +1356,6 @@ describe('Access control syncing', () => {
             }),
           ]);
           assert.equal(syncedRules.length, 0);
-          assert.isTrue(errors.some((e) => e.includes('Invalid PrairieTest exam UUID(s)')));
 
           const assessment = await getAssessment(util.ASSESSMENT_ID);
           assert.isNotNull(assessment.sync_errors);


### PR DESCRIPTION
# Description

Modern access-control validation for student labels and PrairieTest UUIDs ran after `sync_assessments` had already persisted `assessments.sync_errors`, so save jobs could report JSON errors while the file editor saw no per-file sync errors. This moves those DB-dependent checks into a prevalidation step before assessment syncing, then lets normalized access-control table syncing operate on assessments that survived validation. Regression coverage now asserts invalid labels and invalid PrairieTest UUIDs are persisted to `assessments.sync_errors`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
- AI assistance: majority of implementation.

# Testing

Focused access-control sync tests pass locally and cover the affected persisted-error cases.
