### PR TITLE
Emit raw Zod 4 schema output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ check-badge-contrast:
 check-npm-packages:
 	@node scripts/check-npm-packages.mjs
 update-jsonschema:
-	@yarn dlx tsx scripts/gen-jsonschema.mts && yarn prettier --write "apps/prairielearn/src/schemas/**/*.json" && yarn prettier --write "docs/assets/*.schema.json"
+	@yarn dlx tsx scripts/gen-jsonschema.mts
 
 # Runs additional third-party linters
 lint-all: lint-js lint-python lint-html lint-mustache lint-docs lint-docker lint-actions lint-shell lint-sql-migrations lint-sql

--- a/apps/prairielearn/src/schemas/infoAssessment.ts
+++ b/apps/prairielearn/src/schemas/infoAssessment.ts
@@ -7,9 +7,15 @@ export const EnumAssessmentToolSchema = z.enum(['calculator']);
 export type EnumAssessmentTool = z.infer<typeof EnumAssessmentToolSchema>;
 
 function uniqueArray<T extends ZodSchema>(schema: T) {
-  return z.array(schema).refine((items) => new Set(items).size === items.length, {
-    message: 'All items must be unique, no duplicate values allowed',
-  });
+  // Zod cannot express `uniqueItems` directly, and the `.refine()` uniqueness
+  // check is unrepresentable in JSON Schema, so advertise it via metadata that
+  // `z.toJSONSchema` copies through verbatim.
+  return z
+    .array(schema)
+    .refine((items) => new Set(items).size === items.length, {
+      message: 'All items must be unique, no duplicate values allowed',
+    })
+    .meta({ uniqueItems: true });
 }
 
 // TODO: This schema is being deprecated
@@ -105,6 +111,7 @@ export const GroupsJsonSchema = z
     roles: z
       .array(GroupsRoleJsonSchema)
       .describe('Array of custom user roles in a group.')
+      .meta({ uniqueItems: true })
       .optional()
       .default([]),
     studentPermissions: GroupsStudentPermissionsJsonSchema.prefault({}),
@@ -127,7 +134,7 @@ export const AssessmentAccessRuleJsonSchema = z
         'The PrairieTest exam UUID for which a student must be registered. Implies mode: Exam.',
       )
       .optional(),
