### PR TITLE
Fix staff visibility for empty modern access control

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/data.sql
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.sql
@@ -1,71 +1,97 @@
 -- BLOCK select_access_control_rules
 SELECT
   a.id AS assessment_id,
-  to_jsonb(aacr.*) AS access_control_rule,
   COALESCE(
-    array_agg(DISTINCT ace.enrollment_id) FILTER (
+    jsonb_agg(
+      to_jsonb(rules.*) - 'target_type' - 'number'
+      ORDER BY
+        CASE rules.target_type
+          WHEN 'none' THEN 0
+          WHEN 'student_label' THEN 1
+          WHEN 'enrollment' THEN 2
+        END,
+        rules.number
+    ) FILTER (
       WHERE
-        ace.enrollment_id IS NOT NULL
+        rules.access_control_rule IS NOT NULL
     ),
-    '{}'
-  ) AS enrollment_ids,
-  COALESCE(
-    array_agg(DISTINCT acsl.student_label_id) FILTER (
-      WHERE
-        acsl.student_label_id IS NOT NULL
-    ),
-    '{}'
-  ) AS student_label_ids,
-  (
-    SELECT
-      jsonb_agg(
-        jsonb_build_object(
-          'uuid',
-          acpe.uuid,
-          'read_only',
-          acpe.read_only,
-          'after_complete_questions_hidden',
-          acpe.after_complete_questions_hidden,
-          'after_complete_score_hidden',
-          acpe.after_complete_score_hidden
-        )
-        ORDER BY
-          acpe.uuid
-      )
-    FROM
-      assessment_access_control_prairietest_exams acpe
-    WHERE
-      acpe.assessment_access_control_rule_id = aacr.id
-  ) AS prairietest_exams,
-  (
-    SELECT
-      jsonb_agg(
-        jsonb_build_object('date', ed.date, 'credit', ed.credit)
-        ORDER BY
-          ed.date
-      )
-    FROM
-      assessment_access_control_early_deadlines ed
-    WHERE
-      ed.assessment_access_control_rule_id = aacr.id
-  ) AS early_deadlines,
-  (
-    SELECT
-      jsonb_agg(
-        jsonb_build_object('date', ld.date, 'credit', ld.credit)
-        ORDER BY
-          ld.date
-      )
-    FROM
-      assessment_access_control_late_deadlines ld
-    WHERE
-      ld.assessment_access_control_rule_id = aacr.id
-  ) AS late_deadlines
+    '[]'::jsonb
+  ) AS access_control_rules
 FROM
   assessments a
