### PR TITLE
Fix timed exam auto-finish access

### DIFF
--- a/apps/prairielearn/src/middlewares/studentAssessmentAccess.ts
+++ b/apps/prairielearn/src/middlewares/studentAssessmentAccess.ts
@@ -18,28 +18,25 @@ export function checkStudentAssessmentAccess(req: Request, res: Response): boole
   const assessmentInstanceOpen = res.locals.assessment_instance?.open ?? true;
   const assessmentActive = res.locals.authz_result?.active ?? true;
 
+  // Show the blocked assessment view when the selected access rule says the
+  // completed assessment should be hidden and either:
+  //
+  // - the assessment instance is closed, or
+  // - the assessment is inactive for this request.
+  //
+  // The inactive case is intentional. Legacy access rules can use `active: false`
+  // together with `showClosedAssessment: false` to fully hide an assessment
+  // outside an allowed window instead of showing a read-only instance.
+  //
+  // The expired time-limit finish POST is a narrow exception: modern access
+  // control marks the assessment inactive before the browser's auto-finish
+  // request reaches the page handler. Let that cleanup POST through so the
+  // handler can verify the expiry and close the still-open instance.
   if (
     !showClosedAssessment &&
     (!assessmentInstanceOpen || !assessmentActive) &&
     !isExpiredTimeLimitFinish(req, res)
   ) {
-    // We're here because we want to hide closed assessments and one of the following is true:
-    //
-    // - The assessment instance is closed
-    // - There is no assessment instance, or the assessment is not active
-    //
-    // The first case is trivial.
-    //
-    // The second case isn't entirely obvious. One could assume that if the assessment instance
-    // is open, even if the assessment is not active, the student should be able to access it.
-    // However, this is not the case. If one is using `showClosedAssessment: false` with a date
-    // range that *grants* access in a certain time frame, they need to pair that with another
-    // access rule that will also apply `showClosedAssessment: false` outside of that time
-    // frame to ensure that students still can't see it. They need to add `active: false` to
-    // that same access rule to override the default, which would otherwise allow students to
-    // start the assessment when that access rule applies, even though they'd have no credit.
-    // We rely on completely blocking access when `active: false` and `showClosedAssessment: false`
-    // are both used, as there's otherwise no way to totally block access.
     res.status(403).send(
       StudentAssessmentAccess({
         // @ts-expect-error The types on checkStudentAssessmentAccess aren't perfect

--- a/apps/prairielearn/src/middlewares/studentAssessmentAccess.ts
+++ b/apps/prairielearn/src/middlewares/studentAssessmentAccess.ts
@@ -18,7 +18,11 @@ export function checkStudentAssessmentAccess(req: Request, res: Response): boole
   const assessmentInstanceOpen = res.locals.assessment_instance?.open ?? true;
   const assessmentActive = res.locals.authz_result?.active ?? true;
 
-  if (!showClosedAssessment && (!assessmentInstanceOpen || !assessmentActive)) {
+  if (
+    !showClosedAssessment &&
+    (!assessmentInstanceOpen || !assessmentActive) &&
+    !isExpiredTimeLimitFinish(req, res)
+  ) {
     // We're here because we want to hide closed assessments and one of the following is true:
     //
     // - The assessment instance is closed
@@ -57,6 +61,15 @@ export function checkStudentAssessmentAccess(req: Request, res: Response): boole
   }
 
   return true;
+}
+
+function isExpiredTimeLimitFinish(req: Request, res: Response): boolean {
+  return (
+    req.method === 'POST' &&
+    req.body?.__action === 'timeLimitFinish' &&
+    res.locals.assessment_instance?.open === true &&
+    res.locals.assessment_instance_time_limit_expired === true
+  );
 }
 
 export default asyncHandler(async (req, res, next) => {

--- a/apps/prairielearn/src/tests/afterCompleteVisibility.test.ts
+++ b/apps/prairielearn/src/tests/afterCompleteVisibility.test.ts
@@ -4,6 +4,7 @@ import { gradeAssessmentInstance, makeAssessmentInstance } from '../lib/assessme
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
 import type { Assessment } from '../lib/db-types.js';
+import { selectAssessmentInstanceById } from '../models/assessment-instance.js';
 import { selectAssessmentByTid } from '../models/assessment.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { ensureUncheckedEnrollment } from '../models/enrollment.js';
@@ -183,12 +184,31 @@ describe(
     });
 
     describe('timed exam completion after the time limit expires', () => {
-      beforeAll(async () => {
-        const assessmentInstanceId = await createAssessmentInstance({
-          assessment: context.timedExamAssessment,
-          timeLimitMin: 10,
+      test.sequential('student starts the timed exam during the active window', async () => {
+        const timedExamAssessmentUrl = `${context.courseInstanceBaseUrl}/assessment/${context.timedExamAssessment.id}/`;
+        const startPage = await helperClient.fetchCheerio(timedExamAssessmentUrl, {
+          headers: { cookie: activeWindowCookie },
         });
-        context.timedExamAssessmentInstanceUrl = assessmentInstanceUrl(assessmentInstanceId);
+        assert.isTrue(startPage.ok);
+        assert.equal(startPage.$('#start-assessment').text().trim(), 'Start assessment');
+
+        const startCsrfToken = helperClient.getCSRFToken(startPage.$('form'));
+        const response = await helperClient.fetchCheerio(timedExamAssessmentUrl, {
+          method: 'POST',
+          body: new URLSearchParams({
+            __action: 'new_instance',
+            __csrf_token: startCsrfToken,
+          }),
+          headers: { cookie: activeWindowCookie },
+        });
+        assert.isTrue(response.ok);
+        assert.include(response.url, '/assessment_instance/');
+
+        context.timedExamAssessmentInstanceId = String(
+          helperClient.parseAssessmentInstanceId(response.url),
+        );
+        context.timedExamAssessmentInstanceUrl = response.url;
+        context.timedExamCsrfToken = helperClient.getCSRFToken(response.$);
       });
 
       test.sequential('student assessments list omits available credit', async () => {
@@ -202,7 +222,7 @@ describe(
         assert.equal(row.find('td').eq(2).text().trim(), '');
       });
 
-      test.sequential('student assessment instance page shows the closed message', async () => {
+      test.sequential('student assessment instance GET shows the closed message', async () => {
         const response = await helperClient.fetchCheerio(context.timedExamAssessmentInstanceUrl, {
           headers: { cookie: afterTimeLimitCookie },
         });
@@ -212,6 +232,27 @@ describe(
         assert.lengthOf(message, 1);
         assert.match(message.text(), /Assessment is no longer available/);
         assert.lengthOf(response.$('[data-testid="scorebar"]'), 0);
+      });
+
+      test.sequential('timeLimitFinish closes the hidden expired assessment instance', async () => {
+        const response = await helperClient.fetchCheerio(context.timedExamAssessmentInstanceUrl, {
+          method: 'POST',
+          body: new URLSearchParams({
+            __action: 'timeLimitFinish',
+            __csrf_token: context.timedExamCsrfToken,
+          }),
+          headers: { cookie: afterTimeLimitCookie },
+        });
+        assert.equal(response.status, 403);
+        assert.equal(
+          response.url,
+          `${context.timedExamAssessmentInstanceUrl}?timeLimitExpired=true`,
+        );
+
+        const assessmentInstance = await selectAssessmentInstanceById(
+          context.timedExamAssessmentInstanceId,
+        );
+        assert.isFalse(assessmentInstance.open);
       });
     });
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Allow the student assessment access middleware to pass through only an open, expired `timeLimitFinish` POST so the assessment-instance handler can close and grade the timed exam while preserving hidden-after-complete blocking for normal access.

This fixes a modern `accessControl` regression where hidden after-complete visibility made auto-finish requests fail before reaching the existing finish logic.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation by AI assistance under Nathan's direction.

# Testing

Added modern after-complete visibility integration coverage that starts the timed exam through the student flow, verifies expired GET access is still hidden, then posts `__action=timeLimitFinish` and asserts the redirect plus `assessment_instances.open = false`.