-    role: z.enum(['Student', 'TA', 'Instructor']).describe('DEPRECATED -- do not use.').optional(),
+    role: z.enum(['Student', 'TA', 'Instructor']).meta({ deprecated: true }).optional(),
     uids: z
       .array(z.string())
       .describe(
@@ -325,7 +332,7 @@ export const ZoneAssessmentJsonSchema = z.object({
     .optional(),
   comment: CommentJsonSchema.optional(),
   // Do we need to allow for additional keys?
-  comments: CommentJsonSchema.optional().describe('DEPRECATED -- do not use.'),
+  comments: CommentJsonSchema.optional().meta({ deprecated: true }),
   maxPoints: z
     .number()
     .gte(0)
@@ -499,67 +506,71 @@ export const AssessmentJsonSchema = z
     groupWork: z
       .boolean()
       .describe(
-        'Whether the assessment will support group work. DEPRECATED -- prefer using the "groups" property instead.',
+        'Whether the assessment will support group work. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional()
       .default(false),
     groupMaxSize: z
       .number()
       .describe(
-        'Maximum number of students in a group. DEPRECATED -- prefer using the "groups" property instead.',
+        'Maximum number of students in a group. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional(),
     groupMinSize: z
       .number()
       .describe(
-        'Minimum number of students in a group. DEPRECATED -- prefer using the "groups" property instead.',
+        'Minimum number of students in a group. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional(),
     groupRoles: z
       .array(LegacyGroupRoleJsonSchema)
       .describe(
-        'Array of custom user roles in a group. DEPRECATED -- prefer using the "groups" property instead.',
+        'Array of custom user roles in a group. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional()
       .default([]),
     canSubmit: uniqueArray(z.string())
       .describe(
-        'A list of group role names that can submit questions. Only applicable for group assessments. DEPRECATED -- prefer using the "groups" property instead.',
+        'A list of group role names that can submit questions. Only applicable for group assessments. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional()
       .default([]),
     canView: uniqueArray(z.string())
       .describe(
-        'A list of group role names that can view questions. Only applicable for group assessments. DEPRECATED -- prefer using the "groups" property instead.',
+        'A list of group role names that can view questions. Only applicable for group assessments. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional()
       .default([]),
     studentGroupCreate: z
       .boolean()
-      .describe(
-        'Whether students can create groups. DEPRECATED -- prefer using the "groups" property instead.',
-      )
+      .describe('Whether students can create groups. Prefer using the "groups" property instead.')
+      .meta({ deprecated: true })
       .optional()
       .default(false),
     studentGroupChooseName: z
       .boolean()
       .describe(
-        'Whether students can choose a group name when creating a group. Only applicable if studentGroupCreate is true. DEPRECATED -- prefer using the "groups" property instead.',
+        'Whether students can choose a group name when creating a group. Only applicable if studentGroupCreate is true. Prefer using the "groups" property instead.',
       )
+      .meta({ deprecated: true })
       .optional()
       .default(true),
     studentGroupJoin: z
       .boolean()
-      .describe(
-        'Whether students can join groups. DEPRECATED -- prefer using the "groups" property instead.',
-      )
+      .describe('Whether students can join groups. Prefer using the "groups" property instead.')
+      .meta({ deprecated: true })
       .optional()
       .default(false),
     studentGroupLeave: z
       .boolean()
-      .describe(
-        'Whether students can leave groups. DEPRECATED -- prefer using the "groups" property instead.',
-      )
+      .describe('Whether students can leave groups. Prefer using the "groups" property instead.')
+      .meta({ deprecated: true })
       .optional()
       .default(false),
     groups: GroupsJsonSchema.optional(),
@@ -588,7 +599,8 @@ export const AssessmentJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('Configuration data for an assessment.');
+  .describe('Configuration data for an assessment.')
+  .meta({ title: 'Assessment info' });
 
 export type AssessmentJson = z.infer<typeof AssessmentJsonSchema>;
 export type AssessmentJsonInput = z.input<typeof AssessmentJsonSchema>;

--- a/apps/prairielearn/src/schemas/infoCourse.ts
+++ b/apps/prairielearn/src/schemas/infoCourse.ts
@@ -91,7 +91,8 @@ const CourseOptionsJsonSchema = z
     comment: CommentJsonSchema.optional(),
     useNewQuestionRenderer: z
       .boolean()
-      .describe('[DEPRECATED, DO NOT USE] Feature flag to enable the new question renderer.')
+      .describe('Feature flag to enable the new question renderer.')
+      .meta({ deprecated: true })
       .optional(),
     devModeFeatures: z
       .union([
@@ -118,7 +119,8 @@ export const CourseJsonSchema = z
     uuid: z
       .string()
       .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-      .describe('[DEPRECATED, DO NOT USE] Unique identifier (UUID v4).')
+      .describe('Unique identifier (UUID v4).')
+      .meta({ deprecated: true })
       .optional(),
     name: z.string().describe("The course name (e.g., 'TAM 212')."),
     title: z.string().describe("The course title (e.g., 'Introductory Dynamics')."),
@@ -158,7 +160,8 @@ export const CourseJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('The specification file for a course.');
+  .describe('The specification file for a course.')
+  .meta({ title: 'Course information' });
 
 export type CourseJson = z.infer<typeof CourseJsonSchema>;
 export type CourseJsonInput = z.input<typeof CourseJsonSchema>;

--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -11,7 +11,7 @@ const AccessRuleJsonSchema = z
     comment: CommentJsonSchema.optional(),
     role: z
       .enum(['Student', 'TA', 'Instructor', 'Superuser'])
-      .describe('DEPRECATED -- do not use.')
+      .meta({ deprecated: true })
       .optional(),
     uids: z
       .array(z.string())
@@ -76,14 +76,14 @@ export const CourseInstanceJsonSchema = z
       .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
       .describe('Unique identifier (UUID v4).'),
     longName: z.string().describe("The long name of this course instance (e.g., 'Spring 2015')."),
-    shortName: z.string().describe('DEPRECATED -- do not use.').optional(),
+    shortName: z.string().meta({ deprecated: true }).optional(),
     timezone: z
       .string()
       .describe(
         'The timezone for all date input and display (e.g., "America/Chicago"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred. If not specified, the timezone of the course will be used.',
       )
       .optional(),
-    allowIssueReporting: z.boolean().describe('DEPRECATED -- do not use.').optional(),
+    allowIssueReporting: z.boolean().meta({ deprecated: true }).optional(),
     selfEnrollment: z
       .object({
         enabled: z
@@ -117,11 +117,10 @@ export const CourseInstanceJsonSchema = z
       .prefault({}),
     hideInEnrollPage: z
       .boolean()
-      .describe(
-        'DEPRECATED -- The enrollment listing page has been removed. This setting is no longer used.',
-      )
+      .describe('The enrollment listing page has been removed. This setting is no longer used.')
+      .meta({ deprecated: true })
       .optional(),
-    userRoles: z.object({}).catchall(z.any()).describe('DEPRECATED -- do not use.').optional(),
+    userRoles: z.object({}).catchall(z.any()).meta({ deprecated: true }).optional(),
     publishing: PublishingJsonSchema.optional(),
     allowAccess: AllowAccessJsonSchema.optional(),
     groupAssessmentsBy: z
@@ -145,7 +144,8 @@ export const CourseInstanceJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('The specification file for a course instance.');
+  .describe('The specification file for a course instance.')
+  .meta({ title: 'Course instance information' });
 
 export type CourseInstanceJson = z.infer<typeof CourseInstanceJsonSchema>;
 export type CourseInstanceJsonInput = z.input<typeof CourseInstanceJsonSchema>;

--- a/apps/prairielearn/src/schemas/infoElementCore.ts
+++ b/apps/prairielearn/src/schemas/infoElementCore.ts
@@ -7,15 +7,13 @@ const DependencyJsonSchema = z
     comment: CommentJsonSchema.optional(),
     coreStyles: z
       .array(z.string().describe('A .css file located in /public/stylesheets.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The styles required by this element from /public/stylesheets.',
-      )
+      .describe('The styles required by this element from /public/stylesheets.')
+      .meta({ deprecated: true })
       .optional(),
     coreScripts: z
       .array(z.string().describe('A .js file located in /public/javascripts.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The scripts required by this element from /public/javascripts.',
-      )
+      .describe('The scripts required by this element from /public/javascripts.')
+      .meta({ deprecated: true })
       .optional(),
     nodeModulesStyles: z
       .array(z.string().describe('A .css file located in /node_modules.'))
@@ -66,6 +64,7 @@ export const ElementCoreJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('Info files for v3 elements.');
+  .describe('Info files for v3 elements.')
+  .meta({ title: 'Element Info' });
 
 export type ElementCoreJson = z.infer<typeof ElementCoreJsonSchema>;

--- a/apps/prairielearn/src/schemas/infoElementCourse.ts
+++ b/apps/prairielearn/src/schemas/infoElementCourse.ts
@@ -7,15 +7,13 @@ const DependencyJsonSchema = z
     comment: CommentJsonSchema.optional(),
     coreStyles: z
       .array(z.string().describe('A .css file located in /public/stylesheets.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The styles required by this element from /public/stylesheets.',
-      )
+      .describe('The styles required by this element from /public/stylesheets.')
+      .meta({ deprecated: true })
       .optional(),
     coreScripts: z
       .array(z.string().describe('A .js file located in /public/javascripts.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The scripts required by this element from /public/javascripts.',
-      )
+      .describe('The scripts required by this element from /public/javascripts.')
+      .meta({ deprecated: true })
       .optional(),
     nodeModulesStyles: z
       .array(z.string().describe('A .css file located in /node_modules.'))
@@ -74,6 +72,7 @@ export const ElementCourseJsonSchema = z
     dynamicDependencies: DynamicDependencyJsonSchema.optional(),
   })
   .strict()
-  .describe('Info files for v3 elements.');
+  .describe('Info files for v3 elements.')
+  .meta({ title: 'Element Info' });
 
 export type ElementCourseJson = z.infer<typeof ElementCourseJsonSchema>;

--- a/apps/prairielearn/src/schemas/infoElementExtension.ts
+++ b/apps/prairielearn/src/schemas/infoElementExtension.ts
@@ -6,15 +6,13 @@ const DependencyJsonSchema = z
   .object({
     coreStyles: z
       .array(z.string().describe('A .css file located in /public/stylesheets.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The styles required by this extension from /public/stylesheets.',
-      )
+      .describe('The styles required by this extension from /public/stylesheets.')
+      .meta({ deprecated: true })
       .optional(),
     coreScripts: z
       .array(z.string().describe('A .js file located in /public/javascripts.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The scripts required by this extension from /public/javascripts.',
-      )
+      .describe('The scripts required by this extension from /public/javascripts.')
+      .meta({ deprecated: true })
       .optional(),
     nodeModulesStyles: z
       .array(z.string().describe('A .css file located in /node_modules.'))
@@ -72,6 +70,7 @@ export const ElementExtensionJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('Info files for v3 element extensions.');
+  .describe('Info files for v3 element extensions.')
+  .meta({ title: 'Element Extension Info' });
 
 export type ElementExtensionJson = z.infer<typeof ElementExtensionJsonSchema>;

--- a/apps/prairielearn/src/schemas/infoQuestion.ts
+++ b/apps/prairielearn/src/schemas/infoQuestion.ts
@@ -33,15 +33,13 @@ const QuestionDependencyJsonSchema = z
     comment: CommentJsonSchema.optional(),
     coreStyles: z
       .array(z.string().describe('A .css file located in /public/stylesheets.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The styles required by this question from /public/stylesheets.',
-      )
+      .describe('The styles required by this question from /public/stylesheets.')
+      .meta({ deprecated: true })
       .optional(),
     coreScripts: z
       .array(z.string().describe('A .js file located in /public/javascripts.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The scripts required by this question from /public/javascripts.',
-      )
+      .describe('The scripts required by this question from /public/javascripts.')
+      .meta({ deprecated: true })
       .optional(),
     nodeModulesStyles: z
       .array(z.string().describe('A .css file located in /node_modules.'))
@@ -146,9 +144,8 @@ const WorkspaceOptionsJsonSchema = z
       .default({}),
     syncIgnore: z
       .array(z.string().describe('A single file or directory that will be excluded from sync.'))
-      .describe(
-        '[DEPRECATED, DO NOT USE] The list of files or directories that will be excluded from sync.',
-      )
+      .describe('The list of files or directories that will be excluded from sync.')
+      .meta({ deprecated: true })
       .optional(),
   })
   .strict()
@@ -165,7 +162,8 @@ const ExternalGradingOptionsJsonSchema = z
     comment: CommentJsonSchema.optional(),
     enabled: z
       .boolean()
-      .describe('[DEPRECATED, DO NOT USE] Whether the external grader is currently enabled.')
+      .describe('Whether the external grader is currently enabled.')
+      .meta({ deprecated: true })
       .optional()
       .default(true),
     image: z
@@ -236,17 +234,20 @@ export const QuestionJsonSchema = z
     clientFiles: z
       .array(z.string().describe('A single file accessible by the client.'))
       .describe(
-        '[DEPRECATED] The list of question files accessible by the client. v3 questions should serve files from `clientFilesQuestion/` instead.',
+        'The list of question files accessible by the client. v3 questions should serve files from `clientFilesQuestion/` instead.',
       )
+      .meta({ deprecated: true })
       .optional()
       .default(['client.js', 'question.html', 'answer.html']),
     clientTemplates: z
       .array(z.string().describe('A single template file accessible by the client.'))
-      .describe('[DEPRECATED] List of client-accessible templates to render server-side.')
+      .describe('List of client-accessible templates to render server-side.')
+      .meta({ deprecated: true })
       .optional(),
     template: z
       .string()
-      .describe('[DEPRECATED] The QID of a question that serves as the template for this question.')
+      .describe('The QID of a question that serves as the template for this question.')
+      .meta({ deprecated: true })
       .optional(),
     gradingMethod: z
       .enum(['Internal', 'External', 'Manual'])
@@ -273,8 +274,9 @@ export const QuestionJsonSchema = z
       .object({})
       .catchall(z.any())
       .describe(
-        '[DEPRECATED] Options that define how the question will work, specific to the individual question type (not supported for v3 questions).',
+        'Options that define how the question will work, specific to the individual question type (not supported for v3 questions).',
       )
+      .meta({ deprecated: true })
       .optional(),
     externalGradingOptions: ExternalGradingOptionsJsonSchema.optional(),
     dependencies: QuestionDependencyJsonSchema.optional().default({}),
@@ -296,7 +298,8 @@ export const QuestionJsonSchema = z
     preferences: QuestionPreferencesSchemaJsonSchema.optional(),
   })
   .strict()
-  .describe('Info files for questions.');
+  .describe('Info files for questions.')
+  .meta({ title: 'Question Info' });
 
 export type QuestionJson = z.infer<typeof QuestionJsonSchema>;
 export type QuestionJsonInput = z.input<typeof QuestionJsonSchema>;

--- a/apps/prairielearn/src/schemas/jsonSchemas.ts
+++ b/apps/prairielearn/src/schemas/jsonSchemas.ts
@@ -81,342 +81,61 @@ for (const [id, schema] of Object.entries(namedDefinitions)) {
   z.globalRegistry.add(schema, { ...z.globalRegistry.get(schema), id });
 }
 
-/**
- * Mutate the JSON Schema for canView / canSubmit / roles fields to include
- * `uniqueItems`, which Zod cannot express directly on an array schema.
- */
-function applyUniqueItemsOverride(ctx: {
-  zodSchema: z.core.$ZodTypes;
-  jsonSchema: Record<string, any>;
-  path: (string | number)[];
-}) {
-  const segment = ctx.path[ctx.path.length - 1];
-  const path = ctx.path;
-
-  if (segment === 'canView' || segment === 'canSubmit') {
-    const action = segment === 'canView' ? 'view' : 'submit';
-    const inQuestion = path.includes('ZoneQuestionBlockJsonSchema') || path.includes('questions');
-    const inZone =
-      path.includes('ZoneAssessmentJsonSchema') || (path.includes('zones') && !inQuestion);
-    const inGroups = path.includes('groups');
-
-    if (inGroups) return;
-
-    const replacement: Record<string, any> = {
-      type: 'array',
-      items: { type: 'string' },
-      uniqueItems: true,
-      default: [],
-    };
-
-    if (inQuestion) {
-      replacement.description = `A list of group role names that can ${action} the question. Only applicable for group assessments.`;
-    } else if (inZone) {
-      replacement.description = `A list of group role names that can ${action} questions in this zone. Only applicable for group assessments.`;
-    } else {
-      replacement.description = `A list of group role names that can ${action} questions. Only applicable for group assessments. DEPRECATED -- prefer using the "groups" property instead.`;
-    }
-
-    for (const key of Object.keys(ctx.jsonSchema)) delete ctx.jsonSchema[key];
-    Object.assign(ctx.jsonSchema, replacement);
-    return;
-  }
-
-  if (segment === 'roles' && path.includes('groups')) {
-    // Keep the inline items schema that v4 already emitted and just add the
-    // uniqueItems constraint Zod cannot express directly.
-    ctx.jsonSchema.uniqueItems = true;
-  }
-}
-
-/**
- * Replace `oldKey` with `newKey: newValue` in place, preserving the key's
- * original position so the rewritten object diffs minimally against the
- * previous output (which prettier renders one key per line).
- */
-function replaceKeyInPlace(
-  obj: Record<string, any>,
-  oldKey: string,
-  newKey: string,
-  newValue: unknown,
-) {
-  const entries = Object.entries(obj).map(([k, v]): [string, unknown] =>
-    k === oldKey ? [newKey, newValue] : [k, v],
-  );
-  for (const key of Object.keys(obj)) delete obj[key];
-  Object.assign(obj, Object.fromEntries(entries));
-}
-
-// Keys whose *values* are maps from arbitrary names to subschemas. The keys of
-// those maps are user-controlled names (which can collide with JSON Schema
-// keywords, e.g. a property literally named `default`), so the keyword-level
-// rewrites below must not be applied to them.
-const PROPERTY_MAP_KEYWORDS = new Set([
-  'properties',
-  'patternProperties',
-  'definitions',
-  '$defs',
-  'dependentSchemas',
-]);
-
-/**
- * Walk a generated JSON Schema and undo the purely-syntactic differences that
- * Zod 4's `z.toJSONSchema` introduces relative to the previous
- * `zod-to-json-schema` (Zod 3) output. None of these rewrites change validation
- * semantics.
- *
- * TODO: The sole purpose of this pass is to keep the committed schema files
- * close to their pre-Zod-4 form so the migration diff stays small and
- * reviewable. Once the raw Zod 4 output is accepted as the new baseline, this
- * pass (and its callers) can be deleted.
- *
- * The rewrites:
- *
- *   - `{ allOf: [{ $ref }] }` -> `{ $ref }`. Zod 4 wraps a referenced schema in
- *     a single-element `allOf` whenever a modifier (`.optional()`,
- *     `.default()`, ...) sits on it, because draft-07 forbids sibling keywords
- *     next to `$ref`. The wrapper is inert here, so we hoist the `$ref` back up.
- *   - `{ anyOf: [{ type: 'X' }, { type: 'Y' }, ...] }` -> `{ type: ['X', 'Y'] }`.
- *     Zod 3 expressed unions of bare scalar types (including nullables, where
- *     one branch is `{ type: 'null' }`) with the compact array form.
- *   - Drop tautological constraints Zod 4 newly emits: a `type: 'string'` inside
- *     `propertyNames` (JSON object keys are always strings), `items: {}` (an
- *     empty schema allows anything, same as omitting `items`), and the JS
- *     safe-integer `minimum`/`maximum` bounds Zod 4 stamps onto every unbounded
- *     integer.
- *   - Key order: Zod 4 emits `minItems`, `maxItems`, and `default` *before* the
- *     structural keywords (e.g. `items`), whereas zod-to-json-schema emitted
- *     them *last* (e.g. `{ type, default, enum }` vs `{ type, enum, default }`).
- *     We move them back to the end so the keyword order — and therefore the
- *     line-by-line diff — matches. The `inPropertyMap` guard ensures we only
- *     reorder genuine keywords, never a property whose name happens to collide
- *     with one (e.g. a property literally named `default`).
- */
-export function normalizeGeneratedJsonSchema(node: unknown, inPropertyMap = false): void {
-  if (Array.isArray(node)) {
-    for (const item of node) normalizeGeneratedJsonSchema(item);
-    return;
-  }
-  if (node === null || typeof node !== 'object') return;
-
-  const obj = node as Record<string, any>;
-
-  // Inside a property map the keys are names, not keywords: skip the keyword
-  // rewrites and recurse into each subschema value as a fresh schema node.
-  if (inPropertyMap) {
-    for (const value of Object.values(obj)) normalizeGeneratedJsonSchema(value);
-    return;
-  }
-
-  // Collapse a union of bare scalar types into the compact `type: [...]` form.
-  if (Array.isArray(obj.anyOf) && obj.anyOf.length >= 2 && obj.type === undefined) {
-    const isBareType = (s: any): s is { type: string } =>
-      s !== null &&
-      typeof s === 'object' &&
-      typeof s.type === 'string' &&
-      Object.keys(s).length === 1;
-    if (obj.anyOf.every(isBareType)) {
-      replaceKeyInPlace(
-        obj,
-        'anyOf',
-        'type',
-        obj.anyOf.map((s: { type: string }) => s.type),
-      );
-    }
-  }
-
-  // Hoist a lone `allOf: [{ $ref }]` wrapper back to a sibling `$ref`.
-  const allOf = obj.allOf;
-  if (
-    Array.isArray(allOf) &&
-    allOf.length === 1 &&
-    allOf[0] !== null &&
-    typeof allOf[0] === 'object' &&
-    typeof allOf[0].$ref === 'string' &&
-    Object.keys(allOf[0]).length === 1 &&
-    obj.$ref === undefined
-  ) {
-    replaceKeyInPlace(obj, 'allOf', '$ref', allOf[0].$ref);
-  }
-
-  // Drop tautological constraints Zod 4 emits but the previous output did not.
-  // `propertyNames` always constrains object keys, which are strings by
-  // definition, so a `type: 'string'` there is redundant whether it stands
-  // alone or sits beside a real constraint (`enum`, `minLength`, ...).
-  if (obj.propertyNames !== null && typeof obj.propertyNames === 'object') {
-    if (Object.keys(obj.propertyNames).length === 1 && obj.propertyNames.type === 'string') {
-      delete obj.propertyNames;
-    } else if (obj.propertyNames.type === 'string') {
-      delete obj.propertyNames.type;
-    }
-  }
-  // `items: {}` allows anything, same as omitting `items`.
-  if (
-    obj.items !== null &&
-    typeof obj.items === 'object' &&
-    !Array.isArray(obj.items) &&
-    Object.keys(obj.items).length === 0
-  ) {
-    delete obj.items;
-  }
-
-  // Zod 4 stamps every unbounded integer with the JS safe-integer range;
-  // zod-to-json-schema left such bounds off. Strip only these sentinel values —
-  // real `.min()` / `.max()` constraints use other numbers and are preserved.
-  if (obj.minimum === -Number.MAX_SAFE_INTEGER) delete obj.minimum;
-  if (obj.maximum === Number.MAX_SAFE_INTEGER) delete obj.maximum;
-
-  // Key order: Zod 4 emits these keywords before the structural ones (e.g.
-  // `items`), but zod-to-json-schema emitted them last. Re-insert each present
-  // keyword so it trails, in the order the previous output used.
-  for (const keyword of ['minItems', 'maxItems', 'default']) {
-    if (keyword in obj) {
-      const value = obj[keyword];
-      delete obj[keyword];
-      obj[keyword] = value;
-    }
-  }
-
-  for (const [key, value] of Object.entries(obj)) {
-    normalizeGeneratedJsonSchema(value, PROPERTY_MAP_KEYWORDS.has(key));
-  }
-}
-
-/**
- * Walk the generated schema and add `deprecated: true` wherever a description
- * mentions "DEPRECATED". Matches the prior `prairielearnZodToJsonSchema`
- * behavior so existing IDE deprecation hints survive the v4 swap.
- */
-function annotateDeprecated(input: any) {
-  if (
-    input !== null &&
-    typeof input === 'object' &&
-    typeof input.description === 'string' &&
-    input.description.toLowerCase().includes('deprecated')
-  ) {
-    input.deprecated = true;
-  }
-  if (input !== null && typeof input === 'object') {
-    for (const value of Object.values(input)) {
-      if (typeof value === 'object' && value !== null) annotateDeprecated(value);
-    }
-  }
-}
-
-function prairielearnZodToJsonSchema(
-  schema: z.ZodType,
-  title: string,
-  definitionKeys: readonly (keyof typeof namedDefinitions)[],
-): Record<string, any> {
-  const jsonSchema: any = z.toJSONSchema(schema, {
+function prairielearnZodToJsonSchema(schema: z.ZodType): Record<string, any> {
+  return z.toJSONSchema(schema, {
     target: 'draft-07',
     io: 'input',
     unrepresentable: 'any',
     reused: 'inline',
-    override: applyUniqueItemsOverride,
   });
-
-  jsonSchema.title = title;
-
-  // `z.toJSONSchema` with `target: 'draft-07'` emits `definitions`, but it
-  // includes every registered schema reachable from the root, in encounter
-  // order. Rebuild the map from the explicit allow-list so each output carries
-  // only the definitions it historically did, in a stable order (the previous
-  // toolchain emitted definitions in the order they were listed) — this keeps
-  // the diff minimal.
-  if (jsonSchema.definitions) {
-    const definitions = jsonSchema.definitions;
-    jsonSchema.definitions = Object.fromEntries(
-      definitionKeys.filter((key) => key in definitions).map((key) => [key, definitions[key]]),
-    );
-  }
-
-  // Normalize first so `default` is moved to the end of each object, then
-  // append `deprecated` — the previous toolchain emitted `{ ..., default,
-  // deprecated }` in that order.
-  normalizeGeneratedJsonSchema(jsonSchema);
-  annotateDeprecated(jsonSchema);
-
-  return jsonSchema;
 }
 
-export const infoAssessment = prairielearnZodToJsonSchema(AssessmentJsonSchema, 'Assessment info', [
-  'PointsJsonSchema',
-  'PointsListJsonSchema',
-  'PointsSingleJsonSchema',
-  'QuestionIdJsonSchema',
-  'ForceMaxPointsJsonSchema',
-  'AssessmentAccessRuleJsonSchema',
-  'QuestionAlternativeJsonSchema',
-  'ZoneAssessmentJsonSchema',
-  'ZoneQuestionBlockJsonSchema',
-  'QuestionPreferencesJsonSchema',
-  'LegacyGroupRoleJsonSchema',
-  'GroupsRoleJsonSchema',
-  'AdvanceScorePercJsonSchema',
-  'CommentJsonSchema',
-  'DatetimeLocalStringSchema',
-  'AccessControlJsonSchema',
-  'DeadlineEntryJsonSchema',
-]) as JSONSchemaType<AssessmentJson>;
+export const infoAssessment = prairielearnZodToJsonSchema(
+  AssessmentJsonSchema,
+) as JSONSchemaType<AssessmentJson>;
 
-export const infoCourse = prairielearnZodToJsonSchema(CourseJsonSchema, 'Course information', [
-  'ColorJsonSchema',
-  'CommentJsonSchema',
-]) as JSONSchemaType<CourseJson>;
+export const infoCourse = prairielearnZodToJsonSchema(
+  CourseJsonSchema,
+) as JSONSchemaType<CourseJson>;
 
 export const infoCourseInstance = prairielearnZodToJsonSchema(
   CourseInstanceJsonSchema,
-  'Course instance information',
-  ['ColorJsonSchema', 'CommentJsonSchema'],
 ) as JSONSchemaType<CourseInstanceJson>;
 
-const infoElementCore = prairielearnZodToJsonSchema(ElementCoreJsonSchema, 'Element Info', [
-  'CommentJsonSchema',
-]) as JSONSchemaType<ElementCoreJson>;
+const infoElementCore = prairielearnZodToJsonSchema(
+  ElementCoreJsonSchema,
+) as JSONSchemaType<ElementCoreJson>;
 
-const infoElementCourse = prairielearnZodToJsonSchema(ElementCourseJsonSchema, 'Element Info', [
-  'CommentJsonSchema',
-]) as JSONSchemaType<ElementCourseJson>;
+const infoElementCourse = prairielearnZodToJsonSchema(
+  ElementCourseJsonSchema,
+) as JSONSchemaType<ElementCourseJson>;
 
 const infoElementExtension = prairielearnZodToJsonSchema(
   ElementExtensionJsonSchema,
-  'Element Extension Info',
-  ['CommentJsonSchema'],
 ) as JSONSchemaType<ElementExtensionJson>;
 
-export const infoQuestion = prairielearnZodToJsonSchema(QuestionJsonSchema, 'Question Info', [
-  'CommentJsonSchema',
-]) as JSONSchemaType<QuestionJson>;
+export const infoQuestion = prairielearnZodToJsonSchema(
+  QuestionJsonSchema,
+) as JSONSchemaType<QuestionJson>;
 
 const questionOptionsCalculation = prairielearnZodToJsonSchema(
   QuestionOptionsCalculationJsonSchema,
-  'Calculation question options',
-  ['CommentJsonSchema'],
 ) as JSONSchemaType<QuestionOptionsCalculationJson>;
 
 const questionOptionsCheckbox = prairielearnZodToJsonSchema(
   QuestionOptionsCheckboxJsonSchema,
-  'Checkbox question options',
-  ['CommentJsonSchema'],
 ) as JSONSchemaType<QuestionOptionsCheckboxJson>;
 
 const questionOptionsFile = prairielearnZodToJsonSchema(
   QuestionOptionsFileJsonSchema,
-  'File question options',
-  ['CommentJsonSchema'],
 ) as JSONSchemaType<QuestionOptionsFileJson>;
 
 const questionOptionsMultipleChoice = prairielearnZodToJsonSchema(
   QuestionOptionsMultipleChoiceJsonSchema,
-  'MultipleChoice question options',
-  ['CommentJsonSchema'],
 ) as JSONSchemaType<QuestionOptionsMultipleChoiceJson>;
 
 const questionOptionsMultipleTrueFalse = prairielearnZodToJsonSchema(
   QuestionOptionsMultipleTrueFalseJsonSchema,
-  'MultipleTrueFalse question options',
-  ['CommentJsonSchema'],
 ) as JSONSchemaType<QuestionOptionsMultipleTrueFalseJson>;
 
 export const ajvSchemas = {

--- a/apps/prairielearn/src/schemas/questionOptionsCalculation.ts
+++ b/apps/prairielearn/src/schemas/questionOptionsCalculation.ts
@@ -7,6 +7,7 @@ export const QuestionOptionsCalculationJsonSchema = z
     comment: CommentJsonSchema.optional(),
   })
   .passthrough()
-  .describe('Options for a Calculation question.');
+  .describe('Options for a Calculation question.')
+  .meta({ title: 'Calculation question options' });
 
 export type QuestionOptionsCalculationJson = z.infer<typeof QuestionOptionsCalculationJsonSchema>;

--- a/apps/prairielearn/src/schemas/questionOptionsCheckbox.ts
+++ b/apps/prairielearn/src/schemas/questionOptionsCheckbox.ts
@@ -32,6 +32,7 @@ export const QuestionOptionsCheckboxJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('Options for a Checkbox question.');
+  .describe('Options for a Checkbox question.')
+  .meta({ title: 'Checkbox question options' });
 
 export type QuestionOptionsCheckboxJson = z.infer<typeof QuestionOptionsCheckboxJsonSchema>;

--- a/apps/prairielearn/src/schemas/questionOptionsFile.ts
+++ b/apps/prairielearn/src/schemas/questionOptionsFile.ts
@@ -8,6 +8,7 @@ export const QuestionOptionsFileJsonSchema = z
     fileName: z.string().describe('Filename of the file to download').optional(),
   })
   .strict()
-  .describe('Options for a File question.');
+  .describe('Options for a File question.')
+  .meta({ title: 'File question options' });
 
 export type QuestionOptionsFileJson = z.infer<typeof QuestionOptionsFileJsonSchema>;

--- a/apps/prairielearn/src/schemas/questionOptionsMultipleChoice.ts
+++ b/apps/prairielearn/src/schemas/questionOptionsMultipleChoice.ts
@@ -20,7 +20,8 @@ export const QuestionOptionsMultipleChoiceJsonSchema = z
       .optional(),
   })
   .strict()
-  .describe('Options for a MultipleChoice question.');
+  .describe('Options for a MultipleChoice question.')
+  .meta({ title: 'MultipleChoice question options' });
 
 export type QuestionOptionsMultipleChoiceJson = z.infer<
   typeof QuestionOptionsMultipleChoiceJsonSchema

--- a/apps/prairielearn/src/schemas/questionOptionsMultipleTrueFalse.ts
+++ b/apps/prairielearn/src/schemas/questionOptionsMultipleTrueFalse.ts
@@ -14,7 +14,8 @@ export const QuestionOptionsMultipleTrueFalseJsonSchema = z
       .describe('A list of false statements for the question. Each is an HTML string.'),
   })
   .strict()
-  .describe('Options for a MultipleTrueFalse question.');
+  .describe('Options for a MultipleTrueFalse question.')
+  .meta({ title: 'MultipleTrueFalse question options' });
 
 export type QuestionOptionsMultipleTrueFalseJson = z.infer<
   typeof QuestionOptionsMultipleTrueFalseJsonSchema

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -1,764 +1,456 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Assessment info",
-  "description": "Configuration data for an assessment.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["uuid", "type", "title", "set", "number"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "uuid": {
-      "description": "Unique identifier (UUID v4).",
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "description": "Unique identifier (UUID v4)."
     },
     "type": {
-      "description": "Type of the assessment.",
       "type": "string",
-      "enum": ["Homework", "Exam"]
+      "enum": ["Homework", "Exam"],
+      "description": "Type of the assessment."
     },
     "title": {
-      "description": "The title of the assessment (e.g., 'Derivatives and anti-derivatives').",
-      "type": "string"
+      "type": "string",
+      "description": "The title of the assessment (e.g., 'Derivatives and anti-derivatives')."
     },
     "set": {
-      "description": "Which assessmentSet this one belongs to (e.g., 'Homework', 'Practice Quiz').",
-      "type": "string"
+      "type": "string",
+      "description": "Which assessmentSet this one belongs to (e.g., 'Homework', 'Practice Quiz')."
     },
     "number": {
-      "description": "The number of this assessment within the set (e.g., '1', '2R', '3B').",
-      "type": "string"
+      "type": "string",
+      "description": "The number of this assessment within the set (e.g., '1', '2R', '3B')."
     },
     "allowIssueReporting": {
-      "description": "Whether to allow students to report issues for assessment questions",
+      "default": true,
       "type": "boolean",
-      "default": true
+      "description": "Whether to allow students to report issues for assessment questions"
     },
     "multipleInstance": {
-      "description": "Whether to allow students to create additional instances of the assessment",
+      "default": false,
       "type": "boolean",
-      "default": false
+      "description": "Whether to allow students to create additional instances of the assessment"
     },
     "shuffleQuestions": {
-      "description": "Whether the questions will be shuffled in the student view of an assessment. If the assessment type is Exam, this is true by default, and otherwise false.",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Whether the questions will be shuffled in the student view of an assessment. If the assessment type is Exam, this is true by default, and otherwise false."
     },
     "allowAccess": {
-      "description": "List of access rules for the assessment. Access is permitted if any access rule is satisfied.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/AssessmentAccessRuleJsonSchema"
-      }
+      },
+      "description": "List of access rules for the assessment. Access is permitted if any access rule is satisfied."
     },
     "accessControl": {
-      "description": "Access control settings for the assessment.",
+      "maxItems": 101,
       "type": "array",
       "items": {
         "$ref": "#/definitions/AccessControlJsonSchema"
       },
-      "maxItems": 101
+      "description": "Access control settings for the assessment."
     },
     "text": {
-      "description": "HTML text shown on the assessment overview page.",
-      "type": "string"
+      "type": "string",
+      "description": "HTML text shown on the assessment overview page."
     },
     "maxPoints": {
-      "description": "The number of points that must be earned in this assessment to achieve a score of 100%.",
       "type": "number",
-      "minimum": 0
+      "minimum": 0,
+      "description": "The number of points that must be earned in this assessment to achieve a score of 100%."
     },
     "maxBonusPoints": {
-      "description": "The maximum number of additional points that can be earned beyond maxPoints.",
       "type": "number",
-      "minimum": 0
+      "minimum": 0,
+      "description": "The maximum number of additional points that can be earned beyond maxPoints."
     },
     "allowPersonalNotes": {
-      "description": "Whether students are allowed to upload personal notes for this assessment.",
+      "default": true,
       "type": "boolean",
-      "default": true
+      "description": "Whether students are allowed to upload personal notes for this assessment."
     },
     "autoClose": {
-      "description": "Whether to automatically close the assessment after a period of inactivity.",
+      "default": true,
       "type": "boolean",
-      "default": true
+      "description": "Whether to automatically close the assessment after a period of inactivity."
     },
     "zones": {
-      "description": "Array of \"zones\" in the assessment, each containing questions that can be randomized within the zone.",
+      "default": [],
       "type": "array",
       "items": {
         "$ref": "#/definitions/ZoneAssessmentJsonSchema"
       },
-      "default": []
+      "description": "Array of \"zones\" in the assessment, each containing questions that can be randomized within the zone."
     },
     "constantQuestionValue": {
-      "description": "Whether to keep the value of a question constant after a student solves it correctly.",
+      "default": false,
       "type": "boolean",
-      "default": false
+      "description": "Whether to keep the value of a question constant after a student solves it correctly."
     },
     "allowRealTimeGrading": {
-      "description": "Removes the student \"Grade\" buttons to prevent real-time grading while the assessment is being taken. Real-time grading is allowed by default.",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Removes the student \"Grade\" buttons to prevent real-time grading while the assessment is being taken. Real-time grading is allowed by default."
     },
     "requireHonorCode": {
-      "description": "Requires the student to accept an honor code before starting the assessment. Set to true for Exam assessments by default. Only configurable for Exam assessments.",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Requires the student to accept an honor code before starting the assessment. Set to true for Exam assessments by default. Only configurable for Exam assessments."
     },
     "honorCode": {
-      "description": "Custom text for the honor code to be accepted before starting the assessment. Supports Markdown formatting; HTML is not supported. Only available for Exam assessments.",
-      "type": "string"
+      "type": "string",
+      "description": "Custom text for the honor code to be accepted before starting the assessment. Supports Markdown formatting; HTML is not supported. Only available for Exam assessments."
     },
     "showQuestionTitles": {
-      "description": "Whether to show question titles in the student view.",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Whether to show question titles in the student view."
     },
     "groupWork": {
-      "description": "Whether the assessment will support group work. DEPRECATED -- prefer using the \"groups\" property instead.",
-      "type": "boolean",
       "default": false,
+      "type": "boolean",
+      "description": "Whether the assessment will support group work. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "groupMaxSize": {
-      "description": "Maximum number of students in a group. DEPRECATED -- prefer using the \"groups\" property instead.",
       "type": "number",
+      "description": "Maximum number of students in a group. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "groupMinSize": {
-      "description": "Minimum number of students in a group. DEPRECATED -- prefer using the \"groups\" property instead.",
       "type": "number",
+      "description": "Minimum number of students in a group. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "groupRoles": {
-      "description": "Array of custom user roles in a group. DEPRECATED -- prefer using the \"groups\" property instead.",
+      "default": [],
       "type": "array",
       "items": {
         "$ref": "#/definitions/LegacyGroupRoleJsonSchema"
       },
-      "default": [],
+      "description": "Array of custom user roles in a group. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "canSubmit": {
-      "description": "A list of group role names that can submit questions. Only applicable for group assessments. DEPRECATED -- prefer using the \"groups\" property instead.",
+      "default": [],
       "type": "array",
       "items": {
         "type": "string"
       },
       "uniqueItems": true,
-      "default": [],
+      "description": "A list of group role names that can submit questions. Only applicable for group assessments. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "canView": {
-      "description": "A list of group role names that can view questions. Only applicable for group assessments. DEPRECATED -- prefer using the \"groups\" property instead.",
+      "default": [],
       "type": "array",
       "items": {
         "type": "string"
       },
       "uniqueItems": true,
-      "default": [],
+      "description": "A list of group role names that can view questions. Only applicable for group assessments. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "studentGroupCreate": {
-      "description": "Whether students can create groups. DEPRECATED -- prefer using the \"groups\" property instead.",
-      "type": "boolean",
       "default": false,
+      "type": "boolean",
+      "description": "Whether students can create groups. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "studentGroupChooseName": {
-      "description": "Whether students can choose a group name when creating a group. Only applicable if studentGroupCreate is true. DEPRECATED -- prefer using the \"groups\" property instead.",
-      "type": "boolean",
       "default": true,
+      "type": "boolean",
+      "description": "Whether students can choose a group name when creating a group. Only applicable if studentGroupCreate is true. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "studentGroupJoin": {
-      "description": "Whether students can join groups. DEPRECATED -- prefer using the \"groups\" property instead.",
-      "type": "boolean",
       "default": false,
+      "type": "boolean",
+      "description": "Whether students can join groups. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "studentGroupLeave": {
-      "description": "Whether students can leave groups. DEPRECATED -- prefer using the \"groups\" property instead.",
-      "type": "boolean",
       "default": false,
+      "type": "boolean",
+      "description": "Whether students can leave groups. Prefer using the \"groups\" property instead.",
       "deprecated": true
     },
     "groups": {
-      "description": "Configuration for group-based assessments.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "minMembers": {
-          "description": "Minimum number of students in a group.",
-          "type": "number"
+          "type": "number",
+          "description": "Minimum number of students in a group."
         },
         "maxMembers": {
-          "description": "Maximum number of students in a group.",
-          "type": "number"
+          "type": "number",
+          "description": "Maximum number of students in a group."
         },
         "roles": {
-          "description": "Array of custom user roles in a group.",
+          "default": [],
           "type": "array",
           "items": {
             "$ref": "#/definitions/GroupsRoleJsonSchema"
           },
-          "uniqueItems": true,
-          "default": []
+          "description": "Array of custom user roles in a group.",
+          "uniqueItems": true
         },
         "studentPermissions": {
-          "description": "Student permissions for group management.",
+          "default": {},
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "canCreateGroup": {
-              "description": "Whether students can create groups.",
+              "default": true,
               "type": "boolean",
-              "default": true
+              "description": "Whether students can create groups."
             },
             "canJoinGroup": {
-              "description": "Whether students can join groups.",
+              "default": true,
               "type": "boolean",
-              "default": true
+              "description": "Whether students can join groups."
             },
             "canLeaveGroup": {
-              "description": "Whether students can leave groups.",
+              "default": true,
               "type": "boolean",
-              "default": true
+              "description": "Whether students can leave groups."
             },
             "canNameGroup": {
-              "description": "Whether students can choose a group name when creating a group.",
+              "default": true,
               "type": "boolean",
-              "default": true
+              "description": "Whether students can choose a group name when creating a group."
             }
           },
-          "default": {}
+          "additionalProperties": false,
+          "description": "Student permissions for group management."
         },
         "rolePermissions": {
-          "description": "Role-based permissions for group assessments.",
+          "default": {},
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "canAssignRoles": {
-              "description": "Role names that can assign other users to roles.",
+              "default": [],
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "default": []
+              "uniqueItems": true,
+              "description": "Role names that can assign other users to roles."
             },
             "canView": {
-              "description": "Role names that can view questions.",
+              "default": [],
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "default": []
+              "uniqueItems": true,
+              "description": "Role names that can view questions."
             },
             "canSubmit": {
-              "description": "Role names that can submit questions.",
+              "default": [],
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "default": []
+              "uniqueItems": true,
+              "description": "Role names that can submit questions."
             }
           },
-          "default": {}
-        }
-      }
-    },
-    "advanceScorePerc": {
-      "$ref": "#/definitions/AdvanceScorePercJsonSchema"
-    },
-    "gradeRateMinutes": {
-      "description": "Minimum amount of time (in minutes) between graded submissions to the same question.",
-      "type": "number",
-      "minimum": 0
-    },
-    "module": {
-      "description": "Module that this assessment belongs to, as defined in infoCourse.json.",
-      "type": "string"
-    },
-    "shareSourcePublicly": {
-      "description": "If true, the assessment's JSON configuration and question list are available for others to view and copy.",
-      "type": "boolean",
-      "default": false
-    },
-    "tools": {
-      "description": "Configuration for assessment tools.",
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "required": ["enabled"],
-        "properties": {
-          "enabled": {
-            "description": "Whether this assessment tool is enabled.",
-            "type": "boolean"
-          }
+          "additionalProperties": false,
+          "description": "Role-based permissions for group assessments."
         }
       },
+      "additionalProperties": false,
+      "description": "Configuration for group-based assessments."
+    },
+    "advanceScorePerc": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AdvanceScorePercJsonSchema"
+        }
+      ]
+    },
+    "gradeRateMinutes": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Minimum amount of time (in minutes) between graded submissions to the same question."
+    },
+    "module": {
+      "type": "string",
+      "description": "Module that this assessment belongs to, as defined in infoCourse.json."
+    },
+    "shareSourcePublicly": {
+      "default": false,
+      "type": "boolean",
+      "description": "If true, the assessment's JSON configuration and question list are available for others to view and copy."
+    },
+    "tools": {
+      "type": "object",
       "propertyNames": {
+        "type": "string",
         "enum": ["calculator"]
-      }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether this assessment tool is enabled."
+          }
+        },
+        "required": ["enabled"]
+      },
+      "description": "Configuration for assessment tools."
     }
   },
+  "required": ["uuid", "type", "title", "set", "number"],
+  "additionalProperties": false,
+  "description": "Configuration data for an assessment.",
+  "title": "Assessment info",
   "definitions": {
+    "CommentJsonSchema": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {}
+        },
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {}
+        }
+      ],
+      "description": "Arbitrary comment for reference purposes."
+    },
     "AssessmentAccessRuleJsonSchema": {
-      "description": "An access rule that permits people to access this assessment. All restrictions in the rule must be satisfied for the rule to allow access.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "mode": {
-          "description": "The server mode required for access.",
           "type": "string",
-          "enum": ["Public", "Exam"]
+          "enum": ["Public", "Exam"],
+          "description": "The server mode required for access."
         },
         "examUuid": {
-          "description": "The PrairieTest exam UUID for which a student must be registered. Implies mode: Exam.",
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "description": "The PrairieTest exam UUID for which a student must be registered. Implies mode: Exam."
         },
         "role": {
-          "description": "DEPRECATED -- do not use.",
           "type": "string",
           "enum": ["Student", "TA", "Instructor"],
           "deprecated": true
         },
         "uids": {
-          "description": "A list of UIDs (like 'username@example.com'), one of which is required for access.",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "A list of UIDs (like 'username@example.com'), one of which is required for access."
         },
         "credit": {
-          "description": "How much credit is awarded for doing the homework, as a percentage (100 means full credit).",
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 9007199254740991,
+          "description": "How much credit is awarded for doing the homework, as a percentage (100 means full credit)."
         },
         "startDate": {
-          "description": "The earliest date on which access is permitted.",
-          "type": "string"
+          "type": "string",
+          "description": "The earliest date on which access is permitted."
         },
         "endDate": {
-          "description": "The latest date on which access is permitted.",
-          "type": "string"
+          "type": "string",
+          "description": "The latest date on which access is permitted."
         },
         "timeLimitMin": {
-          "description": "The time limit to complete the assessment, in minutes (only for Exams).",
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 9007199254740991,
+          "description": "The time limit to complete the assessment, in minutes (only for Exams)."
         },
         "password": {
-          "description": "Password to begin the assessment. Typically used for proctored exams.",
-          "type": "string"
+          "type": "string",
+          "description": "Password to begin the assessment. Typically used for proctored exams."
         },
         "showClosedAssessment": {
-          "description": "Whether the student can view the assessment after it has been closed",
+          "default": true,
           "type": "boolean",
-          "default": true
+          "description": "Whether the student can view the assessment after it has been closed"
         },
         "showClosedAssessmentScore": {
-          "description": "Whether the student can view the assessment grade after it has been closed. Only works if showClosedAssessment is also set to false",
+          "default": true,
           "type": "boolean",
-          "default": true
+          "description": "Whether the student can view the assessment grade after it has been closed. Only works if showClosedAssessment is also set to false"
         },
         "active": {
-          "description": "Whether the student can create a new assessment instance and submit answers to questions. If set to false, the available credit must be 0.",
+          "default": true,
           "type": "boolean",
-          "default": true
+          "description": "Whether the student can create a new assessment instance and submit answers to questions. If set to false, the available credit must be 0."
         }
