### PR TITLE
Increase student label limit to 100

### DIFF
--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { CommentJsonSchema } from './comment.js';
 import { ColorJsonSchema } from './infoCourse.js';
 
-export const MAX_STUDENT_LABELS_PER_COURSE_INSTANCE = 25;
+export const MAX_STUDENT_LABELS_PER_COURSE_INSTANCE = 100;
 
 const AccessRuleJsonSchema = z
   .object({

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -159,7 +159,7 @@
           }
         }
       },
-      "maxItems": 25
+      "maxItems": 100
     }
   },
   "definitions": {

--- a/docs/courseInstance/index.md
+++ b/docs/courseInstance/index.md
@@ -270,7 +270,7 @@ Allowable timezones are those in the TZ column in the [list of tz database time 
 
 ## Student labels
 
-Student labels let you organize students with colored badges. Use them for sections, TA assignments, accommodations, or any other grouping. Each course instance can have up to 25 student labels.
+Student labels let you organize students with colored badges. Use them for sections, TA assignments, accommodations, or any other grouping. Each course instance can have up to 100 student labels.
 
 To review configured labels and their assigned students, go to **Students → Labels**. Users with student data viewer access can view that page. Users who have both course editor and student data editor access can create, rename, delete, and assign labels there by entering UIDs. Student data editors can also apply existing labels from the main Students page using batch actions, or from an individual student's page.
 


### PR DESCRIPTION
# Description

Increases the per-course-instance student label limit from 25 to 100 across the course instance schema, generated JSON schema, and docs. This lets instructors configure more labels for sections, TA assignments, accommodations, or other student groupings without hitting the previous cap.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Level: majority of implementation.

# Testing

Ran the focused student-label integration test suite covering label operations and limit enforcement.
