### PR TITLE
Clarify after-completion visibility copy

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1851,7 +1851,7 @@ describe('afterComplete cross-field validation', () => {
       issues: [
         {
           ruleIndex: 0,
-          message: /Questions cannot be visible after completion while the score is hidden/,
+          message: /Questions cannot be made visible after completion while the score is hidden/,
         },
       ],
     },
@@ -2027,7 +2027,7 @@ describe('afterComplete cross-field validation', () => {
       issues: [
         {
           ruleIndex: 1,
-          message: /Questions cannot be visible after completion while the score is hidden/,
+          message: /Questions cannot be made visible after completion while the score is hidden/,
         },
       ],
     },

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -1851,7 +1851,7 @@ describe('afterComplete cross-field validation', () => {
       issues: [
         {
           ruleIndex: 0,
-          message: /score cannot be hidden after completion while questions are visible/,
+          message: /Questions cannot be visible after completion while the score is hidden/,
         },
       ],
     },
@@ -2027,7 +2027,7 @@ describe('afterComplete cross-field validation', () => {
       issues: [
         {
           ruleIndex: 1,
-          message: /score cannot be hidden after completion while questions are visible/,
+          message: /Questions cannot be visible after completion while the score is hidden/,
         },
       ],
     },

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -661,7 +661,7 @@ export function getAfterCompleteCrossFieldIssue(
   if (score.hidden && !questions.hidden) {
     return {
       kind: 'score_hidden_requires_questions_hidden',
-      message: 'The score cannot be hidden after completion while questions are visible.',
+      message: 'Questions cannot be visible after completion while the score is hidden.',
     };
   }
   if (!questions.hidden || questions.visibleFromDate === undefined) return null;

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -661,7 +661,7 @@ export function getAfterCompleteCrossFieldIssue(
   if (score.hidden && !questions.hidden) {
     return {
       kind: 'score_hidden_requires_questions_hidden',
-      message: 'Questions cannot be visible after completion while the score is hidden.',
+      message: 'Questions cannot be made visible after completion while the score is hidden.',
     };
   }
   if (!questions.hidden || questions.visibleFromDate === undefined) return null;

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -99,6 +99,7 @@ function QuestionVisibilityInput({
   idPrefix,
   hasPrairieTest = false,
   hasCompletionMechanism = true,
+  error,
   visibleFromDateError,
   visibleUntilDateError,
   displayTimezone,
@@ -108,6 +109,7 @@ function QuestionVisibilityInput({
   idPrefix: string;
   hasPrairieTest?: boolean;
   hasCompletionMechanism?: boolean;
+  error?: string;
   visibleFromDateError?: string;
   visibleUntilDateError?: string;
   displayTimezone: string;
@@ -158,6 +160,7 @@ function QuestionVisibilityInput({
           id={`${idPrefix}-question-visibility-mode`}
           minWidth={300}
           disabled={!ruleEditable}
+          errorMessage={error}
           onChange={handleModeChange}
         />
         {selectedDescription && (
@@ -279,12 +282,14 @@ function ScoreVisibilityInput({
   value,
   onChange,
   idPrefix,
+  error,
   visibleFromDateError,
   displayTimezone,
 }: {
   value: ScoreVisibilityValue;
   onChange: (value: ScoreVisibilityValue) => void;
   idPrefix: string;
+  error?: string;
   visibleFromDateError?: string;
   displayTimezone: string;
 }) {
@@ -323,6 +328,7 @@ function ScoreVisibilityInput({
           id={`${idPrefix}-score-visibility-mode`}
           minWidth={300}
           disabled={!ruleEditable}
+          errorMessage={error}
           onChange={handleModeChange}
         />
         {selectedDescription && (
@@ -440,6 +446,7 @@ export function DefaultAfterCompleteForm({
     errors,
     'defaultRule.questionVisibility.visibleFromDate',
   )?.message;
+  const qvError: string | undefined = get(errors, 'defaultRule.questionVisibility')?.message;
   const visibleUntilDateError: string | undefined = get(
     errors,
     'defaultRule.questionVisibility.visibleUntilDate',
@@ -448,6 +455,7 @@ export function DefaultAfterCompleteForm({
     errors,
     'defaultRule.scoreVisibility.visibleFromDate',
   )?.message;
+  const svError: string | undefined = get(errors, 'defaultRule.scoreVisibility')?.message;
 
   const dateControlEnabled = useWatch<AccessControlFormData, 'defaultRule.dateControlEnabled'>({
     name: 'defaultRule.dateControlEnabled',
@@ -490,6 +498,7 @@ export function DefaultAfterCompleteForm({
         <ScoreVisibilityInput
           value={svField.value}
           idPrefix="defaultRule"
+          error={svError}
           visibleFromDateError={svVisibleFromError}
           displayTimezone={displayTimezone}
           onChange={svField.onChange}
@@ -504,6 +513,7 @@ export function DefaultAfterCompleteForm({
           idPrefix="defaultRule"
           hasPrairieTest={hasPrairieTest}
           hasCompletionMechanism={hasCompletionMechanism}
+          error={qvError}
           visibleFromDateError={qvVisibleFromError}
           visibleUntilDateError={visibleUntilDateError}
           displayTimezone={displayTimezone}
@@ -540,6 +550,7 @@ export function OverrideAfterCompleteForm({
     errors,
     `overrides.${index}.questionVisibility.visibleFromDate`,
   )?.message;
+  const qvError: string | undefined = get(errors, `overrides.${index}.questionVisibility`)?.message;
   const visibleUntilDateError: string | undefined = get(
     errors,
     `overrides.${index}.questionVisibility.visibleUntilDate`,
@@ -548,6 +559,7 @@ export function OverrideAfterCompleteForm({
     errors,
     `overrides.${index}.scoreVisibility.visibleFromDate`,
   )?.message;
+  const svError: string | undefined = get(errors, `overrides.${index}.scoreVisibility`)?.message;
 
   const {
     isOverridden: qvOverridden,
@@ -593,6 +605,7 @@ export function OverrideAfterCompleteForm({
           <ScoreVisibilityInput
             value={svField.value}
             idPrefix={`overrides-${index}`}
+            error={svError}
             visibleFromDateError={svVisibleFromError}
             displayTimezone={displayTimezone}
             onChange={svField.onChange}
@@ -617,6 +630,7 @@ export function OverrideAfterCompleteForm({
             value={qvField.value}
             idPrefix={`overrides-${index}`}
             hasPrairieTest={hasPrairieTest}
+            error={qvError}
             visibleFromDateError={qvVisibleFromError}
             visibleUntilDateError={visibleUntilDateError}
             displayTimezone={displayTimezone}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -26,23 +26,25 @@ const QUESTION_VISIBILITY_ITEMS: RichSelectItem<HideQuestionsMode>[] = [
   {
     value: 'hide_questions_forever',
     label: 'Hide questions permanently',
-    description: 'Questions will never be visible after completion',
+    description: 'Questions and submissions will never be visible after completion',
   },
   {
     value: 'show_questions',
     label: 'Show questions after completion',
     description:
-      'Students can see questions and answers immediately after completing the assessment',
+      'Students can review questions and their submissions immediately after completing the assessment',
   },
   {
     value: 'hide_questions_between_dates',
     label: 'Show questions between dates',
-    description: 'Questions will be visible between these dates, hidden before and after',
+    description:
+      'Questions and submissions will be visible between these dates, hidden before and after',
   },
   {
     value: 'hide_questions_until_date',
     label: 'Show questions after date',
-    description: 'Questions will be hidden after completion and become visible on this date',
+    description:
+      'Questions and submissions will be hidden after completion and become visible on this date',
   },
 ];
 
@@ -50,17 +52,19 @@ const SCORE_VISIBILITY_ITEMS: RichSelectItem<HideScoreMode>[] = [
   {
     value: 'hide_score_forever',
     label: 'Hide score permanently',
-    description: 'Score will never be visible after completion',
+    description: 'The overall assessment score will never be visible after completion',
   },
   {
     value: 'show_score',
     label: 'Show score after completion',
-    description: 'Students can see their score immediately after completing the assessment',
+    description:
+      'Students can see their overall assessment score immediately after completing the assessment',
   },
   {
     value: 'hide_score_until_date',
     label: 'Show score after date',
-    description: 'Score will be hidden after completion and become visible on this date',
+    description:
+      'The overall assessment score will be hidden after completion and become visible on this date',
   },
 ];
 
@@ -480,6 +484,18 @@ export function DefaultAfterCompleteForm({
         </Alert>
       )}
       <div>
+        <Form.Label className="fw-bold" htmlFor="defaultRule-score-visibility-mode">
+          Score visibility
+        </Form.Label>
+        <ScoreVisibilityInput
+          value={svField.value}
+          idPrefix="defaultRule"
+          visibleFromDateError={svVisibleFromError}
+          displayTimezone={displayTimezone}
+          onChange={svField.onChange}
+        />
+      </div>
+      <div>
         <Form.Label className="fw-bold" htmlFor="defaultRule-question-visibility-mode">
           Question visibility
         </Form.Label>
@@ -492,18 +508,6 @@ export function DefaultAfterCompleteForm({
           visibleUntilDateError={visibleUntilDateError}
           displayTimezone={displayTimezone}
           onChange={qvField.onChange}
-        />
-      </div>
-      <div>
-        <Form.Label className="fw-bold" htmlFor="defaultRule-score-visibility-mode">
-          Score visibility
-        </Form.Label>
-        <ScoreVisibilityInput
-          value={svField.value}
-          idPrefix="defaultRule"
-          visibleFromDateError={svVisibleFromError}
-          displayTimezone={displayTimezone}
-          onChange={svField.onChange}
         />
       </div>
     </AfterCompleteCard>
@@ -574,6 +578,29 @@ export function OverrideAfterCompleteForm({
     <AfterCompleteCard title={title}>
       <div>
         <FieldWrapper
+          isOverridden={svOverridden}
+          label="Score visibility"
+          onOverride={() => {
+            svField.onChange({ ...defaultRuleSV });
+            addSvOverride();
+            void trigger(qvField.name);
+          }}
+          onRemoveOverride={() => {
+            removeSvOverride();
+            void trigger(qvField.name);
+          }}
+        >
+          <ScoreVisibilityInput
+            value={svField.value}
+            idPrefix={`overrides-${index}`}
+            visibleFromDateError={svVisibleFromError}
+            displayTimezone={displayTimezone}
+            onChange={svField.onChange}
+          />
+        </FieldWrapper>
+      </div>
+      <div>
+        <FieldWrapper
           isOverridden={qvOverridden}
           label="Question visibility"
           onOverride={() => {
@@ -594,29 +621,6 @@ export function OverrideAfterCompleteForm({
             visibleUntilDateError={visibleUntilDateError}
             displayTimezone={displayTimezone}
             onChange={qvField.onChange}
-          />
-        </FieldWrapper>
-      </div>
-      <div>
-        <FieldWrapper
-          isOverridden={svOverridden}
-          label="Score visibility"
-          onOverride={() => {
-            svField.onChange({ ...defaultRuleSV });
-            addSvOverride();
-            void trigger(qvField.name);
-          }}
-          onRemoveOverride={() => {
-            removeSvOverride();
-            void trigger(qvField.name);
-          }}
-        >
-          <ScoreVisibilityInput
-            value={svField.value}
-            idPrefix={`overrides-${index}`}
-            visibleFromDateError={svVisibleFromError}
-            displayTimezone={displayTimezone}
-            onChange={svField.onChange}
           />
         </FieldWrapper>
       </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
@@ -26,19 +26,19 @@ const AFTER_COMPLETE_VISIBILITY_ITEMS: RichSelectItem<AfterCompleteVisibilityMod
     value: 'show_questions_and_score',
     label: 'Show questions and score',
     description:
-      'Students see questions and their score after finishing while the reservation is still active',
+      'Students see questions, their submissions, and their overall assessment score after finishing while the reservation is still active',
   },
   {
     value: 'show_score_only',
     label: 'Show score only',
     description:
-      'Students see their score but not the questions after finishing while the reservation is still active',
+      'Students see their overall assessment score, but not questions or submissions, after finishing while the reservation is still active',
   },
   {
     value: 'hide_questions_and_score',
     label: 'Hide questions and score',
     description:
-      'Students see neither questions nor score after finishing while the reservation is still active',
+      'Students do not see questions, submissions, or their overall assessment score after finishing while the reservation is still active',
   },
 ];
 
@@ -101,7 +101,8 @@ function ExamAfterCompleteFields({ index }: { index: number }) {
       )}
       {readOnly && (
         <Form.Text className="text-muted d-block">
-          Questions and scores are always shown during read-only reservations.
+          Questions, submissions, and the overall assessment score are always shown during read-only
+          reservations.
         </Form.Text>
       )}
     </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -249,7 +249,7 @@ describe('getGlobalDateValidationErrors', () => {
 
     expect(errors).toContainEqual({
       path: 'defaultRule.questionVisibility',
-      message: 'Questions cannot be visible after completion while the score is hidden.',
+      message: 'Questions cannot be made visible after completion while the score is hidden.',
     });
     expect(errors.find((e) => e.path === 'overrides.0.questionVisibility')).toBeUndefined();
     expect(errors.find((e) => e.path === 'overrides.0.scoreVisibility')).toBeUndefined();

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -233,7 +233,7 @@ describe('getGlobalDateValidationErrors', () => {
 
     expect(errors).toContainEqual({
       path: 'overrides.0.scoreVisibility',
-      message: 'Questions cannot be visible after completion while the score is hidden.',
+      message: 'The score cannot be hidden after completion while questions are visible.',
     });
     expect(errors.find((e) => e.path === 'overrides.0.questionVisibility')).toBeUndefined();
   });

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -233,7 +233,7 @@ describe('getGlobalDateValidationErrors', () => {
 
     expect(errors).toContainEqual({
       path: 'overrides.0.scoreVisibility',
-      message: 'The score cannot be hidden after completion while questions are visible.',
+      message: 'Questions cannot be visible after completion while the score is hidden.',
     });
     expect(errors.find((e) => e.path === 'overrides.0.questionVisibility')).toBeUndefined();
   });
@@ -249,7 +249,7 @@ describe('getGlobalDateValidationErrors', () => {
 
     expect(errors).toContainEqual({
       path: 'defaultRule.questionVisibility',
-      message: 'The score cannot be hidden after completion while questions are visible.',
+      message: 'Questions cannot be visible after completion while the score is hidden.',
     });
     expect(errors.find((e) => e.path === 'overrides.0.questionVisibility')).toBeUndefined();
     expect(errors.find((e) => e.path === 'overrides.0.scoreVisibility')).toBeUndefined();

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -151,13 +151,13 @@ function mapIssueToFormFieldPath(
   }
 }
 
-function mapIssueToEditableFormFieldPath(
+function mapIssueToEditableFormError(
   issue: AccessControlValidationIssue,
   formData: AccessControlFormData,
-): AccessControlFormFieldPath | null {
+): AccessControlFormValidationError | null {
   const path = mapIssueToFormFieldPath(issue);
   if (!path) return null;
-  if (isFormFieldPathEditable(formData, path)) return path;
+  if (isFormFieldPathEditable(formData, path)) return { path, message: issue.message };
 
   // The "score hidden while questions visible" rule is a cross-field
   // constraint between question and score visibility. The default mapping
@@ -172,7 +172,12 @@ function mapIssueToEditableFormFieldPath(
     issue.ruleIndex > 0
   ) {
     const scorePath: AccessControlFormFieldPath = `overrides.${issue.ruleIndex - 1}.scoreVisibility`;
-    if (isFormFieldPathEditable(formData, scorePath)) return scorePath;
+    if (isFormFieldPathEditable(formData, scorePath)) {
+      return {
+        path: scorePath,
+        message: 'The score cannot be hidden after completion while questions are visible.',
+      };
+    }
   }
 
   return null;
@@ -241,10 +246,10 @@ export function getGlobalDateValidationErrors(
     validateAfterCompleteCrossFieldIssues(validationRules),
   ]) {
     for (const issue of issues) {
-      const path = mapIssueToEditableFormFieldPath(issue, formData);
-      if (!path || seenPaths.has(path)) continue;
-      seenPaths.add(path);
-      results.push({ path, message: issue.message });
+      const error = mapIssueToEditableFormError(issue, formData);
+      if (!error || seenPaths.has(error.path)) continue;
+      seenPaths.add(error.path);
+      results.push(error);
     }
   }
 
@@ -258,10 +263,10 @@ export function getGlobalDateValidationErrors(
     }
     for (const issues of issueGroups) {
       for (const issue of issues) {
-        const path = mapIssueToEditableFormFieldPath(issue, formData);
-        if (!path || seenPaths.has(path)) continue;
-        seenPaths.add(path);
-        results.push({ path, message: issue.message });
+        const error = mapIssueToEditableFormError(issue, formData);
+        if (!error || seenPaths.has(error.path)) continue;
+        seenPaths.add(error.path);
+        results.push(error);
       }
     }
   }


### PR DESCRIPTION
# Description

Clarifies the modern access editor's after-completion visibility copy so "score" refers to the overall assessment score and question visibility refers to questions and submissions.

Reorders the top-level fields to show score visibility before question visibility, and surfaces question/score visibility validation errors inline in the editor selectors.

- [x] I have disclosed the level of AI assistance used (majority of implementation by Codex under Nathan's direction).

# Testing

Focused access-control validation tests cover the updated cross-field validation message and field mapping; no manual UI preview was performed.