-      }
-    },
-    "ZoneAssessmentJsonSchema": {
-      "type": "object",
-      "required": ["questions"],
-      "properties": {
-        "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
-        },
-        "title": {
-          "description": "Zone title, displayed to the students at the top of the question list for the zone.",
-          "type": "string"
-        },
-        "comments": {
-          "description": "DEPRECATED -- do not use.",
-          "$ref": "#/definitions/CommentJsonSchema",
-          "deprecated": true
-        },
-        "maxPoints": {
-          "description": "Only this many of the points that are awarded for answering questions in this zone will count toward the total points.",
-          "type": "number",
-          "minimum": 0
-        },
-        "numberChoose": {
-          "description": "Number of questions to choose from this zone.",
-          "type": "integer",
-          "minimum": 0
-        },
-        "bestQuestions": {
-          "description": "Only this many of the questions in this zone, with the highest number of awarded points, will count toward the total points.",
-          "type": "integer",
-          "minimum": 0
-        },
-        "lockpoint": {
-          "description": "If true, students must explicitly acknowledge advancing past this point. All questions in previous zones become read-only after crossing.",
-          "type": "boolean",
-          "default": false
-        },
-        "questions": {
-          "description": "Array of questions in the zone.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ZoneQuestionBlockJsonSchema"
-          },
-          "minItems": 1
-        },
-        "advanceScorePerc": {
-          "$ref": "#/definitions/AdvanceScorePercJsonSchema"
-        },
-        "gradeRateMinutes": {
-          "description": "Minimum amount of time (in minutes) between graded submissions to the same question.",
-          "type": "number",
-          "minimum": 0
-        },
-        "allowRealTimeGrading": {
-          "description": "Whether to allow real-time grading for questions in this zone. If not specified, inherits from the assessment level.",
-          "type": "boolean"
-        },
-        "canSubmit": {
-          "description": "A list of group role names that can submit questions in this zone. Only applicable for group assessments.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true,
-          "default": []
-        },
-        "canView": {
-          "description": "A list of group role names that can view questions in this zone. Only applicable for group assessments.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true,
-          "default": []
-        },
-        "tools": {
-          "description": "Tools available for questions in this zone. Overrides assessment-level tools.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "object",
-            "required": ["enabled"],
-            "properties": {
-              "enabled": {
-                "description": "Whether this assessment tool is enabled.",
-                "type": "boolean"
-              }
-            }
-          },
-          "propertyNames": {
-            "enum": ["calculator"]
-          }
-        }
-      }
-    },
-    "ZoneQuestionBlockJsonSchema": {
-      "type": "object",
-      "properties": {
-        "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
-        },
-        "points": {
-          "$ref": "#/definitions/PointsJsonSchema"
-        },
-        "autoPoints": {
-          "$ref": "#/definitions/PointsJsonSchema"
-        },
-        "maxPoints": {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        "maxAutoPoints": {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        "manualPoints": {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        "id": {
-          "$ref": "#/definitions/QuestionIdJsonSchema"
-        },
-        "forceMaxPoints": {
-          "$ref": "#/definitions/ForceMaxPointsJsonSchema"
-        },
-        "alternatives": {
-          "description": "Array of question alternatives to choose from.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/QuestionAlternativeJsonSchema"
-          },
-          "minItems": 1
-        },
-        "numberChoose": {
-          "description": "Number of questions to choose from this pool.",
-          "type": "integer",
-          "minimum": 0
-        },
-        "triesPerVariant": {
-          "description": "The maximum number of graded submissions allowed for each question instance.",
-          "type": "integer",
-          "minimum": 1
-        },
-        "advanceScorePerc": {
-          "$ref": "#/definitions/AdvanceScorePercJsonSchema"
-        },
-        "gradeRateMinutes": {
-          "description": "Minimum amount of time (in minutes) between graded submissions to the same question.",
-          "type": "number",
-          "minimum": 0
-        },
-        "allowRealTimeGrading": {
-          "description": "Whether to allow real-time grading for this question. If not specified, inherits from the zone level.",
-          "type": "boolean"
-        },
-        "canSubmit": {
-          "description": "A list of group role names that can submit the question. Only applicable for group assessments.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true,
-          "default": []
-        },
-        "canView": {
-          "description": "A list of group role names that can view the question. Only applicable for group assessments.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true,
-          "default": []
-        },
-        "preferences": {
-          "description": "The preferences passed to the question to customize its behavior.",
-          "$ref": "#/definitions/QuestionPreferencesJsonSchema"
-        }
-      }
-    },
-    "QuestionAlternativeJsonSchema": {
-      "type": "object",
-      "required": ["id"],
-      "properties": {
-        "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
-        },
-        "points": {
-          "$ref": "#/definitions/PointsJsonSchema"
-        },
-        "autoPoints": {
-          "$ref": "#/definitions/PointsJsonSchema"
-        },
-        "maxPoints": {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        "maxAutoPoints": {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        "manualPoints": {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        "id": {
-          "$ref": "#/definitions/QuestionIdJsonSchema"
-        },
-        "forceMaxPoints": {
-          "$ref": "#/definitions/ForceMaxPointsJsonSchema"
-        },
-        "triesPerVariant": {
-          "description": "The maximum number of graded submissions allowed for each question instance.",
-          "type": "integer",
-          "minimum": 1
-        },
-        "advanceScorePerc": {
-          "$ref": "#/definitions/AdvanceScorePercJsonSchema"
-        },
-        "gradeRateMinutes": {
-          "description": "Minimum amount of time (in minutes) between graded submissions to the same question.",
-          "type": "number",
-          "minimum": 0
-        },
-        "allowRealTimeGrading": {
-          "description": "Whether to allow real-time grading for this question alternative. If not specified, inherits from the question level.",
-          "type": "boolean"
-        },
-        "preferences": {
-          "description": "The preferences passed to the question to customize its behavior.",
-          "$ref": "#/definitions/QuestionPreferencesJsonSchema"
-        }
-      }
-    },
-    "PointsJsonSchema": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PointsSingleJsonSchema"
-        },
-        {
-          "$ref": "#/definitions/PointsListJsonSchema"
-        }
-      ]
-    },
-    "PointsSingleJsonSchema": {
-      "description": "A single point value.",
-      "type": "number",
-      "minimum": 0
-    },
-    "PointsListJsonSchema": {
-      "description": "An array of point values.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PointsSingleJsonSchema"
       },
-      "minItems": 1
-    },
-    "QuestionIdJsonSchema": {
-      "description": "Question ID (directory name of the question).",
-      "type": "string"
-    },
-    "ForceMaxPointsJsonSchema": {
-      "description": "Whether to force this question to be awarded maximum points on a regrade.",
-      "type": "boolean"
-    },
-    "AdvanceScorePercJsonSchema": {
-      "description": "Minimum score percentage to unlock access to subsequent questions.",
-      "type": "number",
-      "minimum": 0,
-      "maximum": 100
-    },
-    "QuestionPreferencesJsonSchema": {
-      "type": "object",
-      "additionalProperties": {
-        "type": ["string", "number", "boolean"]
-      },
-      "propertyNames": {
-        "minLength": 1
-      }
-    },
-    "LegacyGroupRoleJsonSchema": {
-      "description": "A custom role for use in group assessments that allows control over certain permissions.",
-      "type": "object",
-      "required": ["name"],
-      "properties": {
-        "name": {
-          "description": "The group role's name (i.e. Manager, Reflector, Recorder).",
-          "type": "string"
-        },
-        "minimum": {
-          "description": "The minimum number of users that should be in this role in a group.",
-          "type": "number",
-          "default": 0
-        },
-        "maximum": {
-          "description": "The maximum number of users that should be in this role in a group.",
-          "type": "number"
-        },
-        "canAssignRoles": {
-          "description": "Whether users with this role can assign other users' group roles.",
-          "type": "boolean",
-          "default": false
-        }
-      }
-    },
-    "GroupsRoleJsonSchema": {
-      "description": "A custom role for use in group assessments.",
-      "type": "object",
       "additionalProperties": false,
-      "required": ["name"],
-      "properties": {
-        "name": {
-          "description": "The group role's name (e.g., Manager, Recorder).",
-          "type": "string"
-        },
-        "minMembers": {
-          "description": "The minimum number of users that should be in this role.",
-          "type": "number",
-          "default": 0
-        },
-        "maxMembers": {
-          "description": "The maximum number of users that should be in this role.",
-          "type": "number"
-        }
-      }
-    },
-    "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array"
-        },
-        {
-          "type": "object",
-          "additionalProperties": {},
-          "properties": {}
-        }
-      ]
-    },
-    "DatetimeLocalStringSchema": {
-      "type": "string",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2})?$"
+      "description": "An access rule that permits people to access this assessment. All restrictions in the rule must be satisfied for the rule to allow access."
     },
     "AccessControlJsonSchema": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": {
           "description": "Array of student label names this set targets",
+          "maxItems": 100,
           "type": "array",
           "items": {
             "type": "string",
             "minLength": 1,
             "maxLength": 255
-          },
-          "maxItems": 100
+          }
         },
         "beforeRelease": {
           "description": "Only valid on the first entry (defaults). Controls assessment visibility before the release date.",
           "type": "object",
-          "additionalProperties": false,
-          "required": ["listed"],
           "properties": {
             "listed": {
-              "description": "Whether to list the assessment title before the release date. Students can see the title but cannot open the assessment.",
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether to list the assessment title before the release date. Students can see the title but cannot open the assessment."
             }
-          }
+          },
+          "required": ["listed"],
+          "additionalProperties": false
         },
         "dateControl": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "release": {
               "description": "Controls when the assessment becomes available to students",
               "type": "object",
-              "additionalProperties": false,
-              "required": ["date"],
               "properties": {
                 "date": {
                   "description": "Release date as ISO String",
                   "$ref": "#/definitions/DatetimeLocalStringSchema"
                 }
-              }
+              },
+              "required": ["date"],
+              "additionalProperties": false
             },
             "due": {
               "description": "Due date configuration. Overrides replace the entire due object atomically.",
               "type": "object",
-              "additionalProperties": false,
-              "required": ["date"],
               "properties": {
                 "date": {
-                  "description": "Due date as ISO String, or null for no due date",
                   "anyOf": [
                     {
                       "$ref": "#/definitions/DatetimeLocalStringSchema"
@@ -766,7 +458,8 @@
                     {
                       "type": "null"
                     }
-                  ]
+                  ],
+                  "description": "Due date as ISO String, or null for no due date"
                 },
                 "credit": {
                   "description": "Custom credit percentage at the due date (0-200). Omitted means default 100% credit.",
@@ -774,17 +467,19 @@
                   "minimum": 0,
                   "maximum": 200
                 }
-              }
+              },
+              "required": ["date"],
+              "additionalProperties": false
             },
             "earlyDeadlines": {
               "description": "Array of early deadlines with credit as percentages",
               "anyOf": [
                 {
+                  "maxItems": 10,
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/DeadlineEntryJsonSchema"
-                  },
-                  "maxItems": 10
+                  }
                 },
                 {
                   "type": "null"
@@ -795,11 +490,11 @@
               "description": "Array of late deadlines with credit as percentages",
               "anyOf": [
                 {
+                  "maxItems": 10,
                   "type": "array",
                   "items": {
                     "$ref": "#/definitions/DeadlineEntryJsonSchema"
-                  },
-                  "maxItems": 10
+                  }
                 },
                 {
                   "type": "null"
@@ -807,12 +502,9 @@
               ]
             },
             "afterLastDeadline": {
-              "description": "Controls for assessment behavior after last deadline. Null means no access; omitted on overrides inherits from the default rule. On the default rule, omitting is equivalent to null (no access).",
               "anyOf": [
                 {
                   "type": "object",
-                  "additionalProperties": false,
-                  "required": ["allowSubmissions"],
                   "properties": {
                     "allowSubmissions": {
                       "type": "boolean"
@@ -822,12 +514,15 @@
                       "minimum": 0,
                       "maximum": 99
                     }
-                  }
+                  },
+                  "required": ["allowSubmissions"],
+                  "additionalProperties": false
                 },
                 {
                   "type": "null"
                 }
-              ]
+              ],
+              "description": "Controls for assessment behavior after last deadline. Null means no access; omitted on overrides inherits from the default rule. On the default rule, omitting is equivalent to null (no access)."
             },
             "durationMinutes": {
               "description": "Desired duration limit for assessment",
@@ -855,28 +550,26 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         },
         "integrations": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "prairieTest": {
               "type": "object",
-              "additionalProperties": false,
               "properties": {
                 "exams": {
                   "description": "Array of associated PrairieTest exam configs",
+                  "maxItems": 10,
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "additionalProperties": false,
-                    "required": ["examUuid"],
                     "properties": {
                       "examUuid": {
-                        "description": "UUID of associated PrairieTest exam",
                         "type": "string",
-                        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+                        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                        "description": "UUID of associated PrairieTest exam"
                       },
                       "readOnly": {
                         "description": "Whether the exam is read-only for students",
@@ -885,91 +578,532 @@
                       "afterComplete": {
                         "description": "Controls visibility after the student finishes the assessment during an active PrairieTest reservation. Only applies while a matching reservation is active; ignored otherwise.",
                         "type": "object",
-                        "additionalProperties": false,
                         "properties": {
                           "questions": {
                             "type": "object",
-                            "additionalProperties": false,
-                            "required": ["hidden"],
                             "properties": {
                               "hidden": {
                                 "type": "boolean"
                               }
-                            }
+                            },
+                            "required": ["hidden"],
+                            "additionalProperties": false
                           },
                           "score": {
                             "type": "object",
-                            "additionalProperties": false,
-                            "required": ["hidden"],
                             "properties": {
                               "hidden": {
                                 "type": "boolean"
                               }
-                            }
+                            },
+                            "required": ["hidden"],
+                            "additionalProperties": false
                           }
-                        }
+                        },
+                        "additionalProperties": false
                       }
-                    }
-                  },
-                  "maxItems": 10
+                    },
+                    "required": ["examUuid"],
+                    "additionalProperties": false
+                  }
                 }
-              }
+              },
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
         },
         "afterComplete": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "questions": {
               "type": "object",
-              "additionalProperties": false,
-              "required": ["hidden"],
               "properties": {
                 "hidden": {
                   "type": "boolean"
                 },
                 "visibleFromDate": {
-                  "$ref": "#/definitions/DatetimeLocalStringSchema"
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DatetimeLocalStringSchema"
+                    }
+                  ]
                 },
                 "visibleUntilDate": {
-                  "$ref": "#/definitions/DatetimeLocalStringSchema"
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DatetimeLocalStringSchema"
+                    }
+                  ]
                 }
-              }
+              },
+              "required": ["hidden"],
+              "additionalProperties": false
             },
             "score": {
               "type": "object",
-              "additionalProperties": false,
-              "required": ["hidden"],
               "properties": {
                 "hidden": {
                   "type": "boolean"
                 },
                 "visibleFromDate": {
-                  "$ref": "#/definitions/DatetimeLocalStringSchema"
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/DatetimeLocalStringSchema"
+                    }
+                  ]
                 }
-              }
+              },
+              "required": ["hidden"],
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
         }
-      }
+      },
+      "additionalProperties": false
+    },
+    "DatetimeLocalStringSchema": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2})?$"
     },
     "DeadlineEntryJsonSchema": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["date", "credit"],
       "properties": {
         "date": {
           "description": "Date as ISO String for additional deadline",
           "$ref": "#/definitions/DatetimeLocalStringSchema"
         },
         "credit": {
-          "description": "Integer credit percentage to allow",
           "type": "integer",
           "minimum": 0,
-          "maximum": 200
+          "maximum": 200,
+          "description": "Integer credit percentage to allow"
+        }
+      },
+      "required": ["date", "credit"],
+      "additionalProperties": false
+    },
+    "ZoneAssessmentJsonSchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Zone title, displayed to the students at the top of the question list for the zone."
+        },
+        "comment": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
+        },
+        "comments": {
+          "deprecated": true,
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
+        },
+        "maxPoints": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Only this many of the points that are awarded for answering questions in this zone will count toward the total points."
+        },
+        "numberChoose": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991,
+          "description": "Number of questions to choose from this zone."
+        },
+        "bestQuestions": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991,
+          "description": "Only this many of the questions in this zone, with the highest number of awarded points, will count toward the total points."
+        },
+        "lockpoint": {
+          "default": false,
+          "type": "boolean",
+          "description": "If true, students must explicitly acknowledge advancing past this point. All questions in previous zones become read-only after crossing."
+        },
+        "questions": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ZoneQuestionBlockJsonSchema"
+          },
+          "description": "Array of questions in the zone."
+        },
+        "advanceScorePerc": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AdvanceScorePercJsonSchema"
+            }
+          ]
+        },
+        "gradeRateMinutes": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minimum amount of time (in minutes) between graded submissions to the same question."
+        },
+        "allowRealTimeGrading": {
+          "type": "boolean",
+          "description": "Whether to allow real-time grading for questions in this zone. If not specified, inherits from the assessment level."
+        },
+        "canSubmit": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "A list of group role names that can submit questions in this zone. Only applicable for group assessments."
+        },
+        "canView": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "A list of group role names that can view questions in this zone. Only applicable for group assessments."
+        },
+        "tools": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "enum": ["calculator"]
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Whether this assessment tool is enabled."
+              }
+            },
+            "required": ["enabled"]
+          },
+          "description": "Tools available for questions in this zone. Overrides assessment-level tools."
+        }
+      },
+      "required": ["questions"]
+    },
+    "ZoneQuestionBlockJsonSchema": {
+      "type": "object",
+      "properties": {
+        "points": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsJsonSchema"
+            }
+          ]
+        },
+        "autoPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsJsonSchema"
+            }
+          ]
+        },
+        "maxPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsSingleJsonSchema"
+            }
+          ]
+        },
+        "maxAutoPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsSingleJsonSchema"
+            }
+          ]
+        },
+        "manualPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsSingleJsonSchema"
+            }
+          ]
+        },
+        "comment": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
+        },
+        "id": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/QuestionIdJsonSchema"
+            }
+          ]
+        },
+        "forceMaxPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForceMaxPointsJsonSchema"
+            }
+          ]
+        },
+        "alternatives": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/QuestionAlternativeJsonSchema"
+          },
+          "description": "Array of question alternatives to choose from."
+        },
+        "numberChoose": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 9007199254740991,
+          "description": "Number of questions to choose from this pool."
+        },
+        "triesPerVariant": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991,
+          "description": "The maximum number of graded submissions allowed for each question instance."
+        },
+        "advanceScorePerc": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AdvanceScorePercJsonSchema"
+            }
+          ]
+        },
+        "gradeRateMinutes": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minimum amount of time (in minutes) between graded submissions to the same question."
+        },
+        "allowRealTimeGrading": {
+          "type": "boolean",
+          "description": "Whether to allow real-time grading for this question. If not specified, inherits from the zone level."
+        },
+        "canSubmit": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "A list of group role names that can submit the question. Only applicable for group assessments."
+        },
+        "canView": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "description": "A list of group role names that can view the question. Only applicable for group assessments."
+        },
+        "preferences": {
+          "description": "The preferences passed to the question to customize its behavior.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/QuestionPreferencesJsonSchema"
+            }
+          ]
         }
       }
+    },
+    "PointsJsonSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PointsSingleJsonSchema"
+        },
+        {
+          "$ref": "#/definitions/PointsListJsonSchema"
+        }
+      ]
+    },
+    "PointsSingleJsonSchema": {
+      "type": "number",
+      "minimum": 0,
+      "description": "A single point value."
+    },
+    "PointsListJsonSchema": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PointsSingleJsonSchema"
+      },
+      "description": "An array of point values."
+    },
+    "QuestionIdJsonSchema": {
+      "type": "string",
+      "description": "Question ID (directory name of the question)."
+    },
+    "ForceMaxPointsJsonSchema": {
+      "type": "boolean",
+      "description": "Whether to force this question to be awarded maximum points on a regrade."
+    },
+    "QuestionAlternativeJsonSchema": {
+      "type": "object",
+      "properties": {
+        "points": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsJsonSchema"
+            }
+          ]
+        },
+        "autoPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsJsonSchema"
+            }
+          ]
+        },
+        "maxPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsSingleJsonSchema"
+            }
+          ]
+        },
+        "maxAutoPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsSingleJsonSchema"
+            }
+          ]
+        },
+        "manualPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/PointsSingleJsonSchema"
+            }
+          ]
+        },
+        "comment": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/QuestionIdJsonSchema"
+        },
+        "forceMaxPoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ForceMaxPointsJsonSchema"
+            }
+          ]
+        },
+        "triesPerVariant": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9007199254740991,
+          "description": "The maximum number of graded submissions allowed for each question instance."
+        },
+        "advanceScorePerc": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AdvanceScorePercJsonSchema"
+            }
+          ]
+        },
+        "gradeRateMinutes": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minimum amount of time (in minutes) between graded submissions to the same question."
+        },
+        "allowRealTimeGrading": {
+          "type": "boolean",
+          "description": "Whether to allow real-time grading for this question alternative. If not specified, inherits from the question level."
+        },
+        "preferences": {
+          "description": "The preferences passed to the question to customize its behavior.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/QuestionPreferencesJsonSchema"
+            }
+          ]
+        }
+      },
+      "required": ["id"]
+    },
+    "AdvanceScorePercJsonSchema": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "Minimum score percentage to unlock access to subsequent questions."
+    },
+    "QuestionPreferencesJsonSchema": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      }
+    },
+    "LegacyGroupRoleJsonSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The group role's name (i.e. Manager, Reflector, Recorder)."
+        },
+        "minimum": {
+          "default": 0,
+          "type": "number",
+          "description": "The minimum number of users that should be in this role in a group."
+        },
+        "maximum": {
+          "type": "number",
+          "description": "The maximum number of users that should be in this role in a group."
+        },
+        "canAssignRoles": {
+          "default": false,
+          "type": "boolean",
+          "description": "Whether users with this role can assign other users' group roles."
+        }
+      },
+      "required": ["name"],
+      "description": "A custom role for use in group assessments that allows control over certain permissions."
+    },
+    "GroupsRoleJsonSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The group role's name (e.g., Manager, Recorder)."
+        },
+        "minMembers": {
+          "default": 0,
+          "type": "number",
+          "description": "The minimum number of users that should be in this role."
+        },
+        "maxMembers": {
+          "type": "number",
+          "description": "The maximum number of users that should be in this role."
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false,
+      "description": "A custom role for use in group assessments."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/infoCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourse.json
@@ -1,196 +1,235 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Course information",
-  "description": "The specification file for a course.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["name", "title", "topics"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "uuid": {
-      "description": "[DEPRECATED, DO NOT USE] Unique identifier (UUID v4).",
       "type": "string",
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "description": "Unique identifier (UUID v4).",
       "deprecated": true
     },
     "name": {
-      "description": "The course name (e.g., 'TAM 212').",
-      "type": "string"
+      "type": "string",
+      "description": "The course name (e.g., 'TAM 212')."
     },
     "title": {
-      "description": "The course title (e.g., 'Introductory Dynamics').",
-      "type": "string"
+      "type": "string",
+      "description": "The course title (e.g., 'Introductory Dynamics')."
     },
     "timezone": {
-      "description": "The timezone for all date input and display (e.g., \"America/Chicago\"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred.",
-      "type": "string"
+      "type": "string",
+      "description": "The timezone for all date input and display (e.g., \"America/Chicago\"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred."
     },
     "options": {
-      "description": "Options for this course.",
+      "default": {},
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "useNewQuestionRenderer": {
-          "description": "[DEPRECATED, DO NOT USE] Feature flag to enable the new question renderer.",
           "type": "boolean",
+          "description": "Feature flag to enable the new question renderer.",
           "deprecated": true
         },
         "devModeFeatures": {
-          "description": "Feature flags to enable/disable in development mode.",
           "anyOf": [
             {
-              "description": "Legacy format; use an object instead.",
               "type": "array",
               "items": {
-                "description": "A single feature flag.",
-                "type": "string"
-              }
+                "type": "string",
+                "description": "A single feature flag."
+              },
+              "description": "Legacy format; use an object instead."
             },
             {
               "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
               "additionalProperties": {
                 "type": "boolean"
               }
             }
-          ]
+          ],
+          "description": "Feature flags to enable/disable in development mode."
         },
         "questionsReceiveUserData": {
-          "description": "If true, server.py receives the variant owner's identity (UID, UIN, name) and group data (if applicable) via `data[\"options\"][\"user\"]` and `data[\"options\"][\"group\"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. This JSON setting is honored only in development mode. In production, configure this on the course settings page; sync reports a warning if the JSON value differs from the production setting.",
-          "type": "boolean"
+          "type": "boolean",
+          "description": "If true, server.py receives the variant owner's identity (UID, UIN, name) and group data (if applicable) via `data[\"options\"][\"user\"]` and `data[\"options\"][\"group\"]`. The user value is null for group variants. Only takes effect when the question is rendered in its owning course; data is omitted for questions imported via sharing. This JSON setting is honored only in development mode. In production, configure this on the course settings page; sync reports a warning if the JSON value differs from the production setting."
         }
       },
