### PR TITLE
Use default timeout in Java grader examples

### DIFF
--- a/docs/java-grader/index.md
+++ b/docs/java-grader/index.md
@@ -51,11 +51,14 @@ A full `info.json` file should look something like:
   "singleVariant": true,
   "gradingMethod": "External",
   "externalGradingOptions": {
-    "image": "prairielearn/grader-java",
-    "timeout": 10
+    "image": "prairielearn/grader-java"
   }
 }
 ```
+
+!!! note "Timeouts"
+
+    The `timeout` field in the `externalGradingOptions` dictionary, if set, should be long enough to allow the autograder to both compile and run all tests. The default timeout of 30 seconds is typically sufficient for most questions, but instructors may want to adjust this value based on the expected complexity of the question and the number of tests. Note that `javac` may take a few seconds just to compile the student code and the test files, so a timeout of less than 10 seconds may cause a timeout even before the student code itself runs. Longer timeouts are encouraged for more complex questions that require additional compilation time, or questions with a large number of tests or with tests that take a long time to run.
 
 ### `question.html`
 
@@ -153,7 +156,6 @@ By default, the Java compiler will show all compilation warnings to the user, ex
 {
   "externalGradingOptions": {
     "image": "prairielearn/grader-java",
-    "timeout": 10,
     "environment": {
       "JDK_JAVAC_OPTIONS": "-Xlint:-static -Xmaxerrs 3",
       "JDK_JAVA_OPTIONS": "-ea"
@@ -184,8 +186,7 @@ Some questions may include libraries and base classes that are common across mul
 {
   "externalGradingOptions": {
     "image": "prairielearn/grader-java",
-    "serverFilesCourse": ["java/libs/"],
-    "timeout": 10
+    "serverFilesCourse": ["java/libs/"]
   }
 }
 ```

--- a/exampleCourse/questions/demo/autograder/java/helloWorld/info.json
+++ b/exampleCourse/questions/demo/autograder/java/helloWorld/info.json
@@ -8,7 +8,6 @@
   "gradingMethod": "External",
   "externalGradingOptions": {
     "image": "prairielearn/grader-java",
-    "timeout": 10,
     "environment": { "JDK_JAVAC_OPTIONS": "--release 11" }
   }
 }

--- a/exampleCourse/questions/demo/autograder/java/square/info.json
+++ b/exampleCourse/questions/demo/autograder/java/square/info.json
@@ -6,8 +6,5 @@
   "type": "v3",
   "singleVariant": true,
   "gradingMethod": "External",
-  "externalGradingOptions": {
-    "image": "prairielearn/grader-java",
-    "timeout": 20
-  }
+  "externalGradingOptions": { "image": "prairielearn/grader-java" }
 }

--- a/exampleCourse/questions/demo/workspace/vscode-java/info.json
+++ b/exampleCourse/questions/demo/workspace/vscode-java/info.json
@@ -13,8 +13,5 @@
   },
   "gradingMethod": "External",
   "showCorrectAnswer": false,
-  "externalGradingOptions": {
-    "image": "prairielearn/grader-java",
-    "timeout": 5
-  }
+  "externalGradingOptions": { "image": "prairielearn/grader-java" }
 }


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #15270. The Java grader takes a few seconds to compile code, so a timeout that is too short would be triggered in some cases even before the code itself runs.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: some assistance in the phrasing of the docs warning.

# Testing

No change in code behaviour, the affected questions run within the allotted time with typical submissions.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
