### PR TITLE
Use consistent 24-hour format in formatDateWithinRange

### DIFF
--- a/.changeset/wild-ravens-marry.md
+++ b/.changeset/wild-ravens-marry.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/formatter': patch
+---
+
+Bugfix: consistently use 24-hour format in formatDateWithinRange

--- a/packages/formatter/src/date.test.ts
+++ b/packages/formatter/src/date.test.ts
@@ -48,14 +48,14 @@ describe('date formatting', () => {
     });
     it('formats dates with the long timezone name', () => {
       const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 20, 59, 32));
       assert.equal(
         formatDate(date1, 'America/Chicago', { longTz: true }),
         '2018-01-01 06:00:00 (Central Standard Time)',
       );
       assert.equal(
         formatDate(date2, 'America/Chicago', { longTz: true }),
-        '2023-01-01 12:59:32 (Central Standard Time)',
+        '2023-01-01 14:59:32 (Central Standard Time)',
       );
     });
   });
@@ -74,9 +74,9 @@ describe('date formatting', () => {
 
     it('formats a CST date with timezone offset', () => {
       const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 20, 59, 32));
       assert.equal(formatDateISO(date1, 'America/Chicago'), '2018-01-01T06:00:00-06:00');
-      assert.equal(formatDateISO(date2, 'America/Chicago'), '2023-01-01T12:59:32-06:00');
+      assert.equal(formatDateISO(date2, 'America/Chicago'), '2023-01-01T14:59:32-06:00');
     });
 
     it('formats a date in Asia/Kolkata with timezone offset', () => {

--- a/packages/formatter/src/date.test.ts
+++ b/packages/formatter/src/date.test.ts
@@ -13,34 +13,49 @@ import {
 describe('date formatting', () => {
   describe('formatDate', () => {
     it('formats a UTC date', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDate(date, 'UTC'), '2018-01-01 12:00:00 (UTC)');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDate(date1, 'UTC'), '2018-01-01 12:00:00 (UTC)');
+      assert.equal(formatDate(date2, 'UTC'), '2023-01-01 18:59:32 (UTC)');
     });
     it('formats a CST date', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDate(date, 'America/Chicago'), '2018-01-01 06:00:00 (CST)');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 20, 59, 32));
+      assert.equal(formatDate(date1, 'America/Chicago'), '2018-01-01 06:00:00 (CST)');
+      assert.equal(formatDate(date2, 'America/Chicago'), '2023-01-01 14:59:32 (CST)');
     });
     it('formats a CDT date', () => {
-      const date = new Date(Date.UTC(2018, 6, 1, 12, 0, 0));
-      assert.equal(formatDate(date, 'America/Chicago'), '2018-07-01 07:00:00 (CDT)');
+      const date1 = new Date(Date.UTC(2018, 6, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 6, 1, 18, 59, 32));
+      assert.equal(formatDate(date1, 'America/Chicago'), '2018-07-01 07:00:00 (CDT)');
+      assert.equal(formatDate(date2, 'America/Chicago'), '2023-07-01 13:59:32 (CDT)');
     });
     it('formats dates with zero hours', () => {
       const date = new Date(Date.UTC(2018, 0, 1, 0, 1, 0));
       assert.equal(formatDate(date, 'UTC'), '2018-01-01 00:01:00 (UTC)');
     });
     it('formats dates with milliseconds', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 4, 1, 3, 12));
-      assert.equal(formatDate(date, 'UTC', { includeMs: true }), '2018-01-01 04:01:03.012 (UTC)');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 4, 1, 3, 12));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32, 456));
+      assert.equal(formatDate(date1, 'UTC', { includeMs: true }), '2018-01-01 04:01:03.012 (UTC)');
+      assert.equal(formatDate(date2, 'UTC', { includeMs: true }), '2023-01-01 18:59:32.456 (UTC)');
     });
     it('formats dates without the timezone', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDate(date, 'UTC', { includeTz: false }), '2018-01-01 12:00:00');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDate(date1, 'UTC', { includeTz: false }), '2018-01-01 12:00:00');
