### PR TITLE
Hide manual grading badge if user has no student data permission

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.tsx
@@ -161,11 +161,14 @@ export function InstructorAssessments({
                               courseInstanceId: course_instance.id,
                               issueAid: row.tid,
                             })}
-                            ${ManualGradingBadgeHtml({
-                              ungradedSubmissionCount: row.ungraded_manual_grading_submission_count,
-                              courseInstanceId: course_instance.id,
-                              assessmentId: row.id,
-                            })}
+                            ${resLocals.authz_data.has_course_instance_permission_view
+                              ? ManualGradingBadgeHtml({
+                                  ungradedSubmissionCount:
+                                    row.ungraded_manual_grading_submission_count,
+                                  courseInstanceId: course_instance.id,
+                                  assessmentId: row.id,
+                                })
+                              : ''}
                           </td>
 
                           <td class="align-middle">${row.tid}</td>

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -76,6 +76,11 @@ const mockStaff: MockUser[] = [
   { authUid: 'staff3', authName: 'Staff User 3', authUin: 'STAFF003' },
   { authUid: 'staff4', authName: 'Staff User 4', authUin: 'STAFF004' },
 ];
+const mockStaffNoStudentPermission = {
+  authUid: 'staff5',
+  authName: 'Staff User 5',
+  authUin: 'STAFF005',
+};
 
 const assessmentTitle = 'Homework for Internal, External, Manual grading methods';
 const manualGradingQuestionTitle = 'Manual Grading: Fibonacci function, file upload';
@@ -508,6 +513,12 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
         });
       }),
     );
+    await insertCoursePermissionsByUserUid({
+      course_id: '1',
+      uid: mockStaffNoStudentPermission.authUid,
+      course_role: 'Editor',
+      authn_user_id: '1',
+    });
   });
 
   afterAll(() => setUser(defaultUser));
@@ -563,6 +574,20 @@ describe('Manual Grading', { timeout: 80_000 }, function () {
         assert.equal(badge.attr('aria-label'), '1 submission requires manual grading');
         assert.include(badge.text(), '1');
       });
+
+      test.sequential(
+        'assessments listing page should not show manual grading badge if user does not have permission',
+        async () => {
+          setUser(mockStaffNoStudentPermission);
+          const res = await fetch(assessmentsUrl);
+          assert.equal(res.ok, true);
+          const $ = cheerio.load(await res.text());
+          const row = $(`tr:contains("${assessmentTitle}")`);
+          assert.equal(row.length, 1);
+          const badge = row.find('[data-testid="manual-grading-badge"]');
+          assert.equal(badge.length, 0);
+        },
+      );
     });
 
     describe('Manual grading behavior while instance is open', () => {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

#14398 introduced a badge to the assessments page that lists how many instances require manual grading. This badge was added unconditionally, however. Users with no course instance (student data) permission also see the badge, even though (1) this information, although not that sensitive, is not something that the user should have access to, and (2) the link from the badge would not be accessible to this user. This PR hides the badge if the user does not have at least viewer access for student data.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Tested locally by reducing my permissions, the badge is hidden. Also added CI test.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
