### PR TITLE
Fix empty student override targets

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
@@ -6,6 +6,7 @@ import {
   type OverrideData,
   formDataToJson,
   jsonToDefaultRuleFormData,
+  jsonToOverrideFormData,
 } from './types.js';
 
 const TEST_TIMEZONE = 'America/Chicago';
@@ -227,6 +228,28 @@ describe('formDataToJson', () => {
     expect(overrideJson.enrollments).toEqual([
       { enrollmentId: 'e-1', uid: 'user@test.com', name: 'Test User' },
     ]);
+    expect(overrideJson.labels).toBeUndefined();
+  });
+
+  it('round-trips enrollment appliesTo with no selected students', () => {
+    const formData = jsonToOverrideFormData(
+      {
+        id: '1',
+        ruleType: 'enrollment',
+        enrollments: [],
+      },
+      TEST_TIMEZONE,
+    );
+
+    expect(formData.appliesTo).toEqual({
+      targetType: 'enrollment',
+      enrollments: [],
+      studentLabels: [],
+    });
+
+    const overrideJson = formDataToJson(buildFormData(formData))[1];
+    expect(overrideJson.ruleType).toBe('enrollment');
+    expect(overrideJson.enrollments).toEqual([]);
     expect(overrideJson.labels).toBeUndefined();
   });
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -275,10 +275,10 @@ export function jsonToOverrideFormData(
   const ac = json.afterComplete;
 
   let appliesTo: AppliesTo;
-  if (json.ruleType === 'enrollment' && json.enrollments && json.enrollments.length > 0) {
+  if (json.ruleType === 'enrollment') {
     appliesTo = {
       targetType: 'enrollment',
-      enrollments: json.enrollments.map((i) => ({
+      enrollments: (json.enrollments ?? []).map((i) => ({
         enrollmentId: i.enrollmentId,
         uid: i.uid,
         name: i.name,


### PR DESCRIPTION
# Description

This fixes the access-control override editor so a saved student-specific override with no selected students stays targeted at specific students after reload instead of being interpreted as a student-label override. The root cause was `jsonToOverrideFormData` only honoring `ruleType: 'enrollment'` when the enrollment list was non-empty, even though the server persists empty enrollment-targeted rules as `ruleType: 'enrollment'`.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

Added a regression test for the empty enrollment-targeted override round trip.