### PR TITLE
Expose optional grading for drawing objects

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/elements.py
+++ b/apps/prairielearn/elements/pl-drawing/elements.py
@@ -1044,14 +1044,9 @@ class ArcVector(BaseElement):
         else:
             obj_draw = None
 
-        offset_forward = pl.get_float_attrib(el, "offset-forward", 0)
-        offset_backward = pl.get_float_attrib(el, "offset-backward", 0)
-
         grid_size = pl.get_integer_attrib(el, "grid-size", 20)
         tol = pl.get_float_attrib(el, "tol", grid_size / 2)
-        pc, hbox, wbox, _, _ = get_error_box(
-            x1, y1, 0, tol, offset_forward, offset_backward
-        )
+        pc, hbox, wbox, _, _ = get_error_box(x1, y1, 0, tol, 0, 0)
 
         return {
             "left": x1,
@@ -1080,8 +1075,6 @@ class ArcVector(BaseElement):
             "YcenterErrorBox": pc[1] if pc is not None else pc,
             "widthErrorBox": wbox,
             "heightErrorBox": hbox,
-            "offset_forward": offset_forward,
-            "offset_backward": offset_backward,
             "originY": "center",
             "selectable": drawing_defaults["selectable"],
             "clockwiseDirection": clockwise_direction,
@@ -1126,6 +1119,7 @@ class ArcVector(BaseElement):
             "arrow-head-length",
             "disregard-sense",
             "draw-error-box",
+            "optional-grading",
             "anchor-is-tail",
         ]
 
@@ -1297,6 +1291,7 @@ class DistributedLoad(BaseElement):
             "draw-error-box",
             "offset-forward",
             "offset-backward",
+            "optional-grading",
         ]
 
 
@@ -1313,14 +1308,9 @@ class Point(BaseElement):
         else:
             obj_draw = None
 
-        offset_forward = pl.get_float_attrib(el, "offset-forward", 0)
-        offset_backward = pl.get_float_attrib(el, "offset-backward", 0)
-
         grid_size = pl.get_integer_attrib(el, "grid-size", 20)
         tol = pl.get_float_attrib(el, "tol", grid_size / 2)
-        pc, hbox, wbox, _, _ = get_error_box(
-            x1, y1, 0, tol, offset_forward, offset_backward
-        )
+        pc, hbox, wbox, _, _ = get_error_box(x1, y1, 0, tol, 0, 0)
 
         return {
             "left": pl.get_float_attrib(el, "x1", 20),
@@ -1331,8 +1321,6 @@ class Point(BaseElement):
             "YcenterErrorBox": pc[1] if pc is not None else pc,
             "widthErrorBox": wbox,
             "heightErrorBox": hbox,
-            "offset_forward": offset_forward,
-            "offset_backward": offset_backward,
             "label": pl.get_string_attrib(el, "label", drawing_defaults["label"]),
             "offsetx": pl.get_float_attrib(el, "offsetx", 5),
             "offsety": pl.get_float_attrib(el, "offsety", 5),

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -1115,6 +1115,7 @@ More information about the grading attributes in the Grading section below.
 | `arrow-head-length`   | float   | 1       | Scale factor for the length of the arrow head.                                                                                                                                          |
 | `disregard-sense`     | boolean | false   | When `disregard-sense=true`, the correctness of the arc vector only considers the position of the anchor point.                                                                         |
 | `draw-error-box`      | boolean | -       | Draw the error bounding box, where the location of the anchor point is accepted as correct.                                                                                             |
+| `optional-grading`    | boolean | false   | When `true`, the grading algorithm will not assign point values for the object, but it won't penalize either.                                                                           |
 
 #### Example implementations
 
@@ -1183,6 +1184,7 @@ More information about the grading attributes in the Grading section below.
 | `draw-error-box`    | boolean | -                   | Draw the error bounding box, where the location of the anchor point is accepted as correct.                                                                                                                                                                                                                       |
 | `offset-forward`    | float   | 0                   | Length of the bounding box measured from the anchor point in the same orientation of the distributed load.                                                                                                                                                                                                        |
 | `offset-backward`   | float   | `max(w1, w2) * 1.1` | Length of the bounding box measured from the anchor point in the opposite orientation of the distributed load.                                                                                                                                                                                                    |
+| `optional-grading`  | boolean | false               | When `true`, the grading algorithm will not assign point values for the object, but it won't penalize either.                                                                                                                                                                                                     |
 
 #### Example implementations
 


### PR DESCRIPTION
# Description

Expose `optional-grading` as a documented attribute for `pl-arc-vector` and `pl-distributed-load`, matching the existing generation behavior and shared grader support for optional reference objects.

Remove hidden `offset-forward` and `offset-backward` reads from `pl-arc-vector` and `pl-point` so their rendered error boxes match their square `tol`-based grading behavior instead of accepting undocumented sizing overrides.

This change was implemented with AI assistance in Codex.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Existing `pl-drawing` test coverage was run after removing proposed new attribute-specific tests; no manual UI testing was needed for this attribute allow-list and docs-only user-facing change.
