### PR TITLE
Make PR template more clearly require the "why" for any given change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,7 @@ https://docs.prairielearn.com/contributing
 # Description
 
 <!--
-
-- Summarize your changes and explain the rationale for making them.
+- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
 - Include any relevant context from Slack, meetings, or other discussions.
 - If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
 - If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").


### PR DESCRIPTION
# Description
We had an issue recently where code was committed, approved, and merged through normal processes but the actual reasoning for why the change was necessary wasn't captured, causing confusion some time later (in reference to #14893).

This PR alters the description template to explicitly mention that the WHY is required for contributions.

- [X] I have disclosed the level of AI assistance used: None

# Testing
N/A