-      "default": {}
+      "additionalProperties": false,
+      "description": "Options for this course."
     },
     "assessmentSets": {
-      "description": "Assessment sets.",
       "type": "array",
       "items": {
-        "description": "A single assessment set description.",
         "type": "object",
-        "required": ["abbreviation", "name", "heading", "color"],
         "properties": {
           "comment": {
-            "$ref": "#/definitions/CommentJsonSchema"
+            "allOf": [
+              {
+                "$ref": "#/definitions/CommentJsonSchema"
+              }
+            ]
           },
           "abbreviation": {
-            "description": "Abbreviation (preferably 1 to 3 characters), e.g., 'HW', 'Q', 'PQ', etc.",
-            "type": "string"
+            "type": "string",
+            "description": "Abbreviation (preferably 1 to 3 characters), e.g., 'HW', 'Q', 'PQ', etc."
           },
           "name": {
-            "description": "Full singular name (preferably 1 to 3 words), e.g., 'Homework', 'Quiz', 'Practice Quiz'.",
-            "type": "string"
+            "type": "string",
+            "description": "Full singular name (preferably 1 to 3 words), e.g., 'Homework', 'Quiz', 'Practice Quiz'."
           },
           "heading": {
-            "description": "Plural heading for a group of assessments (preferably 1 to 3 words), e.g., 'Homeworks', 'Quizzes'.",
-            "type": "string"
+            "type": "string",
+            "description": "Plural heading for a group of assessments (preferably 1 to 3 words), e.g., 'Homeworks', 'Quizzes'."
           },
           "color": {
             "$ref": "#/definitions/ColorJsonSchema"
           }
-        }
-      }
+        },
+        "required": ["abbreviation", "name", "heading", "color"],
+        "description": "A single assessment set description."
+      },
+      "description": "Assessment sets."
     },
     "assessmentModules": {
-      "description": "Course modules.",
       "type": "array",
       "items": {
-        "description": "A single course module description.",
         "type": "object",
-        "required": ["name", "heading"],
         "properties": {
           "name": {
-            "description": "Short name for a module (preferably 1 to 3 words), e.g., 'Introduction'.",
-            "type": "string"
+            "type": "string",
+            "description": "Short name for a module (preferably 1 to 3 words), e.g., 'Introduction'."
           },
           "heading": {
-            "description": "Full name of the module (visible to students)",
-            "type": "string"
+            "type": "string",
+            "description": "Full name of the module (visible to students)"
           }
-        }
-      }
+        },
+        "required": ["name", "heading"],
+        "description": "A single course module description."
+      },
+      "description": "Course modules."
     },
     "topics": {
-      "description": "Question topics (visible to students).",
       "type": "array",
       "items": {
-        "description": "A single topic, can represent a unit of learning (e.g. 'vectors').",
         "type": "object",
-        "required": ["name", "color"],
         "properties": {
           "comment": {
-            "$ref": "#/definitions/CommentJsonSchema"
+            "allOf": [
+              {
+                "$ref": "#/definitions/CommentJsonSchema"
+              }
+            ]
           },
           "name": {
-            "description": "Long descriptive name (preferably less than 10 words).",
-            "type": "string"
+            "type": "string",
+            "description": "Long descriptive name (preferably less than 10 words)."
           },
           "color": {
             "$ref": "#/definitions/ColorJsonSchema"
           },
           "description": {
-            "description": "Description of the topic.",
-            "type": "string"
+            "type": "string",
+            "description": "Description of the topic."
           }
-        }
-      }
+        },
+        "required": ["name", "color"],
+        "description": "A single topic, can represent a unit of learning (e.g. 'vectors')."
+      },
+      "description": "Question topics (visible to students)."
     },
     "tags": {
-      "description": "Question tags (not visible to students).",
       "type": "array",
       "items": {
-        "description": "A single tag description.",
         "type": "object",
-        "required": ["name", "color"],
         "properties": {
           "comment": {
-            "$ref": "#/definitions/CommentJsonSchema"
+            "allOf": [
+              {
+                "$ref": "#/definitions/CommentJsonSchema"
+              }
+            ]
           },
           "shortName": {
-            "description": "Short name (preferably 2 to 7 characters).",
-            "type": "string"
+            "type": "string",
+            "description": "Short name (preferably 2 to 7 characters)."
           },
           "name": {
-            "description": "Long descriptive name (preferably less than 10 words).",
-            "type": "string"
+            "type": "string",
+            "description": "Long descriptive name (preferably less than 10 words)."
           },
           "color": {
             "$ref": "#/definitions/ColorJsonSchema"
           },
           "description": {
-            "description": "Description of the tag.",
-            "type": "string"
+            "type": "string",
+            "description": "Description of the tag."
           }
-        }
-      }
+        },
+        "required": ["name", "color"],
+        "description": "A single tag description."
+      },
+      "description": "Question tags (not visible to students)."
     },
     "sharingSets": {
-      "description": "Sharing sets.",
       "type": "array",
       "items": {
-        "description": "A sharing set description.",
         "type": "object",
-        "required": ["name"],
         "properties": {
           "name": {
-            "description": "Name of the sharing set.",
-            "type": "string"
+            "type": "string",
+            "description": "Name of the sharing set."
           },
           "description": {
-            "description": "Description of the sharing set.",
-            "type": "string"
+            "type": "string",
+            "description": "Description of the sharing set."
           }
-        }
-      }
+        },
+        "required": ["name"],
+        "description": "A sharing set description."
+      },
+      "description": "Sharing sets."
     }
   },
+  "required": ["name", "title", "topics"],
+  "additionalProperties": false,
+  "description": "The specification file for a course.",
+  "title": "Course information",
   "definitions": {
+    "CommentJsonSchema": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {}
+        },
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {}
+        }
+      ],
+      "description": "Arbitrary comment for reference purposes."
+    },
     "ColorJsonSchema": {
-      "description": "A color name.",
       "type": "string",
       "enum": [
         "red1",
@@ -223,23 +262,8 @@
         "gray1",
         "gray2",
         "gray3"
-      ]
-    },
-    "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array"
-        },
-        {
-          "type": "object",
-          "additionalProperties": {},
-          "properties": {}
-        }
-      ]
+      ],
+      "description": "A color name."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -1,168 +1,188 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Course instance information",
-  "description": "The specification file for a course instance.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["uuid", "longName"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "uuid": {
-      "description": "Unique identifier (UUID v4).",
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "description": "Unique identifier (UUID v4)."
     },
     "longName": {
-      "description": "The long name of this course instance (e.g., 'Spring 2015').",
-      "type": "string"
+      "type": "string",
+      "description": "The long name of this course instance (e.g., 'Spring 2015')."
     },
     "shortName": {
-      "description": "DEPRECATED -- do not use.",
       "type": "string",
       "deprecated": true
     },
     "timezone": {
-      "description": "The timezone for all date input and display (e.g., \"America/Chicago\"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred. If not specified, the timezone of the course will be used.",
-      "type": "string"
+      "type": "string",
+      "description": "The timezone for all date input and display (e.g., \"America/Chicago\"). Must be an official timezone identifier, as listed at <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones>. A canonical identifier is preferred. If not specified, the timezone of the course will be used."
     },
     "allowIssueReporting": {
-      "description": "DEPRECATED -- do not use.",
       "type": "boolean",
       "deprecated": true
     },
     "selfEnrollment": {
+      "default": {},
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "If true, self-enrollment access is controlled by the beforeDate and useEnrollmentCode properties. If false, users can never enroll themselves, and must be either invited or added in the UI. You likely want to set this to true if you are configuring self-enrollment.",
+          "default": true,
           "type": "boolean",
-          "default": true
+          "description": "If true, self-enrollment access is controlled by the beforeDate and useEnrollmentCode properties. If false, users can never enroll themselves, and must be either invited or added in the UI. You likely want to set this to true if you are configuring self-enrollment."
         },
         "restrictToInstitution": {
-          "description": "If true, self-enrollment is restricted to users from the same institution as the course. If false, any user can self-enroll.",
+          "default": true,
           "type": "boolean",
-          "default": true
+          "description": "If true, self-enrollment is restricted to users from the same institution as the course. If false, any user can self-enroll."
         },
         "beforeDate": {
-          "description": "If specified, self-enrollment is allowed before this date and forbidden after this date. If not specified, self-enrollment depends on enabled property.",
-          "type": "string"
+          "type": "string",
+          "description": "If specified, self-enrollment is allowed before this date and forbidden after this date. If not specified, self-enrollment depends on enabled property."
         },
         "useEnrollmentCode": {
-          "description": "If true, self-enrollment requires an enrollment code to enroll. If false, any link to the course instance will allow self-enrollment.",
+          "default": false,
           "type": "boolean",
-          "default": false
+          "description": "If true, self-enrollment requires an enrollment code to enroll. If false, any link to the course instance will allow self-enrollment."
         }
-      },
-      "default": {}
+      }
     },
     "hideInEnrollPage": {
-      "description": "DEPRECATED -- The enrollment listing page has been removed. This setting is no longer used.",
       "type": "boolean",
+      "description": "The enrollment listing page has been removed. This setting is no longer used.",
       "deprecated": true
     },
     "userRoles": {
-      "description": "DEPRECATED -- do not use.",
       "type": "object",
-      "additionalProperties": {},
       "properties": {},
+      "additionalProperties": {},
       "deprecated": true
     },
     "publishing": {
       "type": "object",
       "properties": {
         "startDate": {
-          "description": "When the course instance is published. If specified, endDate must also be specified.",
-          "type": "string"
+          "type": "string",
+          "description": "When the course instance is published. If specified, endDate must also be specified."
         },
         "endDate": {
-          "description": "When the course instance is unpublished. If specified, startDate must also be specified.",
-          "type": "string"
+          "type": "string",
+          "description": "When the course instance is unpublished. If specified, startDate must also be specified."
         }
       }
     },
     "allowAccess": {
-      "description": "List of access rules for the course instance. Access is permitted if any access rule is satisfied.",
       "type": "array",
       "items": {
-        "description": "An access rule that permits people to access this course instance. All restrictions present in the rule must be satisfied for the rule to allow access.",
         "type": "object",
-        "additionalProperties": false,
         "properties": {
           "comment": {
-            "$ref": "#/definitions/CommentJsonSchema"
+            "allOf": [
+              {
+                "$ref": "#/definitions/CommentJsonSchema"
+              }
+            ]
           },
           "role": {
-            "description": "DEPRECATED -- do not use.",
             "type": "string",
             "enum": ["Student", "TA", "Instructor", "Superuser"],
             "deprecated": true
           },
           "uids": {
-            "description": "A list of UIDs (like 'username@example.com'), one of which is required for access.",
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "description": "A list of UIDs (like 'username@example.com'), one of which is required for access."
           },
           "startDate": {
-            "description": "The earliest date on which access is permitted.",
-            "type": "string"
+            "type": "string",
+            "description": "The earliest date on which access is permitted."
           },
           "endDate": {
-            "description": "The latest date on which access is permitted.",
-            "type": "string"
+            "type": "string",
+            "description": "The latest date on which access is permitted."
           },
           "institution": {
-            "description": "The institution from which access is permitted.",
-            "type": "string"
+            "type": "string",
+            "description": "The institution from which access is permitted."
           }
-        }
-      }
+        },
+        "additionalProperties": false,
+        "description": "An access rule that permits people to access this course instance. All restrictions present in the rule must be satisfied for the rule to allow access."
+      },
+      "description": "List of access rules for the course instance. Access is permitted if any access rule is satisfied."
     },
     "groupAssessmentsBy": {
-      "description": "Determines which assessment category will be used to group assessments on the student assessments page.",
+      "default": "Set",
       "type": "string",
       "enum": ["Set", "Module"],
-      "default": "Set"
+      "description": "Determines which assessment category will be used to group assessments on the student assessments page."
     },
     "shareSourcePublicly": {
-      "description": "If true, the course instance's JSON configuration and all of its assessment's JSON configurations are available for others to view and copy.",
+      "default": false,
       "type": "boolean",
-      "default": false
+      "description": "If true, the course instance's JSON configuration and all of its assessment's JSON configurations are available for others to view and copy."
     },
     "studentLabels": {
-      "description": "Student labels.",
+      "maxItems": 100,
       "type": "array",
       "items": {
-        "description": "A single student label, can represent a collection of students (e.g. \"Section A\").",
         "type": "object",
-        "additionalProperties": false,
-        "required": ["uuid", "name", "color"],
         "properties": {
           "uuid": {
-            "description": "Unique identifier (UUID v4).",
             "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            "description": "Unique identifier (UUID v4)."
           },
           "name": {
-            "description": "The name of the student label.",
             "type": "string",
             "minLength": 1,
-            "maxLength": 255
+            "maxLength": 255,
+            "description": "The name of the student label."
           },
           "color": {
             "$ref": "#/definitions/ColorJsonSchema"
           }
-        }
+        },
+        "required": ["uuid", "name", "color"],
+        "additionalProperties": false,
+        "description": "A single student label, can represent a collection of students (e.g. \"Section A\")."
       },
-      "maxItems": 100
+      "description": "Student labels."
     }
   },
+  "required": ["uuid", "longName"],
+  "additionalProperties": false,
+  "description": "The specification file for a course instance.",
+  "title": "Course instance information",
   "definitions": {
+    "CommentJsonSchema": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {}
+        },
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": {}
+        }
+      ],
+      "description": "Arbitrary comment for reference purposes."
+    },
     "ColorJsonSchema": {
-      "description": "A color name.",
       "type": "string",
       "enum": [
         "red1",
@@ -195,23 +215,8 @@
         "gray1",
         "gray2",
         "gray3"
-      ]
-    },
-    "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array"
-        },
-        {
-          "type": "object",
-          "additionalProperties": {},
-          "properties": {}
-        }
-      ]
+      ],
+      "description": "A color name."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/infoElementCore.json
+++ b/apps/prairielearn/src/schemas/schemas/infoElementCore.json
@@ -1,127 +1,146 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Element Info",
-  "description": "Info files for v3 elements.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["controller"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "controller": {
-      "description": "The name of the element's controller file.",
-      "type": "string"
+      "type": "string",
+      "description": "The name of the element's controller file."
     },
     "dependencies": {
-      "description": "The element's client-side dependencies.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "coreStyles": {
-          "description": "[DEPRECATED, DO NOT USE] The styles required by this element from /public/stylesheets.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /public/stylesheets.",
-            "type": "string"
+            "type": "string",
+            "description": "A .css file located in /public/stylesheets."
           },
+          "description": "The styles required by this element from /public/stylesheets.",
           "deprecated": true
         },
         "coreScripts": {
-          "description": "[DEPRECATED, DO NOT USE] The scripts required by this element from /public/javascripts.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /public/javascripts.",
-            "type": "string"
+            "type": "string",
+            "description": "A .js file located in /public/javascripts."
           },
+          "description": "The scripts required by this element from /public/javascripts.",
           "deprecated": true
         },
         "nodeModulesStyles": {
-          "description": "The styles required by this element from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in /node_modules."
+          },
+          "description": "The styles required by this element from /node_modules."
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this element from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in /node_modules."
+          },
+          "description": "The scripts required by this element from /node_modules."
         },
         "elementStyles": {
-          "description": "The styles required by this element from the element's directory.",
           "type": "array",
           "items": {
-            "description": "A .css file located in the element's directory.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in the element's directory."
+          },
+          "description": "The styles required by this element from the element's directory."
         },
         "elementScripts": {
-          "description": "The scripts required by this element from the element's directory.",
           "type": "array",
           "items": {
-            "description": "A .js file located in the element's directory.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in the element's directory."
+          },
+          "description": "The scripts required by this element from the element's directory."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "The element's client-side dependencies."
     },
     "dynamicDependencies": {
-      "description": "The element's client-side dynamic dependencies.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this element from /node_modules as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this element from /node_modules as an importmap."
         },
         "elementScripts": {
-          "description": "The scripts required by this element from the element's directory as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this element from the element's directory as an importmap."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "The element's client-side dynamic dependencies."
     },
     "additionalNames": {
-      "description": "Any additional names to give this element, i.e. for backwards compatibility.",
       "type": "array",
       "items": {
-        "description": "A name for this element to be used in question HTML files.",
-        "type": "string"
-      }
+        "type": "string",
+        "description": "A name for this element to be used in question HTML files."
+      },
+      "description": "Any additional names to give this element, i.e. for backwards compatibility."
     }
   },
+  "required": ["controller"],
+  "additionalProperties": false,
+  "description": "Info files for v3 elements.",
+  "title": "Element Info",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/infoElementCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoElementCourse.json
@@ -1,142 +1,164 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Element Info",
-  "description": "Info files for v3 elements.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["controller"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "controller": {
-      "description": "The name of the element's controller file.",
-      "type": "string"
+      "type": "string",
+      "description": "The name of the element's controller file."
     },
     "dependencies": {
-      "description": "The element's client-side dependencies.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "coreStyles": {
-          "description": "[DEPRECATED, DO NOT USE] The styles required by this element from /public/stylesheets.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /public/stylesheets.",
-            "type": "string"
+            "type": "string",
+            "description": "A .css file located in /public/stylesheets."
           },
+          "description": "The styles required by this element from /public/stylesheets.",
           "deprecated": true
         },
         "coreScripts": {
-          "description": "[DEPRECATED, DO NOT USE] The scripts required by this element from /public/javascripts.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /public/javascripts.",
-            "type": "string"
+            "type": "string",
+            "description": "A .js file located in /public/javascripts."
           },
+          "description": "The scripts required by this element from /public/javascripts.",
           "deprecated": true
         },
         "nodeModulesStyles": {
-          "description": "The styles required by this element from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in /node_modules."
+          },
+          "description": "The styles required by this element from /node_modules."
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this element from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in /node_modules."
+          },
+          "description": "The scripts required by this element from /node_modules."
         },
         "clientFilesCourseStyles": {
-          "description": "The styles required by this element from clientFilesCourse.",
           "type": "array",
           "items": {
-            "description": "A .css file located in clientFilesCourse.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in clientFilesCourse."
+          },
+          "description": "The styles required by this element from clientFilesCourse."
         },
         "clientFilesCourseScripts": {
-          "description": "The scripts required by this element from clientFilesCourse.",
           "type": "array",
           "items": {
-            "description": "A .js file located in clientFilesCourse.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in clientFilesCourse."
+          },
+          "description": "The scripts required by this element from clientFilesCourse."
         },
         "elementStyles": {
-          "description": "The styles required by this element from the element's directory.",
           "type": "array",
           "items": {
-            "description": "A .css file located in the element's directory.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in the element's directory."
+          },
+          "description": "The styles required by this element from the element's directory."
         },
         "elementScripts": {
-          "description": "The scripts required by this element from the element's directory.",
           "type": "array",
           "items": {
-            "description": "A .js file located in the element's directory.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in the element's directory."
+          },
+          "description": "The scripts required by this element from the element's directory."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "The element's client-side dependencies."
     },
     "dynamicDependencies": {
-      "description": "The element's client-side dynamic dependencies.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this element from /node_modules as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this element from /node_modules as an importmap."
         },
         "clientFilesCourseScripts": {
-          "description": "The scripts required by this element from clientFilesCourse as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this element from clientFilesCourse as an importmap."
         },
         "elementScripts": {
-          "description": "The scripts required by this element from the element's directory as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this element from the element's directory as an importmap."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "The element's client-side dynamic dependencies."
     }
   },
+  "required": ["controller"],
+  "additionalProperties": false,
+  "description": "Info files for v3 elements.",
+  "title": "Element Info",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/infoElementExtension.json
+++ b/apps/prairielearn/src/schemas/schemas/infoElementExtension.json
@@ -1,135 +1,149 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Element Extension Info",
-  "description": "Info files for v3 element extensions.",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "controller": {
-      "description": "The name of the extension's Python controller file.",
-      "type": "string"
+      "type": "string",
+      "description": "The name of the extension's Python controller file."
     },
     "dependencies": {
-      "description": "The extension's client-side dependencies.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "coreStyles": {
-          "description": "[DEPRECATED, DO NOT USE] The styles required by this extension from /public/stylesheets.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /public/stylesheets.",
-            "type": "string"
+            "type": "string",
+            "description": "A .css file located in /public/stylesheets."
           },
+          "description": "The styles required by this extension from /public/stylesheets.",
           "deprecated": true
         },
         "coreScripts": {
-          "description": "[DEPRECATED, DO NOT USE] The scripts required by this extension from /public/javascripts.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /public/javascripts.",
-            "type": "string"
+            "type": "string",
+            "description": "A .js file located in /public/javascripts."
           },
+          "description": "The scripts required by this extension from /public/javascripts.",
           "deprecated": true
         },
         "nodeModulesStyles": {
-          "description": "The styles required by this extension from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in /node_modules."
+          },
+          "description": "The styles required by this extension from /node_modules."
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this extension from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in /node_modules."
+          },
+          "description": "The scripts required by this extension from /node_modules."
         },
         "clientFilesCourseStyles": {
-          "description": "The styles required by this extension from clientFilesCourse.",
           "type": "array",
           "items": {
-            "description": "A .css file located in clientFilesCourse.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in clientFilesCourse."
+          },
+          "description": "The styles required by this extension from clientFilesCourse."
         },
         "clientFilesCourseScripts": {
-          "description": "The scripts required by this extension from clientFilesCourse.",
           "type": "array",
           "items": {
-            "description": "A .js file located in clientFilesCourse.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in clientFilesCourse."
+          },
+          "description": "The scripts required by this extension from clientFilesCourse."
         },
         "extensionStyles": {
-          "description": "The styles required by this extension from the extension's directory.",
           "type": "array",
           "items": {
-            "description": "A .css file located in the extension's directory.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in the extension's directory."
+          },
+          "description": "The styles required by this extension from the extension's directory."
         },
         "extensionScripts": {
-          "description": "The scripts required by this extension from the extension's directory.",
           "type": "array",
           "items": {
-            "description": "A .js file located in the extension's directory.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in the extension's directory."
+          },
+          "description": "The scripts required by this extension from the extension's directory."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "The extension's client-side dependencies."
     },
     "dynamicDependencies": {
-      "description": "The element's client-side dynamic dependencies.",
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this element from /node_modules as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this element from /node_modules as an importmap."
         },
         "clientFilesCourseScripts": {
-          "description": "The styles required by this element from clientFilesCourse as an importmap.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The styles required by this element from clientFilesCourse as an importmap."
         },
         "extensionScripts": {
-          "description": "The scripts required by this extension from the extension's directory.",
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "The scripts required by this extension from the extension's directory."
         }
-      }
+      },
+      "additionalProperties": false,
+      "description": "The element's client-side dynamic dependencies."
     }
   },
