### PR TITLE
Increase use of Zod native UUID validation

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -110,14 +110,14 @@ describe('migrateAllowAccess', () => {
     {
       name: 'prairietest with viewing rule',
       rules: [
-        { examUuid: '11111111-1111-1111-1111-111111111111', credit: 100 },
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
         { startDate: '2024-01-01T00:00:00', active: false },
       ],
       expected: {
         accessControl: {
           dateControl: { release: { date: '2024-01-01T00:00:00' } },
           integrations: {
-            prairieTest: { exams: [{ examUuid: '11111111-1111-1111-1111-111111111111' }] },
+            prairieTest: { exams: [{ examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' }] },
           },
         },
         errors: [],
@@ -1097,16 +1097,16 @@ describe('migrateAllowAccess', () => {
     {
       name: 'multiple prairietest exams',
       rules: [
-        { examUuid: '11111111-1111-1111-1111-111111111111', credit: 100 },
-        { examUuid: '22222222-2222-2222-2222-222222222222', credit: 100 },
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
+        { examUuid: 'bffd5230-43a5-4be8-a87c-c43b5525bc65', credit: 100 },
       ],
       expected: {
         accessControl: {
           integrations: {
             prairieTest: {
               exams: [
-                { examUuid: '11111111-1111-1111-1111-111111111111' },
-                { examUuid: '22222222-2222-2222-2222-222222222222' },
+                { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' },
+                { examUuid: 'bffd5230-43a5-4be8-a87c-c43b5525bc65' },
               ],
             },
           },
@@ -1119,17 +1119,17 @@ describe('migrateAllowAccess', () => {
     {
       name: 'duplicate prairietest exam rules are collapsed',
       rules: [
-        { examUuid: '11111111-1111-1111-1111-111111111111', credit: 100 },
-        { examUuid: '11111111-1111-1111-1111-111111111111', credit: 100 },
-        { examUuid: '22222222-2222-2222-2222-222222222222', credit: 100 },
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
+        { examUuid: 'bffd5230-43a5-4be8-a87c-c43b5525bc65', credit: 100 },
       ],
       expected: {
         accessControl: {
           integrations: {
             prairieTest: {
               exams: [
-                { examUuid: '11111111-1111-1111-1111-111111111111' },
-                { examUuid: '22222222-2222-2222-2222-222222222222' },
+                { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' },
+                { examUuid: 'bffd5230-43a5-4be8-a87c-c43b5525bc65' },
               ],
             },
           },
@@ -1142,12 +1142,12 @@ describe('migrateAllowAccess', () => {
     {
       name: 'prairietest rule with password emits a warning note',
       rules: [
-        { examUuid: '11111111-1111-1111-1111-111111111111', credit: 100, password: 'discarded' },
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100, password: 'discarded' },
       ],
       expected: {
         accessControl: {
           integrations: {
-            prairieTest: { exams: [{ examUuid: '11111111-1111-1111-1111-111111111111' }] },
+            prairieTest: { exams: [{ examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' }] },
           },
         },
         errors: [],

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1190,15 +1190,15 @@ describe('Duplicate detection', () => {
       integrations: {
         prairieTest: {
           exams: [
-            { examUuid: '11111111-1111-1111-1111-111111111111' },
-            { examUuid: '11111111-1111-1111-1111-111111111111' },
+            { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' },
+            { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' },
           ],
         },
       },
     });
     const errors = validateRule(rule, 'none');
     assert.isTrue(
-      errors.includes('Duplicate PrairieTest exam UUID: 11111111-1111-1111-1111-111111111111.'),
+      errors.includes('Duplicate PrairieTest exam UUID: 8d38a804-7858-49a6-abe7-7a057604dd34.'),
     );
   });
 
@@ -1211,8 +1211,8 @@ describe('Duplicate detection', () => {
       integrations: {
         prairieTest: {
           exams: [
-            { examUuid: '11111111-1111-1111-1111-111111111111' },
-            { examUuid: '22222222-2222-2222-2222-222222222222' },
+            { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' },
+            { examUuid: 'bffd5230-43a5-4be8-a87c-c43b5525bc65' },
           ],
         },
       },

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -87,7 +87,7 @@ describe('Valid configs', () => {
           prairieTest: {
             exams: [
               { examUuid: '11e89892-3eff-4d7f-90a2-221372f14e5c' },
-              { examUuid: '22f99903-4a00-5e80-a1b3-332483025d6d', readOnly: true },
+              { examUuid: '450a7084-360e-4801-b89e-24a1584c885f', readOnly: true },
             ],
           },
         },

--- a/apps/prairielearn/src/lib/string-util.ts
+++ b/apps/prairielearn/src/lib/string-util.ts
@@ -3,6 +3,8 @@
  */
 import { HttpStatusError } from '@prairielearn/error';
 
+export const UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Parses a string of values separated by commas, whitespace, line breaks, or semicolons
  * into an array of unique values.

--- a/apps/prairielearn/src/lib/string-util.ts
+++ b/apps/prairielearn/src/lib/string-util.ts
@@ -3,6 +3,7 @@
  */
 import { HttpStatusError } from '@prairielearn/error';
 
+export const UUID_REGEXP_INLINE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 export const UUID_REGEXP = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**

--- a/apps/prairielearn/src/middlewares/authn.ts
+++ b/apps/prairielearn/src/middlewares/authn.ts
@@ -1,4 +1,5 @@
 import asyncHandler from 'express-async-handler';
+import z from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
 import { getCheckedSignedTokenData } from '@prairielearn/signed-token';
@@ -11,8 +12,6 @@ import { EnrollmentSchema } from '../lib/db-types.js';
 import { insertAuditEvent } from '../models/audit-event.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
-
-const UUID_REGEXP = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 export default asyncHandler(async (req, res, next) => {
   res.locals.is_administrator = false;
@@ -42,7 +41,7 @@ export default asyncHandler(async (req, res, next) => {
       maxAge: 24 * 60 * 60 * 1000,
     });
 
-    if (!data?.uuid || typeof data.uuid !== 'string' || !UUID_REGEXP.test(data.uuid)) {
+    if (!data?.uuid || typeof data.uuid !== 'string' || !z.uuid().safeParse(data.uuid).success) {
       throw new Error('invalid load_test_token');
     }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -14,6 +14,7 @@ import {
   type RuntimeDateControl,
   buildAccessTimeline,
 } from '../../../lib/assessment-access-control/timeline.js';
+import { UUID_REGEXP } from '../../../lib/string-util.js';
 import type { PrairieTestExamMetadata } from '../../../models/assessment-access-control-rules.js';
 import { useTRPC } from '../../../trpc/assessment/context.js';
 
@@ -26,7 +27,6 @@ import {
   isNonDefaultQuestionVisibility,
   isNonDefaultScoreVisibility,
 } from './types.js';
-import { UUID_PATTERN } from './validation.js';
 
 function formatCreditPercent(credit: number): string {
   return Number.isFinite(credit) ? `${credit}%` : '—';
@@ -1131,7 +1131,7 @@ export function PrairieTestExamsTable({
     new Set(
       exams
         .map((e) => e.examUuid)
-        .filter((u) => UUID_PATTERN.test(u))
+        .filter((u) => UUID_REGEXP.test(u))
         .map((u) => u.toLowerCase()),
     ),
   ).sort();

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -18,6 +18,7 @@ import {
   validateRuleDateOrderingIssues,
   validateRuleStructuralDependencyIssues,
 } from '../../../lib/assessment-access-control/validation.js';
+import { UUID_REGEXP } from '../../../lib/string-util.js';
 import {
   MAX_ACCESS_CONTROL_DURATION_MINUTES,
   MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE,
@@ -37,8 +38,6 @@ import {
   formDataToJson,
   isReleasedNow,
 } from './types.js';
-
-export const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export const DATE_REQUIRED_MESSAGE = 'Date is required';
 
@@ -455,7 +454,7 @@ function validatePrairieTestExams(
 
   const examUuidCounts = new Map<string, number>();
   for (const exam of exams) {
-    if (UUID_PATTERN.test(exam.examUuid)) {
+    if (UUID_REGEXP.test(exam.examUuid)) {
       const normalizedUuid = exam.examUuid.toLowerCase();
       examUuidCounts.set(normalizedUuid, (examUuidCounts.get(normalizedUuid) ?? 0) + 1);
     }
@@ -465,7 +464,7 @@ function validatePrairieTestExams(
     const path: AccessControlFormFieldPath = `defaultRule.prairieTestExams.${index}.examUuid`;
     if (!exam.examUuid) {
       addError(path, 'Exam UUID is required');
-    } else if (!UUID_PATTERN.test(exam.examUuid)) {
+    } else if (!UUID_REGEXP.test(exam.examUuid)) {
       addError(path, 'Invalid UUID format');
     } else if ((examUuidCounts.get(exam.examUuid.toLowerCase()) ?? 0) > 1) {
       addError(path, 'Duplicate exam UUID');

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/dataTransform.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/dataTransform.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import { assert, describe, expect, it, test } from 'vitest';
 
 import { EXAMPLE_COURSE_PATH } from '../../../lib/paths.js';
+import { UUID_REGEXP } from '../../../lib/string-util.js';
 import {
   type ZoneAssessmentJson,
   ZoneAssessmentJsonSchema,
@@ -235,9 +236,7 @@ describe('prepareZonesForEditor', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].trackingId).toBeDefined();
-    expect(result[0].trackingId).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-    );
+    expect(result[0].trackingId).toMatch(UUID_REGEXP);
     expect(result[0].questions[0].trackingId).toBeDefined();
     expect(result[0].questions[1].trackingId).toBeDefined();
     expect(result[0].questions[1].alternatives![0].trackingId).toBeDefined();

--- a/apps/prairielearn/src/schemas/accessControl.ts
+++ b/apps/prairielearn/src/schemas/accessControl.ts
@@ -105,13 +105,7 @@ const ExamAfterCompleteJsonSchema = z
 
 const ExamJsonSchema = z
   .object({
-    examUuid: z
-      .string()
-      .regex(
-        /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
-        'Invalid UUID format',
-      )
-      .describe('UUID of associated PrairieTest exam'),
+    examUuid: z.uuid({ version: 'v4' }).describe('UUID of associated PrairieTest exam'),
     readOnly: z.boolean().optional().describe('Whether the exam is read-only for students'),
     afterComplete: ExamAfterCompleteJsonSchema.describe(
       'Controls visibility after the student finishes the assessment during an active PrairieTest reservation. Only applies while a matching reservation is active; ignored otherwise.',

--- a/apps/prairielearn/src/schemas/infoAssessment.ts
+++ b/apps/prairielearn/src/schemas/infoAssessment.ts
@@ -128,8 +128,7 @@ export const AssessmentAccessRuleJsonSchema = z
     comment: CommentJsonSchema.optional(),
     mode: z.enum(['Public', 'Exam']).describe('The server mode required for access.').optional(),
     examUuid: z
-      .string()
-      .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
+      .uuid({ version: 'v4' })
       .describe(
         'The PrairieTest exam UUID for which a student must be registered. Implies mode: Exam.',
       )
@@ -403,10 +402,7 @@ export type ZoneAssessmentJsonInput = z.input<typeof ZoneAssessmentJsonSchema>;
 export const AssessmentJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z
-      .string()
-      .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-      .describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID v4).'),
     type: z.enum(['Homework', 'Exam']).describe('Type of the assessment.'),
     title: z
       .string()

--- a/apps/prairielearn/src/schemas/infoAssessment.ts
+++ b/apps/prairielearn/src/schemas/infoAssessment.ts
@@ -402,7 +402,7 @@ export type ZoneAssessmentJsonInput = z.input<typeof ZoneAssessmentJsonSchema>;
 export const AssessmentJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z.guid().describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID).'),
     type: z.enum(['Homework', 'Exam']).describe('Type of the assessment.'),
     title: z
       .string()

--- a/apps/prairielearn/src/schemas/infoCourse.ts
+++ b/apps/prairielearn/src/schemas/infoCourse.ts
@@ -116,7 +116,7 @@ const CourseOptionsJsonSchema = z
 export const CourseJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z.guid().describe('Unique identifier (UUID v4).').meta({ deprecated: true }).optional(),
+    uuid: z.guid().describe('Unique identifier (UUID).').meta({ deprecated: true }).optional(),
     name: z.string().describe("The course name (e.g., 'TAM 212')."),
     title: z.string().describe("The course title (e.g., 'Introductory Dynamics')."),
     timezone: z

--- a/apps/prairielearn/src/schemas/infoCourse.ts
+++ b/apps/prairielearn/src/schemas/infoCourse.ts
@@ -116,12 +116,7 @@ const CourseOptionsJsonSchema = z
 export const CourseJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z
-      .string()
-      .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-      .describe('Unique identifier (UUID v4).')
-      .meta({ deprecated: true })
-      .optional(),
+    uuid: z.guid().describe('Unique identifier (UUID v4).').meta({ deprecated: true }).optional(),
     name: z.string().describe("The course name (e.g., 'TAM 212')."),
     title: z.string().describe("The course title (e.g., 'Introductory Dynamics')."),
     timezone: z

--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -51,7 +51,7 @@ const PublishingJsonSchema = z.object({
 
 export const StudentLabelJsonSchema = z
   .object({
-    uuid: z.guid().describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID).'),
     name: z
       .string()
       .trim()
@@ -68,7 +68,7 @@ export type StudentLabelJson = z.infer<typeof StudentLabelJsonSchema>;
 export const CourseInstanceJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z.guid().describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID).'),
     longName: z.string().describe("The long name of this course instance (e.g., 'Spring 2015')."),
     shortName: z.string().meta({ deprecated: true }).optional(),
     timezone: z

--- a/apps/prairielearn/src/schemas/infoCourseInstance.ts
+++ b/apps/prairielearn/src/schemas/infoCourseInstance.ts
@@ -51,10 +51,7 @@ const PublishingJsonSchema = z.object({
 
 export const StudentLabelJsonSchema = z
   .object({
-    uuid: z
-      .string()
-      .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-      .describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID v4).'),
     name: z
       .string()
       .trim()
@@ -71,10 +68,7 @@ export type StudentLabelJson = z.infer<typeof StudentLabelJsonSchema>;
 export const CourseInstanceJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z
-      .string()
-      .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-      .describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID v4).'),
     longName: z.string().describe("The long name of this course instance (e.g., 'Spring 2015')."),
     shortName: z.string().meta({ deprecated: true }).optional(),
     timezone: z

--- a/apps/prairielearn/src/schemas/infoQuestion.ts
+++ b/apps/prairielearn/src/schemas/infoQuestion.ts
@@ -212,7 +212,7 @@ const ExternalGradingOptionsJsonSchema = z
 export const QuestionJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z.guid().describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID).'),
     type: z
       .enum(['Calculation', 'MultipleChoice', 'Checkbox', 'File', 'MultipleTrueFalse', 'v3'])
       .describe('Type of the question. This should be set to "v3" for new questions.'),

--- a/apps/prairielearn/src/schemas/infoQuestion.ts
+++ b/apps/prairielearn/src/schemas/infoQuestion.ts
@@ -212,10 +212,7 @@ const ExternalGradingOptionsJsonSchema = z
 export const QuestionJsonSchema = z
   .object({
     comment: CommentJsonSchema.optional(),
-    uuid: z
-      .string()
-      .regex(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-      .describe('Unique identifier (UUID v4).'),
+    uuid: z.guid().describe('Unique identifier (UUID v4).'),
     type: z
       .enum(['Calculation', 'MultipleChoice', 'Checkbox', 'File', 'MultipleTrueFalse', 'v3'])
       .describe('Type of the question. This should be set to "v3" for new questions.'),

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -13,7 +13,7 @@
       "type": "string",
       "format": "uuid",
       "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
-      "description": "Unique identifier (UUID v4)."
+      "description": "Unique identifier (UUID)."
     },
     "type": {
       "type": "string",

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -11,7 +11,8 @@
     },
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "format": "uuid",
+      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
       "description": "Unique identifier (UUID v4)."
     },
     "type": {
@@ -348,7 +349,8 @@
         },
         "examUuid": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "format": "uuid",
+          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
           "description": "The PrairieTest exam UUID for which a student must be registered. Implies mode: Exam."
         },
         "role": {
@@ -568,7 +570,8 @@
                     "properties": {
                       "examUuid": {
                         "type": "string",
-                        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                        "format": "uuid",
+                        "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
                         "description": "UUID of associated PrairieTest exam"
                       },
                       "readOnly": {

--- a/apps/prairielearn/src/schemas/schemas/infoCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourse.json
@@ -13,7 +13,7 @@
       "type": "string",
       "format": "uuid",
       "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
-      "description": "Unique identifier (UUID v4).",
+      "description": "Unique identifier (UUID).",
       "deprecated": true
     },
     "name": {

--- a/apps/prairielearn/src/schemas/schemas/infoCourse.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourse.json
@@ -11,7 +11,8 @@
     },
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "format": "uuid",
+      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
       "description": "Unique identifier (UUID v4).",
       "deprecated": true
     },

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -11,7 +11,8 @@
     },
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "format": "uuid",
+      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
       "description": "Unique identifier (UUID v4)."
     },
     "longName": {
@@ -140,7 +141,8 @@
         "properties": {
           "uuid": {
             "type": "string",
-            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            "format": "uuid",
+            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
             "description": "Unique identifier (UUID v4)."
           },
           "name": {

--- a/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
+++ b/apps/prairielearn/src/schemas/schemas/infoCourseInstance.json
@@ -13,7 +13,7 @@
       "type": "string",
       "format": "uuid",
       "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
-      "description": "Unique identifier (UUID v4)."
+      "description": "Unique identifier (UUID)."
     },
     "longName": {
       "type": "string",
@@ -143,7 +143,7 @@
             "type": "string",
             "format": "uuid",
             "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
-            "description": "Unique identifier (UUID v4)."
+            "description": "Unique identifier (UUID)."
           },
           "name": {
             "type": "string",

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -13,7 +13,7 @@
       "type": "string",
       "format": "uuid",
       "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
-      "description": "Unique identifier (UUID v4)."
+      "description": "Unique identifier (UUID)."
     },
     "type": {
       "type": "string",

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -11,7 +11,8 @@
     },
     "uuid": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+      "format": "uuid",
+      "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
       "description": "Unique identifier (UUID v4)."
     },
     "type": {

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -18,7 +18,7 @@ import { config } from '../lib/config.js';
 import { features } from '../lib/features/index.js';
 import { convertLegacyGroupsToGroupsConfig } from '../lib/group-config.js';
 import { validatePreferencesSchema } from '../lib/question-settings/validation.js';
-import { UUID_REGEXP } from '../lib/string-util.js';
+import { UUID_REGEXP_INLINE } from '../lib/string-util.js';
 import { findCoursesBySharingNames, selectOptionalCourseById } from '../models/course.js';
 import { selectInstitutionForCourse } from '../models/institution.js';
 import {
@@ -185,7 +185,7 @@ const DEFAULT_TAGS: TagJson[] = [
 ];
 
 // For finding all v4 UUIDs in a string/file
-const FILE_UUID_REGEX = new RegExp(`"uuid":\\s*"(${UUID_REGEXP.source})"`, 'g');
+const FILE_UUID_REGEX = new RegExp(`"uuid":\\s*"(${UUID_REGEXP_INLINE.source})"`, 'g');
 
 // This type is used a lot, so make an alias
 type InfoFile<T> = infofile.InfoFile<T>;
@@ -460,7 +460,7 @@ export async function loadInfoFile<T = { uuid: string }>({
       if (!json.uuid) {
         return infofile.makeError('UUID is missing');
       }
-      if (!UUID_REGEXP.test(json.uuid)) {
+      if (!z.uuid().safeParse(json.uuid).success) {
         return infofile.makeError(`UUID "${json.uuid}" is not a valid v4 UUID`);
       }
     }
@@ -519,7 +519,7 @@ export async function loadInfoFile<T = { uuid: string }>({
 
       // Extract and store UUID. Checking for a falsy value isn't technically
       // required, but it keeps TypeScript happy.
-      const uuid = match[0].match(UUID_REGEXP);
+      const uuid = match[0].match(UUID_REGEXP_INLINE);
       if (!uuid) {
         infofile.addError(result, 'UUID not found in file');
         return result;

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -185,7 +185,7 @@ const DEFAULT_TAGS: TagJson[] = [
 ];
 
 // For finding all UUIDs in a string/file
-const FILE_UUID_REGEX = new RegExp(`"uuid":\\s*"(${UUID_REGEXP_INLINE.source})"`, 'g');
+const FILE_UUID_REGEX = new RegExp(`"uuid":\\s*"(${UUID_REGEXP_INLINE.source})"`, 'gi');
 
 // This type is used a lot, so make an alias
 type InfoFile<T> = infofile.InfoFile<T>;

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -184,7 +184,7 @@ const DEFAULT_TAGS: TagJson[] = [
   { name: 'Fa21', color: 'gray1' },
 ];
 
-// For finding all v4 UUIDs in a string/file
+// For finding all UUIDs in a string/file
 const FILE_UUID_REGEX = new RegExp(`"uuid":\\s*"(${UUID_REGEXP_INLINE.source})"`, 'g');
 
 // This type is used a lot, so make an alias
@@ -461,7 +461,7 @@ export async function loadInfoFile<T = { uuid: string }>({
         return infofile.makeError('UUID is missing');
       }
       if (!z.guid().safeParse(json.uuid).success) {
-        return infofile.makeError(`UUID "${json.uuid}" is not a valid v4 UUID`);
+        return infofile.makeError(`UUID "${json.uuid}" is not a valid UUID`);
       }
     }
 

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -38,7 +38,7 @@ import * as infofile from './infofile.js';
 import { isDraftQid } from './question.js';
 
 // We use a single global instance so that schemas aren't recompiled every time they're used
-const ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
+const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, formats: { uuid: true } });
 
 const DEFAULT_ASSESSMENT_SETS: AssessmentSetJson[] = [
   {

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -460,7 +460,7 @@ export async function loadInfoFile<T = { uuid: string }>({
       if (!json.uuid) {
         return infofile.makeError('UUID is missing');
       }
-      if (!z.uuid().safeParse(json.uuid).success) {
+      if (!z.guid().safeParse(json.uuid).success) {
         return infofile.makeError(`UUID "${json.uuid}" is not a valid v4 UUID`);
       }
     }

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -18,6 +18,7 @@ import { config } from '../lib/config.js';
 import { features } from '../lib/features/index.js';
 import { convertLegacyGroupsToGroupsConfig } from '../lib/group-config.js';
 import { validatePreferencesSchema } from '../lib/question-settings/validation.js';
+import { UUID_REGEXP } from '../lib/string-util.js';
 import { findCoursesBySharingNames, selectOptionalCourseById } from '../models/course.js';
 import { selectInstitutionForCourse } from '../models/institution.js';
 import {
@@ -183,11 +184,8 @@ const DEFAULT_TAGS: TagJson[] = [
   { name: 'Fa21', color: 'gray1' },
 ];
 
-// For testing if a string is a v4 UUID
-const UUID_REGEX = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
 // For finding all v4 UUIDs in a string/file
-const FILE_UUID_REGEX =
-  /"uuid":\s*"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"/g;
+const FILE_UUID_REGEX = new RegExp(`"uuid":\\s*"(${UUID_REGEXP.source})"`, 'g');
 
 // This type is used a lot, so make an alias
 type InfoFile<T> = infofile.InfoFile<T>;
@@ -462,7 +460,7 @@ export async function loadInfoFile<T = { uuid: string }>({
       if (!json.uuid) {
         return infofile.makeError('UUID is missing');
       }
-      if (!UUID_REGEX.test(json.uuid)) {
+      if (!UUID_REGEXP.test(json.uuid)) {
         return infofile.makeError(`UUID "${json.uuid}" is not a valid v4 UUID`);
       }
     }
@@ -521,7 +519,7 @@ export async function loadInfoFile<T = { uuid: string }>({
 
       // Extract and store UUID. Checking for a falsy value isn't technically
       // required, but it keeps TypeScript happy.
-      const uuid = match[0].match(UUID_REGEX);
+      const uuid = match[0].match(UUID_REGEXP);
       if (!uuid) {
         infofile.addError(result, 'UUID not found in file');
         return result;

--- a/apps/prairielearn/src/sync/fromDisk/accessControl.ts
+++ b/apps/prairielearn/src/sync/fromDisk/accessControl.ts
@@ -26,7 +26,6 @@ function mapField<T>(jsonValue: T | null | undefined): {
 }
 
 const JSON_RULE_START = 0;
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Validates constraints that require database state: student label existence
@@ -186,7 +185,7 @@ async function selectInvalidExamUuids(
   for (const { rules } of assessments) {
     for (const rule of rules) {
       for (const e of rule.integrations?.prairieTest?.exams ?? []) {
-        if (UUID_REGEX.test(e.examUuid)) {
+        if (z.uuid().safeParse(e.examUuid).success) {
           allExamUuids.add(e.examUuid);
         }
       }

--- a/apps/prairielearn/src/tests/helperClient.ts
+++ b/apps/prairielearn/src/tests/helperClient.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import fetch, { type RequestInit, type Response } from 'node-fetch';
 import { assert } from 'vitest';
+import z from 'zod';
 
 import { config } from '../lib/config.js';
 
@@ -207,8 +208,6 @@ export async function assertEditError(response: Response, expectedText: string) 
   assert.include(jobOutput, expectedText);
 }
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
-
 /**
  * Generates an API access token for testing by navigating through the settings UI.
  *
@@ -262,7 +261,7 @@ export async function generateApiToken(baseUrl: string, tokenName = 'test'): Pro
   const token = tokenContainer.text().trim();
 
   // Validate token format (UUID)
-  if (!UUID_REGEX.test(token)) {
+  if (!z.uuid().safeParse(token).success) {
     throw new Error(`Generated token does not match expected UUID format: ${token}`);
   }
 

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -16,6 +16,7 @@ import { pullAndUpdateCourse } from '../lib/course.js';
 import { type Course } from '../lib/db-types.js';
 import { getOriginalHash } from '../lib/editorUtil.js';
 import { features } from '../lib/features/index.js';
+import { UUID_REGEXP } from '../lib/string-util.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 import { insertCoursePermissionsByUserUid } from '../models/course-permissions.js';
@@ -49,8 +50,6 @@ const { logger } = makeMockLogger();
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const baseUrl = siteUrl + '/pl';
-
-const UUID_REGEXP = /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/;
 
 const SHARING_COURSE_SHARING_NAME = 'sharing-course';
 const CONSUMING_COURSE_SHARING_NAME = 'consuming-course';

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -16,7 +16,7 @@ import { pullAndUpdateCourse } from '../lib/course.js';
 import { type Course } from '../lib/db-types.js';
 import { getOriginalHash } from '../lib/editorUtil.js';
 import { features } from '../lib/features/index.js';
-import { UUID_REGEXP } from '../lib/string-util.js';
+import { UUID_REGEXP_INLINE } from '../lib/string-util.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceByShortName } from '../models/course-instances.js';
 import { insertCoursePermissionsByUserUid } from '../models/course-permissions.js';
@@ -392,7 +392,7 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
       await client.sharing.regenerateSharingToken.mutate();
 
       const response = await fetchCheerio(sharingPageUrl(sharingCourse.id));
-      const result = UUID_REGEXP.exec(await response.text());
+      const result = UUID_REGEXP_INLINE.exec(await response.text());
       exampleCourseSharingToken = result ? result[0] : null;
       assert(exampleCourseSharingToken != null);
     });
@@ -400,7 +400,7 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
     test.sequential('Get default sharing token for consuming course', async () => {
       const sharingUrl = sharingPageUrl(consumingCourse.id);
       const response = await fetchCheerio(sharingUrl);
-      const result = UUID_REGEXP.exec(await response.text());
+      const result = UUID_REGEXP_INLINE.exec(await response.text());
       testCourseSharingToken = result ? result[0] : null;
       assert(testCourseSharingToken != null);
     });

--- a/apps/prairielearn/src/tests/schemas.test.ts
+++ b/apps/prairielearn/src/tests/schemas.test.ts
@@ -38,13 +38,13 @@ for (const schemaName of Object.keys(ajvSchemas)) {
   describe(`${schemaName} schema`, () => {
     const schema = ajvSchemas[schemaName as keyof typeof ajvSchemas];
     it('compiles', () => {
-      const ajv = new Ajv();
+      const ajv = new Ajv({ formats: { uuid: true } });
       const validate = ajv.compile(schema);
       assert.isFunction(validate);
     });
 
     it('validates', () => {
-      const ajv = new Ajv();
+      const ajv = new Ajv({ formats: { uuid: true } });
       const valid = ajv.validateSchema(schema);
       if (ajv.errors) {
         console.error(ajv.errors);

--- a/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/accessControlSync.test.ts
@@ -1344,7 +1344,7 @@ describe('Access control syncing', () => {
     it('rejects non-existent PrairieTest exam UUIDs when checkAccessRulesExamUuid is enabled', () =>
       runInTransactionAndRollback(() =>
         withConfig({ checkAccessRulesExamUuid: true }, async () => {
-          const fakeUuid = '00000000-0000-0000-0000-000000000000';
+          const fakeUuid = '166da275-8f52-4c11-9cb9-2e7ba9ba62d9';
           const { syncedRules, errors } = await syncRulesAndRead([
             makeAccessControlRule({
               dateControl: undefined,
@@ -1367,7 +1367,7 @@ describe('Access control syncing', () => {
     it('allows non-existent PrairieTest exam UUIDs when checkAccessRulesExamUuid is disabled', () =>
       runInTransactionAndRollback(() =>
         withConfig({ checkAccessRulesExamUuid: false }, async () => {
-          const fakeUuid = '00000000-0000-0000-0000-000000000000';
+          const fakeUuid = '46909567-db2c-44e7-9a79-1510e192bbc1';
           const { syncedRules, errors } = await syncRulesAndRead([
             makeAccessControlRule({
               dateControl: undefined,

--- a/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
+++ b/apps/prairielearn/src/tests/sync/assessmentsSync.test.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 
 import fs from 'fs-extra';
-import { afterAll, assert, beforeAll, beforeEach, describe, it } from 'vitest';
+import { afterAll, assert, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import * as sqldb from '@prairielearn/postgres';
@@ -2944,29 +2944,22 @@ describe('Assessment syncing', () => {
 
       // This assessment has both valid and invalid exam UUIDs.
       const assessment = makeAssessment(courseData);
+      const invalidExamUuid = 'df12ea39-8d47-4825-ab22-bbc690a1fc20';
+      const validExamUuid = 'a817e4b9-b1b1-40b6-b076-c3a752dd8e72';
       assessment.allowAccess = [
-        {
-          mode: 'Exam',
-          examUuid: '00000000-0000-0000-0000-000000000000',
-        },
-        {
-          mode: 'Exam',
-          examUuid: '11111111-1111-1111-1111-111111111111',
-        },
+        { mode: 'Exam', examUuid: invalidExamUuid },
+        { mode: 'Exam', examUuid: validExamUuid },
       ];
       courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;
 
       // Insert a `pt_exams` row for the valid exam UUID.
-      await sqldb.execute(sql.insert_pt_exam, { uuid: '11111111-1111-1111-1111-111111111111' });
+      await sqldb.execute(sql.insert_pt_exam, { uuid: validExamUuid });
 
       await util.writeAndSyncCourseData(courseData);
       const syncedAssessment = await findSyncedAssessment('fail');
       assert.isNotNull(syncedAssessment.sync_warnings);
-      assert.match(
-        syncedAssessment.sync_warnings,
-        /examUuid "00000000-0000-0000-0000-000000000000" not found./,
-      );
-      assert.notMatch(syncedAssessment.sync_warnings, /11111111-1111-1111-1111-111111111111/);
+      expect(syncedAssessment.sync_warnings).to.contain(`examUuid "${invalidExamUuid}" not found.`);
+      expect(syncedAssessment.sync_warnings).to.not.contain(validExamUuid);
     });
 
     it('does not validate exam UUIDs for assessments in an inaccessible course instance', async () => {
@@ -2988,7 +2981,7 @@ describe('Assessment syncing', () => {
       assessment.allowAccess = [
         {
           mode: 'Exam',
-          examUuid: '00000000-0000-0000-0000-000000000000',
+          examUuid: '2ba49357-1592-4f6e-9dab-f8ef3d969321',
         },
       ];
       courseData.courseInstances[util.COURSE_INSTANCE_ID].assessments['fail'] = assessment;

--- a/apps/prairielearn/src/tests/sync/courseDb.test.ts
+++ b/apps/prairielearn/src/tests/sync/courseDb.test.ts
@@ -93,7 +93,7 @@ describe('course database', () => {
       });
     });
 
-    it('errors if UUID is not valid v4 UUID', async () => {
+    it('errors if UUID is not valid UUID', async () => {
       await withTempFile(async (file) => {
         const json = { uuid: 'bar' };
         await fs.writeJson(file.path, json);

--- a/packages/question-conversion/package.json
+++ b/packages/question-conversion/package.json
@@ -27,7 +27,8 @@
     "fast-xml-parser": "^5.8.0",
     "he": "^1.2.0",
     "mime": "^4.1.0",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",

--- a/packages/question-conversion/package.json
+++ b/packages/question-conversion/package.json
@@ -27,8 +27,7 @@
     "fast-xml-parser": "^5.8.0",
     "he": "^1.2.0",
     "mime": "^4.1.0",
-    "uuid": "^14.0.0",
-    "zod": "^4.4.3"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",
@@ -36,6 +35,7 @@
     "@types/node": "^24.12.4",
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.7",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/question-conversion/src/emitters/pl-emitter.test.ts
+++ b/packages/question-conversion/src/emitters/pl-emitter.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from 'vitest';
+import z from 'zod';
 
 import type { IRAssessment, IRAssessmentMeta, IRQuestion } from '../types/ir.js';
 
@@ -42,7 +43,7 @@ describe('PLEmitter', () => {
     assert.equal(q.infoJson.type, 'v3');
     assert.equal(q.infoJson.title, 'Test Question');
     assert.isTrue(q.infoJson.singleVariant);
-    assert.match(q.infoJson.uuid, /^[0-9a-f]{8}-/);
+    assert.doesNotThrow(() => z.uuid().parse(q.infoJson.uuid));
   });
 
   it('generates multiple choice HTML', () => {

--- a/packages/question-conversion/src/utils/uuid.test.ts
+++ b/packages/question-conversion/src/utils/uuid.test.ts
@@ -1,11 +1,12 @@
 import { assert, describe, it } from 'vitest';
+import z from 'zod';
 
 import { stableUuid } from './uuid.js';
 
 describe('stableUuid', () => {
   it('produces a valid UUID string', () => {
     const result = stableUuid('source', 'bank', 'item');
-    assert.match(result, /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    assert.doesNotThrow(() => z.uuid().parse(result));
   });
 
   it('is deterministic for the same inputs', () => {
@@ -22,6 +23,6 @@ describe('stableUuid', () => {
 
   it('works with a single part', () => {
     const result = stableUuid('only-source');
-    assert.match(result, /^[0-9a-f]{8}-/);
+    assert.doesNotThrow(() => z.uuid().parse(result));
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2240,6 +2240,9 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@prairielearn/tsconfig':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2240,9 +2240,6 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.0
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
     devDependencies:
       '@prairielearn/tsconfig':
         specifier: workspace:^
@@ -2262,6 +2259,9 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.100.0)(tsx@4.22.4)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/react:
     dependencies:


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Switches some of the regexp validation of UUIDs to Zod:

* Schemas: exam UUIDs use strict v4 UUID validation, since they're supposed to come from PrairieTest (not manual). Other UUIDs may be manually set by users, so uses the looser `z.guid()` validation instead. Resolves #12591.
* Authn, access control sync, tests: simple check for UUID format changed to use Zod.

A few places I considered changing but they would be a bit more complex to consider, either because they may be executed client-side (avoiding importing zod in client), or because the process is more than validation (e.g., finding UUID strings in a longer string). These were changed to refer to a single unified constant to avoid duplicate code.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: some auto-complete.

# Testing

Relying mostly on CI, with some tests for resources that are not included in tests.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->