+      assert.equal(formatDate(date2, 'UTC', { includeTz: false }), '2023-01-01 18:59:32');
     });
     it('formats dates with the long timezone name', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
       assert.equal(
-        formatDate(date, 'America/Chicago', { longTz: true }),
+        formatDate(date1, 'America/Chicago', { longTz: true }),
         '2018-01-01 06:00:00 (Central Standard Time)',
+      );
+      assert.equal(
+        formatDate(date2, 'America/Chicago', { longTz: true }),
+        '2023-01-01 12:59:32 (Central Standard Time)',
       );
     });
   });
@@ -51,36 +66,51 @@ describe('date formatting', () => {
     });
 
     it('formats a UTC date with timezone offset', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDateISO(date, 'UTC'), '2018-01-01T12:00:00+00:00');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDateISO(date1, 'UTC'), '2018-01-01T12:00:00+00:00');
+      assert.equal(formatDateISO(date2, 'UTC'), '2023-01-01T18:59:32+00:00');
     });
 
     it('formats a CST date with timezone offset', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDateISO(date, 'America/Chicago'), '2018-01-01T06:00:00-06:00');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDateISO(date1, 'America/Chicago'), '2018-01-01T06:00:00-06:00');
+      assert.equal(formatDateISO(date2, 'America/Chicago'), '2023-01-01T12:59:32-06:00');
     });
 
     it('formats a date in Asia/Kolkata with timezone offset', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDateISO(date, 'Asia/Kolkata'), '2018-01-01T17:30:00+05:30');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 19, 59, 32));
+      assert.equal(formatDateISO(date1, 'Asia/Kolkata'), '2018-01-01T17:30:00+05:30');
+      assert.equal(formatDateISO(date2, 'Asia/Kolkata'), '2023-01-02T01:29:32+05:30');
     });
 
     it('formats a date in Asia/Tokyo with timezone offset', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDateISO(date, 'Asia/Tokyo'), '2018-01-01T21:00:00+09:00');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDateISO(date1, 'Asia/Tokyo'), '2018-01-01T21:00:00+09:00');
+      assert.equal(formatDateISO(date2, 'Asia/Tokyo'), '2023-01-02T03:59:32+09:00');
     });
 
     it('formats a date with milliseconds', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 4, 1, 3, 12));
+      const date1 = new Date(Date.UTC(2018, 0, 1, 4, 1, 3, 12));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32, 456));
       assert.equal(
-        formatDateISO(date, 'UTC', { includeMs: true }),
+        formatDateISO(date1, 'UTC', { includeMs: true }),
         '2018-01-01T04:01:03.012+00:00',
+      );
+      assert.equal(
+        formatDateISO(date2, 'UTC', { includeMs: true }),
+        '2023-01-01T18:59:32.456+00:00',
       );
     });
 
     it('formats a date without the timezone', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
-      assert.equal(formatDateISO(date, 'UTC', { includeTz: false }), '2018-01-01T12:00:00');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDateISO(date1, 'UTC', { includeTz: false }), '2018-01-01T12:00:00');
+      assert.equal(formatDateISO(date2, 'UTC', { includeTz: false }), '2023-01-01T18:59:32');
     });
   });
 
