### PR TITLE
Update leftover comments referring to yarn

### DIFF
--- a/apps/prairielearn/src/tests/e2e/captureAccessControlScreenshots.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/captureAccessControlScreenshots.spec.ts
@@ -5,7 +5,7 @@
  * `CAPTURE_SCREENSHOTS=1` is set so normal e2e runs do not
  * rewrite documentation images.
  *
- * Usage: `yarn capture-access-control-screenshots`
+ * Usage: `pnpm capture-access-control-screenshots`
  */
 
 import fs from 'node:fs';

--- a/apps/prairielearn/src/tests/e2e/captureOnboardingScreenshots.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/captureOnboardingScreenshots.spec.ts
@@ -7,7 +7,7 @@
  * reuse the e2e worker server, dev DB, writable testCourse copy, and `page`
  * fixture instead of redefining all of that.
  *
- * Usage: `yarn capture-onboarding-screenshots`
+ * Usage: `pnpm capture-onboarding-screenshots`
  */
 
 import fs from 'node:fs';

--- a/packages/question-conversion/README.md
+++ b/packages/question-conversion/README.md
@@ -4,10 +4,12 @@ Internal package that converts questions from interchange formats into PrairieLe
 
 ## CLI
 
-The `question-convert` binary is exposed via `package.json#bin`. Build the package once (`pnpm --filter @prairielearn/question-conversion build`), then run:
+The package provides a command-line interface for converting content.
 
-```text
-question-convert <input> --course <dir> --course-instance <name> [flags]
+```sh
+# From the root of the PrairieLearn repository:
+make build
+node packages/question-conversion/dist/bin/convert.js <input> --course <dir> --course-instance <name>
 ```
 
 | Flag                       | Required | Description                                                                                                                                                                 |

--- a/packages/question-conversion/README.md
+++ b/packages/question-conversion/README.md
@@ -4,7 +4,7 @@ Internal package that converts questions from interchange formats into PrairieLe
 
 ## CLI
 
-The `question-convert` binary is exposed via `package.json#bin`. Build the package once (`yarn workspace @prairielearn/question-conversion build`), then run:
+The `question-convert` binary is exposed via `package.json#bin`. Build the package once (`pnpm --filter @prairielearn/question-conversion build`), then run:
 
 ```text
 question-convert <input> --course <dir> --course-instance <name> [flags]


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Replaces some leftover comments that refer to yarn instead of pnpm.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Readme/comments only. The updated commands work.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
