### PR TITLE
Alphabetize pl-multiple-choice schema properties

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/schemas/pl-multiple-choice.json
+++ b/apps/prairielearn/elements/pl-multiple-choice/schemas/pl-multiple-choice.json
@@ -2,89 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
-    "answers-name": {
-      "type": "string"
-    },
-    "weight": {
-      "type": "string",
-      "format": "integer"
-    },
-    "number-answers": {
-      "type": "string",
-      "format": "integer"
-    },
-    "order": {
-      "type": "string",
-      "enum": ["random", "ascend", "descend", "fixed"]
-    },
-    "display": {
-      "type": "string",
-      "enum": ["block", "inline", "dropdown"]
-    },
-    "hide-letter-keys": {
-      "type": "string",
-      "format": "boolean"
-    },
-    "fixed-order": {
-      "type": "string",
-      "format": "boolean",
-      "deprecated": true,
-      "description": "Use the \"order\" attribute instead."
-    },
-    "inline": {
-      "type": "string",
-      "format": "boolean",
-      "deprecated": true,
-      "description": "Use the \"display\" attribute instead."
-    },
-    "hide-score-badge": {
-      "type": "string",
-      "format": "boolean"
-    },
-    "allow-blank": {
-      "type": "string",
-      "format": "boolean"
-    },
-    "builtin-grading": {
-      "type": "string",
-      "format": "boolean"
-    },
-    "size": {
-      "type": "string",
-      "format": "integer"
-    },
-    "placeholder": {
-      "type": "string"
-    },
-    "aria-label": {
-      "type": "string"
-    },
-    "external-json": {
-      "type": "string",
-      "deprecated": true,
-      "description": "Define answer choices inline with <pl-answer> instead."
-    },
-    "external-json-correct-key": {
-      "type": "string",
-      "deprecated": true
-    },
-    "external-json-incorrect-key": {
-      "type": "string",
-      "deprecated": true
-    },
     "all-of-the-above": {
-      "anyOf": [
-        {
-          "type": "string",
-          "format": "boolean"
-        },
-        {
-          "type": "string",
-          "enum": ["false", "random", "correct", "incorrect"]
-        }
-      ]
-    },
-    "none-of-the-above": {
       "anyOf": [
         {
           "type": "string",
@@ -99,8 +17,90 @@
     "all-of-the-above-feedback": {
       "type": "string"
     },
+    "allow-blank": {
+      "type": "string",
+      "format": "boolean"
+    },
+    "answers-name": {
+      "type": "string"
+    },
+    "aria-label": {
+      "type": "string"
+    },
+    "builtin-grading": {
+      "type": "string",
+      "format": "boolean"
+    },
+    "display": {
+      "type": "string",
+      "enum": ["block", "inline", "dropdown"]
+    },
+    "external-json": {
+      "type": "string",
+      "deprecated": true,
+      "description": "Define answer choices inline with <pl-answer> instead."
+    },
+    "external-json-correct-key": {
+      "type": "string",
+      "deprecated": true
+    },
+    "external-json-incorrect-key": {
+      "type": "string",
+      "deprecated": true
+    },
+    "fixed-order": {
+      "type": "string",
+      "format": "boolean",
+      "deprecated": true,
+      "description": "Use the \"order\" attribute instead."
+    },
+    "hide-letter-keys": {
+      "type": "string",
+      "format": "boolean"
+    },
+    "hide-score-badge": {
+      "type": "string",
+      "format": "boolean"
+    },
+    "inline": {
+      "type": "string",
+      "format": "boolean",
+      "deprecated": true,
+      "description": "Use the \"display\" attribute instead."
+    },
+    "none-of-the-above": {
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "boolean"
+        },
+        {
+          "type": "string",
+          "enum": ["false", "random", "correct", "incorrect"]
+        }
+      ]
+    },
     "none-of-the-above-feedback": {
       "type": "string"
+    },
+    "number-answers": {
+      "type": "string",
+      "format": "integer"
+    },
+    "order": {
+      "type": "string",
+      "enum": ["random", "ascend", "descend", "fixed"]
+    },
+    "placeholder": {
+      "type": "string"
+    },
+    "size": {
+      "type": "string",
+      "format": "integer"
+    },
+    "weight": {
+      "type": "string",
+      "format": "integer"
     }
   },
   "required": ["answers-name"],

--- a/apps/prairielearn/src/lib/element-schemas/elements/pl-multiple-choice.ts
+++ b/apps/prairielearn/src/lib/element-schemas/elements/pl-multiple-choice.ts
@@ -16,24 +16,13 @@ const plMultipleChoiceAnswerAttributesSchema = z
 
 const plMultipleChoiceAttributesSchema = z
   .object({
-    'answers-name': z.string(),
-    weight: integerFormat().optional(),
-    'number-answers': integerFormat().optional(),
-    order: z.enum(['random', 'ascend', 'descend', 'fixed']).optional(),
-    display: z.enum(['block', 'inline', 'dropdown']).optional(),
-    'hide-letter-keys': booleanFormat().optional(),
-    'fixed-order': booleanFormat()
-      .meta({ deprecated: true, description: 'Use the "order" attribute instead.' })
-      .optional(),
-    inline: booleanFormat()
-      .meta({ deprecated: true, description: 'Use the "display" attribute instead.' })
-      .optional(),
-    'hide-score-badge': booleanFormat().optional(),
+    'all-of-the-above': aotaNotaAttribute().optional(),
+    'all-of-the-above-feedback': z.string().optional(),
     'allow-blank': booleanFormat().optional(),
-    'builtin-grading': booleanFormat().optional(),
-    size: integerFormat().optional(),
-    placeholder: z.string().optional(),
+    'answers-name': z.string(),
     'aria-label': z.string().optional(),
+    'builtin-grading': booleanFormat().optional(),
+    display: z.enum(['block', 'inline', 'dropdown']).optional(),
     'external-json': z
       .string()
       .meta({
@@ -43,10 +32,21 @@ const plMultipleChoiceAttributesSchema = z
       .optional(),
     'external-json-correct-key': z.string().meta({ deprecated: true }).optional(),
     'external-json-incorrect-key': z.string().meta({ deprecated: true }).optional(),
-    'all-of-the-above': aotaNotaAttribute().optional(),
+    'fixed-order': booleanFormat()
+      .meta({ deprecated: true, description: 'Use the "order" attribute instead.' })
+      .optional(),
+    'hide-letter-keys': booleanFormat().optional(),
+    'hide-score-badge': booleanFormat().optional(),
+    inline: booleanFormat()
+      .meta({ deprecated: true, description: 'Use the "display" attribute instead.' })
+      .optional(),
     'none-of-the-above': aotaNotaAttribute().optional(),
-    'all-of-the-above-feedback': z.string().optional(),
     'none-of-the-above-feedback': z.string().optional(),
+    'number-answers': integerFormat().optional(),
+    order: z.enum(['random', 'ascend', 'descend', 'fixed']).optional(),
+    placeholder: z.string().optional(),
+    size: integerFormat().optional(),
+    weight: integerFormat().optional(),
   })
   .strict();
 


### PR DESCRIPTION
# Description

Alphabetizes the `pl-multiple-choice` element schema properties in the source schema module and regenerates the on-disk JSON schema so the checked-in generated file matches the source order. IMO alphabetization is easier for maintenance, and this also matches the docs order.

# Testing

Ran `make check-element-schemas` to verify the generated element schema files are current.
