### PR TITLE
Center assessment header switcher

### DIFF
--- a/apps/prairielearn/assets/stylesheets/pageLayout.css
+++ b/apps/prairielearn/assets/stylesheets/pageLayout.css
@@ -155,11 +155,23 @@ body:has(div.app-main-container) {
  * its vertical padding and soften the default `btn-ghost` gray.
  */
 .assessment-switcher-button.btn.btn-ghost {
-  --bs-btn-padding-y: 0.125rem;
+  --bs-btn-padding-y: 0;
   --bs-btn-hover-bg: rgba(var(--bs-secondary-rgb), 0.15);
   --bs-btn-hover-border-color: transparent;
   --bs-btn-active-bg: rgba(var(--bs-secondary-rgb), 0.25);
   --bs-btn-active-border-color: transparent;
+}
+
+.assessment-switcher-button .h6 {
+  line-height: 1.1;
+}
+
+.assessment-switcher-button .small {
+  line-height: 1.25;
+}
+
+.assessment-switcher-wrapper {
+  min-width: 0;
 }
 
 .assessment-navigation-container {
@@ -169,6 +181,7 @@ body:has(div.app-main-container) {
 
 .assessment-navigation-bar {
   flex-direction: column;
+  padding-top: 0.5rem;
   box-shadow: inset 0 -1px 0 var(--bs-border-color);
 }
 
@@ -187,6 +200,15 @@ body:has(div.app-main-container) {
   .assessment-navigation-bar {
     flex-direction: row;
     align-items: flex-end;
+    padding-top: 0;
+  }
+
+  .assessment-navigation-bar .pl-nav-tabs-bar {
+    padding-top: 0.5rem;
+  }
+
+  .assessment-navigation-bar .assessment-switcher-wrapper {
+    align-self: center;
   }
 
   .assessment-navigation-divider {

--- a/apps/prairielearn/src/components/AssessmentNavigation.tsx
+++ b/apps/prairielearn/src/components/AssessmentNavigation.tsx
@@ -29,7 +29,7 @@ export function AssessmentNavigation({
   embedded?: boolean;
 }) {
   return html`
-    <div class="${clsx(!embedded && 'bg-light pt-2 px-3')}" style="min-width: 0;">
+    <div class="${clsx('assessment-switcher-wrapper', !embedded && 'bg-light pt-2 px-3')}">
       <button
         type="button"
         class="btn btn-ghost text-start assessment-switcher-button"

--- a/apps/prairielearn/src/components/PageLayout.tsx
+++ b/apps/prairielearn/src/components/PageLayout.tsx
@@ -437,7 +437,7 @@ export function PageLayout({
                   return html`
                     <div class="assessment-navigation-container">
                       <div
-                        class="d-flex column-gap-2 row-gap-2 bg-light pt-2 px-3 assessment-navigation-bar"
+                        class="d-flex column-gap-2 row-gap-2 bg-light px-3 assessment-navigation-bar"
                       >
                         ${switcher}
                         <div class="vr assessment-navigation-divider align-self-stretch my-1"></div>

--- a/apps/prairielearn/src/lib/navPageTabs.ts
+++ b/apps/prairielearn/src/lib/navPageTabs.ts
@@ -145,17 +145,17 @@ export function getNavPageTabs() {
         tabLabel: 'Groups',
       },
       {
-        activeSubPage: 'questions',
-        urlSuffix: ({ assessment }) => `/assessment/${assessment.id}/questions`,
-        iconClasses: 'far fa-file-alt',
-        tabLabel: 'Questions',
-      },
-      {
         activeSubPage: 'manual_grading',
         urlSuffix: ({ assessment }) => `/assessment/${assessment.id}/manual_grading`,
         iconClasses: 'fas fa-marker',
         tabLabel: 'Manual grading',
         renderCondition: ({ authz_data }) => authz_data.has_course_instance_permission_view,
+      },
+      {
+        activeSubPage: 'questions',
+        urlSuffix: ({ assessment }) => `/assessment/${assessment.id}/questions`,
+        iconClasses: 'far fa-file-alt',
+        tabLabel: 'Questions',
       },
       {
         activeSubPage: 'settings',


### PR DESCRIPTION
# Description

Center the instructor assessment switcher in the combined assessment navigation bar so its hover background has balanced vertical spacing without increasing the header height. This moves combined-bar padding into `pageLayout.css`, centers the switcher wrapper in the wide row layout, and keeps the assessment tabs aligned to the bottom border. It also reorders the assessment tabs so "Questions" follows "Manual grading" in the otherwise alphabetical sequence.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Before this change:

<img width="371" height="79" alt="Screenshot 2026-06-04 at 10 29 17" src="https://github.com/user-attachments/assets/79ad1b2e-3c30-4079-b39c-62904dfe42bc" />

After this change:

<img width="408" height="73" alt="Screenshot 2026-06-04 at 10 29 52" src="https://github.com/user-attachments/assets/464152e9-80db-439f-869e-ee9d9a4b661a" />