### PR TITLE
Fix handling of remaining time with blank minutes

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/AssessmentInstancesTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/AssessmentInstancesTable.tsx
@@ -458,12 +458,12 @@ export function AssessmentInstancesTable({
         cell: (info) => {
           const row = info.row.original;
           return (
-            <span className="text-nowrap">
-              {row.time_remaining}
+            <span className="text-nowrap d-flex align-items-center">
+              <span className="flex-shrink-1 text-truncate">{row.time_remaining}</span>
               {canEdit ? (
                 <button
                   type="button"
-                  className="btn btn-xs btn-ghost text-muted ms-1"
+                  className="btn btn-xs btn-ghost text-muted ms-1 flex-shrink-0"
                   aria-label="Change time limit"
                   onClick={() => setTimeLimitRow(row)}
                 >

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -136,21 +136,27 @@ export function TimeLimitEditForm({
   }
 
   function proposedClosingTime() {
-    if (singleRow == null || Number.isNaN(form.time_add)) return null;
+    if (singleRow == null || !Number.isFinite(form.time_add)) return null;
     const totalTime = Math.round(singleRow.total_time_sec ?? 0);
 
-    let startDate = Temporal.Instant.from(singleRow.date).toZonedDateTimeISO(timezone);
-    if (form.action === 'set_total') {
-      startDate = startDate.add({ minutes: form.time_add });
-    } else if (form.action === 'set_rem') {
-      startDate = Temporal.Now.zonedDateTimeISO(timezone).add({ minutes: form.time_add });
-    } else if (form.action === 'add') {
-      startDate = startDate.add({ seconds: totalTime }).add({ minutes: form.time_add });
-    } else if (form.action === 'subtract') {
-      startDate = startDate.add({ seconds: totalTime }).subtract({ minutes: form.time_add });
-    }
+    try {
+      let startDate = Temporal.Instant.from(singleRow.date).toZonedDateTimeISO(timezone);
+      if (form.action === 'set_total') {
+        startDate = startDate.add({ minutes: form.time_add });
+      } else if (form.action === 'set_rem') {
+        startDate = Temporal.Now.zonedDateTimeISO(timezone).add({ minutes: form.time_add });
+      } else if (form.action === 'add') {
+        startDate = startDate.add({ seconds: totalTime }).add({ minutes: form.time_add });
+      } else if (form.action === 'subtract') {
+        startDate = startDate.add({ seconds: totalTime }).subtract({ minutes: form.time_add });
+      }
 
-    return formatDate(new Date(startDate.epochMilliseconds), timezone);
+      return formatDate(new Date(startDate.epochMilliseconds), timezone);
+    } catch (err) {
+      // Errors here may be due to large values or invalid inputs.
+      console.error('Error calculating proposed closing time:', err);
+      return null;
+    }
   }
 
   function handleSubmit() {

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -136,8 +136,8 @@ export function TimeLimitEditForm({
   }
 
   function proposedClosingTime() {
-    if (singleRow?.total_time_sec == null) return null;
-    const totalTime = Math.round(singleRow.total_time_sec);
+    if (singleRow == null || Number.isNaN(form.time_add)) return null;
+    const totalTime = Math.round(singleRow.total_time_sec ?? 0);
 
     let startDate = Temporal.Instant.from(singleRow.date).toZonedDateTimeISO(timezone);
     if (form.action === 'set_total') {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #14640. In the assessment instances page (Students tab), when editing remaining time, if the number of minutes to add/subtract/set was blank, the element would crash. The issue was the calculation of the "proposed closing time", which assumed that the value would always be a number.

Also fixes an issue when re-opening a closed instance. In master, if the instance is closed, the "proposed closing time" would always be blank. This is because the "total_time_sec" would be null, even though that property is never used in the calculation for options set for this scenario (it is only used for add/subtract options, which are not available when re-opening a closed assessment).

Also: when the "Remaining" column had content with long text (e.g., "Open (no time limit)"), the edit button would be hidden behind the ellipsis, and would only be visible if the column were extended. This PR uses CSS flex to ensure that the ellipsis only affect the remaining status text, not the button.

<img width="322" height="269" alt="image" src="https://github.com/user-attachments/assets/7ce4203e-ce5d-431d-9520-8e85e716d498" />

<!--

- Summarize your changes and explain the rationale for making them.
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: support with the use of d-shrink-* classes in bootstrap.

# Testing

Tested manually locally. Code works for re-opening a closed instance, or modifying the time limit for an open instance with or without a current time limit.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
