### PR TITLE
Remove deprecated @types/mime dependency

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -295,7 +295,6 @@
     "@types/json-stringify-safe": "^5.0.3",
     "@types/klaw": "^3.0.7",
     "@types/memorystream": "^0.3.4",
-    "@types/mime": "^4.0.0",
     "@types/minimist": "^1.2.5",
     "@types/multer": "^2.1.0",
     "@types/mustache": "^4.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1056,9 +1056,6 @@ importers:
       '@types/memorystream':
         specifier: ^0.3.4
         version: 0.3.4
-      '@types/mime':
-        specifier: ^4.0.0
-        version: 4.0.0
       '@types/minimist':
         specifier: ^1.2.5
         version: 1.2.5
@@ -5308,10 +5305,6 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/mime@4.0.0':
-    resolution: {integrity: sha512-5eEkJZ/BLvTE3vXGKkWlyTSUVZuzj23Wj8PoyOq2lt5I3CYbiLBOPb3XmCW6QcuOibIUE6emHXHt9E/F/rCa6w==}
-    deprecated: This is a stub types definition. mime provides its own type definitions, so you do not need this installed.
 
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
@@ -13544,10 +13537,6 @@ snapshots:
       '@types/node': 24.12.4
 
   '@types/mime@1.3.5': {}
-
-  '@types/mime@4.0.0':
-    dependencies:
-      mime: 4.1.0
 
   '@types/minimist@1.2.5': {}
 


### PR DESCRIPTION
# Description

Removes the direct `@types/mime` devDependency from `@prairielearn/prairielearn` because `mime` v4 ships its own TypeScript definitions and the DefinitelyTyped package is deprecated as a stub.

The lockfile now drops the direct `@types/mime@4.0.0` entry while preserving the older transitive `@types/mime@1.3.5` dependency pulled in by Express-related types.

- [x] I have disclosed the level of AI assistance used: majority of implementation by Codex.

# Testing

Targeted typechecking passed for the two source files that import `mime`.