### PR TITLE
Improve handling of upload with same content

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -3,7 +3,6 @@ import crypto from 'node:crypto';
 import * as path from 'path';
 
 import { Temporal } from '@js-temporal/polyfill';
-import { someLimit } from 'async';
 import debugfn from 'debug';
 import fs from 'fs-extra';
 import { z } from 'zod';
@@ -2286,34 +2285,28 @@ export class FileUploadEditor extends Editor {
     this.files = files;
   }
 
-  async shouldEdit() {
+  async fileContentModified(filePath: string, newContents: Buffer) {
     debug('look for old contents');
-    return await someLimit(Object.entries(this.files), 5, async ([filePath, fileContents]) => {
-      let contents;
-      try {
-        contents = await fs.readFile(filePath);
-      } catch (err: any) {
-        if (err.code === 'ENOENT') {
-          debug('no old contents, so continue with upload');
-          return true;
-        }
-
-        throw err;
-      }
-
-      debug('get hash of old contents and of new contents');
-      const oldHash = getHash(contents);
-      const newHash = getHash(fileContents);
-      debug('oldHash: ' + oldHash);
-      debug('newHash: ' + newHash);
-      if (oldHash === newHash) {
-        debug('new contents are the same as old contents, so abort upload');
-        return false;
-      } else {
-        debug('new contents are different from old contents, so continue with upload');
+    let oldContents;
+    try {
+      oldContents = await fs.readFile(filePath);
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        debug('no old contents, so continue with upload');
         return true;
       }
-    });
+
+      throw err;
+    }
+
+    debug('compare old contents and new contents');
+    if (oldContents.equals(newContents)) {
+      debug('new contents are the same as old contents, so skip this upload');
+      return false;
+    } else {
+      debug('new contents are different from old contents, so continue with upload');
+      return true;
+    }
   }
 
   assertCanEdit() {
@@ -2356,20 +2349,24 @@ export class FileUploadEditor extends Editor {
   async write() {
     debug('FileUploadEditor: write()');
 
-    if (!(await this.shouldEdit())) return null;
+    const pathsToAdd: string[] = [];
 
     for (const [filePath, fileContents] of Object.entries(this.files)) {
-      debug('ensure path exists');
-      await fs.ensureDir(path.dirname(filePath));
+      // If the content is the same as what's already on disk, then we can skip writing it to reduce impact on git history.
+      if (await this.fileContentModified(filePath, fileContents)) {
+        debug('ensure path exists');
+        await fs.ensureDir(path.dirname(filePath));
 
-      debug('write file');
-      await fs.writeFile(filePath, fileContents);
+        debug('write file');
+        await fs.writeFile(filePath, fileContents);
+        pathsToAdd.push(filePath);
+      }
     }
 
-    return {
-      pathsToAdd: Object.keys(this.files),
-      commitMessage: this.description,
-    };
+    // If all uploaded files are the same as what's already on disk, then we can
+    // skip creating a new commit since there are effectively no changes.
+    if (pathsToAdd.length === 0) return null;
+    return { pathsToAdd, commitMessage: this.description };
   }
 }
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Follow-up to #15215. Improves the handling of existing files with same content on upload. This provides basically two improvements:
* In cases of multiple uploads, if one file is modified and the other isn't, then the upload proceeds only on the modified file. Upload was already skipped if all files existed and had the same content. This reduces disk writes and simplifies some git operations.
* Comparison of new and existing content is done with Buffer.equal instead of hashing. There was no advantage to using hashing, since the content of both buffers (new and old) was read anyway to calculate the hashing (i.e., there was no pre-computed hash for it to be worth it). Also, Buffer.equal is able to return as soon as there is a difference, meaning there's no need to read the entire file once a difference is found.

The latter change also remove an inconsistency between upload and other file operations: most operations use a sha256 hash of the base64 encoding of the file, while upload was using the hash of the proper content. Since there is now no longer hashing in upload, this inconsistency no longer exists.

Best reviewed hiding whitespace changes.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none beyond some auto-complete.

# Testing

Tested uploading a new file, an existing file with same content, an existing file with different content. File modification in stat matches expected behaviour. Tested uploading multiple files, where some had content that matched existing content.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
