### PR TITLE
Use labels to define workspace home and port

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.html.tsx
@@ -576,7 +576,6 @@ export const InstructorQuestionSettingsForm = ({
                     defaultValue={defaultValues.workspace_port}
                     aria-errormessage={errors.workspace_port ? 'workspace_port-error' : undefined}
                     {...register('workspace_port', {
-                      required: 'Port is required for workspace',
                       validate: (value) => {
                         if (value === '') return true;
                         const n = Number(value);
@@ -591,7 +590,8 @@ export const InstructorQuestionSettingsForm = ({
                     </div>
                   )}
                   <small className="form-text text-muted">
-                    The port number used in the Docker image.
+                    The port number used in the Docker image. If not provided, the default port for
+                    the image will be used.
                   </small>
                 </div>
 
@@ -607,9 +607,7 @@ export const InstructorQuestionSettingsForm = ({
                     aria-invalid={!!errors.workspace_home || undefined}
                     defaultValue={defaultValues.workspace_home}
                     aria-errormessage={errors.workspace_home ? 'workspace_home-error' : undefined}
-                    {...register('workspace_home', {
-                      required: 'Home is required for workspace',
-                    })}
+                    {...register('workspace_home')}
                   />
                   {errors.workspace_home && (
                     <div id="workspace_home-error" className="invalid-feedback">
@@ -617,7 +615,8 @@ export const InstructorQuestionSettingsForm = ({
                     </div>
                   )}
                   <small className="form-text text-muted">
-                    The home directory of the workspace container.
+                    The home directory of the workspace container. If not provided, the default home
+                    directory for the image will be used.
                   </small>
                 </div>
 

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
@@ -408,9 +408,9 @@ router.post(
       };
 
       // We'll only write the workspace options if the request contains the
-      // required fields. Client-side validation will ensure that these are
-      // present if a workspace is configured.
-      if (workspaceOptions.image && workspaceOptions.port && workspaceOptions.home) {
+      // image. Client-side validation will ensure that it is present if a
+      // workspace is configured.
+      if (workspaceOptions.image) {
         const filteredOptions = Object.fromEntries(
           Object.entries(
             propertyValueWithDefault(

--- a/apps/prairielearn/src/schemas/infoQuestion.ts
+++ b/apps/prairielearn/src/schemas/infoQuestion.ts
@@ -109,6 +109,8 @@ const WorkspaceOptionsJsonSchema = z
     port: z
       .number()
       .int()
+      .min(1)
+      .max(65535)
       .optional()
       .describe(
         'The port number used in the Docker image. If not specified, the port is retrieved from the workspace image labels.',

--- a/apps/prairielearn/src/schemas/infoQuestion.ts
+++ b/apps/prairielearn/src/schemas/infoQuestion.ts
@@ -106,8 +106,19 @@ const WorkspaceOptionsJsonSchema = z
       .describe(
         'The Docker image that will be used to serve this question. Should be specified as Dockerhub image.',
       ),
-    port: z.number().int().describe('The port number used in the Docker image.'),
-    home: z.string().describe('The home directory of the workspace container.'),
+    port: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        'The port number used in the Docker image. If not specified, the port is retrieved from the workspace image labels.',
+      ),
+    home: z
+      .string()
+      .optional()
+      .describe(
+        'The home directory of the workspace container. If not specified, the home directory is retrieved from the workspace image labels.',
+      ),
     args: z
       .union([z.string(), z.array(z.string())])
       .describe('Command line arguments to pass to the Docker container.')

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -286,14 +286,14 @@
           "description": "The Docker image that will be used to serve this question. Should be specified as Dockerhub image."
         },
         "port": {
+          "description": "The port number used in the Docker image. If not specified, the port is retrieved from the workspace image labels.",
           "type": "integer",
           "minimum": -9007199254740991,
-          "maximum": 9007199254740991,
-          "description": "The port number used in the Docker image."
+          "maximum": 9007199254740991
         },
         "home": {
-          "type": "string",
-          "description": "The home directory of the workspace container."
+          "description": "The home directory of the workspace container. If not specified, the home directory is retrieved from the workspace image labels.",
+          "type": "string"
         },
         "args": {
           "anyOf": [
@@ -349,7 +349,7 @@
           "deprecated": true
         }
       },
-      "required": ["image", "port", "home"],
+      "required": ["image"],
       "additionalProperties": false,
       "description": "Options for workspace questions."
     },

--- a/apps/prairielearn/src/schemas/schemas/infoQuestion.json
+++ b/apps/prairielearn/src/schemas/schemas/infoQuestion.json
@@ -288,8 +288,8 @@
         "port": {
           "description": "The port number used in the Docker image. If not specified, the port is retrieved from the workspace image labels.",
           "type": "integer",
-          "minimum": -9007199254740991,
-          "maximum": 9007199254740991
+          "minimum": 1,
+          "maximum": 65535
         },
         "home": {
           "description": "The home directory of the workspace container. If not specified, the home directory is retrieved from the workspace image labels.",

--- a/apps/prairielearn/src/tests/instructorQuestionSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorQuestionSettings.test.ts
@@ -331,8 +331,8 @@ describe('Editing question settings', () => {
         topic: 'Test',
         grading_method: 'Internal',
         workspace_image: 'test_image',
-        workspace_port: '1234',
-        workspace_home: '/home/test',
+        workspace_port: '',
+        workspace_home: '',
         workspace_graded_files: 'test_file.txt',
         workspace_args: '',
         workspace_environment: '',
@@ -344,8 +344,8 @@ describe('Editing question settings', () => {
 
     const questionInfo = JSON.parse(await fs.readFile(questionLiveInfoPath, 'utf8'));
     assert.equal(questionInfo.workspaceOptions.image, 'test_image');
-    assert.equal(questionInfo.workspaceOptions.port, 1234);
-    assert.equal(questionInfo.workspaceOptions.home, '/home/test');
+    assert.notExists(questionInfo.workspaceOptions.port);
+    assert.notExists(questionInfo.workspaceOptions.home);
     assert.equal(questionInfo.workspaceOptions.gradedFiles, 'test_file.txt');
     assert.notExists(questionInfo.workspaceOptions.args);
     assert.notExists(questionInfo.workspaceOptions.environment);

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -1022,12 +1022,12 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
     try {
       await workspaceUtils.updateWorkspaceMessage(workspace.id, 'Creating container');
       container = await _createContainer(workspace);
-    } catch (err) {
+    } catch (err: any) {
       logger.error(`Error creating container for workspace ${workspace.id}`, err);
       safeUpdateWorkspaceState(
         workspace.id,
         'stopped',
-        'Error creating container. Click "Reboot" to try again.',
+        `Error creating container${err.message ? `: ${err.message}` : ''}. Click "Reboot" to try again.`,
       );
       return; // don't set host to unhealthy
     }

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -845,7 +845,7 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
       throw new Error('Workspace port not specified in question settings or image labels');
     }
     const port = Number(portStr);
-    if (!Number.isNaN(port) || port <= 0 || port > 65535) {
+    if (Number.isNaN(port) || port <= 0 || port > 65535) {
       throw new Error('Workspace port is not a valid port number');
     }
     return [home, port];

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -836,14 +836,18 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
     const inspectResults = await docker.getImage(settings.workspace_image).inspect();
     const labels = inspectResults.Config.Labels;
     const home = settings.workspace_home ?? labels?.['com.prairielearn.workspace.home'];
-    const port = settings.workspace_port ?? labels?.['com.prairielearn.workspace.port'];
+    const portStr = settings.workspace_port ?? labels?.['com.prairielearn.workspace.port'];
     if (home == null) {
       throw new Error(
         'Workspace home directory not specified in question settings or image labels',
       );
     }
-    if (port == null) {
+    if (portStr == null) {
       throw new Error('Workspace port not specified in question settings or image labels');
+    }
+    const port = Number(portStr);
+    if (!Number.isNaN(port) || port <= 0 || port > 65535) {
+      throw new Error('Workspace port is not a valid port number');
     }
     return [home, port];
   });

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -92,6 +92,13 @@ interface Workspace {
   settings: WorkspaceSettings;
 }
 
+class SafeForStudentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SafeForStudentError';
+  }
+}
+
 let server: http.Server | undefined;
 const workspace_server_settings: WorkspaceServerSettings = {};
 
@@ -837,16 +844,18 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
     const home = settings.workspace_home ?? labels?.['com.prairielearn.workspace.home'];
     const portStr = settings.workspace_port ?? labels?.['com.prairielearn.workspace.port'];
     if (home == null) {
-      throw new Error(
+      throw new SafeForStudentError(
         'Workspace home directory not specified in question settings or image labels',
       );
     }
     if (portStr == null) {
-      throw new Error('Workspace port not specified in question settings or image labels');
+      throw new SafeForStudentError(
+        'Workspace port not specified in question settings or image labels',
+      );
     }
     const port = Number(portStr);
     if (Number.isNaN(port) || port <= 0 || port > 65535) {
-      throw new Error('Workspace port is not a valid port number');
+      throw new SafeForStudentError('Workspace port is not a valid port number');
     }
     return [home, port];
   });
@@ -1026,7 +1035,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
       safeUpdateWorkspaceState(
         workspace.id,
         'stopped',
-        `Error creating container${err.message ? `: ${err.message}` : ''}. Click "Reboot" to try again.`,
+        `Error creating container${err instanceof SafeForStudentError ? `: ${err.message}` : ''}. Click "Reboot" to try again.`,
       );
       return; // don't set host to unhealthy
     }

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -978,7 +978,6 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
     const workspace = await run(async () => {
       try {
         debug('init: configuring workspace');
-        const settings = await _getWorkspaceSettings(workspace_id);
         return {
           id: workspace_id,
           course_id,
@@ -988,7 +987,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
           local_name: `workspace-${uuid}`,
           remote_name: `workspace-${workspace_id}-${version}`,
           launch_port: await _allocateContainerPort(workspace_id),
-          settings,
+          settings: await _getWorkspaceSettings(workspace_id),
         } satisfies Workspace;
       } catch (err) {
         logger.error(`Error configuring workspace ${workspace_id}`, err);

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -65,8 +65,8 @@ const PortOccupiedSchema = z.boolean();
 
 const WorkspaceSettingsRowSchema = z.object({
   workspace_image: z.string(),
-  workspace_port: z.number(),
-  workspace_home: z.string(),
+  workspace_port: z.number().nullable(),
+  workspace_home: z.string().nullable(),
   workspace_graded_files: z.array(z.string()),
   workspace_args: z.string().nullable(),
   workspace_enable_networking: z.boolean().nullable(),
@@ -828,7 +828,25 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
   // Where we are putting the job files relative to the server (`/jobs` inside Docker container).
   const workspaceJobPath = path.join(jobDirectory, remote_name, 'current');
 
-  const containerPath = settings.workspace_home;
+  const [containerPath, workspacePort] = await run(async () => {
+    if (settings.workspace_home != null && settings.workspace_port != null) {
+      return [settings.workspace_home, settings.workspace_port];
+    }
+    logger.verbose('Retrieving workspace labels from image');
+    const inspectResults = await docker.getImage(settings.workspace_image).inspect();
+    const labels = inspectResults.Config.Labels;
+    const home = settings.workspace_home ?? labels?.['com.prairielearn.workspace.home'];
+    const port = settings.workspace_port ?? labels?.['com.prairielearn.workspace.port'];
+    if (home == null) {
+      throw new Error(
+        'Workspace home directory not specified in question settings or image labels',
+      );
+    }
+    if (port == null) {
+      throw new Error('Workspace port not specified in question settings or image labels');
+    }
+    return [home, port];
+  });
   const args = settings.workspace_args.trim();
 
   let networkMode = 'bridge';
@@ -841,14 +859,14 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
   }
 
   debug(`Creating docker container for image=${settings.workspace_image}`);
-  debug(`Exposed port: ${settings.workspace_port}`);
+  debug(`Exposed port: ${workspacePort}`);
   debug(`Networking enabled: ${settings.workspace_enable_networking}`);
   debug(`Network mode: ${networkMode}`);
   debug(`Env vars: ${settings.workspace_environment}`);
   debug(
     `User binding: ${config.workspaceJobsDirectoryOwnerUid}:${config.workspaceJobsDirectoryOwnerGid}`,
   );
-  debug(`Port binding: ${settings.workspace_port}:${launch_port}`);
+  debug(`Port binding: ${workspacePort}:${launch_port}`);
   debug(`Volume mount: ${workspacePath}:${containerPath}`);
   debug(`Container name: ${local_name}`);
 
@@ -866,13 +884,13 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
   const container = await docker.createContainer({
     Image: settings.workspace_image,
     ExposedPorts: {
-      [`${settings.workspace_port}/tcp`]: {},
+      [`${workspacePort}/tcp`]: {},
     },
     Env: settings.workspace_environment,
     User: `${config.workspaceJobsDirectoryOwnerUid}:${config.workspaceJobsDirectoryOwnerGid}`,
     HostConfig: {
       PortBindings: {
-        [`${settings.workspace_port}/tcp`]: [{ HostPort: `${launch_port}` }],
+        [`${workspacePort}/tcp`]: [{ HostPort: `${launch_port}` }],
       },
       Binds: [`${workspacePath}:${containerPath}`],
       Memory: config.workspaceDockerMemory,
@@ -960,6 +978,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
     const workspace = await run(async () => {
       try {
         debug('init: configuring workspace');
+        const settings = await _getWorkspaceSettings(workspace_id);
         return {
           id: workspace_id,
           course_id,
@@ -969,7 +988,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
           local_name: `workspace-${uuid}`,
           remote_name: `workspace-${workspace_id}-${version}`,
           launch_port: await _allocateContainerPort(workspace_id),
-          settings: await _getWorkspaceSettings(workspace_id),
+          settings,
         } satisfies Workspace;
       } catch (err) {
         logger.error(`Error configuring workspace ${workspace_id}`, err);
@@ -1093,7 +1112,7 @@ async function initSequence(workspace_id: string | number, useInitialZip: boolea
 
 async function sendGradedFilesArchive(workspace_id: string | number, res: Response) {
   const workspace = await _getWorkspace(workspace_id);
-  const workspaceSettings = await _getWorkspaceSettings(workspace_id);
+  const { workspace_graded_files } = await _getWorkspaceSettings(workspace_id);
   const timestamp = new Date().toISOString().replaceAll(/[-T:.]/g, '-');
   const zipName = `${workspace.remote_name}-${timestamp}.zip`;
   const workspaceDir = path.join(config.workspaceHostHomeDirRoot, workspace.remote_name, 'current');
@@ -1102,7 +1121,7 @@ async function sendGradedFilesArchive(workspace_id: string | number, res: Respon
   try {
     gradedFiles = await workspaceUtils.getWorkspaceGradedFiles(
       workspaceDir,
-      workspaceSettings.workspace_graded_files,
+      workspace_graded_files,
       {
         maxFiles: config.workspaceMaxGradedFilesCount,
         maxSize: config.workspaceMaxGradedFilesSize,

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -832,7 +832,6 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
     if (settings.workspace_home != null && settings.workspace_port != null) {
       return [settings.workspace_home, settings.workspace_port];
     }
-    logger.verbose('Retrieving workspace labels from image');
     const inspectResults = await docker.getImage(settings.workspace_image).inspect();
     const labels = inspectResults.Config.Labels;
     const home = settings.workspace_home ?? labels?.['com.prairielearn.workspace.home'];

--- a/docs/workspaces/index.md
+++ b/docs/workspaces/index.md
@@ -48,8 +48,8 @@ The question's `info.json` should set the `singleVariant` and `workspaceOptions`
   - Note that new variants will still be generated in `Staff view`
 - `workspaceOptions` contains the following properties:
   - `image`: Docker Hub image serving the IDE and containing the desired compilers, debuggers, etc.
-  - `port`: port number used by the workspace app inside the Docker image
-  - `home`: home directory inside the Docker image -- this should match the running user's home directory specified by the image maintainer and can't be used (for example) to switch the running user or their home directory
+  - `port` (optional): port number used by the workspace app inside the Docker image. This is only required if the image doesn't provide a default port in its labels. If not provided, PrairieLearn will retrieve the port from the `com.prairielearn.workspace.port` label in the image. For PrairieLearn-maintained workspace images (or custom images using those as a base), the port is always provided in the image labels, so it doesn't need to be included in `info.json`.
+  - `home` (optional): home directory inside the Docker image -- this should match the running user's home directory specified by the image maintainer and can't be used (for example) to switch the running user or their home directory. If not provided, PrairieLearn will retrieve the home directory from the `com.prairielearn.workspace.home` label in the image. For PrairieLearn-maintained workspace images (or custom images using those as a base), the home directory is always provided in the image labels, so it doesn't need to be included in `info.json`.
   - `gradedFiles` (optional, default none): list of file paths (relative to the `home` path) that will be copied out of the workspace container when saving a submission. These files can then be used for grading (either auto-grading or manual grading), previewed in the submission panel, and included in instructor submission downloads. Files can be in subdirectories, but the files must be explicitly listed (e.g. `dir/file.txt`) or use wildcards (e.g., `dir/*`). If a file is in a subdirectory, the relative path to the file will be reconstructed inside the autograder. Wildcards are allowed (e.g., you can specify `dir/*.c`) and will match any files in the workspace that match them. Paths with wildcards are considered optional. The following wildcards are supported:
     - `*` matches everything except path separators and hidden files (names starting with `.`).
     - `**` can be used to identify files in all subdirectories of the workspace (e.g., `**/*.py` will copy the files with `.py` extension in the home directory and in all its subdirectories).
@@ -75,10 +75,7 @@ For an ungraded workspace, a full `info.json` file should look something like:
     "type": "v3",
     "singleVariant": true,
     "workspaceOptions": {
-        "image": "codercom/code-server",
-        "port": 8080,
-        "home": "/home/coder",
-        "args": "--auth none"
+        "image": "prairielearn/workspace-vscode-python"
     }
 }
 ```
@@ -96,10 +93,7 @@ For an externally graded workspace, a full `info.json` file should look somethin
     "type": "v3",
     "singleVariant": true,
     "workspaceOptions": {
-        "image": "codercom/code-server",
-        "port": 8080,
-        "home": "/home/coder",
-        "args": "--auth none",
+        "image": "prairielearn/workspace-vscode-cpp",
         "gradedFiles": [
             "starter_code.h",
             "starter_code.c",
@@ -108,8 +102,7 @@ For an externally graded workspace, a full `info.json` file should look somethin
     },
     "gradingMethod": "External",
     "externalGradingOptions": {
-        "image": "...",
-        "timeout": 20
+        "image": "..."
     }
 }
 ```
@@ -150,7 +143,7 @@ A minimal `question.html` for an externally graded workspace should look somethi
 
 ## Creating files in the workspace home directory
 
-Workspace questions can optionally include a `workspace/` subdirectory within the regular [PrairieLearn question directory structure](../question/overview.md#directory-structure). If this `workspace/` subdirectory exists, its contents will be copied into the home directory of the student's workspace container, as configured in the `home` setting in `info.json`.
+Workspace questions can optionally include a `workspace/` subdirectory within the regular [PrairieLearn question directory structure](../question/overview.md#directory-structure). If this `workspace/` subdirectory exists, its contents will be copied into the home directory of the student's workspace container, as configured in the `home` setting in `info.json` or the Docker image labels.
 
 Questions using workspaces can also be randomized, i.e., include files that contain random and dynamic content. This may be done in two ways: using Mustache-based template files or using [the `server.py` file in the question directory](../question/overview.md#custom-generation-and-grading-serverpy). For template files, a workspace question can optionally include a `workspaceTemplates/` subdirectory within the regular question directory structure. The contents will be copied into the home directory of the student's workspace container, as with the `workspace/` directory. However, files within this directory may include Mustache tags (e.g., `{{params.value}}`), which will be replaced with the equivalent values set by `server.py`. File names may optionally include the `.mustache` extension, and the file will be renamed before being presented to the student. Files in `workspaceTemplates/` will preserve their execute permissions (e.g., if you `chmod +x script.sh` in your course repository, it will remain executable in the workspace). For example, if `server.py` sets `data["params"]["starting_value"]` to `17`, then if the file `main.py.mustache` inside `workspaceTemplates` has the following content:
 

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/info.json
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/info.json
@@ -7,8 +7,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-jupyterlab-python",
-    "port": 8080,
-    "home": "/home/jovyan",
     "rewriteUrl": false
   }
 }

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/info.json
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/info.json
@@ -12,8 +12,6 @@
   },
   "workspaceOptions": {
     "image": "prairielearn/workspace-jupyterlab-python",
-    "port": 8080,
-    "home": "/home/jovyan",
     "rewriteUrl": false,
     "gradedFiles": ["Markov-Chains-2.ipynb"]
   }

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/info.json
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/info.json
@@ -12,8 +12,6 @@
   },
   "workspaceOptions": {
     "image": "prairielearn/workspace-jupyterlab-python",
-    "port": 8080,
-    "home": "/home/jovyan",
     "rewriteUrl": false,
     "gradedFiles": ["Markov-Chains-1.ipynb"]
   }

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/info.json
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/info.json
@@ -12,8 +12,6 @@
   },
   "workspaceOptions": {
     "image": "prairielearn/workspace-jupyterlab-python",
-    "port": 8080,
-    "home": "/home/jovyan",
     "rewriteUrl": false,
     "gradedFiles": ["Markov-Chains-3.ipynb"]
   }

--- a/exampleCourse/questions/demo/workspace/dynamicFiles/info.json
+++ b/exampleCourse/questions/demo/workspace/dynamicFiles/info.json
@@ -7,8 +7,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-xtermjs",
-    "port": 8080,
-    "home": "/home/student",
     "gradedFiles": ["dynamic.txt"]
   }
 }

--- a/exampleCourse/questions/demo/workspace/jupyterlab-python/info.json
+++ b/exampleCourse/questions/demo/workspace/jupyterlab-python/info.json
@@ -7,8 +7,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-jupyterlab-python",
-    "port": 8080,
-    "home": "/home/jovyan",
     "rewriteUrl": false,
     "gradedFiles": ["Workbook.ipynb"]
   },

--- a/exampleCourse/questions/demo/workspace/jupyterlab-r/info.json
+++ b/exampleCourse/questions/demo/workspace/jupyterlab-r/info.json
@@ -7,8 +7,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-jupyterlab-r",
-    "port": 8080,
-    "home": "/home/jovyan",
     "rewriteUrl": false,
     "gradedFiles": ["student.ipynb"],
     "environment": {

--- a/exampleCourse/questions/demo/workspace/rstudio/info.json
+++ b/exampleCourse/questions/demo/workspace/rstudio/info.json
@@ -7,10 +7,8 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-rstudio",
-    "port": 3939,
     "args": "",
     "rewriteUrl": false,
-    "home": "/home/rstudio/workspace",
     "gradedFiles": ["student.R"]
   },
   "gradingMethod": "External",

--- a/exampleCourse/questions/demo/workspace/rstudio/info.json
+++ b/exampleCourse/questions/demo/workspace/rstudio/info.json
@@ -7,7 +7,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-rstudio",
-    "args": "",
     "rewriteUrl": false,
     "gradedFiles": ["student.R"]
   },

--- a/exampleCourse/questions/demo/workspace/vscode-cpp/info.json
+++ b/exampleCourse/questions/demo/workspace/vscode-cpp/info.json
@@ -7,8 +7,6 @@
   "type": "v3",
   "workspaceOptions": {
     "image": "prairielearn/workspace-vscode-cpp",
-    "port": 8080,
-    "home": "/home/coder/workspace",
     "gradedFiles": ["source.cpp"]
   },
   "gradingMethod": "External",

--- a/exampleCourse/questions/demo/workspace/vscode-java/info.json
+++ b/exampleCourse/questions/demo/workspace/vscode-java/info.json
@@ -7,8 +7,6 @@
   "type": "v3",
   "workspaceOptions": {
     "image": "prairielearn/workspace-vscode-java",
-    "port": 8080,
-    "home": "/home/coder/workspace",
     "gradedFiles": ["Square.java"]
   },
   "gradingMethod": "External",

--- a/exampleCourse/questions/demo/workspace/vscode-python/info.json
+++ b/exampleCourse/questions/demo/workspace/vscode-python/info.json
@@ -7,8 +7,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-vscode-python",
-    "port": 8080,
-    "home": "/home/coder/workspace",
     "gradedFiles": ["fibonacci.py"]
   },
   "gradingMethod": "External",

--- a/exampleCourse/questions/demo/workspace/xtermjs/info.json
+++ b/exampleCourse/questions/demo/workspace/xtermjs/info.json
@@ -8,8 +8,6 @@
   "workspaceOptions": {
     "comment": { "why": "testing comments in workspace blocks", "also": "testing object comments" },
     "image": "prairielearn/workspace-xtermjs",
-    "port": 8080,
-    "home": "/home/student",
     "gradedFiles": ["**/*.h", "**/*.c"]
   }
 }

--- a/exampleCourse/questions/demo/workspace/xtermjsPython/info.json
+++ b/exampleCourse/questions/demo/workspace/xtermjsPython/info.json
@@ -6,8 +6,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-xtermjs",
-    "port": 8080,
-    "home": "/home/student",
     "args": ["-c", "/usr/bin/python3"]
   }
 }

--- a/testCourse/questions/variantAccess/info.json
+++ b/testCourse/questions/variantAccess/info.json
@@ -5,8 +5,6 @@
   "type": "v3",
   "sharePublicly": true,
   "workspaceOptions": {
-    "image": "prairielearn/workspace-xtermjs",
-    "port": 8080,
-    "home": "/home/prairie"
+    "image": "prairielearn/workspace-xtermjs"
   }
 }

--- a/testCourse/questions/workspace/info.json
+++ b/testCourse/questions/workspace/info.json
@@ -6,8 +6,6 @@
   "type": "v3",
   "workspaceOptions": {
     "image": "prairielearn/workspace-xtermjs",
-    "port": 8080,
-    "home": "/home/prairie",
     "gradedFiles": ["starter_code.h", "starter_code.c"],
     "environment": { "FOO": "bar baz", "ILL": "ini" }
   }

--- a/testCourse/questions/workspaceCustomHome/info.json
+++ b/testCourse/questions/workspaceCustomHome/info.json
@@ -1,0 +1,17 @@
+{
+  "uuid": "17b53928-700f-4e49-b8c2-69249216bb9a",
+  "title": "Workspace demo: custom home directory",
+  "topic": "Workspace",
+  "type": "v3",
+  "singleVariant": true,
+  "workspaceOptions": {
+    "image": "prairielearn/workspace-vscode-python",
+    "home": "/home/coder/workspace/subdir",
+    "gradedFiles": ["fibonacci.py"]
+  },
+  "gradingMethod": "External",
+  "externalGradingOptions": {
+    "image": "prairielearn/grader-python",
+    "timeout": 20
+  }
+}

--- a/testCourse/questions/workspaceCustomHome/question.html
+++ b/testCourse/questions/workspaceCustomHome/question.html
@@ -1,0 +1,19 @@
+<pl-question-panel>
+  <p>This is a workspace question that launches a version of VS Code directly in the browser. Use the "Open workspace" button below to open VS Code.</p>
+
+  <p>
+    The workspace is configured to use a custom home directory, so when you open the terminal in VS Code, the starter code and graded files will be located in the <code>/home/coder/workspace/subdir</code> directory. Files outside this subdirectory will not be included in the submission or saved between reboots.
+  </p>
+
+  <p>Your code snippet should define the following variables:</p>
+  <pl-external-grader-variables params-name="names_from_user">
+    <pl-variable name="fib" type="python function">Function to compute the $n^\text{th}$ Fibonacci number</pl-variable>
+  </pl-external-grader-variables>
+
+  <pl-workspace></pl-workspace>
+</pl-question-panel>
+
+<pl-submission-panel>
+  <pl-external-grader-results></pl-external-grader-results>
+  <pl-file-preview></pl-file-preview>
+</pl-submission-panel>

--- a/testCourse/questions/workspaceCustomHome/tests/ans.py
+++ b/testCourse/questions/workspaceCustomHome/tests/ans.py
@@ -1,0 +1,5 @@
+def fib(n):
+    if n <= 1:
+        return n
+    else:
+        return fib(n - 1) + fib(n - 2)

--- a/testCourse/questions/workspaceCustomHome/tests/test.py
+++ b/testCourse/questions/workspaceCustomHome/tests/test.py
@@ -1,0 +1,39 @@
+import numpy as np
+from code_feedback import Feedback
+from pl_helpers import name, points
+from pl_unit_test import PLTestCase
+
+
+class Test(PLTestCase):
+    student_code_file = "fibonacci.py"
+
+    @points(1)
+    @name("Check fib(1)")
+    def test_1(self):
+        user_val = Feedback.call_user(self.st.fib, 1)
+        if Feedback.check_scalar("fib(1)", self.ref.fib(1), user_val):
+            Feedback.set_score(1)
+        else:
+            Feedback.set_score(0)
+
+    @points(2)
+    @name("Check fib(7)")
+    def test_2(self):
+        user_val = Feedback.call_user(self.st.fib, 7)
+        if Feedback.check_scalar("fib(7)", self.ref.fib(7), user_val):
+            Feedback.set_score(1)
+        else:
+            Feedback.set_score(0)
+
+    @points(3)
+    @name("Check random values")
+    def test_3(self):
+        points = 0
+        num_tests = 10
+        test_values = np.random.choice(np.arange(2, 30), size=num_tests, replace=False)
+        for in_val in test_values:
+            correct_val = self.ref.fib(in_val)
+            user_val = Feedback.call_user(self.st.fib, in_val)
+            if Feedback.check_scalar(f"fib({in_val})", correct_val, user_val):
+                points += 1
+        Feedback.set_score(points / num_tests)

--- a/testCourse/questions/workspaceCustomHome/workspace/fibonacci.py
+++ b/testCourse/questions/workspaceCustomHome/workspace/fibonacci.py
@@ -1,0 +1,2 @@
+def fib(n):
+    pass

--- a/testCourse/questions/workspaceInvalidDynamicFiles/info.json
+++ b/testCourse/questions/workspaceInvalidDynamicFiles/info.json
@@ -6,8 +6,6 @@
   "type": "v3",
   "workspaceOptions": {
     "image": "prairielearn/workspace-xtermjs",
-    "port": 8080,
-    "home": "/home/prairie",
     "gradedFiles": []
   }
 }

--- a/testCourse/questions/workspaceVSCode/info.json
+++ b/testCourse/questions/workspaceVSCode/info.json
@@ -6,8 +6,6 @@
   "singleVariant": true,
   "workspaceOptions": {
     "image": "prairielearn/workspace-vscode-python",
-    "port": 8080,
-    "home": "/home/coder/workspace",
     "gradedFiles": ["fibonacci.py"]
   },
   "gradingMethod": "External",

--- a/workspaces/jupyterlab-base/Dockerfile
+++ b/workspaces/jupyterlab-base/Dockerfile
@@ -2,6 +2,7 @@ FROM quay.io/jupyter/minimal-notebook:2025-08-04
 ARG CACHEBUST=2026-06-15-15-59-28
 LABEL com.prairielearn.workspace.home="/home/jovyan"
 LABEL com.prairielearn.workspace.port="8080"
+LABEL com.prairielearn.workspace.rewrite-url="false"
 
 ENV XDG_DATA_HOME=/tmp/local/share
 ENV XDG_CACHE_HOME=/tmp/cache

--- a/workspaces/jupyterlab-base/Dockerfile
+++ b/workspaces/jupyterlab-base/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/jupyter/minimal-notebook:2025-08-04
 ARG CACHEBUST=2026-06-15-15-59-28
+LABEL com.prairielearn.workspace.home="/home/jovyan"
+LABEL com.prairielearn.workspace.port="8080"
 
 ENV XDG_DATA_HOME=/tmp/local/share
 ENV XDG_CACHE_HOME=/tmp/cache

--- a/workspaces/rstudio/Dockerfile
+++ b/workspaces/rstudio/Dockerfile
@@ -45,6 +45,7 @@ FROM rocker/rstudio:4.6.0
 ARG CACHEBUST=2026-06-15-15-59-28
 LABEL com.prairielearn.workspace.home="/home/rstudio/workspace"
 LABEL com.prairielearn.workspace.port="3939"
+LABEL com.prairielearn.workspace.rewrite-url="false"
 
 # On PL, we need to use 1001:1001 for the default user account. We adjust the
 # pre-existing rstudio user which is typically uid 1000 otherwise.

--- a/workspaces/rstudio/Dockerfile
+++ b/workspaces/rstudio/Dockerfile
@@ -31,7 +31,6 @@
 
 #    "workspaceOptions": {
 #        "image": "prairielearn/workspace-rstudio",
-#        "args": "",
 #        "rewriteUrl": false
 #    }
 

--- a/workspaces/rstudio/Dockerfile
+++ b/workspaces/rstudio/Dockerfile
@@ -31,10 +31,8 @@
 
 #    "workspaceOptions": {
 #        "image": "prairielearn/workspace-rstudio",
-#        "port": 3939,
 #        "args": "",
-#        "rewriteUrl": false,
-#        "home": "/home/rstudio/workspace"
+#        "rewriteUrl": false
 #    }
 
 # If you just want to use RStudio locally for its own sake:
@@ -46,6 +44,8 @@
 
 FROM rocker/rstudio:4.6.0
 ARG CACHEBUST=2026-06-15-15-59-28
+LABEL com.prairielearn.workspace.home="/home/rstudio/workspace"
+LABEL com.prairielearn.workspace.port="3939"
 
 # On PL, we need to use 1001:1001 for the default user account. We adjust the
 # pre-existing rstudio user which is typically uid 1000 otherwise.

--- a/workspaces/vscode-base/Dockerfile
+++ b/workspaces/vscode-base/Dockerfile
@@ -3,6 +3,7 @@ FROM codercom/code-server:4.123.0-noble
 ARG CACHEBUST=2026-06-15-15-59-28
 LABEL com.prairielearn.workspace.home="/home/coder/workspace" 
 LABEL com.prairielearn.workspace.port="8080"
+LABEL com.prairielearn.workspace.rewrite-url="true"
 
 # On PL, we want to standardize on using 1001:1001 for the user. We change the
 # "coder" account's UID and GID here so that fixuid has no work to do later.

--- a/workspaces/vscode-base/Dockerfile
+++ b/workspaces/vscode-base/Dockerfile
@@ -1,6 +1,8 @@
 # noble is the codename for Ubuntu 24.04 LTS
 FROM codercom/code-server:4.123.0-noble
 ARG CACHEBUST=2026-06-15-15-59-28
+LABEL com.prairielearn.workspace.home="/home/coder/workspace" 
+LABEL com.prairielearn.workspace.port="8080"
 
 # On PL, we want to standardize on using 1001:1001 for the user. We change the
 # "coder" account's UID and GID here so that fixuid has no work to do later.

--- a/workspaces/xtermjs/Dockerfile
+++ b/workspaces/xtermjs/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:26-trixie
 ARG CACHEBUST=2026-06-15-15-59-28
+LABEL com.prairielearn.workspace.home="/home/student"
+LABEL com.prairielearn.workspace.port="8080"
 
 RUN apt-get update \
     && apt-get upgrade -y \

--- a/workspaces/xtermjs/Dockerfile
+++ b/workspaces/xtermjs/Dockerfile
@@ -2,6 +2,7 @@ FROM node:26-trixie
 ARG CACHEBUST=2026-06-15-15-59-28
 LABEL com.prairielearn.workspace.home="/home/student"
 LABEL com.prairielearn.workspace.port="8080"
+LABEL com.prairielearn.workspace.rewrite-url="true"
 
 RUN apt-get update \
     && apt-get upgrade -y \


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Initial handling of #11927. Uses Docker image labels to set defaults for workspace home and port settings. This simplifies the configuration of workspace settings, since instructors no longer need to set these values explicitly and can rely on the defaults associated to the workspace image.

The "rewriteUrl" setting was not updated yet because it is needed in the PrairieLearn app, not the workspace host, so it needs to either be retrieved in a different part of the code or be sent through some means as info from the host to PL. This is left as pending, as mentioned in the issue comments.

Labels are retrieved from docker inspect at the time the container is created. They are not cached in any way. If it is deemed that the cost of a docker inspect is worth caching these, that could be done in a future PR, but I don't think it is worth pursuing at this point.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: minor.

# Testing

Initial testing was successful: settings are used if available, labels are used if settings are not there, and an error is created if neither is set. Further tests in progress (CI does not have a lot of testing for workspaces).

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
