### PR TITLE
Remove override deletion confirmation

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { Alert, Button, Form, Modal } from 'react-bootstrap';
+import { Alert, Form } from 'react-bootstrap';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 
-import { SplitPane, StickySaveBar, type StickySaveBarAlert, useModalState } from '@prairielearn/ui';
+import { SplitPane, StickySaveBar, type StickySaveBarAlert } from '@prairielearn/ui';
 
 import type { PageContext } from '../../../lib/client/page-context.js';
 import type {
@@ -66,7 +66,6 @@ export function AccessControlForm({
   hiddenEnrollmentRuleCount: number;
 }) {
   const [selectedRule, setSelectedRule] = useState<SelectedRule>(null);
-  const deleteModal = useModalState<{ index: number; name: string }>();
 
   const displayTimezone = courseInstance.display_timezone;
   const defaultRule = initialData[0]
@@ -189,23 +188,15 @@ export function AccessControlForm({
     setSelectedRule({ type: 'override', index: newIndex });
   };
 
-  const handleDeleteClick = (index: number) => {
-    deleteModal.showWithData({ index, name: getOverrideName(index) });
-  };
-
-  const handleDeleteConfirm = () => {
-    if (deleteModal.data !== null) {
-      const deletedIndex = deleteModal.data.index;
-      if (selectedRule?.type === 'override') {
-        if (selectedRule.index === deletedIndex) {
-          setSelectedRule(null);
-        } else if (selectedRule.index > deletedIndex) {
-          setSelectedRule({ type: 'override', index: selectedRule.index - 1 });
-        }
+  const handleDeleteOverride = (deletedIndex: number) => {
+    if (selectedRule?.type === 'override') {
+      if (selectedRule.index === deletedIndex) {
+        setSelectedRule(null);
+      } else if (selectedRule.index > deletedIndex) {
+        setSelectedRule({ type: 'override', index: selectedRule.index - 1 });
       }
-      removeOverride(deletedIndex);
     }
-    deleteModal.hide();
+    removeOverride(deletedIndex);
   };
 
   const handleMoveOverride = (fromIndex: number, toIndex: number) => {
@@ -372,7 +363,7 @@ export function AccessControlForm({
                     readOnlyMessage={readOnlyMessage}
                     hiddenEnrollmentRuleCount={hiddenEnrollmentRuleCount}
                     onAddOverride={addOverride}
-                    onRemoveOverride={handleDeleteClick}
+                    onRemoveOverride={handleDeleteOverride}
                     onMoveOverride={handleMoveOverride}
                     onEditDefaultRule={() => setSelectedRule({ type: 'default' })}
                     onClearDefaultRule={() =>
@@ -411,24 +402,6 @@ export function AccessControlForm({
           onClose={() => setSelectedRule(null)}
         />
       </Form>
-
-      <Modal show={deleteModal.show} onHide={deleteModal.hide}>
-        <Modal.Header closeButton>
-          <Modal.Title>Delete override</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          Are you sure you want to delete &quot;{deleteModal.data?.name ?? ''}&quot;? This action
-          cannot be undone.
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary" onClick={deleteModal.hide}>
-            Cancel
-          </Button>
-          <Button variant="danger" onClick={handleDeleteConfirm}>
-            Delete
-          </Button>
-        </Modal.Footer>
-      </Modal>
     </FormProvider>
   );
 }

--- a/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
@@ -49,11 +49,6 @@ function getDetailPanel(page: Page): Locator {
   return page.locator('#pl-ui-split-pane-detail');
 }
 
-/** Returns the currently visible modal dialog (e.g. delete confirmation). */
-function getVisibleModal(page: Page): Locator {
-  return page.locator('[aria-modal="true"]');
-}
-
 /** Returns the override card containing the given label text. */
 function getOverrideCard(page: Page, labelText: string): Locator {
   return page.getByTestId('override-card').filter({ hasText: labelText });
@@ -169,17 +164,7 @@ test.describe('Access control UI', () => {
     const initialRecords = await getAccessControlRecords(assessment.id);
     const initialOverrideCount = initialRecords.filter((r) => r.number > 0).length;
 
-    // Click "Remove" on the Section A override
     await sectionACard.getByRole('button', { name: /Remove/i }).click();
-
-    // Confirm deletion in modal
-    const modal = getVisibleModal(page);
-    await expect(modal).toBeVisible();
-    await expect(modal.getByText('Delete override')).toBeVisible();
-    await modal.getByRole('button', { name: 'Delete' }).click();
-    await expect(modal).not.toBeVisible();
-
-    // Verify card removed from page
     await expect(page.getByText('No overrides configured')).toBeVisible();
 
     // Save


### PR DESCRIPTION
# Description

Removes the per-override deletion confirmation modal from the modern access control editor so clicking Remove deletes the override immediately from the pending form state. The existing selected-rule bookkeeping is preserved so the detail panel closes or shifts when the deleted override was selected.

Rationale: the "cannot be undone" warning is too strong for something that (a) won't actually be committed until "Save" is clicked, and (b) which can be undone by clicking "Cancel".

# Testing

Tested in the browser, it works correctly.