### PR TITLE
Stabilize assessment question reorder test

### DIFF
--- a/apps/prairielearn/src/tests/e2e/assessmentQuestions.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/assessmentQuestions.spec.ts
@@ -9,6 +9,15 @@ import { syncCourse } from '../helperCourse.js';
 
 import { expect, test } from './fixtures.js';
 
+async function waitForBrowserFrames(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
 async function enterEditMode(page: Page, ciId: string, aId: string): Promise<void> {
   await page.goto(`/pl/course_instance/${ciId}/instructor/assessment/${aId}/questions`);
   await page.getByRole('button', { name: 'Edit', exact: true }).click();
@@ -25,15 +34,16 @@ async function keyboardDrag(page: Page, source: Locator, direction: 'up' | 'down
   await source.focus();
   await page.keyboard.press(' ');
   await expect(source).toHaveAttribute('aria-pressed', 'true');
+  await waitForBrowserFrames(page);
   for (let i = 0; i < steps; i++) {
     await page.keyboard.press(arrowKey);
     // dnd-kit's sortableKeyboardCoordinates reads DOM rects to compute
-    // the next drop position. Yield to the event loop so React can
-    // commit the state update and dnd-kit can re-measure rects before
-    // the next arrow press.
-    await page.evaluate(() => new Promise((resolve) => setTimeout(resolve, 0)));
+    // the next drop position. Wait for layout/measurement work to settle
+    // before sending the next key or dropping the item.
+    await waitForBrowserFrames(page);
   }
   await page.keyboard.press(' ');
+  await expect(source).not.toHaveAttribute('aria-pressed', 'true');
 }
 
 async function expectHiddenZoneQuestionIds(


### PR DESCRIPTION
# Description

This test has been flaky in CI for a while now; this PR is Codex's attempt to stabilize it. It waits for browser animation frames after activation and each arrow key before dropping the item. This gives dnd-kit time to update layout measurements and verifies the drag handle is no longer pressed before asserting the serialized zone order.

AI assistance disclosure: Majority of implementation and validation performed with Codex.

# Testing

Stress-ran the formerly flaky Playwright test with `--repeat-each=10` and ran the related cross-zone drag test once.
