### PR TITLE
Remove reteps from CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
           path-to-signatures: signatures.json
           path-to-document: https://github.com/PrairieLearn/cla/blob/main/CLA.md
           branch: main
-          allowlist: dependabot[bot],prairielearn-ci-bot[bot],coderabbitai[bot],Copilot,claude,nwalters512,mwest1066,mfsilva22,reteps,EduardoMVAz,austinbillings-pl,SybelBlue
+          allowlist: dependabot[bot],prairielearn-ci-bot[bot],coderabbitai[bot],Copilot,claude,nwalters512,mwest1066,mfsilva22,EduardoMVAz,austinbillings-pl,SybelBlue
           custom-pr-sign-comment: I have reviewed and hereby sign the CLA
           create-file-commit-message: Create signatures.json
           signed-commit-message: '$contributorName signed the CLA in https://github.com/PrairieLearn/PrairieLearn/pull/$pullRequestNo'


### PR DESCRIPTION
# Description

This removes `reteps` from the CLA Assistant allowlist so future contributions from that account are no longer exempted from the CLA check.

# Testing

N/A
