### PR TITLE
Clarify question user identity docs

### DIFF
--- a/apps/prairielearn/src/schemas/infoCourse.ts
+++ b/apps/prairielearn/src/schemas/infoCourse.ts
@@ -105,7 +105,7 @@ const CourseOptionsJsonSchema = z
     questionsReceiveUserData: z
       .boolean()
       .describe(
-        'If true, server.py will receive information about the viewing user (uid, uin, name) and group (if applicable) via `data["options"]["user"]` and `data["options"]["group"]`. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. In production, this value is authoritative in the database and managed via course settings; this field emits a sync warning if it diverges.',
+        'If true, server.py receives the variant owner\'s identity (uid, uin, name) and group data (if applicable) via `data["options"]["user"]` and `data["options"]["group"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. In production, course settings control the database value; if this JSON field differs from the database value, sync reports a warning.',
       )
       .optional(),
   })

--- a/apps/prairielearn/src/schemas/infoCourse.ts
+++ b/apps/prairielearn/src/schemas/infoCourse.ts
@@ -105,7 +105,7 @@ const CourseOptionsJsonSchema = z
     questionsReceiveUserData: z
       .boolean()
       .describe(
-        'If true, server.py receives the variant owner\'s identity (uid, uin, name) and group data (if applicable) via `data["options"]["user"]` and `data["options"]["group"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. In production, course settings control the database value; if this JSON field differs from the database value, sync reports a warning.',
+        'If true, server.py receives the variant owner\'s identity (UID, UIN, name) and group data (if applicable) via `data["options"]["user"]` and `data["options"]["group"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. This JSON setting is honored only in development mode. In production, configure this on the course settings page; sync reports a warning if the JSON value differs from the production setting.',
       )
       .optional(),
   })

--- a/apps/prairielearn/src/schemas/schemas/infoCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourse.json
@@ -62,7 +62,7 @@
           ]
         },
         "questionsReceiveUserData": {
-          "description": "If true, server.py receives the variant owner's identity (uid, uin, name) and group data (if applicable) via `data[\"options\"][\"user\"]` and `data[\"options\"][\"group\"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. In production, course settings control the database value; if this JSON field differs from the database value, sync reports a warning.",
+          "description": "If true, server.py receives the variant owner's identity (UID, UIN, name) and group data (if applicable) via `data[\"options\"][\"user\"]` and `data[\"options\"][\"group\"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. This JSON setting is honored only in development mode. In production, configure this on the course settings page; sync reports a warning if the JSON value differs from the production setting.",
           "type": "boolean"
         }
       },

--- a/apps/prairielearn/src/schemas/schemas/infoCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourse.json
@@ -62,7 +62,7 @@
           ]
         },
         "questionsReceiveUserData": {
-          "description": "If true, server.py will receive information about the viewing user (uid, uin, name) and group (if applicable) via `data[\"options\"][\"user\"]` and `data[\"options\"][\"group\"]`. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. In production, this value is authoritative in the database and managed via course settings; this field emits a sync warning if it diverges.",
+          "description": "If true, server.py receives the variant owner's identity (uid, uin, name) and group data (if applicable) via `data[\"options\"][\"user\"]` and `data[\"options\"][\"group\"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. In production, course settings control the database value; if this JSON field differs from the database value, sync reports a warning.",
           "type": "boolean"
         }
       },

