### PR TITLE
Fix loading AI question drafts with output-less tool calls

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
@@ -408,6 +408,10 @@ async function createQuestionGenerationAgent({
         ...QUESTION_GENERATION_TOOLS.writeFile,
         execute: ({ path, content }) => {
           files[path] = content;
+          // TODO: see the following issue and PR. If they're ever resolved,
+          // we can consider removing this return value.
+          // https://github.com/vercel/ai/issues/15854
+          // https://github.com/vercel/ai/pull/15855
           return { success: true };
         },
       }),

--- a/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
@@ -89,7 +89,7 @@ const QUESTION_GENERATION_TOOLS = {
       path: z.enum(['question.html', 'server.py']),
       content: z.string(),
     }),
-    outputSchema: z.object({ success: z.boolean() }),
+    outputSchema: z.null(),
   }),
   getElementDocumentation: tool({
     inputSchema: z.object({
@@ -412,7 +412,10 @@ async function createQuestionGenerationAgent({
           // we can consider removing this return value.
           // https://github.com/vercel/ai/issues/15854
           // https://github.com/vercel/ai/pull/15855
-          return { success: true };
+          //
+          // We return `null` (the value also backfilled for historical
+          // output-less parts on load) so old and new data share a shape.
+          return null;
         },
       }),
       getElementDocumentation: tool({

--- a/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
+++ b/apps/prairielearn/src/ee/lib/ai-question-generation/agent.ts
@@ -89,6 +89,7 @@ const QUESTION_GENERATION_TOOLS = {
       path: z.enum(['question.html', 'server.py']),
       content: z.string(),
     }),
+    outputSchema: z.object({ success: z.boolean() }),
   }),
   getElementDocumentation: tool({
     inputSchema: z.object({
@@ -407,6 +408,7 @@ async function createQuestionGenerationAgent({
         ...QUESTION_GENERATION_TOOLS.writeFile,
         execute: ({ path, content }) => {
           files[path] = content;
+          return { success: true };
         },
       }),
       getElementDocumentation: tool({

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -182,7 +182,15 @@ router.get(
         if (message.parts.length === 0) {
           return [{ type: 'text', text: '' }];
         }
-        return message.parts;
+        // Tool calls whose tool returned nothing (e.g. legacy `writeFile`) were
+        // persisted without an `output` field. Zod 4's `validateUIMessages()`
+        // rejects an `output-available` tool part that lacks `output`, so
+        // backfill a null output for these older parts.
+        return message.parts.map((part) =>
+          part?.state === 'output-available' && !('output' in part)
+            ? { ...part, output: null }
+            : part,
+        );
       });
 
       return {

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/instructorAiGenerateDraftEditor.ts
@@ -186,6 +186,14 @@ router.get(
         // persisted without an `output` field. Zod 4's `validateUIMessages()`
         // rejects an `output-available` tool part that lacks `output`, so
         // backfill a null output for these older parts.
+        //
+        // TODO: see the following issue and PR. If they're ever resolved,
+        // we can consider removing this workaround. Specifically, we'll need
+        // the AI SDK to be able to gracefully handle message parts that were
+        // persisted without an explicit `output` property.
+        //
+        // https://github.com/vercel/ai/issues/15854
+        // https://github.com/vercel/ai/pull/15855
         return message.parts.map((part) =>
           part?.state === 'output-available' && !('output' in part)
             ? { ...part, output: null }


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

The `writeFile` tool returns `undefined` and declares no `outputSchema`, so its tool-call parts are persisted without an `output` field. Under Zod 4 (recently deployed), `validateUIMessages()` rejects an `output-available` tool part that lacks `output`, so the AI generation editor 500s when loading any draft whose chat history contains a `writeFile` call. (Zod 3 treated a missing `z.unknown()` key as optional; Zod 4 requires it to be present.)

- Backfill a null `output` for legacy `output-available` tool parts missing it, before validation, so existing drafts load again.
- Give `writeFile` an `outputSchema` and return a value so new parts are valid.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Opened a AI question draft and observed no error.