+  "additionalProperties": false,
+  "description": "Info files for v3 element extensions.",
+  "title": "Element Extension Info",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -1,145 +1,145 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Question Info",
-  "description": "Info files for questions.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["uuid", "type", "title", "topic"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "uuid": {
-      "description": "Unique identifier (UUID v4).",
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "description": "Unique identifier (UUID v4)."
     },
     "type": {
-      "description": "Type of the question. This should be set to \"v3\" for new questions.",
       "type": "string",
-      "enum": ["Calculation", "MultipleChoice", "Checkbox", "File", "MultipleTrueFalse", "v3"]
+      "enum": ["Calculation", "MultipleChoice", "Checkbox", "File", "MultipleTrueFalse", "v3"],
+      "description": "Type of the question. This should be set to \"v3\" for new questions."
     },
     "title": {
-      "description": "The title of the question (e.g., 'Addition of vectors in Cartesian coordinates').",
-      "type": "string"
+      "type": "string",
+      "description": "The title of the question (e.g., 'Addition of vectors in Cartesian coordinates')."
     },
     "topic": {
-      "description": "The category of question (e.g., 'Vectors', 'Energy').",
-      "type": "string"
+      "type": "string",
+      "description": "The category of question (e.g., 'Vectors', 'Energy')."
     },
     "tags": {
-      "description": "Extra tags associated with the question (e.g., 'Exam Only', 'Broken').",
+      "default": [],
       "type": "array",
       "items": {
-        "description": "A tag associated with a question.",
-        "type": "string"
+        "type": "string",
+        "description": "A tag associated with a question."
       },
-      "default": []
+      "description": "Extra tags associated with the question (e.g., 'Exam Only', 'Broken')."
     },
     "authors": {
+      "default": [],
+      "maxItems": 10,
       "type": "array",
       "items": {
-        "description": "An author (individual person, or staff of a course of origin) credited with creating a question.",
         "type": "object",
-        "additionalProperties": false,
         "properties": {
           "name": {
-            "description": "A human-readable name of a question author.",
             "type": "string",
             "minLength": 3,
-            "maxLength": 255
+            "maxLength": 255,
+            "description": "A human-readable name of a question author."
           },
           "email": {
-            "description": "An email address to contact a question author.",
             "type": "string",
-            "maxLength": 255
+            "maxLength": 255,
+            "description": "An email address to contact a question author."
           },
           "orcid": {
-            "description": "An ORCID identifier that uniquely identifies an individual question author.",
             "type": "string",
-            "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9X]{4}$"
+            "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9X]{4}$",
+            "description": "An ORCID identifier that uniquely identifies an individual question author."
           },
           "originCourse": {
-            "description": "The sharing name of a course whose staff is a question author.",
-            "type": "string"
+            "type": "string",
+            "description": "The sharing name of a course whose staff is a question author."
           }
-        }
-      },
-      "maxItems": 10,
-      "default": []
+        },
+        "additionalProperties": false,
+        "description": "An author (individual person, or staff of a course of origin) credited with creating a question."
+      }
     },
     "clientFiles": {
-      "description": "[DEPRECATED] The list of question files accessible by the client. v3 questions should serve files from `clientFilesQuestion/` instead.",
+      "default": ["client.js", "question.html", "answer.html"],
       "type": "array",
       "items": {
-        "description": "A single file accessible by the client.",
-        "type": "string"
+        "type": "string",
+        "description": "A single file accessible by the client."
       },
-      "default": ["client.js", "question.html", "answer.html"],
+      "description": "The list of question files accessible by the client. v3 questions should serve files from `clientFilesQuestion/` instead.",
       "deprecated": true
     },
     "clientTemplates": {
-      "description": "[DEPRECATED] List of client-accessible templates to render server-side.",
       "type": "array",
       "items": {
-        "description": "A single template file accessible by the client.",
-        "type": "string"
+        "type": "string",
+        "description": "A single template file accessible by the client."
       },
+      "description": "List of client-accessible templates to render server-side.",
       "deprecated": true
     },
     "template": {
-      "description": "[DEPRECATED] The QID of a question that serves as the template for this question.",
       "type": "string",
+      "description": "The QID of a question that serves as the template for this question.",
       "deprecated": true
     },
     "gradingMethod": {
-      "description": "The grading method used for this question.",
+      "default": "Internal",
       "type": "string",
       "enum": ["Internal", "External", "Manual"],
-      "default": "Internal"
+      "description": "The grading method used for this question."
     },
     "singleVariant": {
-      "description": "Whether the question is not randomized and only generates a single variant.",
+      "default": false,
       "type": "boolean",
-      "default": false
+      "description": "Whether the question is not randomized and only generates a single variant."
     },
     "showCorrectAnswer": {
-      "description": "Whether to show the correct answer panel.",
+      "default": true,
       "type": "boolean",
-      "default": true
+      "description": "Whether to show the correct answer panel."
     },
     "partialCredit": {
-      "description": "Whether the question will give partial points for fractional scores (defaults to \"false\" for v2 questions and \"true\" for v3.).",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Whether the question will give partial points for fractional scores (defaults to \"false\" for v2 questions and \"true\" for v3.)."
     },
     "options": {
-      "description": "[DEPRECATED] Options that define how the question will work, specific to the individual question type (not supported for v3 questions).",
       "type": "object",
-      "additionalProperties": {},
       "properties": {},
+      "additionalProperties": {},
+      "description": "Options that define how the question will work, specific to the individual question type (not supported for v3 questions).",
       "deprecated": true
     },
     "externalGradingOptions": {
-      "description": "Options for externally graded questions.",
       "type": "object",
-      "additionalProperties": false,
-      "required": ["image"],
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "enabled": {
-          "description": "[DEPRECATED, DO NOT USE] Whether the external grader is currently enabled.",
-          "type": "boolean",
           "default": true,
+          "type": "boolean",
+          "description": "Whether the external grader is currently enabled.",
           "deprecated": true
         },
         "image": {
-          "description": "The Docker image that will be used to grade this question. Should be specified as Dockerhub image.",
-          "type": "string"
+          "type": "string",
+          "description": "The Docker image that will be used to grade this question. Should be specified as Dockerhub image."
         },
         "entrypoint": {
-          "description": "Program or command to run as the entrypoint to your grader. If not provided, the default entrypoint for the image will be used.",
           "anyOf": [
             {
               "type": "string"
@@ -150,136 +150,151 @@
                 "type": "string"
               }
             }
-          ]
+          ],
+          "description": "Program or command to run as the entrypoint to your grader. If not provided, the default entrypoint for the image will be used."
         },
         "serverFilesCourse": {
-          "description": "The list of files or directories that will be copied from course/externalGradingFiles/ to /grade/shared/",
+          "default": [],
           "type": "array",
           "items": {
-            "description": "A single file or directory that will be copied to the external grader.",
-            "type": "string"
+            "type": "string",
+            "description": "A single file or directory that will be copied to the external grader."
           },
-          "default": []
+          "description": "The list of files or directories that will be copied from course/externalGradingFiles/ to /grade/shared/"
         },
         "timeout": {
-          "description": "The number of seconds after which the grading job will timeout.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
+          "description": "The number of seconds after which the grading job will timeout."
         },
         "enableNetworking": {
-          "description": "Whether the grading containers should have network access. Access is disabled by default.",
+          "default": false,
           "type": "boolean",
-          "default": false
+          "description": "Whether the grading containers should have network access. Access is disabled by default."
         },
         "environment": {
-          "description": "Environment variables to set inside the grading container.",
+          "default": {},
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
           },
-          "default": {}
+          "description": "Environment variables to set inside the grading container."
         }
-      }
+      },
+      "required": ["image"],
+      "additionalProperties": false,
+      "description": "Options for externally graded questions."
     },
     "dependencies": {
-      "description": "The question's client-side dependencies.",
+      "default": {},
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "coreStyles": {
-          "description": "[DEPRECATED, DO NOT USE] The styles required by this question from /public/stylesheets.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /public/stylesheets.",
-            "type": "string"
+            "type": "string",
+            "description": "A .css file located in /public/stylesheets."
           },
+          "description": "The styles required by this question from /public/stylesheets.",
           "deprecated": true
         },
         "coreScripts": {
-          "description": "[DEPRECATED, DO NOT USE] The scripts required by this question from /public/javascripts.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /public/javascripts.",
-            "type": "string"
+            "type": "string",
+            "description": "A .js file located in /public/javascripts."
           },
+          "description": "The scripts required by this question from /public/javascripts.",
           "deprecated": true
         },
         "nodeModulesStyles": {
-          "description": "The styles required by this question from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .css file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in /node_modules."
+          },
+          "description": "The styles required by this question from /node_modules."
         },
         "nodeModulesScripts": {
-          "description": "The scripts required by this question from /node_modules.",
           "type": "array",
           "items": {
-            "description": "A .js file located in /node_modules.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in /node_modules."
+          },
+          "description": "The scripts required by this question from /node_modules."
         },
         "clientFilesCourseStyles": {
-          "description": "The styles required by this question from clientFilesCourse.",
           "type": "array",
           "items": {
-            "description": "A .css file located in clientFilesCourse.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in clientFilesCourse."
+          },
+          "description": "The styles required by this question from clientFilesCourse."
         },
         "clientFilesCourseScripts": {
-          "description": "The scripts required by this question from clientFilesCourse.",
           "type": "array",
           "items": {
-            "description": "A .js file located in clientFilesCourse.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in clientFilesCourse."
+          },
+          "description": "The scripts required by this question from clientFilesCourse."
         },
         "clientFilesQuestionStyles": {
-          "description": "The styles required by this question from clientFilesQuestion.",
           "type": "array",
           "items": {
-            "description": "A .css file located in the clientFilesQuestion.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .css file located in the clientFilesQuestion."
+          },
+          "description": "The styles required by this question from clientFilesQuestion."
         },
         "clientFilesQuestionScripts": {
-          "description": "The scripts required by this question from clientFilesQuestion.",
           "type": "array",
           "items": {
-            "description": "A .js file located in the clientFilesQuestion.",
-            "type": "string"
-          }
+            "type": "string",
+            "description": "A .js file located in the clientFilesQuestion."
+          },
+          "description": "The scripts required by this question from clientFilesQuestion."
         }
       },
-      "default": {}
+      "additionalProperties": false,
+      "description": "The question's client-side dependencies."
     },
     "workspaceOptions": {
-      "description": "Options for workspace questions.",
       "type": "object",
-      "additionalProperties": false,
-      "required": ["image", "port", "home"],
       "properties": {
         "comment": {
-          "$ref": "#/definitions/CommentJsonSchema"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommentJsonSchema"
+            }
+          ]
         },
         "image": {
-          "description": "The Docker image that will be used to serve this question. Should be specified as Dockerhub image.",
-          "type": "string"
+          "type": "string",
+          "description": "The Docker image that will be used to serve this question. Should be specified as Dockerhub image."
         },
         "port": {
-          "description": "The port number used in the Docker image.",
-          "type": "integer"
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
+          "description": "The port number used in the Docker image."
         },
         "home": {
-          "description": "The home directory of the workspace container.",
-          "type": "string"
+          "type": "string",
+          "description": "The home directory of the workspace container."
         },
         "args": {
-          "description": "Command line arguments to pass to the Docker container.",
           "anyOf": [
             {
               "type": "string"
@@ -290,107 +305,137 @@
                 "type": "string"
               }
             }
-          ]
+          ],
+          "description": "Command line arguments to pass to the Docker container."
         },
         "rewriteUrl": {
-          "description": "If true, the URL will be rewritten such that the workspace container will see all requests as originating from /.",
+          "default": true,
           "type": "boolean",
-          "default": true
+          "description": "If true, the URL will be rewritten such that the workspace container will see all requests as originating from /."
         },
         "gradedFiles": {
-          "description": "The list of files or directories that will be copied out of the workspace container when saving a submission.",
+          "default": [],
           "type": "array",
           "items": {
-            "description": "A single file or directory that will be copied out of the workspace container when saving a submission.",
-            "type": "string"
+            "type": "string",
+            "description": "A single file or directory that will be copied out of the workspace container when saving a submission."
           },
-          "default": []
+          "description": "The list of files or directories that will be copied out of the workspace container when saving a submission."
         },
         "enableNetworking": {
-          "description": "Whether the workspace should have network access. Access is disabled by default.",
+          "default": false,
           "type": "boolean",
-          "default": false
+          "description": "Whether the workspace should have network access. Access is disabled by default."
         },
         "environment": {
-          "description": "Environment variables to set inside the workspace container.",
+          "default": {},
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "string"
           },
-          "default": {}
+          "description": "Environment variables to set inside the workspace container."
         },
         "syncIgnore": {
-          "description": "[DEPRECATED, DO NOT USE] The list of files or directories that will be excluded from sync.",
           "type": "array",
           "items": {
-            "description": "A single file or directory that will be excluded from sync.",
-            "type": "string"
+            "type": "string",
+            "description": "A single file or directory that will be excluded from sync."
           },
+          "description": "The list of files or directories that will be excluded from sync.",
           "deprecated": true
         }
-      }
+      },
+      "required": ["image", "port", "home"],
+      "additionalProperties": false,
+      "description": "Options for workspace questions."
     },
     "sharingSets": {
-      "description": "The list of sharing sets that this question belongs to.",
       "type": "array",
       "items": {
-        "description": "The name of a sharing set",
-        "type": "string"
-      }
+        "type": "string",
+        "description": "The name of a sharing set"
+      },
+      "description": "The list of sharing sets that this question belongs to."
     },
     "sharePublicly": {
-      "description": "Whether this question is publicly shared.",
+      "default": false,
       "type": "boolean",
-      "default": false
+      "description": "Whether this question is publicly shared."
     },
     "shareSourcePublicly": {
-      "description": "Whether this question's source code is publicly shared.",
+      "default": false,
       "type": "boolean",
-      "default": false
+      "description": "Whether this question's source code is publicly shared."
     },
     "preferences": {
       "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
       "additionalProperties": {
         "type": "object",
-        "additionalProperties": false,
-        "required": ["type", "default"],
         "properties": {
           "type": {
             "type": "string",
             "enum": ["string", "number", "boolean"]
           },
           "default": {
-            "type": ["string", "number", "boolean"]
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
           },
           "enum": {
             "type": "array",
             "items": {
-              "type": ["string", "number"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
             }
           }
-        }
-      },
-      "propertyNames": {
-        "minLength": 1
+        },
+        "required": ["type", "default"],
+        "additionalProperties": false
       }
     }
   },
+  "required": ["uuid", "type", "title", "topic"],
+  "additionalProperties": false,
+  "description": "Info files for questions.",
+  "title": "Question Info",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/questionOptionsCalculation.json
+++ b/apps/prairielearn/src/schemas/schemas/questionOptionsCalculation.json
@@ -1,30 +1,35 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Calculation question options",
-  "description": "Options for a Calculation question.",
   "type": "object",
-  "additionalProperties": {},
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     }
   },
+  "additionalProperties": {},
+  "description": "Options for a Calculation question.",
+  "title": "Calculation question options",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/questionOptionsCheckbox.json
+++ b/apps/prairielearn/src/schemas/schemas/questionOptionsCheckbox.json
@@ -1,64 +1,72 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Checkbox question options",
-  "description": "Options for a Checkbox question.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["text", "correctAnswers", "incorrectAnswers"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "text": {
-      "description": "The question HTML text that comes before the options.",
-      "type": "string"
+      "type": "string",
+      "description": "The question HTML text that comes before the options."
     },
     "correctAnswers": {
-      "description": "A list of correct answers to the question. Each is an HTML string.",
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "A list of correct answers to the question. Each is an HTML string."
     },
     "incorrectAnswers": {
-      "description": "A list of incorrect answers to the question. Each is an HTML string.",
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "A list of incorrect answers to the question. Each is an HTML string."
     },
     "numberAnswers": {
-      "description": "The total number of answers in the list of possible answers.",
       "type": "integer",
-      "minimum": 1
+      "minimum": 1,
+      "maximum": 9007199254740991,
+      "description": "The total number of answers in the list of possible answers."
     },
     "minCorrectAnswers": {
-      "description": "The minimum number of correct answers in the list of possible answers.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "maximum": 9007199254740991,
+      "description": "The minimum number of correct answers in the list of possible answers."
     },
     "maxCorrectAnswers": {
-      "description": "The maximum number of correct answers in the list of possible answers.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "maximum": 9007199254740991,
+      "description": "The maximum number of correct answers in the list of possible answers."
     }
   },
+  "required": ["text", "correctAnswers", "incorrectAnswers"],
+  "additionalProperties": false,
+  "description": "Options for a Checkbox question.",
+  "title": "Checkbox question options",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/questionOptionsFile.json
+++ b/apps/prairielearn/src/schemas/schemas/questionOptionsFile.json
@@ -1,34 +1,39 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "File question options",
-  "description": "Options for a File question.",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "fileName": {
-      "description": "Filename of the file to download",
-      "type": "string"
+      "type": "string",
+      "description": "Filename of the file to download"
     }
   },
+  "additionalProperties": false,
+  "description": "Options for a File question.",
+  "title": "File question options",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/questionOptionsMultipleChoice.json
+++ b/apps/prairielearn/src/schemas/schemas/questionOptionsMultipleChoice.json
@@ -1,54 +1,61 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "MultipleChoice question options",
-  "description": "Options for a MultipleChoice question.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["text", "correctAnswers", "incorrectAnswers"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "text": {
-      "description": "The question HTML text that comes before the options.",
-      "type": "string"
+      "type": "string",
+      "description": "The question HTML text that comes before the options."
     },
     "correctAnswers": {
-      "description": "A list of correct answers to the question. Each is an HTML string.",
+      "minItems": 1,
       "type": "array",
       "items": {
         "type": "string"
       },
-      "minItems": 1
+      "description": "A list of correct answers to the question. Each is an HTML string."
     },
     "incorrectAnswers": {
-      "description": "A list of incorrect answers to the question. Each is an HTML string.",
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "A list of incorrect answers to the question. Each is an HTML string."
     },
     "numberAnswers": {
-      "description": "The total number of answers in the list of possible answers.",
-      "type": "integer"
+      "type": "integer",
+      "minimum": -9007199254740991,
+      "maximum": 9007199254740991,
+      "description": "The total number of answers in the list of possible answers."
     }
   },
+  "required": ["text", "correctAnswers", "incorrectAnswers"],
+  "additionalProperties": false,
+  "description": "Options for a MultipleChoice question.",
+  "title": "MultipleChoice question options",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/apps/prairielearn/src/schemas/schemas/questionOptionsMultipleTrueFalse.json
+++ b/apps/prairielearn/src/schemas/schemas/questionOptionsMultipleTrueFalse.json
@@ -1,49 +1,54 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "MultipleTrueFalse question options",
-  "description": "Options for a MultipleTrueFalse question.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["trueStatements", "falseStatements"],
   "properties": {
     "comment": {
-      "$ref": "#/definitions/CommentJsonSchema"
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommentJsonSchema"
+        }
+      ]
     },
     "text": {
-      "description": "Text to precede the set of statements being given.",
-      "type": "string"
+      "type": "string",
+      "description": "Text to precede the set of statements being given."
     },
     "trueStatements": {
-      "description": "A list of true statements for the question. Each is an HTML string.",
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "A list of true statements for the question. Each is an HTML string."
     },
     "falseStatements": {
-      "description": "A list of false statements for the question. Each is an HTML string.",
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "A list of false statements for the question. Each is an HTML string."
     }
   },
+  "required": ["trueStatements", "falseStatements"],
+  "additionalProperties": false,
+  "description": "Options for a MultipleTrueFalse question.",
+  "title": "MultipleTrueFalse question options",
   "definitions": {
     "CommentJsonSchema": {
-      "description": "Arbitrary comment for reference purposes.",
       "anyOf": [
         {
           "type": "string"
         },
         {
-          "type": "array"
+          "type": "array",
+          "items": {}
         },
         {
           "type": "object",
-          "additionalProperties": {},
-          "properties": {}
+          "properties": {},
+          "additionalProperties": {}
         }
-      ]
+      ],
+      "description": "Arbitrary comment for reference purposes."
     }
   }
 }

--- a/docs/assets/config-grader-host.schema.json
+++ b/docs/assets/config-grader-host.schema.json
@@ -1,159 +1,201 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "maxConcurrentJobs": {
-      "type": "number",
-      "default": 5
+      "default": 5,
+      "type": "number"
     },
     "useEc2MetadataService": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "useConsoleLoggingForJobs": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "useImagePreloading": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "useHealthCheck": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "cacheImageRegistry": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "parallelInitPulls": {
-      "type": "number",
-      "default": 5
+      "default": 5,
+      "type": "number"
     },
     "lifecycleHeartbeatIntervalMS": {
-      "type": "number",
-      "default": 300000
+      "default": 300000,
+      "type": "number"
     },
     "jobLogGroup": {
-      "type": "string",
-      "default": "grading-jobs-debug"
+      "default": "grading-jobs-debug",
+      "type": "string"
     },
     "reportLoad": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "reportIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "graderDockerMemory": {
-      "type": "number",
-      "default": 2147483648
+      "default": 2147483648,
+      "type": "number"
     },
     "graderDockerMemorySwap": {
-      "type": "number",
-      "default": 2147483648
+      "default": 2147483648,
+      "type": "number"
     },
     "graderDockerKernelMemory": {
-      "type": "number",
-      "default": 536870912
+      "default": 536870912,
+      "type": "number"
     },
     "graderDockerDiskQuota": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "graderDockerCpuPeriod": {
-      "type": "number",
-      "default": 100000
+      "default": 100000,
+      "type": "number"
     },
     "graderDockerCpuQuota": {
-      "type": "number",
-      "default": 90000
+      "default": 90000,
+      "type": "number"
     },
     "graderDockerPidsLimit": {
-      "type": "number",
-      "default": 1024
+      "default": 1024,
+      "type": "number"
     },
     "healthCheckPort": {
-      "type": "number",
-      "default": 4000
+      "default": 4000,
+      "type": "number"
     },
     "healthCheckInterval": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "jobsQueueName": {
-      "type": "string",
-      "default": "grading_jobs_dev"
+      "default": "grading_jobs_dev",
+      "type": "string"
     },
     "jobsQueueUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "resultsQueueName": {
-      "type": "string",
-      "default": "grading_results_dev"
+      "default": "grading_results_dev",
+      "type": "string"
     },
     "resultsQueueUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "timeoutOverhead": {
-      "type": "number",
-      "default": 300
+      "default": 300,
+      "type": "number"
     },
     "postgresqlHost": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "postgresqlDatabase": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlUser": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlPassword": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "postgresqlPoolSize": {
-      "type": "number",
-      "default": 2
+      "default": 2,
+      "type": "number"
     },
     "postgresqlIdleTimeoutMillis": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "autoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "instanceId": {