--- a/docs/course/index.md
+++ b/docs/course/index.md
@@ -409,7 +409,7 @@ Allowable timezones are those in the TZ column in the [list of tz database time 
 
 ## Exposing user data to `server.py`
 
-By default, question `server.py` code does not receive identifying information about users or groups. A course can opt in so that `server.py` receives the identity (uid, uin, name) of the user who owns an individual variant through `data["options"]["user"]`, and group membership through `data["options"]["group"]` on group assessments. For group variants, `data["options"]["group"]` contains group membership and `data["options"]["user"]` is `None`. See the [`server.py` documentation](../question/server.md#accessing-user-and-group-identity) for the exact shape and access patterns.
+By default, question `server.py` code does not receive identifying information about users or groups. A course can opt in so that `server.py` receives the identity (UID, UIN, name) of the user who owns an individual variant through `data["options"]["user"]`, and group membership through `data["options"]["group"]` on group assessments. See the [`server.py` documentation](../question/server.md#accessing-user-and-group-identity) for the exact shape and access patterns.
 
 To enable this for a course, on the course settings page, check "Allow questions to access user identity".
 

--- a/docs/course/index.md
+++ b/docs/course/index.md
@@ -409,7 +409,7 @@ Allowable timezones are those in the TZ column in the [list of tz database time 
 
 ## Exposing user data to `server.py`
 
-By default, questions cannot see who is working on them. A course can opt in to passing the identity (uid, uin, name) of the student who owns the variant into `server.py` through `data["options"]["user"]`, and the group membership through `data["options"]["group"]` on group assessments. See the [`server.py` documentation](../question/server.md#accessing-user-and-group-identity) for the exact shape and access patterns.
+By default, question `server.py` code does not receive identifying information about users or groups. A course can opt in so that `server.py` receives the identity (uid, uin, name) of the user who owns an individual variant through `data["options"]["user"]`, and group membership through `data["options"]["group"]` on group assessments. For group variants, `data["options"]["group"]` contains group membership and `data["options"]["user"]` is `None`. See the [`server.py` documentation](../question/server.md#accessing-user-and-group-identity) for the exact shape and access patterns.
 
 To enable this for a course, on the course settings page, check "Allow questions to access user identity".
 
@@ -423,7 +423,7 @@ If you are running in development mode, you can also add the following to `infoC
 }
 ```
 
-The JSON value is only used in development mode. Questions imported from another course (via public sharing or a sharing set) never receive user data, regardless of either course's settings.
+The JSON value is only used in development mode. For questions imported from another course (via public sharing or a sharing set), `server.py` never receives user data, regardless of either course's settings.
 
 ## Comments in JSON files
 

--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -412,9 +412,9 @@ Courses can opt in so that `server.py` receives user and group identity. A cours
 ```python
 def generate(data):
     user = data["options"]["user"]    # Variant owner; None on group assessments
-    # { "uid": "123", "uin": "123456", "name": "John Doe" }
+    # { "uid": "student@example.com", "uin": "123456", "name": "John Doe" }
     group = data["options"]["group"]  # None on individual assessments
-    # { "name": "Group 1", "members": [ { "uid": "123", "uin": "123456", "name": "John Doe" } ] }
+    # { "name": "Group 1", "members": [ { "uid": "student@example.com", "uin": "123456", "name": "John Doe" } ] }
 
     if user is not None:
         data["params"]["greeting"] = f"Hello, {user['name']}!"
@@ -431,7 +431,7 @@ The `group` dict has `name` and `members` (a list with the same shape as `user`)
 
     When a staff member opens a student variant (e.g., in manual grading or opening student view), the `user` corresponds to the student that owns the variant, not the staff member or current viewer. Group assessments receive `None` because the shared variant has no single owner.
 
-    A group's members can change over time: The members when a question was generated may be different than when a question is graded. Similarly, a user's name, uid, and uin may be different. The value of `options["user"]` and `options["group"]` will always reflect the latest information.
+    A group's members can change over time: the members when a question was generated may be different than when a question is graded. Similarly, a user's name, UID, and UIN may also change over time. The value of `options["user"]` and `options["group"]` will always reflect the latest information.
 
 User and group data are provided to `server.py` only when **all** of the following are true:
 

--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -407,11 +407,11 @@ The functions in `server.py` can also retrieve the content from various director
 
 ### Accessing user and group identity
 
-Courses can opt in to exposing user and group identity to `server.py`. A course owner can enable this on the course settings page. When enabled, `data["options"]` contains two extra keys -- `data["options"]["user"]` and `data["options"]["group"]`.
+Courses can opt in so that `server.py` receives user and group identity. A course owner can enable this on the course settings page. When enabled, `data["options"]` contains two extra keys: `data["options"]["user"]` and `data["options"]["group"]`.
 
 ```python
 def generate(data):
-    user = data["options"]["user"]    # None on group assessments
+    user = data["options"]["user"]    # Variant owner; None on group assessments
     # { "uid": "123", "uin": "123456", "name": "John Doe" }
     group = data["options"]["group"]  # None on individual assessments
     # { "name": "Group 1", "members": [ { "uid": "123", "uin": "123456", "name": "John Doe" } ] }
@@ -429,16 +429,16 @@ The `group` dict has `name` and `members` (a list with the same shape as `user`)
 
 ??? info "Whose identity is provided"
 
-    When a staff member opens a student variant (e.g., in manual grading or opening student view), the `user` corresponds to the student that owns the variant, not the staff member that is seeing the variant. Group assessments receive `None` because the shared variant has no single owner.
+    When a staff member opens a student variant (e.g., in manual grading or opening student view), the `user` corresponds to the student that owns the variant, not the staff member or current viewer. Group assessments receive `None` because the shared variant has no single owner.
 
     A group's members can change over time: The members when a question was generated may be different than when a question is graded. Similarly, a user's name, uid, and uin may be different. The value of `options["user"]` and `options["group"]` will always reflect the latest information.
 
-User and group data are passed only when **all** of the following are true:
+User and group data are provided to `server.py` only when **all** of the following are true:
 
-1. The course has opted in to exposing user data. In production, a course owner enables this on the course settings page; for local development, it can instead be set with `"questionsReceiveUserData": true` under `"options"` in `infoCourse.json`, which is honored only in development mode.
-2. The question is rendered in its owning course. Questions imported from another course via sharing (public or sharing set) never receive user data, regardless of either course's settings.
+1. The course has opted in so that `server.py` receives user data. In production, a course owner enables this on the course settings page; for local development, it can instead be set with `"questionsReceiveUserData": true` under `"options"` in `infoCourse.json`, which is honored only in development mode.
+2. The question is rendered in its owning course. For questions imported from another course via sharing (public or sharing set), `server.py` never receives user data, regardless of either course's settings.
 
-When user data is not passed to questions, `data["options"]["user"]` and `data["options"]["group"]` are both `None`. The keys are always present.
+When user data is not provided to `server.py`, `data["options"]["user"]` and `data["options"]["group"]` are both `None`. The keys are always present.
 
 ## Generating dynamic files with `file()`
 

--- a/testCourse/questions/userInfo/info.json
+++ b/testCourse/questions/userInfo/info.json
@@ -1,6 +1,6 @@
 {
   "uuid": "4dab92a4-d801-4276-9346-027b4ea92b24",
-  "title": "Show viewing user info from data['options']['user']",
+  "title": "Show variant owner info from data['options']['user']",
   "topic": "Test",
   "tags": ["v3"],
   "type": "v3"

--- a/testCourse/questions/userInfo/question.html
+++ b/testCourse/questions/userInfo/question.html
@@ -22,8 +22,8 @@
 
   {{^options.user}}
     <p>
-      No user data is available for this question. The course has not opted in, this is a group
-      variant, or this question was imported from another course via sharing.
+      No user data is available for this question. Either the course has not opted in, this is a
+      group variant, or this question was imported from another course via sharing.
     </p>
   {{/options.user}}
 

--- a/testCourse/questions/userInfo/question.html
+++ b/testCourse/questions/userInfo/question.html
@@ -1,17 +1,18 @@
 <pl-question-panel>
   <p>
-    This question shows the viewing user's identity, which the course exposes to questions via
-    <code>data['options']['user']</code>. The same data is available in <code>server.py</code>.
+    This question shows the variant owner's identity from <code>options.user</code>. The same data
+    is available in <code>server.py</code> as <code>data['options']['user']</code>; group variants
+    receive no user identity.
   </p>
   <p>
     See the
-    <a href="https://docs.prairielearn.com/question/server/#accessing-the-viewing-users-identity">
-      documentation on exposing user identity </a
+    <a href="https://docs.prairielearn.com/question/server/#accessing-user-and-group-identity">
+      documentation on user and group identity </a
     >for details.
   </p>
 
   {{#options.user}}
-    <h2>Viewing user</h2>
+    <h2>Variant owner</h2>
     <ul>
       <li>uid: <code>{{options.user.uid}}</code></li>
       <li>name: <code>{{options.user.name}}</code></li>
@@ -21,8 +22,8 @@
 
   {{^options.user}}
     <p>
-      No user data is available for this question. The course has not opted in, or this question was
-      imported from another course via sharing.
+      No user data is available for this question. The course has not opted in, this is a group
+      variant, or this question was imported from another course via sharing.
     </p>
   {{/options.user}}
 


### PR DESCRIPTION
# Description

Clarifies that question `server.py` user data identifies the variant owner rather than the current viewer, and that group variants provide group data without an individual user identity. Updates the course/server docs, the test course example, and the generated `infoCourse` schema description.

Codex drafted and refined the documentation changes in this PR.

# Testing

N/A
