### PR TITLE
Deduplicate access control validation messages

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -702,6 +702,24 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
+      name: 'visibility-only inactive rule reports one completion mechanism error',
+      rules: [
+        {
+          showClosedAssessment: false,
+          showClosedAssessmentScore: false,
+          active: false,
+        },
+      ],
+      expected: {
+        accessControl: null,
+        errors: [
+          'After-complete settings require a deadline, duration limit, or PrairieTest exam.',
+        ],
+        notes: [],
+        hasUidRules: false,
+      },
+    },
+    {
       name: 'separate reveal dates for questions and scores',
       rules: [
         {

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -1157,11 +1157,10 @@ export function validateAccessControlRules({
     // Run the "no completion mechanism" check before the cross-field check,
     // matching the form-side validator. The mechanism error is more
     // fundamental (cross-field consistency is moot when there's no completion
-    // mechanism at all), so surface it first. Errors here are concatenated
-    // rather than deduped by path, so this is purely presentational.
+    // mechanism at all), so surface it first.
     ...validateGlobalAfterCompleteIssues(validationRules).map((issue) => issue.message),
     ...validateAfterCompleteCrossFieldIssues(validationRules).map((issue) => issue.message),
   );
 
-  return { errors, warnings };
+  return { errors: [...new Set(errors)], warnings: [...new Set(warnings)] };
 }


### PR DESCRIPTION
# Description

Deduplicates access-control validation errors and warnings before returning them from `validateAccessControlRules`, so migration previews do not show the same after-complete completion-mechanism message twice. The duplicate happened because the issue-level validator emitted separate question and score issues, but migration displayed only message strings. Adds a regression test for a visibility-only inactive legacy `allowAccess` rule with both `showClosedAssessment` flags set to false.

Implemented by Codex.

# Testing

Added regression coverage for the legacy visibility-only inactive rule that previously produced duplicate after-complete errors.
