### PR TITLE
Allow after-completion visibility without due dates

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -702,7 +702,7 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
-      name: 'visibility-only inactive rule reports one completion mechanism error',
+      name: 'visibility-only inactive rule preserves afterComplete',
       rules: [
         {
           showClosedAssessment: false,
@@ -711,10 +711,10 @@ describe('migrateAllowAccess', () => {
         },
       ],
       expected: {
-        accessControl: null,
-        errors: [
-          'After-complete settings require a deadline, duration limit, or PrairieTest exam.',
-        ],
+        accessControl: {
+          afterComplete: { questions: { hidden: true }, score: { hidden: true } },
+        },
+        errors: [],
         notes: [],
         hasUidRules: false,
       },

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1365,17 +1365,7 @@ describe('Structural field dependency validation', () => {
 
   it.each([
     {
-      label: 'after-complete boolean fields with dateControl but no deadlines',
-      config: {
-        dateControl: { release: { date: '2024-03-14T00:01:00' } },
-        afterComplete: {
-          questions: { hidden: true },
-          score: { hidden: true },
-        },
-      },
-    },
-    {
-      label: 'after-complete dates without dateControl',
+      label: 'afterComplete dates without dateControl',
       config: {
         afterComplete: {
           questions: {
@@ -1390,7 +1380,7 @@ describe('Structural field dependency validation', () => {
       },
     },
     {
-      label: 'after-complete dates with dateControl but no deadlines',
+      label: 'afterComplete dates with dateControl but no deadlines',
       config: {
         dateControl: {
           release: { date: '2024-03-14T00:01:00' },
@@ -1403,34 +1393,6 @@ describe('Structural field dependency validation', () => {
           score: {
             hidden: true,
             visibleFromDate: '2024-03-25T23:59:00',
-          },
-        },
-      },
-    },
-    {
-      label: 'after-complete dates when durationMinutes is set',
-      config: {
-        dateControl: { durationMinutes: 60 },
-        afterComplete: {
-          questions: {
-            hidden: true,
-            visibleFromDate: '2024-03-23T23:59:00',
-          },
-        },
-      },
-    },
-    {
-      label: 'after-complete dates when PrairieTest is configured',
-      config: {
-        integrations: {
-          prairieTest: {
-            exams: [{ examUuid: '11e89892-3eff-4d7f-90a2-221372f14e5c' }],
-          },
-        },
-        afterComplete: {
-          questions: {
-            hidden: true,
-            visibleFromDate: '2024-03-23T23:59:00',
           },
         },
       },
@@ -2211,298 +2173,58 @@ describe('Global afterComplete validation', () => {
     assert.lengthOf(matches, 1);
   });
 
-  it('accepts afterComplete on main rule without dateControl or PrairieTest', () => {
-    const result = validateAccessControlRules({
+  it.each([
+    {
+      name: 'default rule with no dateControl',
       rules: [
-        AccessControlJsonSchema.parse({
-          afterComplete: {
-            questions: { hidden: false },
-          },
-        }),
+        {
+          afterComplete: { questions: { hidden: false } },
+        },
       ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete with score hidden on main rule without dateControl or PrairieTest', () => {
-    const result = validateAccessControlRules({
+    },
+    {
+      name: 'default rule with dateControl but no automatic completion mechanism',
       rules: [
-        AccessControlJsonSchema.parse({
-          afterComplete: {
-            score: { hidden: true },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on main rule with dateControl', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          dateControl: {
-            release: { date: '2024-03-14T00:01:00' },
-            due: { date: '2024-03-21T23:59:00' },
-          },
-          afterComplete: {
-            questions: { hidden: false },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on main rule with PrairieTest', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          integrations: {
-            prairieTest: {
-              exams: [{ examUuid: '11e89892-3eff-4d7f-90a2-221372f14e5c' }],
-            },
-          },
-          afterComplete: {
-            questions: { hidden: true },
-            score: { hidden: true },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on overrides when no rule has dateControl or PrairieTest', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({}),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          afterComplete: {
-            questions: { hidden: false },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on overrides when main rule has dateControl', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          dateControl: {
-            release: { date: '2024-03-14T00:01:00' },
-            due: { date: '2024-03-21T23:59:00' },
-          },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          afterComplete: {
-            questions: { hidden: false },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on overrides when main rule has PrairieTest', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          integrations: {
-            prairieTest: {
-              exams: [{ examUuid: '11e89892-3eff-4d7f-90a2-221372f14e5c' }],
-            },
-          },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          afterComplete: {
-            score: { hidden: true },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on an override that has its own dateControl', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({}),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          dateControl: {
-            due: { date: '2024-03-21T23:59:00' },
-          },
-          afterComplete: {
-            questions: { hidden: false },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on main rule when dateControl has no automatic completion mechanism', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
+        {
           dateControl: { release: { date: '2024-03-14T00:01:00' } },
-          afterComplete: {
-            questions: { hidden: true },
-            score: { hidden: true },
-          },
-        }),
+          afterComplete: { questions: { hidden: true }, score: { hidden: true } },
+        },
       ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on main rule with durationMinutes', () => {
-    const result = validateAccessControlRules({
+    },
+    {
+      name: 'override with no automatic completion mechanism',
       rules: [
-        AccessControlJsonSchema.parse({
-          dateControl: {
-            release: { date: '2024-03-14T00:01:00' },
-            durationMinutes: 60,
-          },
-          afterComplete: { questions: { hidden: true } },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on overrides when default rule has no automatic completion mechanism', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          dateControl: { release: { date: '2024-03-14T00:01:00' } },
-        }),
-        AccessControlJsonSchema.parse({
+        {},
+        {
           labels: ['Section A'],
           afterComplete: { questions: { hidden: true } },
-        }),
+        },
       ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it("accepts afterComplete on an override that explicitly clears the default's only automatic completion mechanism", () => {
-    const result = validateAccessControlRules({
+    },
+    {
+      name: 'override that clears inherited due date',
       rules: [
-        AccessControlJsonSchema.parse({
+        {
           dateControl: {
             release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
           },
-        }),
-        AccessControlJsonSchema.parse({
+        },
+        {
           labels: ['Section A'],
           dateControl: { due: { date: null } },
           afterComplete: { questions: { hidden: true } },
-        }),
+        },
       ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
+    },
+  ] satisfies { name: string; rules: AccessControlJsonInput[] }[])(
+    'accepts afterComplete on $name',
+    ({ rules }) => {
+      const result = validateAccessControlRules({
+        rules: rules.map((rule) => AccessControlJsonSchema.parse(rule)),
+      });
 
-  it("accepts an override that clears the default's due when the default still provides another mechanism", () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          dateControl: {
-            release: { date: '2024-03-14T00:01:00' },
-            due: { date: '2024-03-21T23:59:00' },
-            durationMinutes: 60,
-          },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          dateControl: { due: { date: null } },
-          afterComplete: { questions: { hidden: true } },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on an override when only another override has dateControl', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({}),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          dateControl: {
-            due: { date: '2024-03-21T23:59:00' },
-          },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section B'],
-          afterComplete: {
-            questions: { hidden: false },
-          },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on an override when another override provides duration', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({}),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          dateControl: { durationMinutes: 60 },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section B'],
-          afterComplete: { questions: { hidden: true } },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on an override that clears duration', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({
-          dateControl: {
-            release: { date: '2024-03-14T00:01:00' },
-            durationMinutes: 60,
-          },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          dateControl: { durationMinutes: null },
-          afterComplete: { questions: { hidden: true } },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
-
-  it('accepts afterComplete on an override that clears a due date supplied by another override', () => {
-    const result = validateAccessControlRules({
-      rules: [
-        AccessControlJsonSchema.parse({}),
-        AccessControlJsonSchema.parse({
-          labels: ['Section A'],
-          dateControl: { due: { date: '2024-03-21T23:59:00' } },
-        }),
-        AccessControlJsonSchema.parse({
-          labels: ['Section B'],
-          dateControl: { due: { date: null } },
-          afterComplete: { questions: { hidden: true } },
-        }),
-      ],
-    });
-    assert.deepEqual(result.errors, []);
-  });
+      assert.deepEqual(result.errors, []);
+    },
+  );
 });

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1363,46 +1363,6 @@ describe('Structural field dependency validation', () => {
     assert.isTrue(issues.some((i) => i.message === 'Late deadlines require a due date.'));
   });
 
-  it('should reject after-complete dates when dateControl exists but has no deadlines', () => {
-    const rule = AccessControlJsonSchema.parse({
-      dateControl: {
-        release: { date: '2024-03-14T00:01:00' },
-      },
-      afterComplete: {
-        questions: {
-          hidden: true,
-          visibleFromDate: '2024-03-23T23:59:00',
-        },
-        score: {
-          hidden: true,
-          visibleFromDate: '2024-03-25T23:59:00',
-        },
-      },
-    });
-    const issues = validateRuleStructuralDependencyIssues({
-      rule,
-      targetType: 'none',
-      ruleIndex: 0,
-    });
-    assert.isTrue(
-      issues.some(
-        (i) =>
-          i.message ===
-            'After-complete dates require at least one deadline (due date or late deadline).' &&
-          JSON.stringify(i.path) ===
-            JSON.stringify(['afterComplete', 'questions', 'visibleFromDate']),
-      ),
-    );
-    assert.isTrue(
-      issues.some(
-        (i) =>
-          i.message ===
-            'After-complete dates require at least one deadline (due date or late deadline).' &&
-          JSON.stringify(i.path) === JSON.stringify(['afterComplete', 'score', 'visibleFromDate']),
-      ),
-    );
-  });
-
   it.each([
     {
       label: 'after-complete boolean fields with dateControl but no deadlines',
@@ -1411,6 +1371,39 @@ describe('Structural field dependency validation', () => {
         afterComplete: {
           questions: { hidden: true },
           score: { hidden: true },
+        },
+      },
+    },
+    {
+      label: 'after-complete dates without dateControl',
+      config: {
+        afterComplete: {
+          questions: {
+            hidden: true,
+            visibleFromDate: '2024-03-23T23:59:00',
+          },
+          score: {
+            hidden: true,
+            visibleFromDate: '2024-03-25T23:59:00',
+          },
+        },
+      },
+    },
+    {
+      label: 'after-complete dates with dateControl but no deadlines',
+      config: {
+        dateControl: {
+          release: { date: '2024-03-14T00:01:00' },
+        },
+        afterComplete: {
+          questions: {
+            hidden: true,
+            visibleFromDate: '2024-03-23T23:59:00',
+          },
+          score: {
+            hidden: true,
+            visibleFromDate: '2024-03-25T23:59:00',
+          },
         },
       },
     },
@@ -2196,9 +2189,6 @@ describe('afterComplete cross-field validation', () => {
 });
 
 describe('Global afterComplete validation', () => {
-  const completionMechanismMessage =
-    'After-complete settings require a deadline, duration limit, or PrairieTest exam.';
-
   it('does not duplicate direct afterComplete cross-field errors', () => {
     const result = validateAccessControlRules({
       rules: [
@@ -2221,7 +2211,7 @@ describe('Global afterComplete validation', () => {
     assert.lengthOf(matches, 1);
   });
 
-  it('rejects afterComplete on main rule without dateControl or PrairieTest', () => {
+  it('accepts afterComplete on main rule without dateControl or PrairieTest', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
@@ -2231,10 +2221,10 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it('rejects afterComplete with score hidden on main rule without dateControl or PrairieTest', () => {
+  it('accepts afterComplete with score hidden on main rule without dateControl or PrairieTest', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
@@ -2244,7 +2234,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on main rule with dateControl', () => {
@@ -2261,7 +2251,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on main rule with PrairieTest', () => {
@@ -2280,10 +2270,10 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it('rejects afterComplete on overrides when no rule has dateControl or PrairieTest', () => {
+  it('accepts afterComplete on overrides when no rule has dateControl or PrairieTest', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({}),
@@ -2295,7 +2285,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on overrides when main rule has dateControl', () => {
@@ -2315,7 +2305,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on overrides when main rule has PrairieTest', () => {
@@ -2336,7 +2326,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on an override that has its own dateControl', () => {
@@ -2354,10 +2344,10 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it('rejects afterComplete on main rule when dateControl has no completion mechanism', () => {
+  it('accepts afterComplete on main rule when dateControl has no automatic completion mechanism', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
@@ -2369,22 +2359,25 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on main rule with durationMinutes', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
-          dateControl: { durationMinutes: 60 },
+          dateControl: {
+            release: { date: '2024-03-14T00:01:00' },
+            durationMinutes: 60,
+          },
           afterComplete: { questions: { hidden: true } },
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it('rejects afterComplete on overrides when default rule has no completion mechanism', () => {
+  it('accepts afterComplete on overrides when default rule has no automatic completion mechanism', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
@@ -2396,14 +2389,17 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it("rejects afterComplete on an override that explicitly clears the default's only completion mechanism", () => {
+  it("accepts afterComplete on an override that explicitly clears the default's only automatic completion mechanism", () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
-          dateControl: { due: { date: '2024-03-21T23:59:00' } },
+          dateControl: {
+            release: { date: '2024-03-14T00:01:00' },
+            due: { date: '2024-03-21T23:59:00' },
+          },
         }),
         AccessControlJsonSchema.parse({
           labels: ['Section A'],
@@ -2412,7 +2408,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it("accepts an override that clears the default's due when the default still provides another mechanism", () => {
@@ -2420,6 +2416,7 @@ describe('Global afterComplete validation', () => {
       rules: [
         AccessControlJsonSchema.parse({
           dateControl: {
+            release: { date: '2024-03-14T00:01:00' },
             due: { date: '2024-03-21T23:59:00' },
             durationMinutes: 60,
           },
@@ -2431,12 +2428,10 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on an override when only another override has dateControl', () => {
-    // Globally we count any rule's mechanism, since overrides stack at runtime
-    // and the contributing rule may apply to the same student.
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({}),
@@ -2454,7 +2449,7 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
   it('accepts afterComplete on an override when another override provides duration', () => {
@@ -2471,14 +2466,17 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isFalse(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it('rejects afterComplete on an override that clears the only globally-available mechanism (duration)', () => {
+  it('accepts afterComplete on an override that clears duration', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({
-          dateControl: { durationMinutes: 60 },
+          dateControl: {
+            release: { date: '2024-03-14T00:01:00' },
+            durationMinutes: 60,
+          },
         }),
         AccessControlJsonSchema.parse({
           labels: ['Section A'],
@@ -2487,10 +2485,10 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 
-  it('rejects afterComplete on an override that clears the only global mechanism contributed by another override', () => {
+  it('accepts afterComplete on an override that clears a due date supplied by another override', () => {
     const result = validateAccessControlRules({
       rules: [
         AccessControlJsonSchema.parse({}),
@@ -2505,6 +2503,6 @@ describe('Global afterComplete validation', () => {
         }),
       ],
     });
-    assert.isTrue(result.errors.includes(completionMechanismMessage));
+    assert.deepEqual(result.errors, []);
   });
 });

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -79,45 +79,6 @@ function findLastDeadlineMs(rule: AccessControlJson): number | null {
   return findDueMs(rule);
 }
 
-function hasAnyDeadline(rule: AccessControlJson): boolean {
-  const dc = rule.dateControl;
-  if (!dc) return false;
-  if (dc.due?.date) return true;
-  if (dc.lateDeadlines && dc.lateDeadlines.length > 0) return true;
-  return false;
-}
-
-type CompletionMechanismType = 'deadline' | 'duration' | 'prairieTest';
-
-function getCompletionMechanismTypes(rule: AccessControlJson): Set<CompletionMechanismType> {
-  const types = new Set<CompletionMechanismType>();
-  if (hasAnyDeadline(rule)) types.add('deadline');
-  if (rule.dateControl?.durationMinutes != null) types.add('duration');
-  if ((rule.integrations?.prairieTest?.exams ?? []).length > 0) types.add('prairieTest');
-  return types;
-}
-
-/**
- * Mechanism types that an override actively clears, i.e. nulls out without
- * supplying a replacement. Used to pull a globally-available mechanism out
- * of consideration for this override's resolved view: e.g. a default with only
- * a due date paired with an override of `dateControl: { due: { date: null } }`
- * leaves the override's students with nothing. Overrides cannot define
- * `integrations`, so PrairieTest exams cannot be cleared by an override.
- */
-function overrideClearedMechanismTypes(rule: AccessControlJson): Set<CompletionMechanismType> {
-  const cleared = new Set<CompletionMechanismType>();
-  const dc = rule.dateControl;
-  if (!dc) return cleared;
-  if (!hasAnyDeadline(rule) && dc.due !== undefined && dc.due.date == null) {
-    cleared.add('deadline');
-  }
-  if (dc.durationMinutes === null) {
-    cleared.add('duration');
-  }
-  return cleared;
-}
-
 /**
  * Validates structural field dependencies within a single rule.
  * These are constraints where certain fields are meaningless without
@@ -169,53 +130,6 @@ export function validateRuleStructuralDependencyIssues(
       ['dateControl', 'earlyDeadlines', 0, 'date'],
       'Early deadlines are not allowed when due date credit is below 100%.',
     );
-  }
-
-  // Constraint 3: After-complete date fields require at least one deadline.
-  // The date fields (visibleFromDate, visibleUntilDate) are meant to fire relative
-  // to the last deadline. Boolean fields (hidden) are fine without deadlines.
-  // PrairieTest and timed assessments manage completion independently,
-  // so after-complete dates are valid without deadlines in those cases.
-  // Only enforced on the default rule — overrides may inherit deadlines.
-  // The "no completion mechanism at all" case (no dateControl + no
-  // PrairieTest) is handled by validateGlobalAfterCompleteIssues with a
-  // broader message.
-  const hasPrairieTest = (rule.integrations?.prairieTest?.exams ?? []).length > 0;
-  const hasDuration = dc?.durationMinutes != null;
-  const ac = rule.afterComplete;
-  if (
-    validationRule.targetType === 'none' &&
-    ac &&
-    dc &&
-    !hasAnyDeadline(rule) &&
-    !hasPrairieTest &&
-    !hasDuration
-  ) {
-    const q = ac.questions;
-    if (q?.visibleFromDate) {
-      pushIssue(
-        issues,
-        validationRule,
-        ['afterComplete', 'questions', 'visibleFromDate'],
-        'After-complete dates require at least one deadline (due date or late deadline).',
-      );
-    }
-    if (q?.visibleUntilDate) {
-      pushIssue(
-        issues,
-        validationRule,
-        ['afterComplete', 'questions', 'visibleUntilDate'],
-        'After-complete dates require at least one deadline (due date or late deadline).',
-      );
-    }
-    if (ac.score?.visibleFromDate) {
-      pushIssue(
-        issues,
-        validationRule,
-        ['afterComplete', 'score', 'visibleFromDate'],
-        'After-complete dates require at least one deadline (due date or late deadline).',
-      );
-    }
   }
 
   return issues;
@@ -795,57 +709,6 @@ export function validateAfterCompleteCrossFieldIssues(
 }
 
 /**
- * Cross-rule check: each rule with after-complete settings must have a
- * completion mechanism — a real deadline (due date or late deadline), a
- * duration limit, or a PrairieTest exam. A dateControl with only `release`,
- * `password`, or `due: { date: null }` is not enough since none of those can
- * ever close the assessment, so any after-complete settings would be a no-op.
- *
- * The default rule must carry a mechanism in its own config. Overrides accept
- * any globally-available mechanism (any rule may contribute, since overrides
- * stack at runtime), minus types this override actively clears: a globally
- * unique mechanism type that the override nulls out leaves nothing for the
- * override's students.
- */
-export function validateGlobalAfterCompleteIssues(
-  validationRules: AccessControlValidationRule[],
-): AccessControlValidationIssue[] {
-  const issues: AccessControlValidationIssue[] = [];
-  if (validationRules.length === 0) return issues;
-
-  const message =
-    'After-complete settings require a deadline, duration limit, or PrairieTest exam.';
-
-  const globalMechanisms = new Set<CompletionMechanismType>();
-  for (const vr of validationRules) {
-    for (const t of getCompletionMechanismTypes(vr.rule)) globalMechanisms.add(t);
-  }
-
-  for (const validationRule of validationRules) {
-    const ac = validationRule.rule.afterComplete;
-    if (!ac) continue;
-
-    let hasMechanism: boolean;
-    if (validationRule.targetType === 'none') {
-      hasMechanism = getCompletionMechanismTypes(validationRule.rule).size > 0;
-    } else {
-      const cleared = overrideClearedMechanismTypes(validationRule.rule);
-      hasMechanism = [...globalMechanisms].some((t) => !cleared.has(t));
-    }
-    if (hasMechanism) continue;
-
-    if (ac.questions !== undefined) {
-      pushIssue(issues, validationRule, ['afterComplete', 'questions'], message);
-    }
-    if (ac.score !== undefined) {
-      pushIssue(issues, validationRule, ['afterComplete', 'score'], message);
-    }
-  }
-
-  return issues;
-}
-
-/**
  * Validates date ordering within a single access control rule.
  * Returns an array of error messages (empty if valid).
  */
@@ -1129,11 +992,6 @@ export function validateAccessControlRules({
     ...validateGlobalDateConsistencyIssues(validationRules).map((issue) => issue.message),
     ...validateGlobalCreditConsistencyIssues(validationRules).map((issue) => issue.message),
     ...validateGlobalStructuralDependencyIssues(validationRules).map((issue) => issue.message),
-    // Run the "no completion mechanism" check before the cross-field check,
-    // matching the form-side validator. The mechanism error is more
-    // fundamental (cross-field consistency is moot when there's no completion
-    // mechanism at all), so surface it first.
-    ...validateGlobalAfterCompleteIssues(validationRules).map((issue) => issue.message),
     ...validateAfterCompleteCrossFieldIssues(validationRules).map((issue) => issue.message),
   );
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AccessControlForm.tsx
@@ -90,6 +90,7 @@ export function AccessControlForm({
   onSubmit,
   courseInstance,
   isExam,
+  hasExamAutoClose,
   isSaving = false,
   alert,
   canEditAccessSettings,
@@ -104,6 +105,7 @@ export function AccessControlForm({
   onSubmit: (data: AccessControlJsonWithId[]) => Promise<void>;
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   isExam: boolean;
+  hasExamAutoClose: boolean;
   isSaving?: boolean;
   alert?: StickySaveBarAlert | null;
   canEditAccessSettings: boolean;
@@ -293,7 +295,11 @@ export function AccessControlForm({
     selectedRule?.type === 'default' ? (
       <AccessControlEditabilityProvider ruleEditable={selectedRuleCanEdit}>
         <div className="px-3 pb-3">
-          <DefaultRuleForm displayTimezone={displayTimezone} isExam={isExam} />
+          <DefaultRuleForm
+            displayTimezone={displayTimezone}
+            isExam={isExam}
+            hasExamAutoClose={hasExamAutoClose}
+          />
         </div>
       </AccessControlEditabilityProvider>
     ) : selectedRule?.type === 'override' ? (

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -8,9 +8,9 @@ import { FieldWrapper } from './FieldWrapper.js';
 import { useOverrideField } from './hooks/useOverrideField.js';
 import {
   type AccessControlFormData,
+  type DefaultRuleData,
   type QuestionVisibilityValue,
   type ScoreVisibilityValue,
-  defaultRuleHasCompletionMechanism,
 } from './types.js';
 import { endOfDayDatetime, startOfDayDatetime, tomorrowDate } from './utils/dateUtils.js';
 import { DATE_REQUIRED_MESSAGE, isDateFieldEmpty } from './validation.js';
@@ -63,6 +63,18 @@ const SCORE_VISIBILITY_ITEMS: RichSelectItem<HideScoreMode>[] = [
     description: 'Score will be hidden after completion and become visible on this date',
   },
 ];
+
+function defaultRuleHasCompletionMechanism(
+  rule: Pick<
+    DefaultRuleData,
+    'dateControlEnabled' | 'due' | 'lateDeadlines' | 'durationMinutes' | 'prairieTestExams'
+  > & { hasExamAutoClose: boolean },
+): boolean {
+  const hasDateControlMechanism =
+    rule.dateControlEnabled &&
+    (rule.due.date !== null || rule.lateDeadlines.length > 0 || rule.durationMinutes !== null);
+  return hasDateControlMechanism || rule.prairieTestExams.length > 0 || rule.hasExamAutoClose;
+}
 
 function getHideQuestionsMode(value: QuestionVisibilityValue): HideQuestionsMode {
   if (!value.hidden) return 'show_questions';
@@ -348,8 +360,8 @@ const infoPopoverConfig = {
     <>
       <p>
         These settings apply once submissions are no longer allowed: after the final deadline, when
-        a time limit expires, or when a student's assessment instance is closed (manually or via
-        autoclose). If after-deadline submissions are allowed, these settings apply only after the
+        a time limit expires, or when a student's assessment instance is closed manually or by Exam
+        auto-close. If after-deadline submissions are allowed, these settings apply only after the
         student's assessment instance closes or its time limit expires.
       </p>
       <p>
@@ -400,9 +412,13 @@ function AfterCompleteCard({
 export function DefaultAfterCompleteForm({
   title,
   displayTimezone,
+  isExam,
+  hasExamAutoClose,
 }: {
   title?: string;
   displayTimezone: string;
+  isExam: boolean;
+  hasExamAutoClose: boolean;
 }) {
   const { field: qvField } = useController<AccessControlFormData, 'defaultRule.questionVisibility'>(
     {
@@ -449,10 +465,20 @@ export function DefaultAfterCompleteForm({
     lateDeadlines,
     durationMinutes,
     prairieTestExams,
+    hasExamAutoClose,
   });
+  const automaticCompletionMechanisms = isExam
+    ? 'a due date, time limit, late deadline, PrairieTest exam, or Exam auto-close'
+    : 'a due date, time limit, late deadline, or PrairieTest exam';
 
   return (
     <AfterCompleteCard title={title}>
+      {!hasCompletionMechanism && (
+        <Alert variant="info" className="mb-0">
+          Without {automaticCompletionMechanisms}, these settings will only take effect if an
+          instructor manually closes a student's assessment instance.
+        </Alert>
+      )}
       <div>
         <Form.Label className="fw-bold" htmlFor="defaultRule-question-visibility-mode">
           Question visibility

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AssessmentAccessControl.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AssessmentAccessControl.tsx
@@ -31,6 +31,7 @@ interface AssessmentAccessControlProps {
   origHash: string | null;
   assessmentId: string;
   isExam: boolean;
+  hasExamAutoClose: boolean;
   initialData: AccessControlJsonWithId[];
   prairieTestExamMetadata: PrairieTestExamMetadata[];
   ptHost: string;
@@ -42,6 +43,7 @@ function AssessmentAccessControlInner({
   courseInstance,
   origHash: initialOrigHash,
   isExam,
+  hasExamAutoClose,
   initialData,
   prairieTestExamMetadata,
   ptHost,
@@ -134,6 +136,7 @@ function AssessmentAccessControlInner({
       <AccessControlForm
         courseInstance={courseInstance}
         isExam={isExam}
+        hasExamAutoClose={hasExamAutoClose}
         initialData={initialData}
         prairieTestExamMetadata={prairieTestExamMetadata}
         ptHost={ptHost}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DefaultRuleForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DefaultRuleForm.tsx
@@ -1,5 +1,5 @@
 import { Button, Form } from 'react-bootstrap';
-import { useFormContext, useWatch } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 
 import { OverlayTrigger } from '@prairielearn/ui';
 
@@ -7,7 +7,7 @@ import { useAccessControlRuleEditable } from './AccessControlEditabilityContext.
 import { DefaultAfterCompleteForm } from './AfterCompleteForm.js';
 import { DefaultDateControlForm } from './DateControlForm.js';
 import { IntegrationsSection } from './IntegrationsSection.js';
-import { type AccessControlFormData, defaultRuleHasCompletionMechanism } from './types.js';
+import { type AccessControlFormData } from './types.js';
 
 const beforeReleasePopoverConfig = {
   header: 'What does "before release" mean?',
@@ -30,26 +30,6 @@ export function DefaultRuleForm({
 }) {
   const ruleEditable = useAccessControlRuleEditable();
   const { register } = useFormContext<AccessControlFormData>();
-  const dateControlEnabled = useWatch<AccessControlFormData, 'defaultRule.dateControlEnabled'>({
-    name: 'defaultRule.dateControlEnabled',
-  });
-  const due = useWatch<AccessControlFormData, 'defaultRule.due'>({ name: 'defaultRule.due' });
-  const lateDeadlines = useWatch<AccessControlFormData, 'defaultRule.lateDeadlines'>({
-    name: 'defaultRule.lateDeadlines',
-  });
-  const durationMinutes = useWatch<AccessControlFormData, 'defaultRule.durationMinutes'>({
-    name: 'defaultRule.durationMinutes',
-  });
-  const prairieTestExams = useWatch<AccessControlFormData, 'defaultRule.prairieTestExams'>({
-    name: 'defaultRule.prairieTestExams',
-  });
-  const hasCompletionMechanism = defaultRuleHasCompletionMechanism({
-    dateControlEnabled,
-    due,
-    lateDeadlines,
-    durationMinutes,
-    prairieTestExams,
-  });
 
   return (
     <div className="d-flex flex-column gap-3">
@@ -81,7 +61,7 @@ export function DefaultRuleForm({
           Students can see the assessment title before release
         </Form.Text>
       </div>
-      {hasCompletionMechanism && <DefaultAfterCompleteForm displayTimezone={displayTimezone} />}
+      <DefaultAfterCompleteForm displayTimezone={displayTimezone} />
     </div>
   );
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DefaultRuleForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/DefaultRuleForm.tsx
@@ -24,9 +24,11 @@ const beforeReleasePopoverConfig = {
 export function DefaultRuleForm({
   displayTimezone,
   isExam,
+  hasExamAutoClose,
 }: {
   displayTimezone: string;
   isExam: boolean;
+  hasExamAutoClose: boolean;
 }) {
   const ruleEditable = useAccessControlRuleEditable();
   const { register } = useFormContext<AccessControlFormData>();
@@ -61,7 +63,11 @@ export function DefaultRuleForm({
           Students can see the assessment title before release
         </Form.Text>
       </div>
-      <DefaultAfterCompleteForm displayTimezone={displayTimezone} />
+      <DefaultAfterCompleteForm
+        displayTimezone={displayTimezone}
+        isExam={isExam}
+        hasExamAutoClose={hasExamAutoClose}
+      />
     </div>
   );
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
@@ -282,7 +282,7 @@ describe('formDataToJson', () => {
     expect(overrideJson.afterComplete!.score!.hidden).toBe(true);
   });
 
-  it('omits default afterComplete when dateControl is on but no due date, late deadline, or duration is set', () => {
+  it('emits default afterComplete when dateControl is on but no due date, late deadline, or duration is set', () => {
     const result = formDataToJson({
       defaultRule: {
         ...defaultRuleFixture,
@@ -297,7 +297,10 @@ describe('formDataToJson', () => {
       overrides: [],
     });
 
-    expect(result[0].afterComplete).toBeUndefined();
+    expect(result[0].afterComplete).toEqual({
+      questions: { hidden: false },
+      score: { hidden: true },
+    });
   });
 
   it('omits afterComplete when neither visibility is overridden', () => {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -156,24 +156,6 @@ export function isOverrideEditable(
 }
 
 /**
- * The default rule has an automatic completion mechanism when a due date, late
- * deadline, duration limit, or PrairieTest exam can close the assessment.
- * Manual assessment-instance closure can still trigger after-completion
- * visibility; this helper only controls form advisory copy.
- */
-export function defaultRuleHasCompletionMechanism(
-  rule: Pick<
-    DefaultRuleData,
-    'dateControlEnabled' | 'due' | 'lateDeadlines' | 'durationMinutes' | 'prairieTestExams'
-  >,
-): boolean {
-  const hasDateControlMechanism =
-    rule.dateControlEnabled &&
-    (rule.due.date !== null || rule.lateDeadlines.length > 0 || rule.durationMinutes !== null);
-  return hasDateControlMechanism || rule.prairieTestExams.length > 0;
-}
-
-/**
  * Whether a (timezone-naive) datetime string is at or before "now" in the
  * given display timezone. A null/empty value is treated as released.
  */

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -156,13 +156,10 @@ export function isOverrideEditable(
 }
 
 /**
- * The default rule has a completion mechanism when something can actually
- * close the assessment: a due date, a late deadline, a duration limit, or a
- * PrairieTest exam. `dateControlEnabled` alone is not sufficient — a rule
- * with only a release date or password has date control "on" but nothing to
- * trigger completion. Mirrors the server-side `getCompletionMechanismTypes`
- * in `validation.ts`. Used to gate after-complete UI and serialization on
- * the default rule.
+ * The default rule has an automatic completion mechanism when a due date, late
+ * deadline, duration limit, or PrairieTest exam can close the assessment.
+ * Manual assessment-instance closure can still trigger after-completion
+ * visibility; this helper only controls form advisory copy.
  */
 export function defaultRuleHasCompletionMechanism(
   rule: Pick<
@@ -467,16 +464,15 @@ function defaultRuleToJson(rule: DefaultRuleData): AccessControlJsonWithId {
   }
 
   // Only write afterComplete when values differ from defaults
-  // (questions.hidden: true, score.hidden: false) AND there is a
-  // completion mechanism (dateControl or PrairieTest). Without one,
-  // after-complete settings are meaningless and would fail validation.
-  const hasCompletionMechanism = defaultRuleHasCompletionMechanism(rule);
+  // (questions.hidden: true, score.hidden: false). These settings can apply
+  // even without a scheduled deadline when an instructor manually closes a
+  // student's assessment instance.
   const qv = rule.questionVisibility;
   const sv = rule.scoreVisibility;
   const hasNonDefaultQuestions = isNonDefaultQuestionVisibility(qv);
   const hasNonDefaultScore = isNonDefaultScoreVisibility(sv);
 
-  if (hasCompletionMechanism && (hasNonDefaultQuestions || hasNonDefaultScore)) {
+  if (hasNonDefaultQuestions || hasNonDefaultScore) {
     output.afterComplete = {};
     if (hasNonDefaultQuestions) {
       output.afterComplete.questions = qv.hidden

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -194,14 +194,14 @@ describe('getGlobalDateValidationErrors', () => {
     });
   });
 
-  it('maps after-complete mechanism errors to visible override fields', () => {
+  it('allows after-complete overrides without an automatic completion mechanism', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData(
         [
           makeOverride({
             overriddenFields: ['questionVisibility', 'scoreVisibility'],
             questionVisibility: { hidden: false },
-            scoreVisibility: { hidden: true },
+            scoreVisibility: { hidden: false },
           }),
         ],
         {
@@ -212,20 +212,7 @@ describe('getGlobalDateValidationErrors', () => {
       TEST_TIMEZONE,
     );
 
-    expect(errors).toContainEqual({
-      path: 'overrides.0.questionVisibility',
-      message: 'After-complete settings require a deadline, duration limit, or PrairieTest exam.',
-    });
-    expect(errors).toContainEqual({
-      path: 'overrides.0.scoreVisibility',
-      message: 'After-complete settings require a deadline, duration limit, or PrairieTest exam.',
-    });
-    expect(errors.find((e) => e.path === 'overrides.0.questionVisibility.visibleFromDate')).toBe(
-      undefined,
-    );
-    expect(errors.find((e) => e.path === 'overrides.0.scoreVisibility.visibleFromDate')).toBe(
-      undefined,
-    );
+    expect(errors).toEqual([]);
   });
 
   it('maps inherited after-complete conflicts to an active override field', () => {
@@ -291,7 +278,7 @@ describe('getAccessControlFormValidationErrors', () => {
     });
   });
 
-  it('does not validate hidden default after-complete date inputs without a completion mechanism', () => {
+  it('validates visible default after-complete date inputs without an automatic completion mechanism', () => {
     const errors = getAccessControlFormValidationErrors(
       makeFormData([], {
         dateControlEnabled: false,
@@ -302,13 +289,14 @@ describe('getAccessControlFormValidationErrors', () => {
       TEST_TIMEZONE,
     );
 
-    expect(
-      errors.find(
-        (e) =>
-          e.path === 'defaultRule.questionVisibility.visibleFromDate' ||
-          e.path === 'defaultRule.scoreVisibility.visibleFromDate',
-      ),
-    ).toBeUndefined();
+    expect(errors).toContainEqual({
+      path: 'defaultRule.questionVisibility.visibleFromDate',
+      message: 'Date is required',
+    });
+    expect(errors).toContainEqual({
+      path: 'defaultRule.scoreVisibility.visibleFromDate',
+      message: 'Date is required',
+    });
   });
 
   it('ignores invalid values for inactive override fields', () => {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -278,7 +278,7 @@ describe('getAccessControlFormValidationErrors', () => {
     });
   });
 
-  it('validates visible default after-complete date inputs without an automatic completion mechanism', () => {
+  it('does not skip default after-complete date validation without an automatic completion mechanism', () => {
     const errors = getAccessControlFormValidationErrors(
       makeFormData([], {
         dateControlEnabled: false,

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -10,7 +10,6 @@ import {
   type AccessControlValidationIssue,
   type AccessControlValidationRule,
   validateAfterCompleteCrossFieldIssues,
-  validateGlobalAfterCompleteIssues,
   validateGlobalCreditConsistencyIssues,
   validateGlobalDateConsistencyIssues,
   validateGlobalStructuralDependencyIssues,
@@ -34,7 +33,6 @@ import {
   type OverridableFieldName,
   type QuestionVisibilityValue,
   type ScoreVisibilityValue,
-  defaultRuleHasCompletionMechanism,
   formDataToJson,
   isReleasedNow,
 } from './types.js';
@@ -240,11 +238,6 @@ export function getGlobalDateValidationErrors(
     validateGlobalDateConsistencyIssues(validationRules),
     validateGlobalCreditConsistencyIssues(validationRules),
     validateGlobalStructuralDependencyIssues(validationRules),
-    // Run the "no completion mechanism" check before the cross-field check —
-    // both target the same questionVisibility path, but the mechanism error
-    // is more fundamental (cross-field consistency is moot when there's no
-    // mechanism at all).
-    validateGlobalAfterCompleteIssues(validationRules),
     validateAfterCompleteCrossFieldIssues(validationRules),
   ]) {
     for (const issue of issues) {
@@ -528,14 +521,13 @@ function validateRuleFields(
 
 function validateDefaultRule(formData: AccessControlFormData, addError: AddValidationError) {
   const rule = formData.defaultRule;
-  const hasCompletionMechanism = defaultRuleHasCompletionMechanism(rule);
 
   validateRuleFields(
     rule,
     'defaultRule',
     (fieldName) =>
       fieldName === 'questionVisibility' || fieldName === 'scoreVisibility'
-        ? hasCompletionMechanism
+        ? true
         : rule.dateControlEnabled,
     addError,
   );

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.tsx
@@ -425,6 +425,9 @@ export function InstructorAssessmentAccessNew({
           origHash={origHash}
           assessmentId={resLocals.assessment.id}
           isExam={resLocals.assessment.type === 'Exam'}
+          hasExamAutoClose={
+            resLocals.assessment.type === 'Exam' && (resLocals.assessment.auto_close ?? true)
+          }
           initialData={initialData}
           prairieTestExamMetadata={prairieTestExamMetadata}
           ptHost={ptHost}

--- a/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
@@ -17,6 +17,17 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const ASSESSMENT_TID = 'hw19-accessControlUi';
 
+function getAssessmentJsonPath(testCoursePath: string) {
+  return path.join(
+    testCoursePath,
+    'courseInstances',
+    'Sp15',
+    'assessments',
+    ASSESSMENT_TID,
+    'infoAssessment.json',
+  );
+}
+
 async function getAccessControlRecords(assessmentId: string) {
   return sqldb.queryRows(
     sql.select_access_controls,
@@ -26,14 +37,7 @@ async function getAccessControlRecords(assessmentId: string) {
 }
 
 async function readAssessmentJson(testCoursePath: string) {
-  const filePath = path.join(
-    testCoursePath,
-    'courseInstances',
-    'Sp15',
-    'assessments',
-    ASSESSMENT_TID,
-    'infoAssessment.json',
-  );
+  const filePath = getAssessmentJsonPath(testCoursePath);
   return JSON.parse(await fs.readFile(filePath, 'utf8'));
 }
 
@@ -211,6 +215,42 @@ test.describe('Access control UI', () => {
     const json = await readAssessmentJson(testCoursePath);
     expect(json.accessControl).toHaveLength(1);
     expect(json.accessControl[0].labels).toBeUndefined();
+  });
+
+  test('can edit after-completion visibility without a due date', async ({
+    page,
+    courseInstance,
+    testCoursePath,
+  }) => {
+    const filePath = getAssessmentJsonPath(testCoursePath);
+    const json = JSON.parse(await fs.readFile(filePath, 'utf8'));
+    delete json.accessControl[0].dateControl.due;
+    delete json.accessControl[0].dateControl.afterLastDeadline;
+    delete json.accessControl[0].afterComplete;
+    await fs.writeFile(filePath, JSON.stringify(json, null, 2));
+    await syncCourse(testCoursePath);
+
+    const assessment = await selectAssessmentByTid({
+      course_instance_id: courseInstance.id,
+      tid: ASSESSMENT_TID,
+    });
+    await navigateToAccessPage(page, courseInstance.id, assessment.id);
+
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+
+    const panel = getDetailPanel(page);
+    await expect(panel).toBeVisible();
+    await expect(panel.getByText('After completion', { exact: true })).toBeVisible();
+
+    await panel.getByRole('button', { name: 'Question visibility', exact: true }).click();
+    await page.getByRole('option', { name: 'Show questions after completion' }).click();
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByText('Access control updated successfully.')).toBeVisible();
+
+    const savedJson = await readAssessmentJson(testCoursePath);
+    expect(savedJson.accessControl[0].dateControl.due).toBeUndefined();
+    expect(savedJson.accessControl[0].afterComplete.questions.hidden).toBe(false);
   });
 
   test('can edit override with duration and question visibility', async ({

--- a/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
@@ -17,17 +17,6 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const ASSESSMENT_TID = 'hw19-accessControlUi';
 
-function getAssessmentJsonPath(testCoursePath: string) {
-  return path.join(
-    testCoursePath,
-    'courseInstances',
-    'Sp15',
-    'assessments',
-    ASSESSMENT_TID,
-    'infoAssessment.json',
-  );
-}
-
 async function getAccessControlRecords(assessmentId: string) {
   return sqldb.queryRows(
     sql.select_access_controls,
@@ -37,7 +26,14 @@ async function getAccessControlRecords(assessmentId: string) {
 }
 
 async function readAssessmentJson(testCoursePath: string) {
-  const filePath = getAssessmentJsonPath(testCoursePath);
+  const filePath = path.join(
+    testCoursePath,
+    'courseInstances',
+    'Sp15',
+    'assessments',
+    ASSESSMENT_TID,
+    'infoAssessment.json',
+  );
   return JSON.parse(await fs.readFile(filePath, 'utf8'));
 }
 
@@ -215,42 +211,6 @@ test.describe('Access control UI', () => {
     const json = await readAssessmentJson(testCoursePath);
     expect(json.accessControl).toHaveLength(1);
     expect(json.accessControl[0].labels).toBeUndefined();
-  });
-
-  test('can edit after-completion visibility without a due date', async ({
-    page,
-    courseInstance,
-    testCoursePath,
-  }) => {
-    const filePath = getAssessmentJsonPath(testCoursePath);
-    const json = JSON.parse(await fs.readFile(filePath, 'utf8'));
-    delete json.accessControl[0].dateControl.due;
-    delete json.accessControl[0].dateControl.afterLastDeadline;
-    delete json.accessControl[0].afterComplete;
-    await fs.writeFile(filePath, JSON.stringify(json, null, 2));
-    await syncCourse(testCoursePath);
-
-    const assessment = await selectAssessmentByTid({
-      course_instance_id: courseInstance.id,
-      tid: ASSESSMENT_TID,
-    });
-    await navigateToAccessPage(page, courseInstance.id, assessment.id);
-
-    await page.getByRole('button', { name: 'Edit' }).first().click();
-
-    const panel = getDetailPanel(page);
-    await expect(panel).toBeVisible();
-    await expect(panel.getByText('After completion', { exact: true })).toBeVisible();
-
-    await panel.getByRole('button', { name: 'Question visibility', exact: true }).click();
-    await page.getByRole('option', { name: 'Show questions after completion' }).click();
-
-    await page.getByRole('button', { name: 'Save' }).click();
-    await expect(page.getByText('Access control updated successfully.')).toBeVisible();
-
-    const savedJson = await readAssessmentJson(testCoursePath);
-    expect(savedJson.accessControl[0].dateControl.due).toBeUndefined();
-    expect(savedJson.accessControl[0].afterComplete.questions.hidden).toBe(false);
   });
 
   test('can edit override with duration and question visibility', async ({

--- a/docs/assessment/accessControl.md
+++ b/docs/assessment/accessControl.md
@@ -137,7 +137,7 @@ Disable it when the assessment should be completely hidden until release.
 
 Use **Question visibility** and **Score visibility** to decide what students can see after the assessment is complete.
 
-These settings apply once submissions are no longer allowed: after the final deadline, when a timed assessment closes, or when an instructor closes it. If after-deadline submissions are allowed, **After completion** applies only after the student's assessment instance closes or its time limit expires.
+These settings apply once submissions are no longer allowed: after the final deadline, when a timed assessment closes, when an Exam assessment auto-closes after inactivity, or when an instructor closes it. If after-deadline submissions are allowed, **After completion** applies only after the student's assessment instance closes or its time limit expires.
 
 Question visibility options:
 


### PR DESCRIPTION
# Description

After-completion visibility now remains configurable even when an assessment has no due date, because manually closing an assessment instance can still trigger after-completion behavior.

- [x] I have disclosed the level of AI assistance used: majority of implementation by AI assistant under Nathan's direction.

# Testing

Added and updated focused unit and Playwright coverage for no-due after-completion visibility, including a regression that removes the due date and saves "Show questions after completion".
