### PR TITLE
Retry empty AI grading structured responses

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
@@ -1,6 +1,6 @@
 import { Output, generateText } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import { sanitizeObject } from '@prairielearn/sanitize';
@@ -10,8 +10,10 @@ import { type RubricItem } from '../../../lib/db-types.js';
 import {
   extractAiGradingExplanationFromCompletion,
   generatePrompt,
+  isNoObjectGeneratedResponseError,
   parseAiRubricItems,
   parseSubmission,
+  retryNoObjectGeneratedResponse,
 } from './ai-grading-util.js';
 
 function makeRubricItem(overrides: Partial<RubricItem> & Pick<RubricItem, 'id'>): RubricItem {
@@ -320,6 +322,57 @@ describe('extractAiGradingExplanationFromCompletion', () => {
     expect(completion).toHaveProperty('_output');
 
     expect(extractAiGradingExplanationFromCompletion(completion)).toBe('graded via generateText');
+  });
+});
+
+describe('retryNoObjectGeneratedResponse', () => {
+  function makeNoObjectError() {
+    const err = new Error('No object generated: the model did not return a response.');
+    err.name = 'AI_NoObjectGeneratedError';
+    return err;
+  }
+
+  it('identifies the transient structured-output empty-response error', () => {
+    expect(isNoObjectGeneratedResponseError(makeNoObjectError())).toBe(true);
+    expect(isNoObjectGeneratedResponseError(new Error('schema validation failed'))).toBe(false);
+    expect(isNoObjectGeneratedResponseError('No object generated')).toBe(false);
+  });
+
+  it('retries a transient empty structured-output response once and returns the next result', async () => {
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(makeNoObjectError())
+      .mockResolvedValueOnce('graded');
+    const onRetry = vi.fn();
+
+    await expect(retryNoObjectGeneratedResponse({ operation, onRetry })).resolves.toBe('graded');
+
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ name: 'AI_NoObjectGeneratedError' }),
+    );
+  });
+
+  it('does not retry non-transient structured-output failures', async () => {
+    const err = new Error('schema validation failed');
+    const operation = vi.fn<() => Promise<string>>().mockRejectedValue(err);
+
+    await expect(retryNoObjectGeneratedResponse({ operation })).rejects.toThrow(err);
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors the retry limit for repeated empty structured-output responses', async () => {
+    const operation = vi.fn<() => Promise<string>>().mockRejectedValue(makeNoObjectError());
+
+    await expect(
+      retryNoObjectGeneratedResponse({ operation, maxRetries: 2 }),
+    ).rejects.toMatchObject({
+      name: 'AI_NoObjectGeneratedError',
+    });
+
+    expect(operation).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -78,6 +78,45 @@ const MODELS_SUPPORTING_SYSTEM_MSG_AFTER_USER_MSG = new Set<AiGradingModelId>([
   'gpt-5.4-2026-03-05',
 ]);
 
+export function isNoObjectGeneratedResponseError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+
+  return (
+    err.name === 'AI_NoObjectGeneratedError' ||
+    err.name === 'NoObjectGeneratedError' ||
+    err.message === 'No object generated: the model did not return a response.'
+  );
+}
+
+export async function retryNoObjectGeneratedResponse<T>({
+  operation,
+  maxRetries = 1,
+  onRetry,
+}: {
+  operation: () => Promise<T>;
+  maxRetries?: number;
+  onRetry?: (attempt: number, err: Error) => void;
+}): Promise<T> {
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (err) {
+      if (
+        !(err instanceof Error) ||
+        !isNoObjectGeneratedResponseError(err) ||
+        attempt >= maxRetries
+      ) {
+        throw err;
+      }
+
+      attempt += 1;
+      onRetry?.(attempt, err);
+    }
+  }
+}
+
 export async function generatePrompt({
   questionPrompt,
   questionAnswer,
@@ -848,12 +887,15 @@ async function correctImageOrientation({
     });
   }
 
-  const response = await generateText({
-    model,
-    output: Output.object({ schema: RotationCorrectionOutputSchema }),
-    messages: prompt,
-    // System messages in `messages` are hard-coded authored strings; safe to allow.
-    allowSystemInMessages: true,
+  const response = await retryNoObjectGeneratedResponse({
+    operation: () =>
+      generateText({
+        model,
+        output: Output.object({ schema: RotationCorrectionOutputSchema }),
+        messages: prompt,
+        // System messages in `messages` are hard-coded authored strings; safe to allow.
+        allowSystemInMessages: true,
+      }),
   });
 
   const index = Number.parseInt(response.output.upright_image) - 1;

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
@@ -60,6 +60,7 @@ import {
   insertAiGradingJob,
   insertAiGradingJobWithRotationCorrection,
   parseAiRubricItems,
+  retryNoObjectGeneratedResponse,
   selectInstanceQuestionsForAssessmentQuestion,
   selectLastVariantAndSubmission,
 } from './ai-grading-util.js';
@@ -752,33 +753,47 @@ export async function aiGrade({
             provider !== 'google'
           ) {
             return {
-              finalGradingResponse: await generateText({
-                model,
-                output: Output.object({ schema: RubricGradingResultSchema }),
-                messages: input,
-                // The AI grading prompts in `generatePrompt` (ai-grading-util.ts)
-                // intentionally interleave `role: 'system'` and `role: 'user'`
-                // messages. All system-role content is hard-coded authored strings;
-                // no user-supplied text is ever placed in a system message, so the
-                // SDK's prompt-injection warning does not apply here.
-                allowSystemInMessages: true,
-                providerOptions: {
-                  openai: openaiProviderOptions,
-                },
+              finalGradingResponse: await retryNoObjectGeneratedResponse({
+                operation: () =>
+                  generateText({
+                    model,
+                    output: Output.object({ schema: RubricGradingResultSchema }),
+                    messages: input,
+                    // The AI grading prompts in `generatePrompt` (ai-grading-util.ts)
+                    // intentionally interleave `role: 'system'` and `role: 'user'`
+                    // messages. All system-role content is hard-coded authored strings;
+                    // no user-supplied text is ever placed in a system message, so the
+                    // SDK's prompt-injection warning does not apply here.
+                    allowSystemInMessages: true,
+                    providerOptions: {
+                      openai: openaiProviderOptions,
+                    },
+                  }),
+                onRetry: (attempt, err) =>
+                  logger.info(
+                    `Retrying AI grading structured output after empty provider response (attempt ${attempt}): ${err.message}`,
+                  ),
               }),
               rotationCorrectionApplied: false,
             };
           }
 
-          const initialResponse = await generateText({
-            model,
-            output: Output.object({ schema: RubricImageGradingResultSchema }),
-            messages: input,
-            // System messages in `messages` are hard-coded authored strings; safe to allow.
-            allowSystemInMessages: true,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
+          const initialResponse = await retryNoObjectGeneratedResponse({
+            operation: () =>
+              generateText({
+                model,
+                output: Output.object({ schema: RubricImageGradingResultSchema }),
+                messages: input,
+                // System messages in `messages` are hard-coded authored strings; safe to allow.
+                allowSystemInMessages: true,
+                providerOptions: {
+                  openai: openaiProviderOptions,
+                },
+              }),
+            onRetry: (attempt, err) =>
+              logger.info(
+                `Retrying AI grading structured output after empty provider response (attempt ${attempt}): ${err.message}`,
+              ),
           });
 
           if (
@@ -821,15 +836,22 @@ export async function aiGrade({
           });
 
           // Perform grading with the rotation-corrected images.
-          const finalResponse = await generateText({
-            model,
-            output: Output.object({ schema: RubricImageGradingResultSchema }),
-            messages: input,
-            // System messages in `messages` are hard-coded authored strings; safe to allow.
-            allowSystemInMessages: true,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
+          const finalResponse = await retryNoObjectGeneratedResponse({
+            operation: () =>
+              generateText({
+                model,
+                output: Output.object({ schema: RubricImageGradingResultSchema }),
+                messages: input,
+                // System messages in `messages` are hard-coded authored strings; safe to allow.
+                allowSystemInMessages: true,
+                providerOptions: {
+                  openai: openaiProviderOptions,
+                },
+              }),
+            onRetry: (attempt, err) =>
+              logger.info(
+                `Retrying AI grading structured output after empty provider response (attempt ${attempt}): ${err.message}`,
+              ),
           });
 
           return {
@@ -1002,9 +1024,32 @@ export async function aiGrade({
             provider !== 'google'
           ) {
             return {
-              finalGradingResponse: await generateText({
+              finalGradingResponse: await retryNoObjectGeneratedResponse({
+                operation: () =>
+                  generateText({
+                    model,
+                    output: Output.object({ schema: GradingResultSchema }),
+                    messages: input,
+                    // System messages in `messages` are hard-coded authored strings; safe to allow.
+                    allowSystemInMessages: true,
+                    providerOptions: {
+                      openai: openaiProviderOptions,
+                    },
+                  }),
+                onRetry: (attempt, err) =>
+                  logger.info(
+                    `Retrying AI grading structured output after empty provider response (attempt ${attempt}): ${err.message}`,
+                  ),
+              }),
+              rotationCorrectionApplied: false,
+            };
+          }
+
+          const initialResponse = await retryNoObjectGeneratedResponse({
+            operation: () =>
+              generateText({
                 model,
-                output: Output.object({ schema: GradingResultSchema }),
+                output: Output.object({ schema: ImageGradingResultSchema }),
                 messages: input,
                 // System messages in `messages` are hard-coded authored strings; safe to allow.
                 allowSystemInMessages: true,
@@ -1012,19 +1057,10 @@ export async function aiGrade({
                   openai: openaiProviderOptions,
                 },
               }),
-              rotationCorrectionApplied: false,
-            };
-          }
-
-          const initialResponse = await generateText({
-            model,
-            output: Output.object({ schema: ImageGradingResultSchema }),
-            messages: input,
-            // System messages in `messages` are hard-coded authored strings; safe to allow.
-            allowSystemInMessages: true,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
+            onRetry: (attempt, err) =>
+              logger.info(
+                `Retrying AI grading structured output after empty provider response (attempt ${attempt}): ${err.message}`,
+              ),
           });
 
           if (
@@ -1056,15 +1092,22 @@ export async function aiGrade({
           });
 
           // Perform grading with the rotation-corrected images.
-          const finalResponse = await generateText({
-            model,
-            output: Output.object({ schema: ImageGradingResultSchema }),
-            messages: input,
-            // System messages in `messages` are hard-coded authored strings; safe to allow.
-            allowSystemInMessages: true,
-            providerOptions: {
-              openai: openaiProviderOptions,
-            },
+          const finalResponse = await retryNoObjectGeneratedResponse({
+            operation: () =>
+              generateText({
+                model,
+                output: Output.object({ schema: ImageGradingResultSchema }),
+                messages: input,
+                // System messages in `messages` are hard-coded authored strings; safe to allow.
+                allowSystemInMessages: true,
+                providerOptions: {
+                  openai: openaiProviderOptions,
+                },
+              }),
+            onRetry: (attempt, err) =>
+              logger.info(
+                `Retrying AI grading structured output after empty provider response (attempt ${attempt}): ${err.message}`,
+              ),
           });
 
           return {


### PR DESCRIPTION
## Summary
- Adds a narrow retry helper for AI SDK structured-output calls that fail with `AI_NoObjectGeneratedError` / `No object generated: the model did not return a response.`
- Applies it to AI grading structured `generateText` calls, including the Gemini image rotation-correction path called out in #14491.
- Adds regression tests covering detection, retry success, non-transient errors, and retry limits.

Fixes #14491.

## Testing
- `PATH=/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /Users/ritwij/.bun/bin/bunx pnpm@11.5.0 --filter @prairielearn/prairielearn exec vitest run --coverage --mode=executor-smoke-test ee/lib/ai-grading/ai-grading-util.test.ts`
- `PATH=/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /Users/ritwij/.bun/bin/bunx pnpm@11.5.0 --filter @prairielearn/prairielearn... build`

## Notes
- Kept the retry intentionally narrow so schema/validation failures still surface immediately.
- Codex assisted with implementation and test drafting; I reviewed and ran the focused checks above.