### PR TITLE
Add element schema manifest validation

### DIFF
--- a/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
+++ b/apps/prairielearn/elements/pl-multiple-choice/pl-multiple-choice.py
@@ -61,8 +61,7 @@ PLACEHOLDER_DEFAULT = "Select an option"
 SUBMITTED_ANSWER_BLANK = {"html": "No answer submitted"}
 
 MULTIPLE_CHOICE_MUSTACHE_TEMPLATE_NAME = "pl-multiple-choice.mustache"
-SCHEMA_PATH = pathlib.Path(__file__).parent / "schemas" / "pl-multiple-choice.json"
-ANSWER_SCHEMA_PATH = pathlib.Path(__file__).parent / "schemas" / "pl-answer.json"
+SCHEMA_MANIFEST_PATH = pathlib.Path(__file__).parent / "schema.json"
 
 
 def categorize_options(
@@ -76,9 +75,6 @@ def categorize_options(
     # First, check internal HTML for answer choices
     for child in element:
         if child.tag in {"pl-answer", "pl_answer"}:
-            pl.validate_element(
-                child, ANSWER_SCHEMA_PATH, parent_tag="pl-multiple-choice"
-            )
             correct = pl.get_boolean_attrib(child, "correct", False)
             child_html = pl.inner_html(child)
             child_feedback = pl.get_string_attrib(child, "feedback", FEEDBACK_DEFAULT)
@@ -413,7 +409,7 @@ def prepare_answers_to_display(
 
 def prepare(element_html: str, data: pl.QuestionData) -> None:
     element = lxml.html.fragment_fromstring(element_html)
-    pl.validate_element(element, SCHEMA_PATH)
+    pl.validate_element_tree(element, SCHEMA_MANIFEST_PATH)
     # Before going to the trouble of preparing answers list, check for name duplication
     name = pl.get_string_attrib(element, "answers-name")
 

--- a/apps/prairielearn/elements/pl-multiple-choice/schema.json
+++ b/apps/prairielearn/elements/pl-multiple-choice/schema.json
@@ -1,0 +1,10 @@
+{
+  "tag": "pl-multiple-choice",
+  "schema": "./schemas/pl-multiple-choice.json",
+  "children": [
+    {
+      "tag": "pl-answer",
+      "schema": "./schemas/pl-answer.json"
+    }
+  ]
+}

--- a/apps/prairielearn/python/prairielearn/__init__.py
+++ b/apps/prairielearn/python/prairielearn/__init__.py
@@ -2,6 +2,7 @@
 
 from prairielearn.conversion_utils import *  # noqa: F403
 from prairielearn.element_schemas import validate_element as validate_element
+from prairielearn.element_schemas import validate_element_tree as validate_element_tree
 from prairielearn.extension_utils import *  # noqa: F403
 from prairielearn.grading_utils import *  # noqa: F403
 from prairielearn.html_utils import *  # noqa: F403

--- a/apps/prairielearn/python/prairielearn/element_schemas.py
+++ b/apps/prairielearn/python/prairielearn/element_schemas.py
@@ -1,9 +1,8 @@
-"""JSON Schema validation helpers for PrairieLearn elements.
+"""JSON Schema validation helpers for PrairieLearn element attributes and structure.
 
-The rendered messages intentionally mirror the wording produced by the
-`@prairielearn/tree-sitter-htmlmustache` linter so that an instructor sees the
-same text whether a problem is caught at lint time (in the editor) or at render
-time (in Python). Keep the two in sync when changing either.
+Attribute schema error messages intentionally mirror the wording produced by
+the `@prairielearn/tree-sitter-htmlmustache` linter. Tree validation adds
+Python-side selector context for parent/child paths.
 """
 
 import functools

--- a/apps/prairielearn/python/prairielearn/element_schemas.py
+++ b/apps/prairielearn/python/prairielearn/element_schemas.py
@@ -10,8 +10,9 @@ import functools
 import json
 import pathlib
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, NotRequired, TypedDict, cast
 
+import lxml.etree
 import lxml.html
 from jsonschema import FormatChecker, ValidationError
 from jsonschema.validators import validator_for
@@ -22,7 +23,21 @@ from prairielearn.html_utils import (
     is_integer_attrib,
 )
 
-__all__ = ["validate_element"]
+__all__ = ["validate_element", "validate_element_tree"]
+
+
+class ElementSchemaManifestChild(TypedDict):
+    tag: str
+    schema: NotRequired[str]
+    children: NotRequired[list["ElementSchemaManifestChild"]]
+    allowAdditionalChildren: NotRequired[bool]
+
+
+class ElementSchemaManifest(TypedDict):
+    tag: str
+    schema: str
+    children: NotRequired[list[ElementSchemaManifestChild]]
+
 
 pl_format_checker = FormatChecker(formats=())
 
@@ -52,6 +67,11 @@ def _load_validator(path: pathlib.Path) -> Any:
     return validator_cls(schema, format_checker=pl_format_checker)
 
 
+@functools.cache
+def _load_manifest(path: pathlib.Path) -> ElementSchemaManifest:
+    return cast(ElementSchemaManifest, json.loads(path.read_text()))
+
+
 def validate_element(
     element: lxml.html.HtmlElement,
     schema_path: pathlib.Path,
@@ -62,20 +82,90 @@ def validate_element(
 
     `parent_tag`, when provided, is woven into the message the same way the
     linter does for nested elements (e.g. `<pl-answer> inside <pl-multiple-choice>`).
-
-    Raises:
-        ValueError: If the element's attributes do not satisfy the schema.
     """
+    _validate_element_at_context(
+        element, schema_path, _tag_context(_tag_name(element), parent_tag)
+    )
+
+
+def validate_element_tree(
+    element: lxml.html.HtmlElement,
+    manifest_path: pathlib.Path,
+) -> None:
+    """Validate an element subtree against an element schema manifest.
+
+    This is a lightweight first pass for local structure: the root tag,
+    contextual child tags, and each declared tag's attributes. Element Python
+    code remains responsible for semantic validation.
+    """
+    manifest = _load_manifest(manifest_path)
+    _validate_element_tree_node(
+        element,
+        manifest,
+        manifest_path.parent,
+        manifest["tag"],
+    )
+
+
+def _validate_element_at_context(
+    element: lxml.html.HtmlElement,
+    schema_path: pathlib.Path,
+    context: str,
+) -> None:
     validator = _load_validator(schema_path)
     first = next(validator.iter_errors(_normalize_attrs(dict(element.attrib))), None)
     if first is not None:
-        tag = _tag_name(element)
-        raise ValueError(_render_error(first, tag, parent_tag))
+        raise ValueError(_render_error(first, context))
+
+
+def _validate_element_tree_node(
+    element: lxml.html.HtmlElement,
+    manifest: ElementSchemaManifest | ElementSchemaManifestChild,
+    manifest_dir: pathlib.Path,
+    context: str,
+) -> None:
+    actual_tag = _manifest_tag_name(element)
+    expected_tag = manifest["tag"]
+    if actual_tag != expected_tag:
+        raise ValueError(f"Expected {expected_tag} at {context}, not {actual_tag}.")
+
+    schema_path = manifest.get("schema")
+    if schema_path is not None:
+        _validate_element_at_context(element, manifest_dir / schema_path, context)
+
+    children = manifest.get("children")
+    if children is None:
+        return
+
+    child_manifests = {child["tag"]: child for child in children}
+    child_counts: dict[str, int] = {}
+    for child in element:
+        if isinstance(child, lxml.etree._Comment):
+            continue
+        child_tag = _manifest_tag_name(child)
+        child_counts[child_tag] = child_counts.get(child_tag, 0) + 1
+        child_context = (
+            f"{context} > {child_tag}:nth-of-type({child_counts[child_tag]})"
+        )
+        child_manifest = child_manifests.get(child_tag)
+        if child_manifest is not None:
+            _validate_element_tree_node(
+                child, child_manifest, manifest_dir, child_context
+            )
+        elif not manifest.get("allowAdditionalChildren", False):
+            allowed = ", ".join(sorted(child_manifests))
+            raise ValueError(
+                f"Unexpected child {child_tag} at {child_context}. Expected: {allowed}."
+            )
 
 
 def _tag_name(element: lxml.html.HtmlElement) -> str:
     tag = element.tag
     return tag.lower() if isinstance(tag, str) else "element"
+
+
+def _manifest_tag_name(element: lxml.html.HtmlElement) -> str:
+    return _tag_name(element).replace("_", "-")
 
 
 def _normalize_attrs(attribs: Mapping[str, Any]) -> dict[str, Any]:
@@ -92,7 +182,7 @@ def _tag_context(tag: str, parent_tag: str | None) -> str:
     return f"<{tag}> inside <{parent_tag}>" if parent_tag else f"<{tag}>"
 
 
-def _render_error(error: ValidationError, tag: str, parent_tag: str | None) -> str:
+def _render_error(error: ValidationError, context: str) -> str:
     error_message = (
         error.schema.get("errorMessage") if isinstance(error.schema, dict) else None
     )
@@ -104,8 +194,6 @@ def _render_error(error: ValidationError, tag: str, parent_tag: str | None) -> s
             or error_message.get("_")
             or error.message
         )
-
-    context = _tag_context(tag, parent_tag)
 
     if error.validator == "required":
         missing = _missing_required_attribute(error)

--- a/apps/prairielearn/python/test/test_element_schemas.py
+++ b/apps/prairielearn/python/test/test_element_schemas.py
@@ -9,6 +9,7 @@ from prairielearn.element_schemas import (
     _attribute_name,
     _normalize_attrs,
     validate_element,
+    validate_element_tree,
 )
 
 
@@ -234,3 +235,68 @@ def test_validate_element_success(
     schema_path.write_text(json.dumps(schema))
 
     validate_element(lxml.html.fragment_fromstring(html), schema_path)
+
+
+def _write_element_tree_manifest(tmp_path: Path) -> Path:
+    schemas_dir = tmp_path / "schemas"
+    schemas_dir.mkdir()
+    (schemas_dir / "pl-widget.json").write_text(
+        json.dumps({
+            "type": "object",
+            "properties": {"answers-name": {"type": "string"}},
+            "required": ["answers-name"],
+            "additionalProperties": False,
+        })
+    )
+    (schemas_dir / "pl-answer.json").write_text(
+        json.dumps({
+            "type": "object",
+            "properties": {"correct": {"type": "string", "format": "boolean"}},
+            "additionalProperties": False,
+        })
+    )
+    manifest_path = tmp_path / "schema.json"
+    manifest_path.write_text(
+        json.dumps({
+            "tag": "pl-widget",
+            "schema": "./schemas/pl-widget.json",
+            "children": [
+                {
+                    "tag": "pl-answer",
+                    "schema": "./schemas/pl-answer.json",
+                }
+            ],
+        })
+    )
+    return manifest_path
+
+
+def test_validate_element_tree_success(tmp_path: Path) -> None:
+    manifest_path = _write_element_tree_manifest(tmp_path)
+
+    validate_element_tree(
+        lxml.html.fragment_fromstring(
+            '<pl-widget answers-name="x"><pl-answer correct="true"><strong>A</strong></pl-answer></pl-widget>'
+        ),
+        manifest_path,
+    )
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        (
+            '<pl-widget answers-name="x"><pl-answer bogus="1"></pl-answer></pl-widget>',
+            r'Unknown attribute "bogus" on pl-widget > pl-answer:nth-of-type\(1\)\.',
+        ),
+        (
+            '<pl-widget answers-name="x"><p>A</p></pl-widget>',
+            r"Unexpected child p at pl-widget > p:nth-of-type\(1\)\. Expected: pl-answer\.",
+        ),
+    ],
+)
+def test_validate_element_tree_errors(tmp_path: Path, html: str, expected: str) -> None:
+    manifest_path = _write_element_tree_manifest(tmp_path)
+
+    with pytest.raises(ValueError, match=expected):
+        validate_element_tree(lxml.html.fragment_fromstring(html), manifest_path)

--- a/scripts/gen-element-schemas.mts
+++ b/scripts/gen-element-schemas.mts
@@ -8,6 +8,7 @@
 // `element` of type `ElementSchemaModule`) and regenerates everything derived
 // from them:
 //   - the on-disk JSON schemas under `apps/prairielearn/elements/<tag>/schemas/`
+//   - the element-local schema manifest at `apps/prairielearn/elements/<tag>/schema.json`
 //   - the static module registry `registry.generated.ts`
 //   - the full on-disk linter config `.htmlmustache.jsonc`
 //
@@ -171,6 +172,11 @@ function schemaRelPath(tag: string, schemaTag: string): string {
   return `apps/prairielearn/elements/${tag}/schemas/${schemaTag}.json`;
 }
 
+/** Path on disk for a generated element schema manifest, relative to the repo root. */
+function manifestRelPath(tag: string): string {
+  return `apps/prairielearn/elements/${tag}/schema.json`;
+}
+
 /**
  * All generated schema files for an element, keyed by schema file name: the
  * root schema plus one per (possibly nested) child tag that declares a schema.
@@ -191,6 +197,36 @@ function collectElementSchemas(element: ElementSchemaModule): Map<string, Record
 /** The `./`-prefixed path used to reference a schema from `.htmlmustache.jsonc`. */
 function schemaConfigPath(tag: string, schemaTag: string): string {
   return `./${schemaRelPath(tag, schemaTag)}`;
+}
+
+/** The element-local path used to reference a schema from `schema.json`. */
+function schemaManifestPath(schemaTag: string): string {
+  return `./schemas/${schemaTag}.json`;
+}
+
+function buildChildManifests(
+  children: Record<string, ElementChildSchema>,
+  prefix: string[],
+): Record<string, unknown>[] {
+  return Object.entries(children)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([childTag, child]) => {
+      const childPath = [...prefix, childTag];
+      const manifest: Record<string, unknown> = { tag: childTag };
+      if (child.schema) manifest.schema = schemaManifestPath(childPath.join('.'));
+      if (child.children) manifest.children = buildChildManifests(child.children, childPath);
+      if (child.allowAdditionalChildren) manifest.allowAdditionalChildren = true;
+      return manifest;
+    });
+}
+
+function buildElementManifest(element: ElementSchemaModule): Record<string, unknown> {
+  const manifest: Record<string, unknown> = {
+    tag: element.tag,
+    schema: schemaManifestPath(element.tag),
+  };
+  if (element.children) manifest.children = buildChildManifests(element.children, []);
+  return manifest;
 }
 
 async function format(filePath: string, contents: string): Promise<string> {
@@ -318,6 +354,11 @@ for (const { tag, element } of elements) {
     baseFiles[filePath] = await format(filePath, `${JSON.stringify(schema, null, 2)}\n`);
     schemaPaths.add(filePath);
   }
+  const manifestPath = path.resolve(REPO_ROOT, manifestRelPath(tag));
+  baseFiles[manifestPath] = await format(
+    manifestPath,
+    `${JSON.stringify(buildElementManifest(element), null, 2)}\n`,
+  );
 }
 baseFiles[REGISTRY_PATH] = await format(REGISTRY_PATH, buildRegistry(elements));
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

This adds an on-disk schema manifest for `pl-multiple-choice` that records the root attribute schema and contextual `pl-answer` child schema, with manifest generation wired into `scripts/gen-element-schemas.mts`.

It also adds `validate_element_tree(...)` as a lightweight structural/schema pass over an element subtree and switches `pl-multiple-choice` to use that single manifest-backed pass before existing semantic validation.

Tree validation reports CSS-selector-style child context such as `pl-multiple-choice > pl-answer:nth-of-type(1)`, while semantic checks remain in Python.

- [x] I have disclosed the level of AI assistance used (majority of implementation by Codex under Nathan's direction).

# Testing

Added focused Python coverage for manifest-backed tree validation, including arbitrary child content, contextual child attribute errors, and unexpected-child errors.

Verified `pl-multiple-choice` behavior and generated element schema output locally with the targeted Python tests and element schema check.
