### PR TITLE
Fix reference to dropdowns in QTI docs

### DIFF
--- a/docs/importingContent.md
+++ b/docs/importingContent.md
@@ -32,22 +32,22 @@ Both entry points use the same importer. If you start from the Questions page, P
 
 The import tool supports individual quiz exports (`.zip` files) and full course exports (`.imscc` files). It handles the following QTI 1.2 question types:
 
-| QTI question type             | PrairieLearn output                                               |
-| ----------------------------- | ----------------------------------------------------------------- |
-| Multiple choice               | [`pl-multiple-choice`](elements/pl-multiple-choice.md)            |
-| True/false                    | [`pl-multiple-choice`](elements/pl-multiple-choice.md)            |
-| Multiple answers (select all) | [`pl-checkbox`](elements/pl-checkbox.md)                          |
-| Fill in the blank             | [`pl-string-input`](elements/pl-string-input.md)                  |
-| Fill in multiple blanks       | Inline [`pl-string-input`](elements/pl-string-input.md) blanks    |
-| Multiple dropdowns            | Inline [`pl-dropdown`](elements/pl-dropdown.md) blanks            |
-| Matching                      | [`pl-matching`](elements/pl-matching.md)                          |
-| Numerical answer              | [`pl-number-input`](elements/pl-number-input.md)                  |
-| Short answer                  | `pl-string-input`, `pl-integer-input`, or `pl-number-input`       |
-| Calculated / formula          | [`pl-number-input`](elements/pl-number-input.md) with `server.py` |
-| Essay / free response         | [`pl-rich-text-editor`](elements/pl-rich-text-editor.md)          |
-| File upload                   | [`pl-file-upload`](elements/pl-file-upload.md)                    |
-| Ordering                      | [`pl-order-blocks`](elements/pl-order-blocks.md)                  |
-| Text-only (no response)       | Prompt-only question panel                                        |
+| QTI question type             | PrairieLearn output                                                                     |
+| ----------------------------- | --------------------------------------------------------------------------------------- |
+| Multiple choice               | [`pl-multiple-choice`](elements/pl-multiple-choice.md)                                  |
+| True/false                    | [`pl-multiple-choice`](elements/pl-multiple-choice.md)                                  |
+| Multiple answers (select all) | [`pl-checkbox`](elements/pl-checkbox.md)                                                |
+| Fill in the blank             | [`pl-string-input`](elements/pl-string-input.md)                                        |
+| Fill in multiple blanks       | Inline [`pl-string-input`](elements/pl-string-input.md) blanks                          |
+| Multiple dropdowns            | Inline [`pl-multiple-choice`](elements/pl-multiple-choice.md) with `display="dropdown"` |
+| Matching                      | [`pl-matching`](elements/pl-matching.md)                                                |
+| Numerical answer              | [`pl-number-input`](elements/pl-number-input.md)                                        |
+| Short answer                  | `pl-string-input`, `pl-integer-input`, or `pl-number-input`                             |
+| Calculated / formula          | [`pl-number-input`](elements/pl-number-input.md) with `server.py`                       |
+| Essay / free response         | [`pl-rich-text-editor`](elements/pl-rich-text-editor.md)                                |
+| File upload                   | [`pl-file-upload`](elements/pl-file-upload.md)                                          |
+| Ordering                      | [`pl-order-blocks`](elements/pl-order-blocks.md)                                        |
+| Text-only (no response)       | Prompt-only question panel                                                              |
 
 Referenced images and other non-video media files are imported into each question's `clientFilesQuestion` directory. If a question references a remote image URL instead of an exported file, PrairieLearn leaves that URL in the generated HTML and shows a warning so you can decide whether to keep or replace it after import.
 

--- a/packages/question-conversion/README.md
+++ b/packages/question-conversion/README.md
@@ -43,7 +43,7 @@ The pipeline is `parse` (XML → IR) → `transform` (per-question normalization
 | `multiple_answers_question`                       | `pl-checkbox`                                                                       |
 | `matching_question`                               | `pl-matching`                                                                       |
 | `fill_in_multiple_blanks_question`                | inline `pl-string-input` blanks                                                     |
-| `multiple_dropdowns_question`                     | inline `pl-dropdown` blanks                                                         |
+| `multiple_dropdowns_question`                     | inline `pl-multiple-choice` with `display="dropdown"`                               |
 | `short_answer_question`                           | `pl-string-input` / `pl-integer-input` / `pl-number-input` (chosen by answer shape) |
 | `numerical_question`                              | `pl-number-input`                                                                   |
 | `calculated_question`                             | `pl-number-input` with a generated `server.py`                                      |


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

In the QTI docs and the README for the corresponding package, the multiple dropdowns question type was described as creating `pl-dropdown` output. However, this element is deprecated, and the actual emitter creates `pl-multiple-choice` output with `display="dropdown"`. This PR fixes both references for a proper output.

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: auto-complete only.

# Testing

Docs only.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
