### PR TITLE
Use "net-correct" partial credit strategy on QTI emitted multiple-answer questions

### DIFF
--- a/packages/question-conversion/src/emitters/handlers/checkbox.test.ts
+++ b/packages/question-conversion/src/emitters/handlers/checkbox.test.ts
@@ -17,11 +17,6 @@ describe('checkboxHandler.renderHtml', () => {
     assert.include(html, '</pl-checkbox>');
   });
 
-  it('sets partial-credit="net-correct" to match Canvas grading', () => {
-    const html = checkboxHandler.renderHtml({ type: 'checkbox', choices });
-    assert.include(html, 'partial-credit="net-correct"');
-  });
-
   it('adds order="fixed" when shuffleAnswers is false', () => {
     const html = checkboxHandler.renderHtml({ type: 'checkbox', choices }, false);
     assert.include(html, 'order="fixed"');

--- a/packages/question-conversion/src/emitters/handlers/checkbox.test.ts
+++ b/packages/question-conversion/src/emitters/handlers/checkbox.test.ts
@@ -11,10 +11,15 @@ const choices = [
 describe('checkboxHandler.renderHtml', () => {
   it('renders basic checkbox list', () => {
     const html = checkboxHandler.renderHtml({ type: 'checkbox', choices });
-    assert.include(html, '<pl-checkbox answers-name="answer">');
+    assert.include(html, '<pl-checkbox answers-name="answer" partial-credit="net-correct">');
     assert.include(html, '<pl-answer correct="true">Apple</pl-answer>');
     assert.include(html, '<pl-answer correct="false">Banana</pl-answer>');
     assert.include(html, '</pl-checkbox>');
+  });
+
+  it('sets partial-credit="net-correct" to match Canvas grading', () => {
+    const html = checkboxHandler.renderHtml({ type: 'checkbox', choices });
+    assert.include(html, 'partial-credit="net-correct"');
   });
 
   it('adds order="fixed" when shuffleAnswers is false', () => {

--- a/packages/question-conversion/src/emitters/handlers/checkbox.ts
+++ b/packages/question-conversion/src/emitters/handlers/checkbox.ts
@@ -11,7 +11,9 @@ export const checkboxHandler: BodyEmitHandler = {
     const cb = body as CheckboxBody;
     const deduped = deduplicateChoices(cb.choices);
     const orderAttr = shuffleAnswers === false ? ' order="fixed"' : '';
-    const lines = [`<pl-checkbox answers-name="answer"${orderAttr}>`];
+    // Canvas grants partial credit on multiple-answer questions using a net-correct
+    // strategy, so emit the matching pl-checkbox partial-credit mode.
+    const lines = [`<pl-checkbox answers-name="answer" partial-credit="net-correct"${orderAttr}>`];
     for (const choice of deduped) {
       lines.push(`  <pl-answer correct="${choice.correct}">${choice.html}</pl-answer>`);
     }

--- a/packages/question-conversion/src/emitters/pl-emitter.test.ts
+++ b/packages/question-conversion/src/emitters/pl-emitter.test.ts
@@ -72,7 +72,7 @@ describe('PLEmitter', () => {
     const result = emitter.emit(makeAssessment([q]));
     assert.equal(
       result.questions[0].questionHtml,
-      '<pl-question-panel>\n<p>What is 2+2?</p>\n</pl-question-panel>\n\n<pl-checkbox answers-name="answer">\n  <pl-answer correct="true">A</pl-answer>\n  <pl-answer correct="false">B</pl-answer>\n</pl-checkbox>',
+      '<pl-question-panel>\n<p>What is 2+2?</p>\n</pl-question-panel>\n\n<pl-checkbox answers-name="answer" partial-credit="net-correct">\n  <pl-answer correct="true">A</pl-answer>\n  <pl-answer correct="false">B</pl-answer>\n</pl-checkbox>',
     );
   });
 

--- a/packages/question-conversion/src/pipeline.test.ts
+++ b/packages/question-conversion/src/pipeline.test.ts
@@ -43,7 +43,7 @@ describe('convert (integration)', () => {
       assert.equal(result.questions.length, 1);
       assert.equal(
         result.questions[0].questionHtml,
-        '<pl-question-panel>\n<p>Select all correct answers</p>\n</pl-question-panel>\n\n<pl-checkbox answers-name="answer">\n  <pl-answer correct="true">Correct A</pl-answer>\n  <pl-answer correct="true">Correct B</pl-answer>\n  <pl-answer correct="false">Wrong C</pl-answer>\n</pl-checkbox>',
+        '<pl-question-panel>\n<p>Select all correct answers</p>\n</pl-question-panel>\n\n<pl-checkbox answers-name="answer" partial-credit="net-correct">\n  <pl-answer correct="true">Correct A</pl-answer>\n  <pl-answer correct="true">Correct B</pl-answer>\n  <pl-answer correct="false">Wrong C</pl-answer>\n</pl-checkbox>',
       );
     });
 


### PR DESCRIPTION
> In a QTI pilot call, we observed that Canvas's "multiple answer" questions were being emitted as `<pl-checkbox` without partial-grading attributes, which differs from the standard behavior of these questions in canvas. In order to bring parity to question scoreability from Canvas->PL, we should leverage the `net-correct` partial grading already extant in the PL element

# Description
This PR changes QTI-import-emitted `<pl-checkbox` elements to include `partial-credit="net-correct"`, which imbues into them the expected behavior based on how the same questions were graded in Canvas.

- [X] I have disclosed the level of AI assistance used: Claude executed the change at my direction

# Testing
- Using the `mgt-103-product-marketing-and-management-ehrich-s226-export.imscc` test course export, multiple-answer questions (e.g. Midterm Question 3) manifest as pl-checkbox elements with the aforementioned partial-credit strategy
- tests for QTI `checkbox` and `emitter` are updated to verify the presence of the attribute
- tests pass