-      "type": "string",
-      "default": "server"
+      "default": "server",
+      "type": "string"
     },
     "sentryDsn": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "sentryEnvironment": {
-      "type": "string",
-      "default": "development"
+      "default": "development",
+      "type": "string"
     },
     "awsRegion": {
-      "type": "string",
-      "default": "us-east-2"
+      "default": "us-east-2",
+      "type": "string"
     },
     "visibilityTimeout": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "visibilityTimeoutHeartbeatIntervalSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -1,35 +1,41 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "startServer": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "postgresqlUser": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlPassword": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "postgresqlDatabase": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlHost": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "postgresqlPoolSize": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "postgresqlIdleTimeoutMillis": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "postgresqlSsl": {
       "anyOf": [
@@ -38,34 +44,51 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "rejectUnauthorized": {
-              "type": "boolean",
-              "default": true
+              "default": true,
+              "type": "boolean"
             },
             "ca": {
-              "type": ["string", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "key": {
-              "type": ["string", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "cert": {
-              "type": ["string", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
     "namedLocksRenewIntervalMs": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "courseDirs": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
       "default": [
         "/course",
         "/course2",
@@ -76,65 +99,119 @@
         "/course7",
         "/course8",
         "/course9"
-      ]
+      ],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "courseRepoDefaultBranch": {
-      "type": "string",
-      "default": "master"
+      "default": "master",
+      "type": "string"
     },
     "assetsPrefix": {
-      "type": "string",
-      "default": "/assets"
+      "default": "/assets",
+      "type": "string"
     },
     "coursesRoot": {
-      "type": "string",
-      "default": "/data1/courses"
+      "default": "/data1/courses",
+      "type": "string"
     },
     "redisUrl": {
-      "type": ["string", "null"],
-      "default": "redis://localhost:6379/"
+      "default": "redis://localhost:6379/",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "nonVolatileRedisUrl": {
-      "type": ["string", "null"],
-      "default": "redis://localhost:6379"
+      "default": "redis://localhost:6379",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "logFilename": {
-      "type": "string",
-      "default": "server.log"
+      "default": "server.log",
+      "type": "string"
     },
     "logErrorFilename": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authUid": {
-      "type": ["string", "null"],
-      "default": "dev@example.com"
+      "default": "dev@example.com",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authName": {
-      "type": ["string", "null"],
-      "default": "Dev User"
+      "default": "Dev User",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authUin": {
-      "type": ["string", "null"],
-      "default": "000000000"
+      "default": "000000000",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authEmail": {
-      "type": ["string", "null"],
-      "default": "dev@example.com"
+      "default": "dev@example.com",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authnCookieMaxAgeMilliseconds": {
-      "type": "number",
-      "default": 2592000000
+      "default": 2592000000,
+      "type": "number"
     },
     "sessionStoreExpireSeconds": {
-      "type": "number",
-      "default": 2592000
+      "default": 2592000,
+      "type": "number"
     },
     "sessionStoreAutoExtendThrottleSeconds": {
-      "type": "number",
-      "default": 3600
+      "default": 3600,
+      "type": "number"
     },
     "sessionCookieSameSite": {
+      "default": "lax",
       "anyOf": [
         {
           "type": "boolean"
@@ -143,84 +220,105 @@
           "type": "string",
           "enum": ["none", "lax", "strict"]
         }
-      ],
-      "default": "lax"
+      ]
     },
     "cookieDomain": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "serverType": {
+      "default": "http",
       "type": "string",
-      "enum": ["http", "https"],
-      "default": "http"
+      "enum": ["http", "https"]
     },
     "serverPort": {
-      "type": "string",
-      "default": "3000"
+      "default": "3000",
+      "type": "string"
     },
     "serverTimeout": {
-      "type": "number",
-      "default": 600000
+      "default": 600000,
+      "type": "number"
     },
     "serverKeepAliveTimeout": {
-      "type": "number",
-      "default": 65000
+      "default": 65000,
+      "type": "number"
     },
     "serverCanonicalHost": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "runMigrations": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "runBatchedMigrations": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "batchedMigrationsWorkDurationMs": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "batchedMigrationsSleepDurationMs": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "sslCertificateFile": {
-      "type": "string",
-      "default": "/etc/pki/tls/certs/localhost.crt"
+      "default": "/etc/pki/tls/certs/localhost.crt",
+      "type": "string"
     },
     "sslKeyFile": {
-      "type": "string",
-      "default": "/etc/pki/tls/private/localhost.key"
+      "default": "/etc/pki/tls/private/localhost.key",
+      "type": "string"
     },
     "sslCAFile": {
-      "type": "string",
-      "default": "/etc/pki/tls/certs/server-chain.crt"
+      "default": "/etc/pki/tls/certs/server-chain.crt",
+      "type": "string"
     },
     "fileUploadMaxBytes": {
-      "type": "number",
-      "default": 10000000
+      "default": 10000000,
+      "type": "number"
     },
     "fileUploadMaxParts": {
-      "type": "number",
-      "default": 1000
+      "default": 1000,
+      "type": "number"
     },
     "fileStoreS3Bucket": {
-      "type": ["string", "null"],
-      "default": "file-store"
+      "default": "file-store",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "fileStoreStorageTypeDefault": {
+      "default": "S3",
       "type": "string",
-      "enum": ["S3", "FileSystem"],
-      "default": "S3"
+      "enum": ["S3", "FileSystem"]
     },
     "cronActive": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "cronEnabledJobs": {
+      "default": null,
       "anyOf": [
         {
           "type": "array",
@@ -231,10 +329,10 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "cronDisabledJobs": {
+      "default": null,
       "anyOf": [
         {
           "type": "array",
@@ -245,368 +343,405 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "cronOverrideAllIntervalsSec": {
-      "type": ["number", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cronIntervalAutoFinishExamsSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalErrorAbandonedJobsSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalExternalGraderLoadSec": {
-      "type": "number",
-      "default": 8
+      "default": 8,
+      "type": "number"
     },
     "cronIntervalServerLoadSec": {
-      "type": "number",
-      "default": 8
+      "default": 8,
+      "type": "number"
     },
     "cronIntervalServerUsageSec": {
-      "type": "number",
-      "default": 8
+      "default": 8,
+      "type": "number"
     },
     "cronIntervalCalculateAssessmentQuestionStatsSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalWorkspaceTimeoutStopSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "cronIntervalWorkspaceTimeoutWarnSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "cronIntervalWorkspaceHostLoadsSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "cronIntervalWorkspaceHostTransitionsSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "cronIntervalChunksHostAutoScalingSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "cronIntervalCleanTimeSeriesSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalFetchNewsItemsSec": {
-      "type": "number",
-      "default": 300
+      "default": 300,
+      "type": "number"
     },
     "cronDailySec": {
-      "type": "number",
-      "default": 28800
+      "default": 28800,
+      "type": "number"
     },
     "timeSeriesRetentionPeriodSec": {
-      "type": "number",
-      "default": 86400
+      "default": 86400,
+      "type": "number"
     },
     "nodeMetricsIntervalSec": {
-      "type": "number",
-      "default": 5
+      "default": 5,
+      "type": "number"
     },
     "autoFinishAgeMins": {
-      "type": "number",
-      "default": 360
+      "default": 360,
+      "type": "number"
     },
     "questionTimeoutMilliseconds": {
-      "type": "number",
-      "default": 10000
+      "default": 10000,
+      "type": "number"
     },
     "secretKey": {
-      "type": "string",
-      "default": "THIS_IS_THE_SECRET_KEY"
+      "default": "THIS_IS_THE_SECRET_KEY",
+      "type": "string"
     },
     "databaseEncryptionKey": {
+      "default": "0000000000000000000000000000000000000000000000000000000000000000",
       "type": "string",
-      "pattern": "^[0-9a-f]{64}$",
-      "default": "0000000000000000000000000000000000000000000000000000000000000000"
+      "pattern": "^[0-9a-f]{64}$"
     },
     "secretSlackOpsBotEndpoint": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "secretSlackToken": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "secretSlackCourseRequestChannel": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "githubClientToken": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "githubCourseOwner": {
-      "type": "string",
-      "default": "PrairieLearn"
+      "default": "PrairieLearn",
+      "type": "string"
     },
     "githubCourseTemplate": {
-      "type": "string",
-      "default": "pl-template"
+      "default": "pl-template",
+      "type": "string"
     },
     "githubMachineTeam": {
-      "type": "string",
-      "default": "machine"
+      "default": "machine",
+      "type": "string"
     },
     "githubMachineUser": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "gitSshCommand": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingUseAws": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "externalGradingJobsQueueName": {
-      "type": "string",
-      "default": "grading_jobs_dev"
+      "default": "grading_jobs_dev",
+      "type": "string"
     },
     "externalGradingResultsQueueName": {
-      "type": "string",
-      "default": "grading_results_dev"
+      "default": "grading_results_dev",
+      "type": "string"
     },
     "externalGradingJobsDeadLetterQueueName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingResultsDeadLetterQueueName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingAutoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingS3Bucket": {
-      "type": "string",
-      "default": "prairielearn.dev.grading"
+      "default": "prairielearn.dev.grading",
+      "type": "string"
     },
     "externalGradingDefaultTimeout": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "externalGradingMaximumTimeout": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "externalGradingLoadAverageIntervalSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "externalGradingHistoryLoadIntervalSec": {
-      "type": "number",
-      "default": 900
+      "default": 900,
+      "type": "number"
     },
     "externalGradingCurrentCapacityFactor": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "externalGradingHistoryCapacityFactor": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "externalGradingPullImagesFromDockerHub": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "externalGradingEnableResults": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "runningInEc2": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "cacheImageRegistry": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "fileEditorUseGit": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "workersCount": {
-      "type": ["number", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workersPerCpu": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "workersExecutionMode": {
+      "default": "native",
       "type": "string",
-      "enum": ["container", "native", "disabled"],
-      "default": "native"
+      "enum": ["container", "native", "disabled"]
     },
     "workerUseQueue": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "workerOverloadDelayMS": {
-      "type": "number",
-      "default": 10000
+      "default": 10000,
+      "type": "number"
     },
     "workerPingTimeoutMilliseconds": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "workerExecutorImageRepository": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workerExecutorImageTag": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ensureExecutorImageAtStartup": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "groupName": {
-      "type": "string",
-      "default": "local"
+      "default": "local",
+      "type": "string"
     },
     "instanceId": {
-      "type": "string",
-      "default": "server"
+      "default": "server",
+      "type": "string"
     },
     "hostname": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "reportIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "maxResponseTimeSec": {
-      "type": "number",
-      "default": 500
+      "default": 500,
+      "type": "number"
     },
     "serverLoadAverageIntervalSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "serverUsageIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "blockedWarnEnable": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "blockedAtWarnEnable": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "blockedWarnThresholdMS": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "awsRegion": {
-      "type": "string",
-      "default": "us-east-2"
+      "default": "us-east-2",
+      "type": "string"
     },
     "awsServiceGlobalOptions": {
+      "default": {},
       "type": "object",
-      "additionalProperties": {},
-      "default": {}
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
     },
     "hasShib": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "hideShibLogin": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "shibLinkText": {
-      "type": "string",
-      "default": "Sign in with Illinois"
+      "default": "Sign in with Illinois",
+      "type": "string"
     },
     "shibLinkLogo": {
-      "type": "string",
-      "default": "/images/illinois_logo.svg"
+      "default": "/images/illinois_logo.svg",
+      "type": "string"
     },
     "shibLinkColors": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["normal", "hover", "active", "focus"],
-      "properties": {
-        "normal": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["background", "border", "text"],
-          "properties": {
-            "background": {
-              "type": "string"
-            },
-            "border": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          }
-        },
-        "hover": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["background", "border", "text"],
-          "properties": {
-            "background": {
-              "type": "string"
-            },
-            "border": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          }
-        },
-        "active": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["background", "border", "text"],
-          "properties": {
-            "background": {
-              "type": "string"
-            },
-            "border": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          }
-        },
-        "focus": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["shadow"],
-          "properties": {
-            "shadow": {
-              "type": "string"
-            }
-          }
-        }
-      },
       "default": {
         "normal": {
           "background": "#E84A27",
@@ -626,41 +761,126 @@
         "focus": {
           "shadow": "rgba(255, 83, 0, 0.35)"
         }
-      }
+      },
+      "type": "object",
+      "properties": {
+        "normal": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["background", "border", "text"],
+          "additionalProperties": false
+        },
+        "hover": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["background", "border", "text"],
+          "additionalProperties": false
+        },
+        "active": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["background", "border", "text"],
+          "additionalProperties": false
+        },
+        "focus": {
+          "type": "object",
+          "properties": {
+            "shadow": {
+              "type": "string"
+            }
+          },
+          "required": ["shadow"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["normal", "hover", "active", "focus"],
+      "additionalProperties": false
     },
     "hasAzure": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "hasOauth": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "googleClientId": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "googleClientSecret": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "googleRedirectUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "syncExamIdAccessRules": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "ptHost": {
-      "type": "string",
-      "default": "http://localhost:4000"
+      "default": "http://localhost:4000",
+      "type": "string"
     },
     "checkAccessRulesExamUuid": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "questionRenderCacheType": {
+      "default": null,
       "anyOf": [
         {
           "type": "string",
@@ -669,232 +889,291 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "cacheType": {
+      "default": "none",
       "type": "string",
-      "enum": ["none", "redis", "memory"],
-      "default": "none"
+      "enum": ["none", "redis", "memory"]
     },
     "nonVolatileCacheType": {
+      "default": "redis",
       "type": "string",
-      "enum": ["none", "redis", "memory"],
-      "default": "redis"
+      "enum": ["none", "redis", "memory"]
     },
     "cacheKeyPrefix": {
-      "type": "string",
-      "default": "prairielearn-cache:"
+      "default": "prairielearn-cache:",
+      "type": "string"
     },
     "questionRenderCacheTtlSec": {
-      "type": "number",
-      "default": 3600
+      "default": 3600,
+      "type": "number"
     },
     "ltiRedirectUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "lti13InstancePlatforms": {
+      "default": [],
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "required": ["platform"],
         "properties": {
           "platform": {
             "type": "string"
           },
           "display_order": {
-            "type": "number",
-            "default": 100
+            "default": 100,
+            "type": "number"
           },
           "issuer_params": {},
           "custom_fields": {}
-        }
-      },
-      "default": []
+        },
+        "required": ["platform"],
+        "additionalProperties": false
+      }
     },
     "filesRoot": {
-      "type": "string",
-      "default": "/files"
+      "default": "/files",
+      "type": "string"
     },
     "trustProxy": {
-      "type": ["boolean", "number", "string"],
-      "default": false
+      "default": false,
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "workspaceLogsS3Bucket": {
-      "type": ["string", "null"],
-      "default": "workspace-logs"
+      "default": "workspace-logs",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceLogsFlushIntervalSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceLogsExpirationDays": {
-      "type": ["number", "null"],
-      "default": 120
+      "default": 120,
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceAuthzCookieMaxAgeMilliseconds": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "workspaceJobsDirectoryOwnerUid": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspaceJobsDirectoryOwnerGid": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspaceHeartbeatIntervalSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceHeartbeatTimeoutSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "workspaceVisibilityTimeoutSec": {
-      "type": "number",
-      "default": 1800
+      "default": 1800,
+      "type": "number"
     },
     "workspaceLaunchedTimeoutSec": {
-      "type": "number",
-      "default": 43200
+      "default": 43200,
+      "type": "number"
     },
     "workspaceLaunchedTimeoutWarnSec": {
-      "type": "number",
-      "default": 900
+      "default": 900,
+      "type": "number"
     },
     "workspaceInLaunchingTimeoutSec": {
-      "type": "number",
-      "default": 1800
+      "default": 1800,
+      "type": "number"
     },
     "workspaceLaunchingRetryIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "workspaceLaunchingRetryAttempts": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceEnable": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "workspaceCloudWatchName": {
-      "type": "string",
-      "default": "workspaces_local_dev"
+      "default": "workspaces_local_dev",
+      "type": "string"
     },
     "workspaceLoadCapacityFactor": {
-      "type": "number",
-      "default": 1.3
+      "default": 1.3,
+      "type": "number"
     },
     "workspaceLoadHostCapacity": {
-      "type": "number",
-      "default": 40
+      "default": 40,
+      "type": "number"
     },
     "workspaceLoadLaunchTemplateId": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceLoadLaunchTag": {
-      "type": "string",
-      "default": "workspace-host"
+      "default": "workspace-host",
+      "type": "string"
     },
     "workspaceHostUnhealthyTimeoutSec": {
-      "type": "number",
-      "default": 43200
+      "default": 43200,
+      "type": "number"
     },
     "workspaceHostLaunchTimeoutSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "workspaceUrlRewriteCacheMaxAgeSec": {
-      "type": "number",
-      "default": 3600
+      "default": 3600,
+      "type": "number"
     },
     "workspaceHomeDirRoot": {
-      "type": "string",
-      "default": "/jobs/workspaces"
+      "default": "/jobs/workspaces",
+      "type": "string"
     },
     "workspaceMaxGradedFilesCount": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "workspaceMaxGradedFilesSize": {
-      "type": "number",
-      "default": 104857600
+      "default": 104857600,
+      "type": "number"
     },
     "workspaceAutoscalingEnabled": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "chunksS3Bucket": {
-      "type": "string",
-      "default": "chunks"
+      "default": "chunks",
+      "type": "string"
     },
     "chunksGenerator": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "chunksConsumer": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "chunksConsumerDirectory": {
-      "type": "string",
-      "default": "/chunks"
+      "default": "/chunks",
+      "type": "string"
     },
     "chunksMaxParallelDownload": {
-      "type": "number",
-      "default": 20
+      "default": 20,
+      "type": "number"
     },
     "chunksMaxParallelUpload": {
-      "type": "number",
-      "default": 20
+      "default": 20,
+      "type": "number"
     },
     "chunksAutoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "chunksLoadBalancerDimensionName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "chunksTargetGroupDimensionName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "chunksHostAutoScalingHistoryIntervalSec": {
-      "type": "number",
-      "default": 900
+      "default": 900,
+      "type": "number"
     },
     "chunksPageViewsCapacityFactor": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "chunksActiveWorkersCapacityFactor": {
-      "type": "number",
-      "default": 2
+      "default": 2,
+      "type": "number"
     },
     "chunksLoadBalancerRequestsCapacityFactor": {
-      "type": "number",
-      "default": 1000
+      "default": 1000,
+      "type": "number"
     },
     "isEnterprise": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "prairieTestSharedAuthSecret": {
-      "type": "string",
-      "default": "CHANGE_ME_PRAIRIE_TEST_SHARED_AUTH_SECRET"
+      "default": "CHANGE_ME_PRAIRIE_TEST_SHARED_AUTH_SECRET",
+      "type": "string"
     },
     "openTelemetryEnabled": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "openTelemetryExporter": {
+      "default": null,
       "anyOf": [
         {
           "type": "string",
@@ -903,10 +1182,10 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "openTelemetryMetricExporter": {
+      "default": null,
       "anyOf": [
         {
           "type": "string",
@@ -915,92 +1194,146 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "openTelemetryMetricExportIntervalMillis": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "openTelemetrySamplerType": {
+      "default": "always-on",
       "type": "string",
-      "enum": ["always-on", "always-off", "trace-id-ratio"],
-      "default": "always-on"
+      "enum": ["always-on", "always-off", "trace-id-ratio"]
     },
     "openTelemetrySampleRate": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "honeycombApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "honeycombDataset": {
-      "type": ["string", "null"],
-      "default": "prairielearn-dev"
+      "default": "prairielearn-dev",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "sentryDsn": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "sentryEnvironment": {
-      "type": "string",
-      "default": "development"
+      "default": "development",
+      "type": "string"
     },
     "announcementHtml": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "announcementColor": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "autoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "autoScalingLaunchingLifecycleHookName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "autoScalingTerminatingLifecycleHookName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "serverJobHeartbeatIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "serverJobsAbandonedTimeoutSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "devMode": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "azureClientID": {
-      "type": "string",
-      "default": "<your_client_id>"
+      "default": "<your_client_id>",
+      "type": "string"
     },
     "azureRedirectUrl": {
-      "type": "string",
-      "default": "<your_redirect_url>"
+      "default": "<your_redirect_url>",
+      "type": "string"
     },
     "azureAllowHttpForRedirectUrl": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "azureClientSecret": {
-      "type": "string",
-      "default": "<your_client_secret>"
+      "default": "<your_client_secret>",
+      "type": "string"
     },
     "azureCookieEncryptionKeys": {
+      "default": [],
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "required": ["key", "iv"],
         "properties": {
           "key": {
             "type": "string",
@@ -1012,153 +1345,180 @@
             "minLength": 12,
             "maxLength": 12
           }
-        }
-      },
-      "default": []
+        },
+        "required": ["key", "iv"],
+        "additionalProperties": false
+      }
     },
     "azureLoggingLevel": {
+      "default": "warn",
       "type": "string",
-      "enum": ["error", "warn", "info"],
-      "default": "warn"
+      "enum": ["error", "warn", "info"]
     },
     "azureResourceURL": {
-      "type": ["string", "null"],
-      "default": "https://graph.windows.net"
+      "default": "https://graph.windows.net",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "azureDestroySessionUrl": {
-      "type": ["string", "null"],
-      "default": "https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000"
+      "default": "https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "features": {
+      "default": {},
       "type": "object",
-      "additionalProperties": {
-        "type": "boolean"
-      },
-      "default": {}
-    },
-    "checkSharingOnSync": {
-      "type": "boolean",
-      "default": false
-    },
-    "checkInstitutionsOnSync": {
-      "type": "boolean",
-      "default": false
-    },
-    "stripeSecretKey": {
-      "type": ["string", "null"],
-      "default": null
-    },
-    "stripeWebhookSigningSecret": {
-      "type": ["string", "null"],
-      "default": null
-    },
-    "stripeProductIds": {
-      "type": "object",
-      "additionalProperties": {
+      "propertyNames": {
         "type": "string"
       },
-      "default": {}
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "checkSharingOnSync": {
+      "default": false,
+      "type": "boolean"
+    },
+    "checkInstitutionsOnSync": {
+      "default": false,
+      "type": "boolean"
+    },
+    "stripeSecretKey": {
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "stripeWebhookSigningSecret": {
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "stripeProductIds": {
+      "default": {},
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "stripeAiGradingCreditsProductId": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "stripeAiGradingCreditsRefundsEnabled": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "aiGradingOpenAiApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingOpenAiOrganization": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiQuestionGenerationOpenAiApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiQuestionGenerationOpenAiOrganization": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingGoogleApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingAnthropicApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingRateLimitDollars": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "aiGradingInfrastructureFeePercent": {
+      "default": 0.2,
       "type": "number",
       "minimum": 0,
-      "maximum": 1,
-      "default": 0.2
+      "maximum": 1
     },
     "aiGradingCreditPoolLimits": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["add", "deduct", "setTransferable", "setNonTransferable"],
-      "properties": {
-        "add": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        },
-        "deduct": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        },
-        "setTransferable": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        },
-        "setNonTransferable": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        }
-      },
       "default": {
         "add": {
           "minMilliDollars": 10,
@@ -1176,48 +1536,160 @@
           "minMilliDollars": 0,
           "maxMilliDollars": 1000000000
         }
-      }
+      },
+      "type": "object",
+      "properties": {
+        "add": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        },
+        "deduct": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        },
+        "setTransferable": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        },
+        "setNonTransferable": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["add", "deduct", "setTransferable", "setNonTransferable"],
+      "additionalProperties": false
     },
     "aiQuestionGenerationRateLimitDollars": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "administratorOpenAiApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "administratorOpenAiOrganization": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "requireTermsAcceptance": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "pyroscopeEnabled": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "pyroscopeServerAddress": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "pyroscopeBasicAuthUser": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "pyroscopeBasicAuthPassword": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "pyroscopeTags": {
+      "default": {},
       "type": "object",
-      "additionalProperties": {
+      "propertyNames": {
         "type": "string"
       },
-      "default": {}
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "trpcSecretKeys": {
+      "default": null,
       "anyOf": [
         {
           "type": "array",
@@ -1228,304 +1700,54 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "courseFilesApiTransport": {
+      "default": "process",
       "type": "string",
-      "enum": ["process", "network"],
-      "default": "process"
+      "enum": ["process", "network"]
     },
     "courseFilesApiUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "newsFeedUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "newsFeedBlogUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "newsFeedCategories": {
+      "default": [],
       "type": "array",
       "items": {
         "type": "string"
-      },
-      "default": []
+      }
     },
     "costPerMillionTokens": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "gpt-4o-2024-11-20",
-        "gpt-5-2025-08-07",
-        "gpt-5.2-2025-12-11",
-        "gpt-5.4-mini-2026-03-17",
-        "gpt-5.4-2026-03-05",
-        "gemini-3.5-flash",
-        "gemini-3-flash-preview",
-        "gemini-3.1-pro-preview",
-        "claude-haiku-4-5",
-        "claude-sonnet-4-6",
-        "claude-opus-4-7"
-      ],
-      "properties": {
-        "gpt-4o-2024-11-20": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5-2025-08-07": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5.2-2025-12-11": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5.4-mini-2026-03-17": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5.4-2026-03-05": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gemini-3.5-flash": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gemini-3-flash-preview": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gemini-3.1-pro-preview": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "claude-haiku-4-5": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "claude-sonnet-4-6": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "claude-opus-4-7": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        }
-      },
       "default": {
         "gpt-4o-2024-11-20": {
           "input": 2.5,
@@ -1593,11 +1815,282 @@
           "cacheWrite": 6.25,
           "output": 25
         }
-      }
+      },
+      "type": "object",
+      "properties": {
+        "gpt-4o-2024-11-20": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5-2025-08-07": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5.2-2025-12-11": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5.4-mini-2026-03-17": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5.4-2026-03-05": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gemini-3.5-flash": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gemini-3-flash-preview": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gemini-3.1-pro-preview": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "claude-haiku-4-5": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "claude-sonnet-4-6": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "claude-opus-4-7": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "gpt-4o-2024-11-20",
+        "gpt-5-2025-08-07",
+        "gpt-5.2-2025-12-11",
+        "gpt-5.4-mini-2026-03-17",
+        "gpt-5.4-2026-03-05",
+        "gemini-3.5-flash",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "claude-haiku-4-5",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7"
+      ],
+      "additionalProperties": false
     },
     "exampleCoursePath": {
-      "type": "string",
-      "default": "./exampleCourse"
+      "default": "./exampleCourse",
+      "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -1,292 +1,347 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "maxConcurrentJobs": {
-      "type": "number",
-      "default": 5
+      "default": 5,
+      "type": "number"
     },
     "useEc2MetadataService": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "useConsoleLoggingForJobs": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "useImagePreloading": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "useHealthCheck": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "cacheImageRegistry": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "parallelInitPulls": {
-      "type": "number",
-      "default": 5
+      "default": 5,
+      "type": "number"
     },
     "lifecycleHeartbeatIntervalMS": {
-      "type": "number",
-      "default": 300000
+      "default": 300000,
+      "type": "number"
     },
     "jobLogGroup": {
-      "type": "string",
-      "default": "grading-jobs-debug"
+      "default": "grading-jobs-debug",
+      "type": "string"
     },
     "reportLoad": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "reportIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "graderDockerMemory": {
-      "type": "number",
-      "default": 2147483648
+      "default": 2147483648,
+      "type": "number"
     },
     "graderDockerMemorySwap": {
-      "type": "number",
-      "default": 2147483648
+      "default": 2147483648,
+      "type": "number"
     },
     "graderDockerKernelMemory": {
-      "type": "number",
-      "default": 536870912
+      "default": 536870912,
+      "type": "number"
     },
     "graderDockerDiskQuota": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "graderDockerCpuPeriod": {
-      "type": "number",
-      "default": 100000
+      "default": 100000,
+      "type": "number"
     },
     "graderDockerCpuQuota": {
-      "type": "number",
-      "default": 90000
+      "default": 90000,
+      "type": "number"
     },
     "graderDockerPidsLimit": {
-      "type": "number",
-      "default": 1024
+      "default": 1024,
+      "type": "number"
     },
     "healthCheckPort": {
-      "type": "number",
-      "default": 4000
+      "default": 4000,
+      "type": "number"
     },
     "healthCheckInterval": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "jobsQueueName": {
-      "type": "string",
-      "default": "grading_jobs_dev"
+      "default": "grading_jobs_dev",
+      "type": "string"
     },
     "jobsQueueUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "resultsQueueName": {
-      "type": "string",
-      "default": "grading_results_dev"
+      "default": "grading_results_dev",
+      "type": "string"
     },
     "resultsQueueUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "timeoutOverhead": {