-  LEFT JOIN assessment_access_control_rules aacr ON aacr.assessment_id = a.id
-  LEFT JOIN assessment_access_control_enrollments ace ON ace.assessment_access_control_rule_id = aacr.id
-  LEFT JOIN assessment_access_control_student_labels acsl ON acsl.assessment_access_control_rule_id = aacr.id
+  LEFT JOIN LATERAL (
+    SELECT
+      to_jsonb(aacr.*) AS access_control_rule,
+      aacr.target_type,
+      aacr.number,
+      COALESCE(
+        array_agg(DISTINCT ace.enrollment_id) FILTER (
+          WHERE
+            ace.enrollment_id IS NOT NULL
+        ),
+        '{}'
+      ) AS enrollment_ids,
+      COALESCE(
+        array_agg(DISTINCT acsl.student_label_id) FILTER (
+          WHERE
+            acsl.student_label_id IS NOT NULL
+        ),
+        '{}'
+      ) AS student_label_ids,
+      (
+        SELECT
+          jsonb_agg(
+            jsonb_build_object(
+              'uuid',
+              acpe.uuid,
+              'read_only',
+              acpe.read_only,
+              'after_complete_questions_hidden',
+              acpe.after_complete_questions_hidden,
+              'after_complete_score_hidden',
+              acpe.after_complete_score_hidden
+            )
+            ORDER BY
+              acpe.uuid
+          )
+        FROM
+          assessment_access_control_prairietest_exams acpe
+        WHERE
+          acpe.assessment_access_control_rule_id = aacr.id
+      ) AS prairietest_exams,
+      (
+        SELECT
+          jsonb_agg(
+            jsonb_build_object('date', ed.date, 'credit', ed.credit)
+            ORDER BY
+              ed.date
+          )
+        FROM
+          assessment_access_control_early_deadlines ed
+        WHERE
+          ed.assessment_access_control_rule_id = aacr.id
+      ) AS early_deadlines,
+      (
+        SELECT
+          jsonb_agg(
+            jsonb_build_object('date', ld.date, 'credit', ld.credit)
+            ORDER BY
+              ld.date
+          )
+        FROM
+          assessment_access_control_late_deadlines ld
+        WHERE
+          ld.assessment_access_control_rule_id = aacr.id
+      ) AS late_deadlines
+    FROM
+      assessment_access_control_rules aacr
+      LEFT JOIN assessment_access_control_enrollments ace ON ace.assessment_access_control_rule_id = aacr.id
+      LEFT JOIN assessment_access_control_student_labels acsl ON acsl.assessment_access_control_rule_id = aacr.id
+    WHERE
+      aacr.assessment_id = a.id
+    GROUP BY
+      aacr.id
+  ) AS rules ON TRUE
 WHERE
   (
     $assessment_id::bigint IS NOT NULL
@@ -78,16 +104,9 @@ WHERE
     AND a.deleted_at IS NULL
   )
 GROUP BY
-  a.id,
-  aacr.id
+  a.id
 ORDER BY
-  a.id,
-  CASE aacr.target_type
-    WHEN 'none' THEN 0
-    WHEN 'student_label' THEN 1
-    WHEN 'enrollment' THEN 2
-  END,
-  aacr.number;
+  a.id;
 
 -- BLOCK select_user_access_context
 WITH

--- a/apps/prairielearn/src/lib/assessment-access-control/data.sql
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.sql
@@ -1,96 +1,108 @@
 -- BLOCK select_access_control_rules
 SELECT
   a.id AS assessment_id,
