### PR TITLE
Add legacy allowAccess student assessment tests

### DIFF
--- a/apps/prairielearn/src/tests/access.test.ts
+++ b/apps/prairielearn/src/tests/access.test.ts
@@ -19,7 +19,7 @@ import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { ensureUncheckedEnrollment } from '../models/enrollment.js';
 
-import { withPTReservation } from './helperExam.js';
+import { exam1AutomaticTestSuite, withPTReservation } from './helperExam.js';
 import * as helperServer from './helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
@@ -124,6 +124,7 @@ describe('Access control', { timeout: 20000 }, function () {
         userId: user.id,
         accessStart: new Date('1920-07-07 23:59:59'),
         accessEnd: new Date('2300-07-10 23:59:59'),
+        examUuid: exam1AutomaticTestSuite.examUuid,
       };
     });
   });

--- a/apps/prairielearn/src/tests/helperExam.ts
+++ b/apps/prairielearn/src/tests/helperExam.ts
@@ -62,10 +62,12 @@ export async function withPTReservation<T>(
     userId,
     accessStart,
     accessEnd,
+    examUuid,
   }: {
     userId: string;
     accessStart: Date;
     accessEnd: Date;
+    examUuid: string;
   },
   fn: () => Promise<T>,
 ) {
@@ -74,7 +76,7 @@ export async function withPTReservation<T>(
       user_id: userId,
       access_start: accessStart,
       access_end: accessEnd,
-      exam_uuid: exam1AutomaticTestSuite.examUuid,
+      exam_uuid: examUuid,
     });
     return await fn();
   } finally {

--- a/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
+++ b/apps/prairielearn/src/tests/instructorAssessmentDownloads.test.ts
@@ -338,6 +338,7 @@ describe('Instructor Assessment Downloads', { timeout: 60_000 }, function () {
           userId: studentUser.id,
           accessStart: new Date(Date.now() - 60_000),
           accessEnd: new Date(Date.now() + 600_000),
+          examUuid: helperExam.exam1AutomaticTestSuite.examUuid,
         },
         () =>
           withUser(studentUser, async () => {

--- a/apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts
+++ b/apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts
@@ -13,21 +13,85 @@ import {
   writeCourseToTempDirectory,
 } from './sync/util.js';
 
-const assessmentTids = {
-  open: 'legacy-open',
-  future: 'legacy-future',
-  inactive: 'legacy-inactive',
-  matchingUid: 'legacy-matching-uid',
-  password: 'legacy-password',
-} as const;
+interface LegacyAssessmentFixture {
+  tid: string;
+  title: string;
+  number: string;
+  allowAccess: NonNullable<AssessmentJsonInput['allowAccess']>;
+}
 
-const assessmentTitles: Record<keyof typeof assessmentTids, string> = {
-  open: 'Legacy open assessment',
-  future: 'Legacy future assessment',
-  inactive: 'Legacy inactive assessment',
-  matchingUid: 'Legacy matching UID assessment',
-  password: 'Legacy password assessment',
-};
+const assessmentFixtures = {
+  open: {
+    tid: 'legacy-open',
+    title: 'Legacy open assessment',
+    number: '1',
+    allowAccess: [
+      {
+        startDate: '2000-01-01T00:00:00',
+        endDate: '3000-01-01T00:00:00',
+        credit: 100,
+      },
+    ],
+  },
+  future: {
+    tid: 'legacy-future',
+    title: 'Legacy future assessment',
+    number: '2',
+    allowAccess: [
+      {
+        startDate: '2999-01-01T00:00:00',
+        endDate: '3000-01-01T00:00:00',
+        credit: 100,
+      },
+    ],
+  },
+  inactive: {
+    tid: 'legacy-inactive',
+    title: 'Legacy inactive assessment',
+    number: '3',
+    allowAccess: [
+      {
+        startDate: '2000-01-01T00:00:00',
+        endDate: '3000-01-01T00:00:00',
+        active: false,
+        credit: 0,
+      },
+    ],
+  },
+  matchingUid: {
+    tid: 'legacy-matching-uid',
+    title: 'Legacy matching UID assessment',
+    number: '4',
+    allowAccess: [
+      {
+        uids: ['student@example.com'],
+        startDate: '2000-01-01T00:00:00',
+        endDate: '3000-01-01T00:00:00',
+        credit: 100,
+      },
+    ],
+  },
+  password: {
+    tid: 'legacy-password',
+    title: 'Legacy password assessment',
+    number: '5',
+    allowAccess: [
+      {
+        startDate: '2000-01-01T00:00:00',
+        endDate: '3000-01-01T00:00:00',
+        password: 'legacy-password',
+        credit: 100,
+      },
+    ],
+  },
+} satisfies Record<string, LegacyAssessmentFixture>;
+
+type AssessmentKey = keyof typeof assessmentFixtures;
+type AssessmentUrls = Record<AssessmentKey, string>;
+
+function assessmentEntries() {
+  return Object.entries(assessmentFixtures) as [AssessmentKey, LegacyAssessmentFixture][];
+}
 
 function makeLegacyAssessment({
   number,
@@ -50,8 +114,8 @@ function makeLegacyAssessment({
 }
 
 function assessmentRows($: cheerio.CheerioAPI, title: string) {
-  return $('table[aria-label="Assessments"] tbody tr').filter((_, elem) =>
-    $(elem).text().includes(title),
+  return $('table[aria-label="Assessments"] tbody tr').filter(
+    (_, elem) => $(elem).children('td').eq(1).text().trim() === title,
   );
 }
 
@@ -59,7 +123,11 @@ function assertLinkedAssessment($: cheerio.CheerioAPI, title: string) {
   const row = assessmentRows($, title);
   assert.lengthOf(row, 1);
   assert.lengthOf(
-    row.find('a').filter((_, elem) => $(elem).text().includes(title)),
+    row
+      .children('td')
+      .eq(1)
+      .find('a')
+      .filter((_, elem) => $(elem).text().trim() === title),
     1,
   );
 }
@@ -68,13 +136,31 @@ function assertPlainAssessment($: cheerio.CheerioAPI, title: string) {
   const row = assessmentRows($, title);
   assert.lengthOf(row, 1);
   assert.lengthOf(
-    row.find('a').filter((_, elem) => $(elem).text().includes(title)),
+    row
+      .children('td')
+      .eq(1)
+      .find('a')
+      .filter((_, elem) => $(elem).text().trim() === title),
     0,
   );
 }
 
 function assertNoAssessment($: cheerio.CheerioAPI, title: string) {
   assert.lengthOf(assessmentRows($, title), 0);
+}
+
+async function buildAssessmentUrls(courseInstanceUrl: string): Promise<AssessmentUrls> {
+  return Object.fromEntries(
+    await Promise.all(
+      assessmentEntries().map(async ([key, { tid }]) => {
+        const assessment = await selectAssessmentByTid({
+          course_instance_id: '1',
+          tid,
+        });
+        return [key, `${courseInstanceUrl}/assessment/${assessment.id}/`];
+      }),
+    ),
+  ) as AssessmentUrls;
 }
 
 describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, () => {
@@ -88,7 +174,7 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
   const otherStudentHeaders = {
     cookie: 'pl_test_date=2024-06-01T00:00:00Z',
   };
-  const assessmentUrls: Partial<Record<keyof typeof assessmentTids, string>> = {};
+  let assessmentUrls: AssessmentUrls;
 
   beforeAll(async () => {
     storedConfig.authUid = config.authUid;
@@ -100,80 +186,13 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
 
     const course = getCourseData();
     const courseInstance = course.courseInstances[COURSE_INSTANCE_TID];
-    courseInstance.assessments = {
-      [assessmentTids.open]: makeLegacyAssessment({
-        number: '1',
-        title: assessmentTitles.open,
-        allowAccess: [
-          {
-            startDate: '2000-01-01T00:00:00',
-            endDate: '3000-01-01T00:00:00',
-            credit: 100,
-          },
-        ],
-      }),
-      [assessmentTids.future]: makeLegacyAssessment({
-        number: '2',
-        title: assessmentTitles.future,
-        allowAccess: [
-          {
-            startDate: '2999-01-01T00:00:00',
-            endDate: '3000-01-01T00:00:00',
-            credit: 100,
-          },
-        ],
-      }),
-      [assessmentTids.inactive]: makeLegacyAssessment({
-        number: '3',
-        title: assessmentTitles.inactive,
-        allowAccess: [
-          {
-            startDate: '2000-01-01T00:00:00',
-            endDate: '3000-01-01T00:00:00',
-            active: false,
-            credit: 0,
-          },
-        ],
-      }),
-      [assessmentTids.matchingUid]: makeLegacyAssessment({
-        number: '4',
-        title: assessmentTitles.matchingUid,
-        allowAccess: [
-          {
-            uids: ['student@example.com'],
-            startDate: '2000-01-01T00:00:00',
-            endDate: '3000-01-01T00:00:00',
-            credit: 100,
-          },
-        ],
-      }),
-      [assessmentTids.password]: makeLegacyAssessment({
-        number: '5',
-        title: assessmentTitles.password,
-        allowAccess: [
-          {
-            startDate: '2000-01-01T00:00:00',
-            endDate: '3000-01-01T00:00:00',
-            password: 'legacy-password',
-            credit: 100,
-          },
-        ],
-      }),
-    };
+    courseInstance.assessments = Object.fromEntries(
+      assessmentEntries().map(([, fixture]) => [fixture.tid, makeLegacyAssessment(fixture)]),
+    );
 
     const courseDir = await writeCourseToTempDirectory(course);
     await helperServer.before(courseDir)();
-
-    await Promise.all(
-      Object.entries(assessmentTids).map(async ([key, tid]) => {
-        const assessment = await selectAssessmentByTid({
-          course_instance_id: '1',
-          tid,
-        });
-        assessmentUrls[key as keyof typeof assessmentTids] =
-          `${courseInstanceUrl}/assessment/${assessment.id}/`;
-      }),
-    );
+    assessmentUrls = await buildAssessmentUrls(courseInstanceUrl);
   });
 
   afterAll(async () => {
@@ -185,7 +204,7 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
     'syncs the fixture assessments as legacy access-control assessments',
     async () => {
       await Promise.all(
-        Object.values(assessmentTids).map(async (tid) => {
+        assessmentEntries().map(async ([, { tid }]) => {
           const assessment = await selectAssessmentByTid({
             course_instance_id: '1',
             tid,
@@ -203,11 +222,11 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
     });
 
     assert.isTrue(response.ok);
-    assertLinkedAssessment(response.$, assessmentTitles.open);
-    assertLinkedAssessment(response.$, assessmentTitles.matchingUid);
-    assertLinkedAssessment(response.$, assessmentTitles.password);
-    assertPlainAssessment(response.$, assessmentTitles.inactive);
-    assertNoAssessment(response.$, assessmentTitles.future);
+    assertLinkedAssessment(response.$, assessmentFixtures.open.title);
+    assertLinkedAssessment(response.$, assessmentFixtures.matchingUid.title);
+    assertLinkedAssessment(response.$, assessmentFixtures.password.title);
+    assertPlainAssessment(response.$, assessmentFixtures.inactive.title);
+    assertNoAssessment(response.$, assessmentFixtures.future.title);
   });
 
   test.sequential('hides a UID-gated legacy assessment from other students', async () => {
@@ -216,12 +235,12 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
     });
 
     assert.isTrue(response.ok);
-    assertNoAssessment(response.$, assessmentTitles.matchingUid);
+    assertNoAssessment(response.$, assessmentFixtures.matchingUid.title);
   });
 
   test.sequential('allows direct access when a legacy rule authorizes the student', async () => {
     for (const key of ['open', 'matchingUid'] as const) {
-      const response = await helperClient.fetchCheerio(assessmentUrls[key]!, {
+      const response = await helperClient.fetchCheerio(assessmentUrls[key], {
         headers: studentHeaders,
       });
 
@@ -231,17 +250,15 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
   });
 
   test.sequential('blocks direct access when legacy date, UID, or active checks fail', async () => {
-    const futureResponse = await helperClient.fetchCheerio(assessmentUrls.future!, {
-      headers: studentHeaders,
-    });
-    assert.equal(futureResponse.status, 403);
+    for (const { key, headers } of [
+      { key: 'future', headers: studentHeaders },
+      { key: 'matchingUid', headers: otherStudentHeaders },
+    ] satisfies { key: AssessmentKey; headers: typeof studentHeaders }[]) {
+      const response = await helperClient.fetchCheerio(assessmentUrls[key], { headers });
+      assert.equal(response.status, 403);
+    }
 
-    const nonMatchingUidResponse = await helperClient.fetchCheerio(assessmentUrls.matchingUid!, {
-      headers: otherStudentHeaders,
-    });
-    assert.equal(nonMatchingUidResponse.status, 403);
-
-    const inactiveResponse = await helperClient.fetchCheerio(assessmentUrls.inactive!, {
+    const inactiveResponse = await helperClient.fetchCheerio(assessmentUrls.inactive, {
       headers: studentHeaders,
     });
     assert.equal(inactiveResponse.status, 403);
@@ -249,7 +266,7 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
   });
 
   test.sequential('requires the legacy assessment password before direct access', async () => {
-    const response = await helperClient.fetchCheerio(assessmentUrls.password!, {
+    const response = await helperClient.fetchCheerio(assessmentUrls.password, {
       headers: studentHeaders,
       redirect: 'manual',
     });

--- a/apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts
+++ b/apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts
@@ -3,9 +3,11 @@ import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import { type Config, config } from '../lib/config.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
+import { selectOrInsertUserByUid } from '../models/user.js';
 import type { AssessmentJsonInput } from '../schemas/index.js';
 
 import * as helperClient from './helperClient.js';
+import { withPTReservation } from './helperExam.js';
 import * as helperServer from './helperServer.js';
 import {
   COURSE_INSTANCE_ID as COURSE_INSTANCE_TID,
@@ -19,6 +21,8 @@ interface LegacyAssessmentFixture {
   number: string;
   allowAccess: NonNullable<AssessmentJsonInput['allowAccess']>;
 }
+
+const legacyPrairieTestExamUuid = 'a817e4b9-b1b1-40b6-b076-c3a752dd8e72';
 
 const assessmentFixtures = {
   open: {
@@ -80,6 +84,20 @@ const assessmentFixtures = {
         startDate: '2000-01-01T00:00:00',
         endDate: '3000-01-01T00:00:00',
         password: 'legacy-password',
+        credit: 100,
+      },
+    ],
+  },
+  prairieTest: {
+    tid: 'legacy-prairietest',
+    title: 'Legacy PrairieTest assessment',
+    number: '6',
+    allowAccess: [
+      {
+        mode: 'Exam',
+        examUuid: legacyPrairieTestExamUuid,
+        startDate: '2000-01-01T00:00:00',
+        endDate: '3000-01-01T00:00:00',
         credit: 100,
       },
     ],
@@ -171,6 +189,9 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
   const studentHeaders = {
     cookie: 'pl_test_user=test_student; pl_test_date=2024-06-01T00:00:00Z',
   };
+  const examStudentHeaders = {
+    cookie: `${studentHeaders.cookie}; pl_test_mode=Exam`,
+  };
   const otherStudentHeaders = {
     cookie: 'pl_test_date=2024-06-01T00:00:00Z',
   };
@@ -180,9 +201,11 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
     storedConfig.authUid = config.authUid;
     storedConfig.authName = config.authName;
     storedConfig.authUin = config.authUin;
+    storedConfig.checkAccessRulesExamUuid = config.checkAccessRulesExamUuid;
     config.authUid = 'other-student@example.com';
     config.authName = 'Other Student';
     config.authUin = '000000002';
+    config.checkAccessRulesExamUuid = false;
 
     const course = getCourseData();
     const courseInstance = course.courseInstances[COURSE_INSTANCE_TID];
@@ -227,6 +250,7 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
     assertLinkedAssessment(response.$, assessmentFixtures.password.title);
     assertPlainAssessment(response.$, assessmentFixtures.inactive.title);
     assertNoAssessment(response.$, assessmentFixtures.future.title);
+    assertNoAssessment(response.$, assessmentFixtures.prairieTest.title);
   });
 
   test.sequential('hides a UID-gated legacy assessment from other students', async () => {
@@ -273,5 +297,57 @@ describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, 
 
     assert.equal(response.status, 302);
     assert.equal(response.headers.get('location'), '/pl/password');
+  });
+
+  test.sequential('requires a matching PrairieTest reservation in Exam mode', async () => {
+    const noReservationAssessmentsResponse = await helperClient.fetchCheerio(assessmentsUrl, {
+      headers: examStudentHeaders,
+    });
+    assert.isTrue(noReservationAssessmentsResponse.ok);
+    assertNoAssessment(noReservationAssessmentsResponse.$, assessmentFixtures.open.title);
+    assertNoAssessment(noReservationAssessmentsResponse.$, assessmentFixtures.prairieTest.title);
+
+    const noReservationAssessmentResponse = await helperClient.fetchCheerio(
+      assessmentUrls.prairieTest,
+      {
+        headers: examStudentHeaders,
+      },
+    );
+    assert.equal(noReservationAssessmentResponse.status, 403);
+
+    const student = await selectOrInsertUserByUid('student@example.com');
+    await withPTReservation(
+      {
+        userId: student.id,
+        accessStart: new Date('2024-05-31T00:00:00Z'),
+        accessEnd: new Date('2024-06-02T00:00:00Z'),
+        examUuid: legacyPrairieTestExamUuid,
+      },
+      async () => {
+        const assessmentsResponse = await helperClient.fetchCheerio(assessmentsUrl, {
+          headers: examStudentHeaders,
+        });
+        assert.isTrue(assessmentsResponse.ok);
+        assertNoAssessment(assessmentsResponse.$, assessmentFixtures.open.title);
+        assertLinkedAssessment(assessmentsResponse.$, assessmentFixtures.prairieTest.title);
+
+        const publicAssessmentResponse = await helperClient.fetchCheerio(assessmentUrls.open, {
+          headers: examStudentHeaders,
+        });
+        assert.equal(publicAssessmentResponse.status, 403);
+
+        const prairieTestAssessmentResponse = await helperClient.fetchCheerio(
+          assessmentUrls.prairieTest,
+          {
+            headers: examStudentHeaders,
+          },
+        );
+        assert.isTrue(prairieTestAssessmentResponse.ok);
+        assert.equal(
+          prairieTestAssessmentResponse.$('#start-assessment').text().trim(),
+          'Start assessment',
+        );
+      },
+    );
   });
 });

--- a/apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts
+++ b/apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts
@@ -1,0 +1,260 @@
+import type * as cheerio from 'cheerio';
+import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+
+import { type Config, config } from '../lib/config.js';
+import { selectAssessmentByTid } from '../models/assessment.js';
+import type { AssessmentJsonInput } from '../schemas/index.js';
+
+import * as helperClient from './helperClient.js';
+import * as helperServer from './helperServer.js';
+import {
+  COURSE_INSTANCE_ID as COURSE_INSTANCE_TID,
+  getCourseData,
+  writeCourseToTempDirectory,
+} from './sync/util.js';
+
+const assessmentTids = {
+  open: 'legacy-open',
+  future: 'legacy-future',
+  inactive: 'legacy-inactive',
+  matchingUid: 'legacy-matching-uid',
+  password: 'legacy-password',
+} as const;
+
+const assessmentTitles: Record<keyof typeof assessmentTids, string> = {
+  open: 'Legacy open assessment',
+  future: 'Legacy future assessment',
+  inactive: 'Legacy inactive assessment',
+  matchingUid: 'Legacy matching UID assessment',
+  password: 'Legacy password assessment',
+};
+
+function makeLegacyAssessment({
+  number,
+  title,
+  allowAccess,
+}: {
+  number: string;
+  title: string;
+  allowAccess: NonNullable<AssessmentJsonInput['allowAccess']>;
+}): AssessmentJsonInput {
+  return {
+    uuid: crypto.randomUUID(),
+    type: 'Exam',
+    title,
+    set: 'TEST',
+    number,
+    zones: [],
+    allowAccess,
+  };
+}
+
+function assessmentRows($: cheerio.CheerioAPI, title: string) {
+  return $('table[aria-label="Assessments"] tbody tr').filter((_, elem) =>
+    $(elem).text().includes(title),
+  );
+}
+
+function assertLinkedAssessment($: cheerio.CheerioAPI, title: string) {
+  const row = assessmentRows($, title);
+  assert.lengthOf(row, 1);
+  assert.lengthOf(
+    row.find('a').filter((_, elem) => $(elem).text().includes(title)),
+    1,
+  );
+}
+
+function assertPlainAssessment($: cheerio.CheerioAPI, title: string) {
+  const row = assessmentRows($, title);
+  assert.lengthOf(row, 1);
+  assert.lengthOf(
+    row.find('a').filter((_, elem) => $(elem).text().includes(title)),
+    0,
+  );
+}
+
+function assertNoAssessment($: cheerio.CheerioAPI, title: string) {
+  assert.lengthOf(assessmentRows($, title), 0);
+}
+
+describe('Legacy allowAccess on student assessment pages', { timeout: 60_000 }, () => {
+  const siteUrl = `http://localhost:${config.serverPort}`;
+  const courseInstanceUrl = `${siteUrl}/pl/course_instance/1`;
+  const assessmentsUrl = `${courseInstanceUrl}/assessments`;
+  const storedConfig: Partial<Config> = {};
+  const studentHeaders = {
+    cookie: 'pl_test_user=test_student; pl_test_date=2024-06-01T00:00:00Z',
+  };
+  const otherStudentHeaders = {
+    cookie: 'pl_test_date=2024-06-01T00:00:00Z',
+  };
+  const assessmentUrls: Partial<Record<keyof typeof assessmentTids, string>> = {};
+
+  beforeAll(async () => {
+    storedConfig.authUid = config.authUid;
+    storedConfig.authName = config.authName;
+    storedConfig.authUin = config.authUin;
+    config.authUid = 'other-student@example.com';
+    config.authName = 'Other Student';
+    config.authUin = '000000002';
+
+    const course = getCourseData();
+    const courseInstance = course.courseInstances[COURSE_INSTANCE_TID];
+    courseInstance.assessments = {
+      [assessmentTids.open]: makeLegacyAssessment({
+        number: '1',
+        title: assessmentTitles.open,
+        allowAccess: [
+          {
+            startDate: '2000-01-01T00:00:00',
+            endDate: '3000-01-01T00:00:00',
+            credit: 100,
+          },
+        ],
+      }),
+      [assessmentTids.future]: makeLegacyAssessment({
+        number: '2',
+        title: assessmentTitles.future,
+        allowAccess: [
+          {
+            startDate: '2999-01-01T00:00:00',
+            endDate: '3000-01-01T00:00:00',
+            credit: 100,
+          },
+        ],
+      }),
+      [assessmentTids.inactive]: makeLegacyAssessment({
+        number: '3',
+        title: assessmentTitles.inactive,
+        allowAccess: [
+          {
+            startDate: '2000-01-01T00:00:00',
+            endDate: '3000-01-01T00:00:00',
+            active: false,
+            credit: 0,
+          },
+        ],
+      }),
+      [assessmentTids.matchingUid]: makeLegacyAssessment({
+        number: '4',
+        title: assessmentTitles.matchingUid,
+        allowAccess: [
+          {
+            uids: ['student@example.com'],
+            startDate: '2000-01-01T00:00:00',
+            endDate: '3000-01-01T00:00:00',
+            credit: 100,
+          },
+        ],
+      }),
+      [assessmentTids.password]: makeLegacyAssessment({
+        number: '5',
+        title: assessmentTitles.password,
+        allowAccess: [
+          {
+            startDate: '2000-01-01T00:00:00',
+            endDate: '3000-01-01T00:00:00',
+            password: 'legacy-password',
+            credit: 100,
+          },
+        ],
+      }),
+    };
+
+    const courseDir = await writeCourseToTempDirectory(course);
+    await helperServer.before(courseDir)();
+
+    await Promise.all(
+      Object.entries(assessmentTids).map(async ([key, tid]) => {
+        const assessment = await selectAssessmentByTid({
+          course_instance_id: '1',
+          tid,
+        });
+        assessmentUrls[key as keyof typeof assessmentTids] =
+          `${courseInstanceUrl}/assessment/${assessment.id}/`;
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await helperServer.after();
+    Object.assign(config, storedConfig);
+  });
+
+  test.sequential(
+    'syncs the fixture assessments as legacy access-control assessments',
+    async () => {
+      await Promise.all(
+        Object.values(assessmentTids).map(async (tid) => {
+          const assessment = await selectAssessmentByTid({
+            course_instance_id: '1',
+            tid,
+          });
+
+          assert.isFalse(assessment.modern_access_control);
+        }),
+      );
+    },
+  );
+
+  test.sequential('applies legacy rules on the student assessments page', async () => {
+    const response = await helperClient.fetchCheerio(assessmentsUrl, {
+      headers: studentHeaders,
+    });
+
+    assert.isTrue(response.ok);
+    assertLinkedAssessment(response.$, assessmentTitles.open);
+    assertLinkedAssessment(response.$, assessmentTitles.matchingUid);
+    assertLinkedAssessment(response.$, assessmentTitles.password);
+    assertPlainAssessment(response.$, assessmentTitles.inactive);
+    assertNoAssessment(response.$, assessmentTitles.future);
+  });
+
+  test.sequential('hides a UID-gated legacy assessment from other students', async () => {
+    const response = await helperClient.fetchCheerio(assessmentsUrl, {
+      headers: otherStudentHeaders,
+    });
+
+    assert.isTrue(response.ok);
+    assertNoAssessment(response.$, assessmentTitles.matchingUid);
+  });
+
+  test.sequential('allows direct access when a legacy rule authorizes the student', async () => {
+    for (const key of ['open', 'matchingUid'] as const) {
+      const response = await helperClient.fetchCheerio(assessmentUrls[key]!, {
+        headers: studentHeaders,
+      });
+
+      assert.isTrue(response.ok);
+      assert.equal(response.$('#start-assessment').text().trim(), 'Start assessment');
+    }
+  });
+
+  test.sequential('blocks direct access when legacy date, UID, or active checks fail', async () => {
+    const futureResponse = await helperClient.fetchCheerio(assessmentUrls.future!, {
+      headers: studentHeaders,
+    });
+    assert.equal(futureResponse.status, 403);
+
+    const nonMatchingUidResponse = await helperClient.fetchCheerio(assessmentUrls.matchingUid!, {
+      headers: otherStudentHeaders,
+    });
+    assert.equal(nonMatchingUidResponse.status, 403);
+
+    const inactiveResponse = await helperClient.fetchCheerio(assessmentUrls.inactive!, {
+      headers: studentHeaders,
+    });
+    assert.equal(inactiveResponse.status, 403);
+    assert.lengthOf(inactiveResponse.$('[data-testid="assessment-closed-message"]'), 1);
+  });
+
+  test.sequential('requires the legacy assessment password before direct access', async () => {
+    const response = await helperClient.fetchCheerio(assessmentUrls.password!, {
+      headers: studentHeaders,
+      redirect: 'manual',
+    });
+
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get('location'), '/pl/password');
+  });
+});

--- a/apps/prairielearn/src/tests/permissions/studentData.test.ts
+++ b/apps/prairielearn/src/tests/permissions/studentData.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../models/course-permissions.js';
 import { ensureUncheckedEnrollment } from '../../models/enrollment.js';
 import * as helperClient from '../helperClient.js';
-import { withPTReservation } from '../helperExam.js';
+import { exam1AutomaticTestSuite, withPTReservation } from '../helperExam.js';
 import * as helperServer from '../helperServer.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
@@ -107,6 +107,7 @@ describe('student data access', { timeout: 60_000 }, function () {
         userId: context.userIdStudent,
         accessStart: new Date(Date.now() - 60 * 60 * 1000),
         accessEnd: new Date(Date.now() + 60 * 60 * 1000),
+        examUuid: exam1AutomaticTestSuite.examUuid,
       },
       async () => await helperClient.fetchCheerio(context.examAssessmentUrl, { headers }),
     );
@@ -122,6 +123,7 @@ describe('student data access', { timeout: 60_000 }, function () {
         userId: context.userIdStudent,
         accessStart: new Date(Date.now() - 60 * 60 * 1000),
         accessEnd: new Date(Date.now() + 60 * 60 * 1000),
+        examUuid: exam1AutomaticTestSuite.examUuid,
       },
       async () =>
         await helperClient.fetchCheerio(context.examAssessmentUrl, {
@@ -155,6 +157,7 @@ describe('student data access', { timeout: 60_000 }, function () {
         userId: context.userIdStudent,
         accessStart: new Date(Date.now() - 60 * 60 * 1000),
         accessEnd: new Date(Date.now() + 60 * 60 * 1000),
+        examUuid: exam1AutomaticTestSuite.examUuid,
       },
       async () => await helperClient.fetchCheerio(context.examQuestionInstanceUrl, { headers }),
     );
@@ -520,6 +523,7 @@ describe('student data access', { timeout: 60_000 }, function () {
           userId: context.userIdStudent,
           accessStart: new Date(Date.now() - 60 * 60 * 1000),
           accessEnd: new Date(Date.now() + 60 * 60 * 1000),
+          examUuid: exam1AutomaticTestSuite.examUuid,
         },
         async () => {
           let response = await helperClient.fetchCheerio(context.examAssessmentInstanceUrl, {
@@ -554,6 +558,7 @@ describe('student data access', { timeout: 60_000 }, function () {
           userId: context.userIdStudent,
           accessStart: new Date(Date.now() - 60 * 60 * 1000),
           accessEnd: new Date(Date.now() + 60 * 60 * 1000),
+          examUuid: exam1AutomaticTestSuite.examUuid,
         },
         async () => {
           let response = await helperClient.fetchCheerio(context.examQuestionInstanceUrl, {


### PR DESCRIPTION
# Description

Adds an isolated integration test fixture that keeps legacy `allowAccess` coverage for student assessment runtime behavior now that example and test courses can move to modern `accessControl`. The test exercises list visibility/link state and direct assessment access for open, future-dated, inactive, UID-gated, and password-gated legacy rules. AI assistance disclosure: majority of implementation.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

- Added and ran `pnpm test apps/prairielearn/src/tests/legacyAllowAccessStudentAssessments.test.ts`.