-      "type": "number",
-      "default": 300
+      "default": 300,
+      "type": "number"
     },
     "postgresqlHost": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "postgresqlDatabase": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlUser": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlPassword": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "postgresqlPoolSize": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "postgresqlIdleTimeoutMillis": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "autoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "instanceId": {
-      "type": "string",
-      "default": "server"
+      "default": "server",
+      "type": "string"
     },
     "sentryDsn": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "sentryEnvironment": {
-      "type": "string",
-      "default": "development"
+      "default": "development",
+      "type": "string"
     },
     "awsRegion": {
-      "type": "string",
-      "default": "us-east-2"
+      "default": "us-east-2",
+      "type": "string"
     },
     "visibilityTimeout": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "visibilityTimeoutHeartbeatIntervalSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "cacheType": {
+      "default": "none",
       "type": "string",
-      "enum": ["none", "redis", "memory"],
-      "default": "none"
+      "enum": ["none", "redis", "memory"]
     },
     "cacheKeyPrefix": {
-      "type": "string",
-      "default": "prairielearn-cache:"
+      "default": "prairielearn-cache:",
+      "type": "string"
     },
     "redisUrl": {
-      "type": ["string", "null"],
-      "default": "redis://localhost:6379/"
+      "default": "redis://localhost:6379/",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "runningInEc2": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "hostname": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "workspaceDevHostInstanceId": {
-      "type": "string",
-      "default": "devWSHost1"
+      "default": "devWSHost1",
+      "type": "string"
     },
     "workspaceDevHostHostname": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "workspaceDevContainerHostname": {
-      "type": "string",
-      "default": "host.docker.internal"
+      "default": "host.docker.internal",
+      "type": "string"
     },
     "workspaceHostPort": {
-      "type": "number",
-      "default": 8081
+      "default": 8081,
+      "type": "number"
     },
     "workspaceHostPruneContainersSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceHostMinPortRange": {
-      "type": "number",
-      "default": 1024
+      "default": 1024,
+      "type": "number"
     },
     "workspaceHostMaxPortRange": {
-      "type": "number",
-      "default": 45000
+      "default": 45000,
+      "type": "number"
     },
     "workspaceHostMaxPortAllocationAttempts": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspacePullImagesFromDockerHub": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "workspacePercentMessageRateLimitSec": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "workspaceSupportNoInternet": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "workspaceHostHomeDirRoot": {
-      "type": "string",
-      "default": "/jobs/workspaces"
+      "default": "/jobs/workspaces",
+      "type": "string"
     },
     "workspaceJobsDirectoryOwnerUid": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspaceJobsDirectoryOwnerGid": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspaceDockerMemory": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "workspaceDockerMemorySwap": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "workspaceDockerKernelMemory": {
-      "type": "number",
-      "default": 536870912
+      "default": 536870912,
+      "type": "number"
     },
     "workspaceDockerDiskQuota": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "workspaceDockerCpuPeriod": {
-      "type": "number",
-      "default": 100000
+      "default": 100000,
+      "type": "number"
     },
     "workspaceDockerCpuQuota": {
-      "type": "number",
-      "default": 90000
+      "default": 90000,
+      "type": "number"
     },
     "workspaceDockerPidsLimit": {
-      "type": "number",
-      "default": 1024
+      "default": 1024,
+      "type": "number"
     },
     "workspaceMaxGradedFilesCount": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "workspaceMaxGradedFilesSize": {
-      "type": "number",
-      "default": 104857600
+      "default": 104857600,
+      "type": "number"
     },
     "workspaceLogsS3Bucket": {
-      "type": ["string", "null"],
-      "default": "workspace-logs"
+      "default": "workspace-logs",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceStartTimeoutSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "workspaceHealthCheckIntervalSec": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "workspaceHealthCheckTimeoutSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "startServer": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "postgresqlSsl": {
       "anyOf": [
@@ -295,34 +350,51 @@
         },
         {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "rejectUnauthorized": {
-              "type": "boolean",
-              "default": true
+              "default": true,
+              "type": "boolean"
             },
             "ca": {
-              "type": ["string", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "key": {
-              "type": ["string", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "cert": {
-              "type": ["string", "null"]
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       ]
     },
     "namedLocksRenewIntervalMs": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "courseDirs": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      },
       "default": [
         "/course",
         "/course2",
@@ -333,61 +405,108 @@
         "/course7",
         "/course8",
         "/course9"
-      ]
+      ],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "courseRepoDefaultBranch": {
-      "type": "string",
-      "default": "master"
+      "default": "master",
+      "type": "string"
     },
     "assetsPrefix": {
-      "type": "string",
-      "default": "/assets"
+      "default": "/assets",
+      "type": "string"
     },
     "coursesRoot": {
-      "type": "string",
-      "default": "/data1/courses"
+      "default": "/data1/courses",
+      "type": "string"
     },
     "nonVolatileRedisUrl": {
-      "type": ["string", "null"],
-      "default": "redis://localhost:6379"
+      "default": "redis://localhost:6379",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "logFilename": {
-      "type": "string",
-      "default": "server.log"
+      "default": "server.log",
+      "type": "string"
     },
     "logErrorFilename": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authUid": {
-      "type": ["string", "null"],
-      "default": "dev@example.com"
+      "default": "dev@example.com",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authName": {
-      "type": ["string", "null"],
-      "default": "Dev User"
+      "default": "Dev User",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authUin": {
-      "type": ["string", "null"],
-      "default": "000000000"
+      "default": "000000000",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authEmail": {
-      "type": ["string", "null"],
-      "default": "dev@example.com"
+      "default": "dev@example.com",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "authnCookieMaxAgeMilliseconds": {
-      "type": "number",
-      "default": 2592000000
+      "default": 2592000000,
+      "type": "number"
     },
     "sessionStoreExpireSeconds": {
-      "type": "number",
-      "default": 2592000
+      "default": 2592000,
+      "type": "number"
     },
     "sessionStoreAutoExtendThrottleSeconds": {
-      "type": "number",
-      "default": 3600
+      "default": 3600,
+      "type": "number"
     },
     "sessionCookieSameSite": {
+      "default": "lax",
       "anyOf": [
         {
           "type": "boolean"
@@ -396,84 +515,105 @@
           "type": "string",
           "enum": ["none", "lax", "strict"]
         }
-      ],
-      "default": "lax"
+      ]
     },
     "cookieDomain": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "serverType": {
+      "default": "http",
       "type": "string",
-      "enum": ["http", "https"],
-      "default": "http"
+      "enum": ["http", "https"]
     },
     "serverPort": {
-      "type": "string",
-      "default": "3000"
+      "default": "3000",
+      "type": "string"
     },
     "serverTimeout": {
-      "type": "number",
-      "default": 600000
+      "default": 600000,
+      "type": "number"
     },
     "serverKeepAliveTimeout": {
-      "type": "number",
-      "default": 65000
+      "default": 65000,
+      "type": "number"
     },
     "serverCanonicalHost": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "runMigrations": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "runBatchedMigrations": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "batchedMigrationsWorkDurationMs": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "batchedMigrationsSleepDurationMs": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "sslCertificateFile": {
-      "type": "string",
-      "default": "/etc/pki/tls/certs/localhost.crt"
+      "default": "/etc/pki/tls/certs/localhost.crt",
+      "type": "string"
     },
     "sslKeyFile": {
-      "type": "string",
-      "default": "/etc/pki/tls/private/localhost.key"
+      "default": "/etc/pki/tls/private/localhost.key",
+      "type": "string"
     },
     "sslCAFile": {
-      "type": "string",
-      "default": "/etc/pki/tls/certs/server-chain.crt"
+      "default": "/etc/pki/tls/certs/server-chain.crt",
+      "type": "string"
     },
     "fileUploadMaxBytes": {
-      "type": "number",
-      "default": 10000000
+      "default": 10000000,
+      "type": "number"
     },
     "fileUploadMaxParts": {
-      "type": "number",
-      "default": 1000
+      "default": 1000,
+      "type": "number"
     },
     "fileStoreS3Bucket": {
-      "type": ["string", "null"],
-      "default": "file-store"
+      "default": "file-store",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "fileStoreStorageTypeDefault": {
+      "default": "S3",
       "type": "string",
-      "enum": ["S3", "FileSystem"],
-      "default": "S3"
+      "enum": ["S3", "FileSystem"]
     },
     "cronActive": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "cronEnabledJobs": {
+      "default": null,
       "anyOf": [
         {
           "type": "array",
@@ -484,10 +624,10 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "cronDisabledJobs": {
+      "default": null,
       "anyOf": [
         {
           "type": "array",
@@ -498,344 +638,374 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "cronOverrideAllIntervalsSec": {
-      "type": ["number", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "cronIntervalAutoFinishExamsSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalErrorAbandonedJobsSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalExternalGraderLoadSec": {
-      "type": "number",
-      "default": 8
+      "default": 8,
+      "type": "number"
     },
     "cronIntervalServerLoadSec": {
-      "type": "number",
-      "default": 8
+      "default": 8,
+      "type": "number"
     },
     "cronIntervalServerUsageSec": {
-      "type": "number",
-      "default": 8
+      "default": 8,
+      "type": "number"
     },
     "cronIntervalCalculateAssessmentQuestionStatsSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalWorkspaceTimeoutStopSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "cronIntervalWorkspaceTimeoutWarnSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "cronIntervalWorkspaceHostLoadsSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "cronIntervalWorkspaceHostTransitionsSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "cronIntervalChunksHostAutoScalingSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "cronIntervalCleanTimeSeriesSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "cronIntervalFetchNewsItemsSec": {
-      "type": "number",
-      "default": 300
+      "default": 300,
+      "type": "number"
     },
     "cronDailySec": {
-      "type": "number",
-      "default": 28800
+      "default": 28800,
+      "type": "number"
     },
     "timeSeriesRetentionPeriodSec": {
-      "type": "number",
-      "default": 86400
+      "default": 86400,
+      "type": "number"
     },
     "nodeMetricsIntervalSec": {
-      "type": "number",
-      "default": 5
+      "default": 5,
+      "type": "number"
     },
     "autoFinishAgeMins": {
-      "type": "number",
-      "default": 360
+      "default": 360,
+      "type": "number"
     },
     "questionTimeoutMilliseconds": {
-      "type": "number",
-      "default": 10000
+      "default": 10000,
+      "type": "number"
     },
     "secretKey": {
-      "type": "string",
-      "default": "THIS_IS_THE_SECRET_KEY"
+      "default": "THIS_IS_THE_SECRET_KEY",
+      "type": "string"
     },
     "databaseEncryptionKey": {
+      "default": "0000000000000000000000000000000000000000000000000000000000000000",
       "type": "string",
-      "pattern": "^[0-9a-f]{64}$",
-      "default": "0000000000000000000000000000000000000000000000000000000000000000"
+      "pattern": "^[0-9a-f]{64}$"
     },
     "secretSlackOpsBotEndpoint": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "secretSlackToken": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "secretSlackCourseRequestChannel": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "githubClientToken": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "githubCourseOwner": {
-      "type": "string",
-      "default": "PrairieLearn"
+      "default": "PrairieLearn",
+      "type": "string"
     },
     "githubCourseTemplate": {
-      "type": "string",
-      "default": "pl-template"
+      "default": "pl-template",
+      "type": "string"
     },
     "githubMachineTeam": {
-      "type": "string",
-      "default": "machine"
+      "default": "machine",
+      "type": "string"
     },
     "githubMachineUser": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "gitSshCommand": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingUseAws": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "externalGradingJobsQueueName": {
-      "type": "string",
-      "default": "grading_jobs_dev"
+      "default": "grading_jobs_dev",
+      "type": "string"
     },
     "externalGradingResultsQueueName": {
-      "type": "string",
-      "default": "grading_results_dev"
+      "default": "grading_results_dev",
+      "type": "string"
     },
     "externalGradingJobsDeadLetterQueueName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingResultsDeadLetterQueueName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingAutoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "externalGradingS3Bucket": {
-      "type": "string",
-      "default": "prairielearn.dev.grading"
+      "default": "prairielearn.dev.grading",
+      "type": "string"
     },
     "externalGradingDefaultTimeout": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "externalGradingMaximumTimeout": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "externalGradingLoadAverageIntervalSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "externalGradingHistoryLoadIntervalSec": {
-      "type": "number",
-      "default": 900
+      "default": 900,
+      "type": "number"
     },
     "externalGradingCurrentCapacityFactor": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "externalGradingHistoryCapacityFactor": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "externalGradingPullImagesFromDockerHub": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "externalGradingEnableResults": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "fileEditorUseGit": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "workersCount": {
-      "type": ["number", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workersPerCpu": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "workersExecutionMode": {
+      "default": "native",
       "type": "string",
-      "enum": ["container", "native", "disabled"],
-      "default": "native"
+      "enum": ["container", "native", "disabled"]
     },
     "workerUseQueue": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "workerOverloadDelayMS": {
-      "type": "number",
-      "default": 10000
+      "default": 10000,
+      "type": "number"
     },
     "workerPingTimeoutMilliseconds": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "workerExecutorImageRepository": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workerExecutorImageTag": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ensureExecutorImageAtStartup": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "groupName": {
-      "type": "string",
-      "default": "local"
+      "default": "local",
+      "type": "string"
     },
     "maxResponseTimeSec": {
-      "type": "number",
-      "default": 500
+      "default": 500,
+      "type": "number"
     },
     "serverLoadAverageIntervalSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "serverUsageIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "blockedWarnEnable": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "blockedAtWarnEnable": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "blockedWarnThresholdMS": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "awsServiceGlobalOptions": {
+      "default": {},
       "type": "object",
-      "additionalProperties": {},
-      "default": {}
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {}
     },
     "hasShib": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "hideShibLogin": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "shibLinkText": {
-      "type": "string",
-      "default": "Sign in with Illinois"
+      "default": "Sign in with Illinois",
+      "type": "string"
     },
     "shibLinkLogo": {
-      "type": "string",
-      "default": "/images/illinois_logo.svg"
+      "default": "/images/illinois_logo.svg",
+      "type": "string"
     },
     "shibLinkColors": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["normal", "hover", "active", "focus"],
-      "properties": {
-        "normal": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["background", "border", "text"],
-          "properties": {
-            "background": {
-              "type": "string"
-            },
-            "border": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          }
-        },
-        "hover": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["background", "border", "text"],
-          "properties": {
-            "background": {
-              "type": "string"
-            },
-            "border": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          }
-        },
-        "active": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["background", "border", "text"],
-          "properties": {
-            "background": {
-              "type": "string"
-            },
-            "border": {
-              "type": "string"
-            },
-            "text": {
-              "type": "string"
-            }
-          }
-        },
-        "focus": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["shadow"],
-          "properties": {
-            "shadow": {
-              "type": "string"
-            }
-          }
-        }
-      },
       "default": {
         "normal": {
           "background": "#E84A27",
@@ -855,41 +1025,126 @@
         "focus": {
           "shadow": "rgba(255, 83, 0, 0.35)"
         }
-      }
+      },
+      "type": "object",
+      "properties": {
+        "normal": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["background", "border", "text"],
+          "additionalProperties": false
+        },
+        "hover": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["background", "border", "text"],
+          "additionalProperties": false
+        },
+        "active": {
+          "type": "object",
+          "properties": {
+            "background": {
+              "type": "string"
+            },
+            "border": {
+              "type": "string"
+            },
+            "text": {
+              "type": "string"
+            }
+          },
+          "required": ["background", "border", "text"],
+          "additionalProperties": false
+        },
+        "focus": {
+          "type": "object",
+          "properties": {
+            "shadow": {
+              "type": "string"
+            }
+          },
+          "required": ["shadow"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["normal", "hover", "active", "focus"],
+      "additionalProperties": false
     },
     "hasAzure": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "hasOauth": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "googleClientId": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "googleClientSecret": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "googleRedirectUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "syncExamIdAccessRules": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "ptHost": {
-      "type": "string",
-      "default": "http://localhost:4000"
+      "default": "http://localhost:4000",
+      "type": "string"
     },
     "checkAccessRulesExamUuid": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "questionRenderCacheType": {
+      "default": null,
       "anyOf": [
         {
           "type": "string",
@@ -898,203 +1153,255 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "nonVolatileCacheType": {
+      "default": "redis",
       "type": "string",
-      "enum": ["none", "redis", "memory"],
-      "default": "redis"
+      "enum": ["none", "redis", "memory"]
     },
     "questionRenderCacheTtlSec": {
-      "type": "number",
-      "default": 3600
+      "default": 3600,
+      "type": "number"
     },
     "ltiRedirectUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "lti13InstancePlatforms": {
+      "default": [],
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "required": ["platform"],
         "properties": {
           "platform": {
             "type": "string"
           },
           "display_order": {
-            "type": "number",
-            "default": 100
+            "default": 100,
+            "type": "number"
           },
           "issuer_params": {},
           "custom_fields": {}
-        }
-      },
-      "default": []
+        },
+        "required": ["platform"],
+        "additionalProperties": false
+      }
     },
     "filesRoot": {
-      "type": "string",
-      "default": "/files"
+      "default": "/files",
+      "type": "string"
     },
     "trustProxy": {
-      "type": ["boolean", "number", "string"],
-      "default": false
+      "default": false,
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "workspaceLogsFlushIntervalSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceLogsExpirationDays": {
-      "type": ["number", "null"],
-      "default": 120
+      "default": 120,
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceAuthzCookieMaxAgeMilliseconds": {
-      "type": "number",
-      "default": 60000
+      "default": 60000,
+      "type": "number"
     },
     "workspaceHeartbeatIntervalSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceHeartbeatTimeoutSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "workspaceVisibilityTimeoutSec": {
-      "type": "number",
-      "default": 1800
+      "default": 1800,
+      "type": "number"
     },
     "workspaceLaunchedTimeoutSec": {
-      "type": "number",
-      "default": 43200
+      "default": 43200,
+      "type": "number"
     },
     "workspaceLaunchedTimeoutWarnSec": {
-      "type": "number",
-      "default": 900
+      "default": 900,
+      "type": "number"
     },
     "workspaceInLaunchingTimeoutSec": {
-      "type": "number",
-      "default": 1800
+      "default": 1800,
+      "type": "number"
     },
     "workspaceLaunchingRetryIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "workspaceLaunchingRetryAttempts": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceEnable": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "workspaceCloudWatchName": {
-      "type": "string",
-      "default": "workspaces_local_dev"
+      "default": "workspaces_local_dev",
+      "type": "string"
     },
     "workspaceLoadCapacityFactor": {
-      "type": "number",
-      "default": 1.3
+      "default": 1.3,
+      "type": "number"
     },
     "workspaceLoadHostCapacity": {
-      "type": "number",
-      "default": 40
+      "default": 40,
+      "type": "number"
     },
     "workspaceLoadLaunchTemplateId": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceLoadLaunchTag": {
-      "type": "string",
-      "default": "workspace-host"
+      "default": "workspace-host",
+      "type": "string"
     },
     "workspaceHostUnhealthyTimeoutSec": {
-      "type": "number",
-      "default": 43200
+      "default": 43200,
+      "type": "number"
     },
     "workspaceHostLaunchTimeoutSec": {
-      "type": "number",
-      "default": 600
+      "default": 600,
+      "type": "number"
     },
     "workspaceUrlRewriteCacheMaxAgeSec": {
-      "type": "number",
-      "default": 3600
+      "default": 3600,
+      "type": "number"
     },
     "workspaceHomeDirRoot": {
-      "type": "string",
-      "default": "/jobs/workspaces"
+      "default": "/jobs/workspaces",
+      "type": "string"
     },
     "workspaceAutoscalingEnabled": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "chunksS3Bucket": {
-      "type": "string",
-      "default": "chunks"
+      "default": "chunks",
+      "type": "string"
     },
     "chunksGenerator": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "chunksConsumer": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "chunksConsumerDirectory": {
-      "type": "string",
-      "default": "/chunks"
+      "default": "/chunks",
+      "type": "string"
     },
     "chunksMaxParallelDownload": {
-      "type": "number",
-      "default": 20
+      "default": 20,
+      "type": "number"
     },
     "chunksMaxParallelUpload": {
-      "type": "number",
-      "default": 20
+      "default": 20,
+      "type": "number"
     },
     "chunksAutoScalingGroupName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "chunksLoadBalancerDimensionName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "chunksTargetGroupDimensionName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "chunksHostAutoScalingHistoryIntervalSec": {
-      "type": "number",
-      "default": 900
+      "default": 900,
+      "type": "number"
     },
     "chunksPageViewsCapacityFactor": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "chunksActiveWorkersCapacityFactor": {
-      "type": "number",
-      "default": 2
+      "default": 2,
+      "type": "number"
     },
     "chunksLoadBalancerRequestsCapacityFactor": {
-      "type": "number",
-      "default": 1000
+      "default": 1000,
+      "type": "number"
     },
     "isEnterprise": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "prairieTestSharedAuthSecret": {
-      "type": "string",
-      "default": "CHANGE_ME_PRAIRIE_TEST_SHARED_AUTH_SECRET"
+      "default": "CHANGE_ME_PRAIRIE_TEST_SHARED_AUTH_SECRET",
+      "type": "string"
     },
     "openTelemetryEnabled": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "openTelemetryExporter": {
+      "default": null,
       "anyOf": [
         {
           "type": "string",
@@ -1103,10 +1410,10 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "openTelemetryMetricExporter": {
+      "default": null,
       "anyOf": [
         {
           "type": "string",
@@ -1115,80 +1422,120 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "openTelemetryMetricExportIntervalMillis": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "openTelemetrySamplerType": {
+      "default": "always-on",
       "type": "string",
-      "enum": ["always-on", "always-off", "trace-id-ratio"],
-      "default": "always-on"
+      "enum": ["always-on", "always-off", "trace-id-ratio"]
     },
     "openTelemetrySampleRate": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "honeycombApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "honeycombDataset": {
-      "type": ["string", "null"],
-      "default": "prairielearn-dev"
+      "default": "prairielearn-dev",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "announcementHtml": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "announcementColor": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "autoScalingLaunchingLifecycleHookName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "autoScalingTerminatingLifecycleHookName": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "serverJobHeartbeatIntervalSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "serverJobsAbandonedTimeoutSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "devMode": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "azureClientID": {
-      "type": "string",
-      "default": "<your_client_id>"
+      "default": "<your_client_id>",
+      "type": "string"
     },
     "azureRedirectUrl": {
-      "type": "string",
-      "default": "<your_redirect_url>"
+      "default": "<your_redirect_url>",
+      "type": "string"
     },
     "azureAllowHttpForRedirectUrl": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "azureClientSecret": {
-      "type": "string",
-      "default": "<your_client_secret>"
+      "default": "<your_client_secret>",
+      "type": "string"
     },
     "azureCookieEncryptionKeys": {
+      "default": [],
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
-        "required": ["key", "iv"],
         "properties": {
           "key": {
             "type": "string",
@@ -1200,153 +1547,180 @@
             "minLength": 12,
             "maxLength": 12
           }
-        }
-      },
-      "default": []
+        },
+        "required": ["key", "iv"],
+        "additionalProperties": false
+      }
     },
     "azureLoggingLevel": {
+      "default": "warn",
       "type": "string",
-      "enum": ["error", "warn", "info"],
-      "default": "warn"
+      "enum": ["error", "warn", "info"]
     },
     "azureResourceURL": {
-      "type": ["string", "null"],
-      "default": "https://graph.windows.net"
+      "default": "https://graph.windows.net",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "azureDestroySessionUrl": {
-      "type": ["string", "null"],
-      "default": "https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000"
+      "default": "https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "features": {
+      "default": {},
       "type": "object",
-      "additionalProperties": {
-        "type": "boolean"
-      },
-      "default": {}
-    },
-    "checkSharingOnSync": {
-      "type": "boolean",
-      "default": false
-    },
-    "checkInstitutionsOnSync": {
-      "type": "boolean",
-      "default": false
-    },
-    "stripeSecretKey": {
-      "type": ["string", "null"],
-      "default": null
-    },
-    "stripeWebhookSigningSecret": {
-      "type": ["string", "null"],
-      "default": null
-    },
-    "stripeProductIds": {
-      "type": "object",
-      "additionalProperties": {
+      "propertyNames": {
         "type": "string"
       },
-      "default": {}
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "checkSharingOnSync": {
+      "default": false,
+      "type": "boolean"
+    },
+    "checkInstitutionsOnSync": {
+      "default": false,
+      "type": "boolean"
+    },
+    "stripeSecretKey": {
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "stripeWebhookSigningSecret": {
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "stripeProductIds": {
+      "default": {},
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "stripeAiGradingCreditsProductId": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "stripeAiGradingCreditsRefundsEnabled": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "aiGradingOpenAiApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingOpenAiOrganization": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiQuestionGenerationOpenAiApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiQuestionGenerationOpenAiOrganization": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingGoogleApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingAnthropicApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "aiGradingRateLimitDollars": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     },
     "aiGradingInfrastructureFeePercent": {
+      "default": 0.2,
       "type": "number",
       "minimum": 0,
-      "maximum": 1,
-      "default": 0.2
+      "maximum": 1
     },
     "aiGradingCreditPoolLimits": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["add", "deduct", "setTransferable", "setNonTransferable"],
-      "properties": {
-        "add": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        },
-        "deduct": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        },
-        "setTransferable": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        },
-        "setNonTransferable": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["minMilliDollars", "maxMilliDollars"],
-          "properties": {
-            "minMilliDollars": {
-              "type": "integer"
-            },
-            "maxMilliDollars": {
-              "type": "integer"
-            }
-          }
-        }
-      },
       "default": {
         "add": {
           "minMilliDollars": 10,
@@ -1364,48 +1738,160 @@
           "minMilliDollars": 0,
           "maxMilliDollars": 1000000000
         }
-      }
+      },
+      "type": "object",
+      "properties": {
+        "add": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        },
+        "deduct": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        },
+        "setTransferable": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        },
+        "setNonTransferable": {
+          "type": "object",
+          "properties": {
+            "minMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "maxMilliDollars": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            }
+          },
+          "required": ["minMilliDollars", "maxMilliDollars"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["add", "deduct", "setTransferable", "setNonTransferable"],
+      "additionalProperties": false
     },
     "aiQuestionGenerationRateLimitDollars": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "administratorOpenAiApiKey": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "administratorOpenAiOrganization": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "requireTermsAcceptance": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "pyroscopeEnabled": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "pyroscopeServerAddress": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "pyroscopeBasicAuthUser": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "pyroscopeBasicAuthPassword": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "pyroscopeTags": {
+      "default": {},
       "type": "object",
-      "additionalProperties": {
+      "propertyNames": {
         "type": "string"
       },
-      "default": {}
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "trpcSecretKeys": {
+      "default": null,
       "anyOf": [
         {
           "type": "array",
@@ -1416,304 +1902,54 @@
         {
           "type": "null"
         }
-      ],
-      "default": null
+      ]
     },
     "courseFilesApiTransport": {
+      "default": "process",
       "type": "string",
-      "enum": ["process", "network"],
-      "default": "process"
+      "enum": ["process", "network"]
     },
     "courseFilesApiUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "newsFeedUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "newsFeedBlogUrl": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "newsFeedCategories": {
+      "default": [],
       "type": "array",
       "items": {
         "type": "string"
-      },
-      "default": []
+      }
     },
     "costPerMillionTokens": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "gpt-4o-2024-11-20",
-        "gpt-5-2025-08-07",
-        "gpt-5.2-2025-12-11",
-        "gpt-5.4-mini-2026-03-17",
-        "gpt-5.4-2026-03-05",
-        "gemini-3.5-flash",
-        "gemini-3-flash-preview",
-        "gemini-3.1-pro-preview",
-        "claude-haiku-4-5",
-        "claude-sonnet-4-6",
-        "claude-opus-4-7"
-      ],
-      "properties": {
-        "gpt-4o-2024-11-20": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5-2025-08-07": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5.2-2025-12-11": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5.4-mini-2026-03-17": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gpt-5.4-2026-03-05": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gemini-3.5-flash": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gemini-3-flash-preview": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "gemini-3.1-pro-preview": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "claude-haiku-4-5": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "claude-sonnet-4-6": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        },
-        "claude-opus-4-7": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["input", "cachedInput", "cacheWrite", "output"],
-          "properties": {
-            "input": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cachedInput": {
-              "type": "number",
-              "minimum": 0
-            },
-            "cacheWrite": {
-              "type": "number",
-              "minimum": 0
-            },
-            "output": {
-              "type": "number",
-              "minimum": 0
-            }
-          }
-        }
-      },
       "default": {
         "gpt-4o-2024-11-20": {
           "input": 2.5,
@@ -1781,11 +2017,282 @@
           "cacheWrite": 6.25,
           "output": 25
         }
-      }
+      },
+      "type": "object",
+      "properties": {
+        "gpt-4o-2024-11-20": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5-2025-08-07": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5.2-2025-12-11": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5.4-mini-2026-03-17": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gpt-5.4-2026-03-05": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gemini-3.5-flash": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gemini-3-flash-preview": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "gemini-3.1-pro-preview": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "claude-haiku-4-5": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "claude-sonnet-4-6": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        },
+        "claude-opus-4-7": {
+          "type": "object",
+          "properties": {
+            "input": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cachedInput": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cacheWrite": {
+              "type": "number",
+              "minimum": 0
+            },
+            "output": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": ["input", "cachedInput", "cacheWrite", "output"],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "gpt-4o-2024-11-20",
+        "gpt-5-2025-08-07",
+        "gpt-5.2-2025-12-11",
+        "gpt-5.4-mini-2026-03-17",
+        "gpt-5.4-2026-03-05",
+        "gemini-3.5-flash",
+        "gemini-3-flash-preview",
+        "gemini-3.1-pro-preview",
+        "claude-haiku-4-5",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7"
+      ],
+      "additionalProperties": false
     },
     "exampleCoursePath": {
-      "type": "string",
-      "default": "./exampleCourse"
+      "default": "./exampleCourse",
+      "type": "string"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/docs/assets/config-workspace-host.schema.json
+++ b/docs/assets/config-workspace-host.schema.json
@@ -1,180 +1,208 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "postgresqlUser": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlPassword": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "postgresqlDatabase": {
-      "type": "string",
-      "default": "postgres"
+      "default": "postgres",
+      "type": "string"
     },
     "postgresqlHost": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "postgresqlPoolSize": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "postgresqlIdleTimeoutMillis": {
-      "type": "number",
-      "default": 30000
+      "default": 30000,
+      "type": "number"
     },
     "cacheType": {
+      "default": "none",
       "type": "string",
-      "enum": ["none", "redis", "memory"],
-      "default": "none"
+      "enum": ["none", "redis", "memory"]
     },
     "cacheKeyPrefix": {
-      "type": "string",
-      "default": "workspace-host-cache:"
+      "default": "workspace-host-cache:",
+      "type": "string"
     },
     "redisUrl": {
-      "type": "string",
-      "default": "redis://localhost:6379/"
+      "default": "redis://localhost:6379/",
+      "type": "string"
     },
     "runningInEc2": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "cacheImageRegistry": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "awsRegion": {
-      "type": "string",
-      "default": "us-east-2"
+      "default": "us-east-2",
+      "type": "string"
     },
     "instanceId": {
-      "type": "string",
-      "default": "server"
+      "default": "server",
+      "type": "string"
     },
     "hostname": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "sentryDsn": {
-      "type": ["string", "null"],
-      "default": null
+      "default": null,
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "sentryEnvironment": {
-      "type": "string",
-      "default": "development"
+      "default": "development",
+      "type": "string"
     },
     "workspaceDevHostInstanceId": {
-      "type": "string",
-      "default": "devWSHost1"
+      "default": "devWSHost1",
+      "type": "string"
     },
     "workspaceDevHostHostname": {
-      "type": "string",
-      "default": "localhost"
+      "default": "localhost",
+      "type": "string"
     },
     "workspaceDevContainerHostname": {
-      "type": "string",
-      "default": "host.docker.internal"
+      "default": "host.docker.internal",
+      "type": "string"
     },
     "workspaceHostPort": {
-      "type": "number",
-      "default": 8081
+      "default": 8081,
+      "type": "number"
     },
     "workspaceHostPruneContainersSec": {
-      "type": "number",
-      "default": 60
+      "default": 60,
+      "type": "number"
     },
     "workspaceHostMinPortRange": {
-      "type": "number",
-      "default": 1024
+      "default": 1024,
+      "type": "number"
     },
     "workspaceHostMaxPortRange": {
-      "type": "number",
-      "default": 45000
+      "default": 45000,
+      "type": "number"
     },
     "workspaceHostMaxPortAllocationAttempts": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspacePullImagesFromDockerHub": {
-      "type": "boolean",
-      "default": true
+      "default": true,
+      "type": "boolean"
     },
     "workspacePercentMessageRateLimitSec": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "workspaceSupportNoInternet": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "workspaceHostHomeDirRoot": {
-      "type": "string",
-      "default": "/jobs/workspaces"
+      "default": "/jobs/workspaces",
+      "type": "string"
     },
     "workspaceJobsDirectoryOwnerUid": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspaceJobsDirectoryOwnerGid": {
-      "type": "number",
-      "default": 0
+      "default": 0,
+      "type": "number"
     },
     "workspaceDockerMemory": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "workspaceDockerMemorySwap": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "workspaceDockerKernelMemory": {
-      "type": "number",
-      "default": 536870912
+      "default": 536870912,
+      "type": "number"
     },
     "workspaceDockerDiskQuota": {
-      "type": "number",
-      "default": 1073741824
+      "default": 1073741824,
+      "type": "number"
     },
     "workspaceDockerCpuPeriod": {
-      "type": "number",
-      "default": 100000
+      "default": 100000,
+      "type": "number"
     },
     "workspaceDockerCpuQuota": {
-      "type": "number",
-      "default": 90000
+      "default": 90000,
+      "type": "number"
     },
     "workspaceDockerPidsLimit": {
-      "type": "number",
-      "default": 1024
+      "default": 1024,
+      "type": "number"
     },
     "workspaceMaxGradedFilesCount": {
-      "type": "number",
-      "default": 100
+      "default": 100,
+      "type": "number"
     },
     "workspaceMaxGradedFilesSize": {
-      "type": "number",
-      "default": 104857600
+      "default": 104857600,
+      "type": "number"
     },
     "workspaceLogsS3Bucket": {
-      "type": ["string", "null"],
-      "default": "workspace-logs"
+      "default": "workspace-logs",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "workspaceStartTimeoutSec": {
-      "type": "number",
-      "default": 30
+      "default": 30,
+      "type": "number"
     },
     "workspaceHealthCheckIntervalSec": {
-      "type": "number",
-      "default": 1
+      "default": 1,
+      "type": "number"
     },
     "workspaceHealthCheckTimeoutSec": {
-      "type": "number",
-      "default": 10
+      "default": 10,
+      "type": "number"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/docs/scripts/gen_jsonschemas.py
+++ b/docs/scripts/gen_jsonschemas.py
@@ -19,7 +19,7 @@ def _collapse_scalar_union(obj: dict[str, Any]) -> dict[str, Any]:
     ``type: [X, ...]`` form. Zod 4 emits every union (including nullables) as
     ``anyOf``, which jsonschema2md would otherwise expand into a verbose nested
     list instead of an inline "string or null".
-    
+
     If the following issue is ever addressed, drop this manual adjustment:
     https://github.com/colinhacks/zod/issues/6047
     """

--- a/docs/scripts/gen_jsonschemas.py
+++ b/docs/scripts/gen_jsonschemas.py
@@ -10,6 +10,47 @@ import mkdocs_gen_files
 SCHEMAS_ROOT = Path("apps") / "prairielearn" / "src" / "schemas" / "schemas"
 SOURCE_ROOT = mkdocs_gen_files.config.repo_url + "/blob/master/"
 
+MAX_SAFE_INT = 9007199254740991
+SCALAR_TYPES = frozenset({"string", "number", "integer", "boolean", "null"})
+
+
+def _collapse_scalar_union(obj: dict[str, Any]) -> dict[str, Any]:
+    """Render a union of bare scalar ``{type: X}`` branches as the compact
+    ``type: [X, ...]`` form. Zod 4 emits every union (including nullables) as
+    ``anyOf``, which jsonschema2md would otherwise expand into a verbose nested
+    list instead of an inline "string or null".
+    """
+    for keyword in ("anyOf", "oneOf"):
+        branches = obj.get(keyword)
+        if (
+            isinstance(branches, list)
+            and len(branches) >= 2
+            and "type" not in obj
+            and all(
+                isinstance(b, dict) and set(b) == {"type"} and b["type"] in SCALAR_TYPES
+                for b in branches
+            )
+        ):
+            return {
+                **{k: v for k, v in obj.items() if k != keyword},
+                "type": [b["type"] for b in branches],
+            }
+    return obj
+
+
+def _strip_safe_integer_bounds(obj: dict[str, Any]) -> dict[str, Any]:
+    """Drop the JS safe-integer sentinel bounds Zod 4 stamps on every unbounded
+    integer; rendering "Maximum: 9007199254740991" on each one reads as noise.
+    Real ``.min()`` / ``.max()`` constraints use other values and are kept.
+    """
+    if obj.get("minimum") == -MAX_SAFE_INT or obj.get("maximum") == MAX_SAFE_INT:
+        obj = dict(obj)
+        if obj.get("minimum") == -MAX_SAFE_INT:
+            del obj["minimum"]
+        if obj.get("maximum") == MAX_SAFE_INT:
+            del obj["maximum"]
+    return obj
+
 
 def build_and_write_schemas() -> None:
     """
@@ -21,13 +62,27 @@ def build_and_write_schemas() -> None:
     """
 
     class CustomParser(jsonschema2md.Parser):
-        """Custom parser that hides [Test](...) links and 'additionalFields: true' in the schema documentation."""
+        """Custom parser that renders the raw Zod 4 output sensibly: it hides
+        [Test](...) links and 'additional properties' notes, collapses scalar
+        anyOf/oneOf unions into the inline `type: [...]` form, and drops the
+        safe-integer sentinel bounds Zod 4 stamps on every integer.
+        """
+
+        def _parse_object(self, obj: Any, *args: Any, **kwargs: Any) -> list[str]:
+            """Collapse scalar unions before the base parser expands them into a list."""
+            if isinstance(obj, dict):
+                obj = _collapse_scalar_union(obj)
+            return super()._parse_object(obj, *args, **kwargs)
 
         def _construct_description_line(
-            self, *args: Any, **kwargs: Any
+            self, obj: Any, *args: Any, **kwargs: Any
         ) -> Sequence[str]:
-            """Override to hide the [Test](...) links  and 'additionalFields: true' in the description line."""
-            result = super()._construct_description_line(*args, **kwargs)
+            """Override to hide the [Test](...) links, 'additional properties' notes,
+            and the safe-integer sentinel bounds in the description line.
+            """
+            if isinstance(obj, dict):
+                obj = _strip_safe_integer_bounds(obj)
+            result = super()._construct_description_line(obj, *args, **kwargs)
             result = [re.sub(r" \(\[Test\]\((.*?)\)\)", "", line) for line in result]
             result = [
                 line.replace("Can contain additional properties.", "")

--- a/docs/scripts/gen_jsonschemas.py
+++ b/docs/scripts/gen_jsonschemas.py
@@ -19,6 +19,9 @@ def _collapse_scalar_union(obj: dict[str, Any]) -> dict[str, Any]:
     ``type: [X, ...]`` form. Zod 4 emits every union (including nullables) as
     ``anyOf``, which jsonschema2md would otherwise expand into a verbose nested
     list instead of an inline "string or null".
+    
+    If the following issue is ever addressed, drop this manual adjustment:
+    https://github.com/colinhacks/zod/issues/6047
     """
     for keyword in ("anyOf", "oneOf"):
         branches = obj.get(keyword)

--- a/scripts/gen-jsonschema.mts
+++ b/scripts/gen-jsonschema.mts
@@ -6,6 +6,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import * as prettier from 'prettier';
 import { z } from 'zod';
 
 import { ConfigSchema as GraderHostConfigSchema } from '../apps/grader-host/src/lib/config.js';
@@ -13,18 +14,15 @@ import {
   ConfigSchema as EnvSpecificPrairieLearnConfigSchema,
   STANDARD_COURSE_DIRS,
 } from '../apps/prairielearn/src/lib/config.js';
-import {
-  ajvSchemas,
-  normalizeGeneratedJsonSchema,
-} from '../apps/prairielearn/src/schemas/jsonSchemas.js';
+import { ajvSchemas } from '../apps/prairielearn/src/schemas/jsonSchemas.js';
 import { ConfigSchema as WorkspaceHostConfigSchema } from '../apps/workspace-host/src/lib/config.js';
 
 // Zod 4's `z.toJSONSchema` only emits `additionalProperties: false` for strict
 // objects, but the runtime config schema is a plain (non-strict) `z.object` that
 // silently strips unknown keys. The *published* config schemas should still flag
 // unknown/misspelled keys for editors validating against them, so we close plain
-// objects here (records keep their own `additionalProperties`). This restores the
-// prior `zod-to-json-schema` output without making the runtime schema strict.
+// objects here (records keep their own `additionalProperties`) without making the
+// runtime schema strict.
 const closeObjectsForDocs = (node: unknown): void => {
   if (Array.isArray(node)) {
     node.forEach(closeObjectsForDocs);
@@ -44,86 +42,18 @@ const configToJsonSchema = (schema: z.ZodType) => {
     unrepresentable: 'any',
   });
   closeObjectsForDocs(jsonSchema);
-  normalizeGeneratedJsonSchema(jsonSchema);
   return jsonSchema;
+};
+
+// Serialize the raw Zod 4 output and format it with the repo's prettier config so
+// the result is identical to the committed files (no separate prettier pass needed).
+const formatSchema = async (filePath: string, schema: unknown) => {
+  const config = await prettier.resolveConfig(filePath);
+  return prettier.format(JSON.stringify(schema, null, 2), { ...config, filepath: filePath });
 };
 
 // determine if we are checking or writing
 const check = process.argv[2] === 'check';
-
-const orderedStringify = (schema: any) => {
-  // TODO: this is a hack to get the schemas to be in a consistent order
-  // Remove in a future PR
-  const headKeys = [
-    '$schema',
-    'title',
-    'description',
-    'type',
-    'additionalProperties',
-    'required',
-    'comment',
-    // infoAssessment to improve diff
-    'GroupRoleJsonSchema',
-    'AssessmentAccessRuleJsonSchema',
-    'ZoneAssessmentJsonSchema',
-    'ZoneQuestionBlockJsonSchema',
-    'QuestionAlternativeJsonSchema',
-    'PointsJsonSchema',
-    'PointsSingleJsonSchema',
-    'PointsListJsonSchema',
-    'QuestionIdJsonSchema',
-    'ForceMaxPointsJsonSchema',
-    'AdvanceScorePercJsonSchema',
-  ];
-
-  const tailKeys = ['definitions'];
-
-  return JSON.stringify(
-    schema,
-    (key, value) => {
-      if (key === 'additionalProperties' && value === true) return undefined;
-
-      let localHeadKeys = headKeys;
-      if (key === 'properties') {
-        localHeadKeys = headKeys.filter((k) => !['title', 'type', 'description'].includes(k));
-      }
-
-      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-        return Object.keys(value)
-          .filter((k) => {
-            return !(k === 'additionalProperties' && value[k] === true);
-          })
-          .sort((a, b) => {
-            if (localHeadKeys.includes(a) && localHeadKeys.includes(b)) {
-              return localHeadKeys.indexOf(a) - localHeadKeys.indexOf(b);
-            }
-            if (tailKeys.includes(a) && tailKeys.includes(b)) {
-              return tailKeys.indexOf(a) - tailKeys.indexOf(b);
-            }
-            if (localHeadKeys.includes(a)) {
-              return -1;
-            }
-            if (localHeadKeys.includes(b)) {
-              return 1;
-            }
-            if (tailKeys.includes(a)) {
-              return 1;
-            }
-            if (tailKeys.includes(b)) {
-              return -1;
-            }
-            return 0;
-          })
-          .reduce<Record<string, any>>((acc, key) => {
-            acc[key] = value[key];
-            return acc;
-          }, {});
-      }
-      return value;
-    },
-    2,
-  );
-};
 
 console.log(check ? 'Checking schemas...' : 'Writing schemas...');
 const schemaDir = path.resolve(import.meta.dirname, '../apps/prairielearn/src/schemas/schemas');
@@ -156,44 +86,31 @@ const configSchemas = {
     configToJsonSchema(GraderHostConfigSchema),
 };
 
+const targets: [filePath: string, schema: unknown][] = [
+  ...Object.entries(ajvSchemas).map(([name, schema]): [string, unknown] => [
+    `${schemaDir}/${name}.json`,
+    schema,
+  ]),
+  ...Object.entries(configSchemas),
+];
+
 if (check) {
-  for (const [name, schema] of Object.entries(ajvSchemas)) {
-    // Compare abstract contents are the same since prettier formatting may be different
+  for (const [filePath, schema] of targets) {
     try {
-      const file = orderedStringify(
-        JSON.parse(fs.readFileSync(`${schemaDir}/${name}.json`, 'utf8')),
-      );
-      if (file !== orderedStringify(schema)) {
-        console.error(`Mismatch in ${name} (Do you need to run \`make update-jsonschema\`?)`);
+      const file = fs.readFileSync(filePath, 'utf8');
+      if (file !== (await formatSchema(filePath, schema))) {
+        console.error(
+          `Mismatch in ${path.basename(filePath)} (Do you need to run \`make update-jsonschema\`?)`,
+        );
         process.exit(1);
       }
     } catch (error) {
-      console.error(`Error reading schema file ${name}.json:`, error);
-      process.exit(1);
-    }
-  }
-  // docs/assets/config-*.schema.json
-  for (const [filePath, schema] of Object.entries(configSchemas)) {
-    try {
-      const file = orderedStringify(JSON.parse(fs.readFileSync(filePath, 'utf8')));
-      if (file !== orderedStringify(schema)) {
-        console.error(`Mismatch in ${filePath} (Do you need to run \`make update-jsonschema\`?)`);
-        process.exit(1);
-      }
-    } catch (error) {
-      console.error(`Error reading config path ${filePath}:`, error);
+      console.error(`Error reading schema file ${filePath}:`, error);
       process.exit(1);
     }
   }
 } else {
-  for (const [name, schema] of Object.entries(ajvSchemas)) {
-    // These schemas still need to be prettified, so we won't format them at all
-    // However, we want to preserve the order of the keys, so we'll use the replacer function
-
-    fs.writeFileSync(`${schemaDir}/${name}.json`, orderedStringify(schema));
-  }
-
-  for (const [filePath, schema] of Object.entries(configSchemas)) {
-    fs.writeFileSync(filePath, orderedStringify(schema));
+  for (const [filePath, schema] of targets) {
+    fs.writeFileSync(filePath, await formatSchema(filePath, schema));
   }
 }


### PR DESCRIPTION
# Description

Closes #15161 -- stops rewriting the generated Zod 4 schema output. The committed JSON schemas (`apps/prairielearn/src/schemas/schemas/*.json` and `docs/assets/config-*.schema.json`) are now the raw `z.toJSONSchema` output.

- Delete the `normalizeGeneratedJsonSchema` compatibility pass and the `orderedStringify` key-reordering hack; emit Zod's output as-is.
- Replace the generator's post-processing overrides with native Zod metadata on the schemas
- Teach the docs generator (`gen_jsonschemas.py`) to render the raw output sensibly: collapse scalar `anyOf`/`oneOf` unions into the inline `type: [...]` form, and hide the JS safe-integer sentinel bounds Zod stamps on every integer.
- Format the generated schemas with prettier inside the generator

- The `groups.rolePermissions.{canAssignRoles,canView,canSubmit}` arrays now carry `uniqueItems`. They are `uniqueArray()`s that the old override skipped only to match the pre-Zod-4 output; uniqueness was already enforced at runtime.

- [x] I have disclosed the level of AI assistance used (majority of implementation).

# Testing

Rendered every schema doc page from the new raw output with the updated `gen_jsonschemas.py` and confirmed it matches the previous docs, except the intended `uniqueItems` additions on `groups.rolePermissions`. Spot-checked that the generated docs read sensibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)