@@ -105,16 +135,22 @@ describe('date formatting', () => {
 
   describe('formatDateYMDHM()', () => {
     it('should handle a UTC date', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
-      assert.equal(formatDateYMDHM(date, 'UTC'), '2018-01-01 12:34');
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 18, 59, 32));
+      assert.equal(formatDateYMDHM(date1, 'UTC'), '2018-01-01 12:34');
+      assert.equal(formatDateYMDHM(date2, 'UTC'), '2023-01-01 18:59');
     });
     it('should handle a CST date', () => {
-      const date = new Date(Date.UTC(2018, 0, 3, 5, 10, 50));
-      assert.equal(formatDateYMDHM(date, 'America/Chicago'), '2018-01-02 23:10');
+      const date1 = new Date(Date.UTC(2018, 0, 3, 5, 10, 50));
+      const date2 = new Date(Date.UTC(2023, 0, 1, 15, 59, 32));
+      assert.equal(formatDateYMDHM(date1, 'America/Chicago'), '2018-01-02 23:10');
+      assert.equal(formatDateYMDHM(date2, 'America/Chicago'), '2023-01-01 09:59');
     });
     it('should handle a CDT date', () => {
-      const date = new Date(Date.UTC(2018, 6, 1, 19, 8, 19));
-      assert.equal(formatDateYMDHM(date, 'America/Chicago'), '2018-07-01 14:08');
+      const date1 = new Date(Date.UTC(2018, 6, 1, 19, 8, 19));
+      const date2 = new Date(Date.UTC(2023, 6, 1, 15, 59, 32));
+      assert.equal(formatDateYMDHM(date1, 'America/Chicago'), '2018-07-01 14:08');
+      assert.equal(formatDateYMDHM(date2, 'America/Chicago'), '2023-07-01 10:59');
     });
     it('should correctly format dates with zero hours', () => {
       const date = new Date(Date.UTC(2018, 0, 1, 0, 1, 0));
@@ -124,28 +160,36 @@ describe('date formatting', () => {
 
   describe('formatDateWithinRange()', () => {
     it('should handle a date within the same day in UTC', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date2 = new Date(Date.UTC(2018, 0, 1, 19, 58, 31));
       const start = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
       const end = new Date(Date.UTC(2018, 0, 1, 12, 59, 59));
-      assert.equal(formatDateWithinRange(date, start, end, 'UTC'), '12:34');
+      assert.equal(formatDateWithinRange(date1, start, end, 'UTC'), '12:34');
+      assert.equal(formatDateWithinRange(date2, start, end, 'UTC'), '19:58');
     });
     it('should handle a date within the same day in CST', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 23, 8, 57));
+      const date1 = new Date(Date.UTC(2018, 0, 1, 23, 8, 57));
+      const date2 = new Date(Date.UTC(2018, 0, 1, 13, 58, 31));
       const start = new Date(Date.UTC(2018, 0, 1, 21, 0, 0));
       const end = new Date(Date.UTC(2018, 0, 2, 2, 14, 0));
-      assert.equal(formatDateWithinRange(date, start, end, 'America/Chicago'), '17:08');
+      assert.equal(formatDateWithinRange(date1, start, end, 'America/Chicago'), '17:08');
+      assert.equal(formatDateWithinRange(date2, start, end, 'America/Chicago'), '07:58');
     });
     it('should handle a date within the same year in UTC', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date2 = new Date(Date.UTC(2018, 6, 1, 18, 34, 7));
       const start = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
       const end = new Date(Date.UTC(2018, 0, 4, 12, 59, 59));
-      assert.equal(formatDateWithinRange(date, start, end, 'UTC'), 'Jan 1, 12:34');
+      assert.equal(formatDateWithinRange(date1, start, end, 'UTC'), 'Jan 1, 12:34');
+      assert.equal(formatDateWithinRange(date2, start, end, 'UTC'), 'Jul 1, 18:34');
     });
     it('should handle a date within different years in UTC', () => {
-      const date = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date1 = new Date(Date.UTC(2018, 0, 1, 12, 34, 7));
+      const date2 = new Date(Date.UTC(2018, 6, 1, 18, 34, 7));
       const start = new Date(Date.UTC(2018, 0, 1, 12, 0, 0));
       const end = new Date(Date.UTC(2019, 0, 1, 12, 59, 59));
-      assert.equal(formatDateWithinRange(date, start, end, 'UTC'), '2018-01-01 12:34');
+      assert.equal(formatDateWithinRange(date1, start, end, 'UTC'), '2018-01-01 12:34');
+      assert.equal(formatDateWithinRange(date2, start, end, 'UTC'), '2018-07-01 18:34');
     });
   });
 

--- a/packages/formatter/src/date.ts
+++ b/packages/formatter/src/date.ts
@@ -279,6 +279,7 @@ export function formatDateWithinRange(
   if (dateY === startY && dateY === endY) {
     const options: Intl.DateTimeFormatOptions = {
       timeZone,
+      hourCycle: 'h23',
       month: 'short',
       day: 'numeric',
       hour: '2-digit',


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #15255. Ensures formatDateWithinRange uses a consistent 24-hour format in all cases.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: some auto-complete in test implementation.

# Testing

New tests were added that check the result for dates that would have different results in 12-hour or 24-hour formats. For completeness, similar tests were added to other formatting functions. The formatDateFriendly tests were not changed because they use 12-hour formatting and already properly check the output accordingly.

Tests were updated before the fixed implementation to ensure the tests caught the previously incorrect case.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
