### PR TITLE
Never expose user identity to shared questions

### DIFF
--- a/apps/prairielearn/src/question-servers/user-context.test.ts
+++ b/apps/prairielearn/src/question-servers/user-context.test.ts
@@ -10,8 +10,16 @@ import * as helperServer from '../tests/helperServer.js';
 
 import { buildQuestionUserContext } from './user-context.js';
 
-function makeQuestion(course_id: string): Pick<Question, 'course_id'> {
-  return { course_id };
+function makeQuestion({
+  course_id,
+  share_publicly = false,
+  share_source_publicly = false,
+}: {
+  course_id: string;
+  share_publicly?: boolean;
+  share_source_publicly?: boolean;
+}): Pick<Question, 'course_id' | 'share_publicly' | 'share_source_publicly'> {
+  return { course_id, share_publicly, share_source_publicly };
 }
 
 function makeVariantCourse(id: string): Pick<Course, 'id'> {
@@ -24,15 +32,23 @@ function call({
   courseOptedIn,
   userId,
   groupId,
+  sharePublicly = false,
+  shareSourcePublicly = false,
 }: {
   questionCourseId?: string;
   variantCourseId?: string;
   courseOptedIn: boolean;
   userId: string | null;
   groupId: string | null;
+  sharePublicly?: boolean;
+  shareSourcePublicly?: boolean;
 }) {
   return buildQuestionUserContext({
-    question: makeQuestion(questionCourseId),
+    question: makeQuestion({
+      course_id: questionCourseId,
+      share_publicly: sharePublicly,
+      share_source_publicly: shareSourcePublicly,
+    }),
     course: { questions_receive_user_data: courseOptedIn },
     caller: {
       userId,
@@ -77,6 +93,26 @@ describe('buildQuestionUserContext', { timeout: 30_000 }, () => {
 
   it('returns null user/group when no effective user is provided', async () => {
     const ctx = await call({ courseOptedIn: true, userId: null, groupId: null });
+    assert.deepEqual(ctx, { user: null, group: null });
+  });
+
+  it('returns null user/group for a publicly shared question, even when otherwise gated through', async () => {
+    const ctx = await call({
+      courseOptedIn: true,
+      userId,
+      groupId: null,
+      sharePublicly: true,
+    });
+    assert.deepEqual(ctx, { user: null, group: null });
+  });
+
+  it('returns null user/group for a source-publicly shared question, even when otherwise gated through', async () => {
+    const ctx = await call({
+      courseOptedIn: true,
+      userId,
+      groupId: null,
+      shareSourcePublicly: true,
+    });
     assert.deepEqual(ctx, { user: null, group: null });
   });
 

--- a/apps/prairielearn/src/question-servers/user-context.ts
+++ b/apps/prairielearn/src/question-servers/user-context.ts
@@ -53,9 +53,15 @@ function toQuestionUser({
  * Build the user/group context to expose to `server.py` for a question phase.
  *
  * Gating rules (all must be true to expose any data):
- *   1. The question's owning course has `questions_receive_user_data = true`.
- *   2. The question is rendered in its owning course (`question.course_id === caller.variantCourse.id`).
- *      This excludes public sharing, sharing-set imports, and instructor preview of foreign questions.
+ *   1. The question is not shared (`share_publicly` / `share_source_publicly` are
+ *      both false). A shared question never receives user data, in any context.
+ *      This closes the public-preview leak: a public preview renders the question
+ *      inside its own owning course, so the course-id check below would otherwise
+ *      pass and expose the viewer's identity.
+ *   2. The question's owning course has `questions_receive_user_data = true`.
+ *   3. The question is rendered in its owning course (`question.course_id === caller.variantCourse.id`).
+ *      This excludes sharing-set imports and instructor preview of foreign questions,
+ *      which are shared to specific courses without setting the public-share flags.
  *
  * On group variants the individual viewing user's identity is never exposed
  * (`user` is `null`); only the stable group roster (`group.members`) is provided,
@@ -66,11 +72,12 @@ export async function buildQuestionUserContext({
   course,
   caller,
 }: {
-  question: Pick<Question, 'course_id'>;
+  question: Pick<Question, 'course_id' | 'share_publicly' | 'share_source_publicly'>;
   /** The question's owning course; `questions_receive_user_data` is the opt-in switch. */
   course: Pick<Course, 'questions_receive_user_data'>;
   caller: QuestionCaller;
 }): Promise<QuestionUserContext> {
+  if (question.share_publicly || question.share_source_publicly) return EMPTY_USER_CONTEXT;
   if (!course.questions_receive_user_data) return EMPTY_USER_CONTEXT;
   if (!idsEqual(question.course_id, caller.variantCourse.id)) return EMPTY_USER_CONTEXT;
 

--- a/apps/prairielearn/src/question-servers/user-context.ts
+++ b/apps/prairielearn/src/question-servers/user-context.ts
@@ -56,10 +56,10 @@ function toQuestionUser({
  *   1. The question is not shared (`share_publicly` / `share_source_publicly` are
  *      both false). A shared question never receives user data, in any context.
  *      This closes the public-preview leak: a public preview renders the question
- *      inside its own owning course, so the course-id check below would otherwise
+ *      inside its own original course, so the course-id check below would otherwise
  *      pass and expose the viewer's identity.
- *   2. The question's owning course has `questions_receive_user_data = true`.
- *   3. The question is rendered in its owning course (`question.course_id === caller.variantCourse.id`).
+ *   2. The question's original course has `questions_receive_user_data = true`.
+ *   3. The question is rendered in its original course (`question.course_id === caller.variantCourse.id`).
  *      This excludes sharing-set imports and instructor preview of foreign questions,
  *      which are shared to specific courses without setting the public-share flags.
  *
@@ -73,7 +73,7 @@ export async function buildQuestionUserContext({
   caller,
 }: {
   question: Pick<Question, 'course_id' | 'share_publicly' | 'share_source_publicly'>;
-  /** The question's owning course; `questions_receive_user_data` is the opt-in switch. */
+  /** The question's original course; `questions_receive_user_data` is the opt-in switch. */
   course: Pick<Course, 'questions_receive_user_data'>;
   caller: QuestionCaller;
 }): Promise<QuestionUserContext> {

--- a/apps/prairielearn/src/tests/sharedQuestionPreview.test.ts
+++ b/apps/prairielearn/src/tests/sharedQuestionPreview.test.ts
@@ -172,6 +172,7 @@ describe('Shared Question Preview', { timeout: 60_000 }, function () {
         const text = await res.text();
         assert.include(text, 'No user data is available');
         assert.notInclude(text, 'Variant owner');
+        assert.notInclude(text, config.authUid!);
       });
 
       it('does not expose user identity in the public preview', async () => {
@@ -182,6 +183,7 @@ describe('Shared Question Preview', { timeout: 60_000 }, function () {
         const text = await res.text();
         assert.include(text, 'No user data is available');
         assert.notInclude(text, 'Variant owner');
+        assert.notInclude(text, config.authUid!);
       });
     });
   });

--- a/apps/prairielearn/src/tests/sharedQuestionPreview.test.ts
+++ b/apps/prairielearn/src/tests/sharedQuestionPreview.test.ts
@@ -5,7 +5,7 @@ import * as sqldb from '@prairielearn/postgres';
 
 import { config } from '../lib/config.js';
 import { features } from '../lib/features/index.js';
-import { updateCourseSharingName } from '../models/course.js';
+import { updateCourseQuestionsReceiveUserData, updateCourseSharingName } from '../models/course.js';
 
 import {
   testElementClientFiles,
@@ -127,6 +127,61 @@ describe('Shared Question Preview', { timeout: 60_000 }, function () {
           },
         });
         assert.equal(res.status, 403);
+      });
+    });
+  });
+
+  describe('User identity is never exposed for shared questions', () => {
+    let userInfoQuestionId: string;
+
+    beforeAll(async () => {
+      userInfoQuestionId = await sqldb.queryScalar(
+        sql.select_question_id,
+        { qid: 'userInfo' },
+        z.string(),
+      );
+      // Opt the owning course in to receiving user data. The `userInfo` question
+      // renders the variant owner's identity from `data['options']['user']`.
+      await updateCourseQuestionsReceiveUserData({
+        course_id: '1',
+        questions_receive_user_data: true,
+        authn_user_id: '1',
+        user_id: '1',
+        old_questions_receive_user_data: false,
+      });
+    });
+
+    it('exposes user identity in the owning course when the question is not shared', async () => {
+      const res = await fetch(`${baseUrl}/course/1/question/${userInfoQuestionId}/preview`);
+      assert.equal(res.status, 200);
+      const text = await res.text();
+      // First-party render: toggle on, owning course, question not shared, so
+      // `options.user` is populated and the viewer's uid appears.
+      assert.include(text, 'Variant owner');
+      assert.include(text, config.authUid!);
+    });
+
+    describe('once the question is shared publicly', () => {
+      beforeAll(async () => {
+        await sqldb.execute(sql.update_share_publicly, { question_id: userInfoQuestionId });
+      });
+
+      it('stops exposing user identity in the owning course preview', async () => {
+        const res = await fetch(`${baseUrl}/course/1/question/${userInfoQuestionId}/preview`);
+        assert.equal(res.status, 200);
+        const text = await res.text();
+        assert.include(text, 'No user data is available');
+        assert.notInclude(text, 'Variant owner');
+      });
+
+      it('does not expose user identity in the public preview', async () => {
+        const res = await fetch(
+          `${baseUrl}/public/course/1/question/${userInfoQuestionId}/preview`,
+        );
+        assert.equal(res.status, 200);
+        const text = await res.text();
+        assert.include(text, 'No user data is available');
+        assert.notInclude(text, 'Variant owner');
       });
     });
   });

--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -436,7 +436,8 @@ The `group` dict has `name` and `members` (a list with the same shape as `user`)
 User and group data are provided to `server.py` only when **all** of the following are true:
 
 1. The course has opted in so that `server.py` receives user data. In production, a course owner enables this on the course settings page; for local development, it can instead be set with `"questionsReceiveUserData": true` under `"options"` in `infoCourse.json`, which is honored only in development mode.
-2. The question is rendered in its owning course. For questions imported from another course via sharing (public or sharing set), `server.py` never receives user data, regardless of either course's settings.
+2. The question is not shared. Once a question is shared publicly or has its source shared publicly, `server.py` never receives user data, including in the question's own course and in public previews.
+3. The question is rendered in its owning course. For questions imported from another course via a sharing set, `server.py` never receives user data, regardless of either course's settings.
 
 When user data is not provided to `server.py`, `data["options"]["user"]` and `data["options"]["group"]` are both `None`. The keys are always present.
 

--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -437,7 +437,7 @@ User and group data are provided to `server.py` only when **all** of the followi
 
 1. The course has opted in so that `server.py` receives user data. In production, a course owner enables this on the course settings page; for local development, it can instead be set with `"questionsReceiveUserData": true` under `"options"` in `infoCourse.json`, which is honored only in development mode.
 2. The question is not shared. Once a question is shared publicly or has its source shared publicly, `server.py` never receives user data, including in the question's own course and in public previews.
-3. The question is rendered in its owning course. For questions imported from another course via a sharing set, `server.py` never receives user data, regardless of either course's settings.
+3. The question is rendered in its original course. For questions imported from another course via a sharing set, `server.py` never receives user data, regardless of either course's settings.
 
 When user data is not provided to `server.py`, `data["options"]["user"]` and `data["options"]["group"]` are both `None`. The keys are always present.
 

--- a/testCourse/questions/userInfo/question.html
+++ b/testCourse/questions/userInfo/question.html
@@ -23,7 +23,8 @@
   {{^options.user}}
     <p>
       No user data is available for this question. Either the course has not opted in, this is a
-      group variant, or this question was imported from another course via sharing.
+      group variant, this question is shared, or this question was imported from another course via
+      sharing.
     </p>
   {{/options.user}}
 


### PR DESCRIPTION
# Description

This prevent user/group context if a question is publicly shared.

- [x] I have disclosed the level of AI assistance used (majority of implementation, via Claude Code, with design decisions reviewed by me).

# Testing

- Unit test (`user-context.test.ts`): empty user/group context is returned for both `share_publicly` and `share_source_publicly` questions, even when otherwise fully gated through.
- End-to-end test (`sharedQuestionPreview.test.ts`) using the `userInfo` question (which renders `options.user`): identity flows for a non-shared question in its owning course, then stops in **both** the owning-course instructor preview and the public preview once the question is shared.