-  COALESCE(
-    jsonb_agg(
-      to_jsonb(rules.*) - 'target_type' - 'number'
-      ORDER BY
-        CASE rules.target_type
-          WHEN 'none' THEN 0
-          WHEN 'student_label' THEN 1
-          WHEN 'enrollment' THEN 2
-        END,
-        rules.number
-    ) FILTER (
-      WHERE
-        rules.access_control_rule IS NOT NULL
-    ),
-    '[]'::jsonb
-  ) AS access_control_rules
+  COALESCE(rules.access_control_rules, '[]'::jsonb) AS access_control_rules
 FROM
   assessments a
   LEFT JOIN LATERAL (
     SELECT
-      to_jsonb(aacr.*) AS access_control_rule,
-      aacr.target_type,
-      aacr.number,
-      COALESCE(
-        array_agg(DISTINCT ace.enrollment_id) FILTER (
-          WHERE
-            ace.enrollment_id IS NOT NULL
-        ),
-        '{}'
-      ) AS enrollment_ids,
-      COALESCE(
-        array_agg(DISTINCT acsl.student_label_id) FILTER (
-          WHERE
-            acsl.student_label_id IS NOT NULL
-        ),
-        '{}'
-      ) AS student_label_ids,
-      (
-        SELECT
-          jsonb_agg(
-            jsonb_build_object(
-              'uuid',
-              acpe.uuid,
-              'read_only',
-              acpe.read_only,
-              'after_complete_questions_hidden',
-              acpe.after_complete_questions_hidden,
-              'after_complete_score_hidden',
-              acpe.after_complete_score_hidden
-            )
-            ORDER BY
-              acpe.uuid
+      jsonb_agg(
+        jsonb_build_object(
+          'access_control_rule',
+          to_jsonb(aacr.*),
+          'enrollment_ids',
+          COALESCE(
+            (
+              SELECT
+                array_agg(
+                  ace.enrollment_id
+                  ORDER BY
+                    ace.enrollment_id
+                )
+              FROM
+                assessment_access_control_enrollments ace
+              WHERE
+                ace.assessment_access_control_rule_id = aacr.id
+            ),
+            ARRAY[]::bigint[]
+          ),
+          'student_label_ids',
+          COALESCE(
+            (
+              SELECT
+                array_agg(
+                  acsl.student_label_id
+                  ORDER BY
+                    acsl.student_label_id
+                )
+              FROM
+                assessment_access_control_student_labels acsl
+              WHERE
+                acsl.assessment_access_control_rule_id = aacr.id
+            ),
+            ARRAY[]::bigint[]
+          ),
+          'prairietest_exams',
+          (
+            SELECT
+              jsonb_agg(
+                jsonb_build_object(
+                  'uuid',
+                  acpe.uuid,
+                  'read_only',
+                  acpe.read_only,
+                  'after_complete_questions_hidden',
+                  acpe.after_complete_questions_hidden,
+                  'after_complete_score_hidden',
+                  acpe.after_complete_score_hidden
+                )
+                ORDER BY
+                  acpe.uuid
+              )
+            FROM
+              assessment_access_control_prairietest_exams acpe
+            WHERE
+              acpe.assessment_access_control_rule_id = aacr.id
+          ),
+          'early_deadlines',
+          (
+            SELECT
+              jsonb_agg(
+                jsonb_build_object('date', ed.date, 'credit', ed.credit)
+                ORDER BY
+                  ed.date
+              )
+            FROM
+              assessment_access_control_early_deadlines ed
+            WHERE
+              ed.assessment_access_control_rule_id = aacr.id
+          ),
+          'late_deadlines',
+          (
+            SELECT
+              jsonb_agg(
+                jsonb_build_object('date', ld.date, 'credit', ld.credit)
+                ORDER BY
+                  ld.date
+              )
+            FROM
+              assessment_access_control_late_deadlines ld
+            WHERE
+              ld.assessment_access_control_rule_id = aacr.id
           )
-        FROM
-          assessment_access_control_prairietest_exams acpe
-        WHERE
-          acpe.assessment_access_control_rule_id = aacr.id
-      ) AS prairietest_exams,
-      (
-        SELECT
-          jsonb_agg(
-            jsonb_build_object('date', ed.date, 'credit', ed.credit)
-            ORDER BY
-              ed.date
-          )
-        FROM
-          assessment_access_control_early_deadlines ed
-        WHERE
-          ed.assessment_access_control_rule_id = aacr.id
-      ) AS early_deadlines,
-      (
-        SELECT
-          jsonb_agg(
-            jsonb_build_object('date', ld.date, 'credit', ld.credit)
-            ORDER BY
-              ld.date
-          )
-        FROM
-          assessment_access_control_late_deadlines ld
-        WHERE
-          ld.assessment_access_control_rule_id = aacr.id
-      ) AS late_deadlines
+        )
+        ORDER BY
+          CASE aacr.target_type
+            WHEN 'none' THEN 0
+            WHEN 'student_label' THEN 1
+            WHEN 'enrollment' THEN 2
+          END,
+          aacr.number
+      ) AS access_control_rules
     FROM
       assessment_access_control_rules aacr
-      LEFT JOIN assessment_access_control_enrollments ace ON ace.assessment_access_control_rule_id = aacr.id
-      LEFT JOIN assessment_access_control_student_labels acsl ON acsl.assessment_access_control_rule_id = aacr.id
     WHERE
       aacr.assessment_id = a.id
-    GROUP BY
-      aacr.id
   ) AS rules ON TRUE
 WHERE
   (
@@ -103,8 +115,6 @@ WHERE
     AND a.modern_access_control
     AND a.deleted_at IS NULL
   )
-GROUP BY
-  a.id
 ORDER BY
   a.id;
 

--- a/apps/prairielearn/src/lib/assessment-access-control/data.sql
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.sql
@@ -1,6 +1,10 @@
 -- BLOCK select_access_control_rules
 SELECT
-  to_jsonb(aacr.*) AS access_control_rule,
+  a.id AS assessment_id,
+  CASE
+    WHEN aacr.id IS NULL THEN NULL
+    ELSE to_jsonb(aacr.*)
+  END AS access_control_rule,
   COALESCE(
     array_agg(DISTINCT ace.enrollment_id) FILTER (
       WHERE
@@ -61,24 +65,26 @@ SELECT
       ld.assessment_access_control_rule_id = aacr.id
   ) AS late_deadlines
 FROM
-  assessment_access_control_rules aacr
-  JOIN assessments a ON a.id = aacr.assessment_id
+  assessments a
+  LEFT JOIN assessment_access_control_rules aacr ON aacr.assessment_id = a.id
   LEFT JOIN assessment_access_control_enrollments ace ON ace.assessment_access_control_rule_id = aacr.id
   LEFT JOIN assessment_access_control_student_labels acsl ON acsl.assessment_access_control_rule_id = aacr.id
 WHERE
   (
     $assessment_id::bigint IS NOT NULL
-    AND aacr.assessment_id = $assessment_id
+    AND a.id = $assessment_id
   )
   OR (
     $course_instance_id::bigint IS NOT NULL
     AND a.course_instance_id = $course_instance_id
+    AND a.modern_access_control
     AND a.deleted_at IS NULL
   )
 GROUP BY
+  a.id,
   aacr.id
 ORDER BY
-  aacr.assessment_id,
+  a.id,
   CASE aacr.target_type
     WHEN 'none' THEN 0
     WHEN 'student_label' THEN 1

--- a/apps/prairielearn/src/lib/assessment-access-control/data.sql
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.sql
@@ -1,10 +1,7 @@
 -- BLOCK select_access_control_rules
 SELECT
   a.id AS assessment_id,
-  CASE
-    WHEN aacr.id IS NULL THEN NULL
-    ELSE to_jsonb(aacr.*)
-  END AS access_control_rule,
+  to_jsonb(aacr.*) AS access_control_rule,
   COALESCE(
     array_agg(DISTINCT ace.enrollment_id) FILTER (
       WHERE

--- a/apps/prairielearn/src/lib/assessment-access-control/data.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.ts
@@ -35,7 +35,8 @@ const PrairieTestExamJsonSchema = z
   .nullable();
 
 const AccessControlRuleRowSchema = z.object({
-  access_control_rule: AssessmentAccessControlRuleSchema,
+  assessment_id: IdSchema,
+  access_control_rule: AssessmentAccessControlRuleSchema.nullable(),
   enrollment_ids: z.array(IdSchema),
   student_label_ids: z.array(IdSchema),
   prairietest_exams: PrairieTestExamJsonSchema,
@@ -45,6 +46,13 @@ const AccessControlRuleRowSchema = z.object({
 
 type AccessControlRuleRow = z.infer<typeof AccessControlRuleRowSchema>;
 type AssessmentAccessControlRule = z.infer<typeof AssessmentAccessControlRuleSchema>;
+type AccessControlRuleRowWithRule = AccessControlRuleRow & {
+  access_control_rule: AssessmentAccessControlRule;
+};
+
+function hasAccessControlRule(row: AccessControlRuleRow): row is AccessControlRuleRowWithRule {
+  return row.access_control_rule != null;
+}
 
 function buildDateControl(
   rule: AssessmentAccessControlRule,
@@ -130,7 +138,7 @@ function buildAfterComplete(rule: AssessmentAccessControlRule): RuntimeAfterComp
   return Object.keys(afterComplete).length > 0 ? afterComplete : undefined;
 }
 
-function rowToAccessControlRuleInput(row: AccessControlRuleRow): AccessControlRuleInput {
+function rowToAccessControlRuleInput(row: AccessControlRuleRowWithRule): AccessControlRuleInput {
   const rule = row.access_control_rule;
   const dateControl = buildDateControl(rule, row.early_deadlines, row.late_deadlines);
   const afterComplete = buildAfterComplete(rule);
@@ -183,7 +191,7 @@ export async function selectAccessControlRulesForAssessment(
     { assessment_id: assessment.id, course_instance_id: null },
     AccessControlRuleRowSchema,
   );
-  return rows.map(rowToAccessControlRuleInput);
+  return rows.filter(hasAccessControlRule).map(rowToAccessControlRuleInput);
 }
 
 export async function selectAccessControlRulesForCourseInstance(
@@ -197,11 +205,13 @@ export async function selectAccessControlRulesForCourseInstance(
 
   const result = new Map<string, AccessControlRuleInput[]>();
   for (const row of rows) {
-    const assessmentId = row.access_control_rule.assessment_id;
+    const assessmentId = row.assessment_id;
     if (!result.has(assessmentId)) {
       result.set(assessmentId, []);
     }
-    result.get(assessmentId)!.push(rowToAccessControlRuleInput(row));
+    if (hasAccessControlRule(row)) {
+      result.get(assessmentId)!.push(rowToAccessControlRuleInput(row));
+    }
   }
   return result;
 }

--- a/apps/prairielearn/src/lib/assessment-access-control/data.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.ts
@@ -7,6 +7,7 @@ import { DateFromISOString, IdSchema } from '@prairielearn/zod';
 import {
   type Assessment,
   AssessmentAccessControlPrairietestExamSchema,
+  type AssessmentAccessControlRule,
   AssessmentAccessControlRuleSchema,
   type CourseInstance,
 } from '../db-types.js';
@@ -22,6 +23,7 @@ import type { RuntimeDateControl } from './timeline.js';
 const sql = loadSqlEquiv(import.meta.url);
 
 const DeadlineJsonSchema = z.array(z.object({ date: z.string(), credit: z.number() })).nullable();
+type DeadlineJson = z.infer<typeof DeadlineJsonSchema>;
 
 const PrairieTestExamJsonSchema = z
   .array(
@@ -42,19 +44,17 @@ const AccessControlRuleRowSchema = z.object({
   early_deadlines: DeadlineJsonSchema,
   late_deadlines: DeadlineJsonSchema,
 });
+type AccessControlRuleRow = z.infer<typeof AccessControlRuleRowSchema>;
 
 const AssessmentAccessControlRulesRowSchema = z.object({
   assessment_id: IdSchema,
   access_control_rules: z.array(AccessControlRuleRowSchema),
 });
 
-type AssessmentAccessControlRule = z.infer<typeof AssessmentAccessControlRuleSchema>;
-type AccessControlRuleRow = z.infer<typeof AccessControlRuleRowSchema>;
-
 function buildDateControl(
   rule: AssessmentAccessControlRule,
-  earlyDeadlines: z.infer<typeof DeadlineJsonSchema>,
-  lateDeadlines: z.infer<typeof DeadlineJsonSchema>,
+  earlyDeadlines: DeadlineJson,
+  lateDeadlines: DeadlineJson,
 ): RuntimeDateControl | undefined {
   // Only include fields that were explicitly configured (overridden flag is true).
   const dateControl: RuntimeDateControl = {};
@@ -183,12 +183,12 @@ function rowToAccessControlRuleInput(row: AccessControlRuleRow): AccessControlRu
 export async function selectAccessControlRulesForAssessment(
   assessment: Assessment,
 ): Promise<AccessControlRuleInput[]> {
-  const rows = await queryRows(
+  const row = await queryRow(
     sql.select_access_control_rules,
     { assessment_id: assessment.id, course_instance_id: null },
     AssessmentAccessControlRulesRowSchema,
   );
-  return rows.flatMap((row) => row.access_control_rules.map(rowToAccessControlRuleInput));
+  return row.access_control_rules.map(rowToAccessControlRuleInput);
 }
 
 export async function selectAccessControlRulesForCourseInstance(

--- a/apps/prairielearn/src/lib/assessment-access-control/data.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/data.ts
@@ -35,8 +35,7 @@ const PrairieTestExamJsonSchema = z
   .nullable();
 
 const AccessControlRuleRowSchema = z.object({
-  assessment_id: IdSchema,
-  access_control_rule: AssessmentAccessControlRuleSchema.nullable(),
+  access_control_rule: AssessmentAccessControlRuleSchema,
   enrollment_ids: z.array(IdSchema),
   student_label_ids: z.array(IdSchema),
   prairietest_exams: PrairieTestExamJsonSchema,
@@ -44,15 +43,13 @@ const AccessControlRuleRowSchema = z.object({
   late_deadlines: DeadlineJsonSchema,
 });
 
-type AccessControlRuleRow = z.infer<typeof AccessControlRuleRowSchema>;
-type AssessmentAccessControlRule = z.infer<typeof AssessmentAccessControlRuleSchema>;
-type AccessControlRuleRowWithRule = AccessControlRuleRow & {
-  access_control_rule: AssessmentAccessControlRule;
-};
+const AssessmentAccessControlRulesRowSchema = z.object({
+  assessment_id: IdSchema,
+  access_control_rules: z.array(AccessControlRuleRowSchema),
+});
 
-function hasAccessControlRule(row: AccessControlRuleRow): row is AccessControlRuleRowWithRule {
-  return row.access_control_rule != null;
-}
+type AssessmentAccessControlRule = z.infer<typeof AssessmentAccessControlRuleSchema>;
+type AccessControlRuleRow = z.infer<typeof AccessControlRuleRowSchema>;
 
 function buildDateControl(
   rule: AssessmentAccessControlRule,
@@ -138,7 +135,7 @@ function buildAfterComplete(rule: AssessmentAccessControlRule): RuntimeAfterComp
   return Object.keys(afterComplete).length > 0 ? afterComplete : undefined;
 }
 
-function rowToAccessControlRuleInput(row: AccessControlRuleRowWithRule): AccessControlRuleInput {
+function rowToAccessControlRuleInput(row: AccessControlRuleRow): AccessControlRuleInput {
   const rule = row.access_control_rule;
   const dateControl = buildDateControl(rule, row.early_deadlines, row.late_deadlines);
   const afterComplete = buildAfterComplete(rule);
@@ -189,9 +186,9 @@ export async function selectAccessControlRulesForAssessment(
   const rows = await queryRows(
     sql.select_access_control_rules,
     { assessment_id: assessment.id, course_instance_id: null },
-    AccessControlRuleRowSchema,
+    AssessmentAccessControlRulesRowSchema,
   );
-  return rows.filter(hasAccessControlRule).map(rowToAccessControlRuleInput);
+  return rows.flatMap((row) => row.access_control_rules.map(rowToAccessControlRuleInput));
 }
 
 export async function selectAccessControlRulesForCourseInstance(
@@ -200,20 +197,15 @@ export async function selectAccessControlRulesForCourseInstance(
   const rows = await queryRows(
     sql.select_access_control_rules,
     { assessment_id: null, course_instance_id: courseInstance.id },
-    AccessControlRuleRowSchema,
+    AssessmentAccessControlRulesRowSchema,
   );
 
-  const result = new Map<string, AccessControlRuleInput[]>();
-  for (const row of rows) {
-    const assessmentId = row.assessment_id;
-    if (!result.has(assessmentId)) {
-      result.set(assessmentId, []);
-    }
-    if (hasAccessControlRule(row)) {
-      result.get(assessmentId)!.push(rowToAccessControlRuleInput(row));
-    }
-  }
-  return result;
+  return new Map(
+    rows.map((row) => [
+      row.assessment_id,
+      row.access_control_rules.map(rowToAccessControlRuleInput),
+    ]),
+  );
 }
 
 interface UserAccessContext {

--- a/apps/prairielearn/src/tests/modernAccessControlStudentAssessments.test.ts
+++ b/apps/prairielearn/src/tests/modernAccessControlStudentAssessments.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+
+import { config } from '../lib/config.js';
+import { selectAccessControlRules } from '../models/assessment-access-control-rules.js';
+import { selectAssessmentByTid } from '../models/assessment.js';
+import { insertCoursePermissionsByUserUid } from '../models/course-permissions.js';
+
+import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
+import { ASSESSMENT_ID, getCourseData, writeCourseToTempDirectory } from './sync/util.js';
+import { withConfig } from './utils/config.js';
+
+describe('Modern access control on the student assessments page', { timeout: 60_000 }, () => {
+  const siteUrl = `http://localhost:${config.serverPort}`;
+  const assessmentTitle = 'Explicit empty access control';
+  let assessmentsUrl: string;
+
+  beforeAll(async () => {
+    const course = getCourseData();
+    course.courseInstances.Fa19.assessments[ASSESSMENT_ID] = {
+      ...course.courseInstances.Fa19.assessments[ASSESSMENT_ID],
+      title: assessmentTitle,
+      accessControl: [],
+    };
+
+    const courseDir = await writeCourseToTempDirectory(course);
+    await withConfig({ features: { 'enhanced-access-control': true } }, async () => {
+      await helperServer.before(courseDir)();
+    });
+    await insertCoursePermissionsByUserUid({
+      course_id: '1',
+      uid: 'instructor@example.com',
+      course_role: 'Previewer',
+      authn_user_id: '1',
+    });
+
+    assessmentsUrl = `${siteUrl}/pl/course_instance/1/assessments`;
+  });
+
+  afterAll(helperServer.after);
+
+  test.sequential(
+    'syncs explicit empty access control as a modern assessment with no rules',
+    async () => {
+      const assessment = await selectAssessmentByTid({
+        course_instance_id: '1',
+        tid: ASSESSMENT_ID,
+      });
+      const rules = await selectAccessControlRules(assessment, [
+        'none',
+        'student_label',
+        'enrollment',
+      ]);
+
+      assert.isTrue(assessment.modern_access_control);
+      assert.lengthOf(rules, 0);
+    },
+  );
+
+  test.sequential('hides the assessment from students', async () => {
+    const response = await helperClient.fetchCheerio(assessmentsUrl, {
+      headers: { cookie: 'pl_test_user=test_student' },
+    });
+
+    assert.isTrue(response.ok);
+    assert.lengthOf(response.$(`td:contains("${assessmentTitle}")`), 0);
+    assert.lengthOf(response.$(`a:contains("${assessmentTitle}")`), 0);
+  });
+
+  test.sequential('shows the assessment to staff via the staff override', async () => {
+    const response = await helperClient.fetchCheerio(assessmentsUrl, {
+      headers: { cookie: 'pl_test_user=test_instructor' },
+    });
+
+    assert.isTrue(response.ok);
+    assert.lengthOf(response.$(`a:contains("${assessmentTitle}")`), 1);
+  });
+});


### PR DESCRIPTION
# Description

Modern access-control loading now returns one row per modern assessment with a grouped rule array, so assessments with explicit `accessControl: []` produce an empty rule list instead of disappearing before staff override can apply.

This preserves student denial for zero-rule modern assessments while allowing staff to see them.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): Majority of implementation was AI-assisted.

# Testing

Added integration coverage that syncs a temp course with explicit `accessControl: []`, verifies it has no rule rows, verifies students do not see it, and verifies a Previewer does see it.
