### PR TITLE
Improve self-enrollment settings UI

### DIFF
--- a/apps/prairielearn/src/components/CourseInstanceSelfEnrollmentForm.tsx
+++ b/apps/prairielearn/src/components/CourseInstanceSelfEnrollmentForm.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
@@ -44,11 +45,11 @@ export function CourseInstanceSelfEnrollmentForm({ formId }: { formId: string })
           Allow self-enrollment
         </label>
         <div className="small text-muted">
-          If not checked, students will need to be invited to this course instance.
+          If self-enrollment is disabled, students must be invited to this course instance.
         </div>
       </div>
 
-      <div className="mb-3 form-check">
+      <div className={clsx('mb-3 form-check', !selfEnrollmentEnabled && 'd-none')}>
         <input
           className="form-check-input"
           type="checkbox"
@@ -65,10 +66,10 @@ export function CourseInstanceSelfEnrollmentForm({ formId }: { formId: string })
           className="form-check-label"
           htmlFor={`${formId}-self-enrollment-use-enrollment-code`}
         >
-          Use enrollment code for self-enrollment
+          Require enrollment code for self-enrollment
         </label>
         <div className="small text-muted">
-          If not checked, any link to anything in the course instance will allow self-enrollment.
+          If an enrollment code is not required, any course instance link allows self-enrollment.
         </div>
       </div>
     </>

--- a/apps/prairielearn/src/components/CourseInstanceSelfEnrollmentForm.tsx
+++ b/apps/prairielearn/src/components/CourseInstanceSelfEnrollmentForm.tsx
@@ -69,7 +69,8 @@ export function CourseInstanceSelfEnrollmentForm({ formId }: { formId: string })
           Require enrollment code for self-enrollment
         </label>
         <div className="small text-muted">
-          If an enrollment code is not required, any course instance link allows self-enrollment.
+          If an enrollment code is not required, any course instance or assessment link allows
+          self-enrollment.
         </div>
       </div>
     </>

--- a/apps/prairielearn/src/components/LinkSharing.tsx
+++ b/apps/prairielearn/src/components/LinkSharing.tsx
@@ -62,15 +62,13 @@ export function PublicLinkSharing({
 export function StudentLinkSharing({
   studentLink,
   studentLinkMessage,
-  className = 'mb-3',
 }: {
   studentLink: string;
   studentLinkMessage: string;
-  className?: string;
 }) {
   const [showQR, setShowQR] = useState(false);
   return (
-    <div className={className}>
+    <div className="mb-0">
       <label className="form-label" htmlFor="student_link">
         Student link
       </label>

--- a/apps/prairielearn/src/components/LinkSharing.tsx
+++ b/apps/prairielearn/src/components/LinkSharing.tsx
@@ -62,13 +62,15 @@ export function PublicLinkSharing({
 export function StudentLinkSharing({
   studentLink,
   studentLinkMessage,
+  className = 'mb-3',
 }: {
   studentLink: string;
   studentLinkMessage: string;
+  className?: string;
 }) {
   const [showQR, setShowQR] = useState(false);
   return (
-    <div className="mb-3">
+    <div className={className}>
       <label className="form-label" htmlFor="student_link">
         Student link
       </label>

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
@@ -1103,6 +1103,7 @@ function InstructorAssessmentSettingsInner({
               <StudentLinkSharing
                 studentLink={studentLink}
                 studentLinkMessage="The link that students will use to access this assessment."
+                className="mb-0"
               />
             </div>
           </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentSettings/instructorAssessmentSettings.html.tsx
@@ -1103,7 +1103,6 @@ function InstructorAssessmentSettingsInner({
               <StudentLinkSharing
                 studentLink={studentLink}
                 studentLinkMessage="The link that students will use to access this assessment."
-                className="mb-0"
               />
             </div>
           </div>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/SelfEnrollmentSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/SelfEnrollmentSettings.tsx
@@ -54,7 +54,7 @@ function SelfEnrollmentLink({
   const [showConfirm, setShowConfirm] = useState(false);
   return (
     <>
-      <div className="mb-3">
+      <div className="mb-0">
         <label className="form-label" htmlFor="self_enrollment_link">
           Self-enrollment link
         </label>
@@ -219,7 +219,7 @@ export function SelfEnrollmentSettings({
           Allow self-enrollment
         </label>
         <div className="small text-muted">
-          If not checked, students will need to be invited to this course instance.
+          If self-enrollment is disabled, students must be invited to this course instance.
         </div>
       </div>
 
@@ -240,10 +240,10 @@ export function SelfEnrollmentSettings({
           />
         )}
         <label className="form-check-label" htmlFor="self_enrollment_use_enrollment_code">
-          Use enrollment code for self-enrollment
+          Require enrollment code for self-enrollment
         </label>
         <div className="small text-muted">
-          If not checked, any link to anything in the course instance will allow self-enrollment.
+          If an enrollment code is not required, any course instance link allows self-enrollment.
         </div>
       </div>
 
@@ -267,7 +267,7 @@ export function SelfEnrollmentSettings({
           Restrict self-enrollment to institution "{institution.long_name}"
         </label>
         <div className="small text-muted">
-          If not checked, users from any institution can self-enroll.
+          If the institution restriction is disabled, users from any institution can self-enroll.
         </div>
       </div>
 
@@ -361,6 +361,7 @@ export function SelfEnrollmentSettings({
         <StudentLinkSharing
           studentLink={studentLink}
           studentLinkMessage={`This is the link that students will use to ${selfEnrollmentEnabled ? 'access the course' : 'accept invitations'}. You can copy this link to share with students.`}
+          className="mb-0"
         />
       )}
     </>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/SelfEnrollmentSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/SelfEnrollmentSettings.tsx
@@ -243,7 +243,8 @@ export function SelfEnrollmentSettings({
           Require enrollment code for self-enrollment
         </label>
         <div className="small text-muted">
-          If an enrollment code is not required, any course instance link allows self-enrollment.
+          If an enrollment code is not required, any course instance or assessment link allows
+          self-enrollment.
         </div>
       </div>
 
@@ -361,7 +362,6 @@ export function SelfEnrollmentSettings({
         <StudentLinkSharing
           studentLink={studentLink}
           studentLinkMessage={`This is the link that students will use to ${selfEnrollmentEnabled ? 'access the course' : 'accept invitations'}. You can copy this link to share with students.`}
-          className="mb-0"
         />
       )}
     </>


### PR DESCRIPTION
# Description

Improves the self-enrollment settings UI by hiding the enrollment-code option when self-enrollment is disabled, renaming the option to "Require enrollment code for self-enrollment," and replacing checkbox-mechanics copy with state-based descriptions.

Also removes the extra bottom margin below student/self-enrollment link controls on course instance and assessment settings pages.

AI assistance: majority of implementation completed by Codex.

# Testing

I manually verified the updated settings pages.
