### PR TITLE
Fix inactive legacy access rule migration

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -8,6 +8,7 @@ import { AccessControlJsonSchema } from '../../schemas/accessControl.js';
 import type { AssessmentAccessRuleJson } from '../../schemas/infoAssessment.js';
 
 import {
+  INACTIVE_WINDOW_NOTE,
   type Migration,
   analyzeAssessmentFile,
   analyzeCourseInstanceAssessments,
@@ -22,6 +23,8 @@ import { validateAccessControlRules } from './validation.js';
 // Cases whose legacy rules don't supply a startDate (always-open, password-only)
 // get this fallback as their release date in `expected`.
 const FALLBACK_RELEASE = '2000-01-01T00:00:00';
+const INACTIVE_PASSWORD_NOTE =
+  '1 password on inactive legacy access rule discarded because inactive rules do not allow submissions.';
 
 describe('migrateAllowAccess', () => {
   const cases: {
@@ -123,36 +126,6 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
-      name: 'prairietest with viewing rule',
-      rules: [
-        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
-        { startDate: '2024-01-01T00:00:00', active: false },
-      ],
-      expected: {
-        accessControl: {
-          dateControl: { release: { date: '2024-01-01T00:00:00' } },
-          integrations: {
-            prairieTest: { exams: [{ examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' }] },
-          },
-        },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      },
-    },
-    {
-      name: 'view-only',
-      rules: [{ startDate: '2024-01-01T00:00:00', active: false }],
-      expected: {
-        accessControl: {
-          dateControl: { release: { date: '2024-01-01T00:00:00' } },
-        },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      },
-    },
-    {
       name: 'password-gated',
       rules: [
         {
@@ -170,16 +143,6 @@ describe('migrateAllowAccess', () => {
             due: { date: '2024-06-01T00:00:00' },
           },
         },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      },
-    },
-    {
-      name: 'hidden',
-      rules: [{ active: false }],
-      expected: {
-        accessControl: {},
         errors: [],
         notes: [],
         hasUidRules: false,
@@ -708,24 +671,6 @@ describe('migrateAllowAccess', () => {
             release: { date: '2024-01-01T00:00:00' },
             due: { date: '2024-06-01T00:00:00' },
           },
-          afterComplete: { score: { hidden: true } },
-        },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      },
-    },
-    {
-      name: 'visibility-only inactive rule preserves afterComplete',
-      rules: [
-        {
-          showClosedAssessment: false,
-          showClosedAssessmentScore: false,
-          active: false,
-        },
-      ],
-      expected: {
-        accessControl: {
           afterComplete: { score: { hidden: true } },
         },
         errors: [],
@@ -1614,6 +1559,134 @@ describe('migrateAllowAccess', () => {
 
     const { errors } = validateAccessControlRules({ rules: [result.accessControl] });
     assert.deepEqual(errors, []);
+  });
+
+  describe('inactive legacy rules without date-control access', () => {
+    const inactiveDatedRule = {
+      active: false,
+      showClosedAssessment: true,
+      startDate: '2026-01-01T23:55:01',
+      endDate: '2026-12-25T23:59:59',
+    } satisfies AssessmentAccessRuleJson;
+
+    it.each([
+      {
+        name: 'view-only dated rule',
+        rules: [inactiveDatedRule],
+        notes: [INACTIVE_WINDOW_NOTE],
+      },
+      {
+        name: 'inactive rule with submission-only fields',
+        rules: [{ ...inactiveDatedRule, credit: 100, timeLimitMin: 90 }],
+        notes: [INACTIVE_WINDOW_NOTE],
+      },
+      {
+        name: 'inactive password rule',
+        rules: [{ ...inactiveDatedRule, credit: 0, password: 'foo' }],
+        notes: [INACTIVE_PASSWORD_NOTE, INACTIVE_WINDOW_NOTE],
+      },
+      {
+        name: 'hidden inactive rule',
+        rules: [
+          {
+            active: false,
+            showClosedAssessment: false,
+            showClosedAssessmentScore: false,
+          },
+        ],
+        notes: [INACTIVE_WINDOW_NOTE],
+      },
+    ] satisfies { name: string; rules: AssessmentAccessRuleJson[]; notes: string[] }[])(
+      '$name',
+      ({ rules, notes }) => {
+        assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
+          accessControl: {},
+          errors: [],
+          notes,
+          hasUidRules: false,
+        });
+      },
+    );
+
+    it('does not list before release for inactive windows that hide the assessment', () => {
+      const rules: AssessmentAccessRuleJson[] = [
+        {
+          active: false,
+          showClosedAssessment: false,
+          startDate: '2024-01-01T00:00:00',
+        },
+        {
+          credit: 100,
+          startDate: '2024-02-01T00:00:00',
+          endDate: '2024-06-01T00:00:00',
+        },
+      ];
+
+      assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
+        accessControl: {
+          dateControl: {
+            release: { date: '2024-02-01T00:00:00' },
+            due: { date: '2024-06-01T00:00:00' },
+          },
+        },
+        errors: [],
+        notes: [],
+        hasUidRules: false,
+      });
+    });
+
+    it('keeps PrairieTest integration without turning inactive viewing into a release date', () => {
+      const rules: AssessmentAccessRuleJson[] = [
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
+        { startDate: '2024-01-01T00:00:00', active: false },
+      ];
+
+      assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
+        accessControl: {
+          integrations: {
+            prairieTest: { exams: [{ examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' }] },
+          },
+        },
+        errors: [],
+        notes: [INACTIVE_WINDOW_NOTE],
+        hasUidRules: false,
+      });
+    });
+
+    it('ignores inactive positive-credit rules for active credit monotonicity', () => {
+      const rules: AssessmentAccessRuleJson[] = [
+        {
+          credit: 50,
+          startDate: '2026-01-01T23:55:01',
+          endDate: '2026-06-01T23:59:59',
+        },
+        {
+          active: false,
+          credit: 100,
+          startDate: '2026-07-01T23:55:01',
+          endDate: '2026-12-25T23:59:59',
+        },
+      ];
+
+      assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
+        accessControl: {
+          dateControl: {
+            release: { date: '2026-01-01T23:55:01' },
+            due: { date: '2026-06-01T23:59:59', credit: 50 },
+          },
+          afterComplete: {
+            questions: {
+              hidden: true,
+              visibleFromDate: '2026-07-01T23:55:01',
+              visibleUntilDate: '2026-12-25T23:59:59',
+            },
+          },
+        },
+        errors: [],
+        notes: [],
+        hasUidRules: false,
+      });
+    });
   });
 });
 

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -1395,6 +1395,24 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
+      name: 'mode-gated only with inactive positive-credit rule',
+      rules: [
+        { mode: 'Exam' },
+        {
+          active: false,
+          credit: 100,
+          startDate: '2026-01-01T00:00:00',
+          endDate: '2026-12-25T23:59:59',
+        },
+      ],
+      expected: {
+        accessControl: null,
+        errors: ['Mode-only access rules are not supported.'],
+        notes: [],
+        hasUidRules: false,
+      },
+    },
+    {
       name: 'all-UID rules filtered to no-op',
       rules: [{ uids: ['user@example.com'], credit: 100, endDate: '2024-06-01T00:00:00' }],
       expected: {

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -8,7 +8,6 @@ import { AccessControlJsonSchema } from '../../schemas/accessControl.js';
 import type { AssessmentAccessRuleJson } from '../../schemas/infoAssessment.js';
 
 import {
-  INACTIVE_WINDOW_NOTE,
   type Migration,
   analyzeAssessmentFile,
   analyzeCourseInstanceAssessments,
@@ -23,8 +22,6 @@ import { validateAccessControlRules } from './validation.js';
 // Cases whose legacy rules don't supply a startDate (always-open, password-only)
 // get this fallback as their release date in `expected`.
 const FALLBACK_RELEASE = '2000-01-01T00:00:00';
-const INACTIVE_PASSWORD_NOTE =
-  '1 password on inactive legacy access rule discarded because inactive rules do not allow submissions.';
 
 describe('migrateAllowAccess', () => {
   const cases: {
@@ -1515,6 +1512,165 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
+      name: 'view-only inactive rule without date-control access',
+      rules: [
+        {
+          active: false,
+          showClosedAssessment: true,
+          startDate: '2026-01-01T23:55:01',
+          endDate: '2026-12-25T23:59:59',
+        },
+      ],
+      expected: {
+        accessControl: {},
+        errors: [],
+        notes: [
+          'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
+        ],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'inactive rule with submission-only fields',
+      rules: [
+        {
+          active: false,
+          credit: 100,
+          timeLimitMin: 90,
+          showClosedAssessment: true,
+          startDate: '2026-01-01T23:55:01',
+          endDate: '2026-12-25T23:59:59',
+        },
+      ],
+      expected: {
+        accessControl: {},
+        errors: [],
+        notes: [
+          'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
+        ],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'inactive password rule',
+      rules: [
+        {
+          active: false,
+          credit: 0,
+          password: 'foo',
+          showClosedAssessment: true,
+          startDate: '2026-01-01T23:55:01',
+          endDate: '2026-12-25T23:59:59',
+        },
+      ],
+      expected: {
+        accessControl: {},
+        errors: [],
+        notes: [
+          '1 password on inactive legacy access rule discarded because inactive rules do not allow submissions.',
+          'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
+        ],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'hidden inactive rule without date-control access',
+      rules: [
+        {
+          active: false,
+          showClosedAssessment: false,
+          showClosedAssessmentScore: false,
+        },
+      ],
+      expected: {
+        accessControl: {},
+        errors: [],
+        notes: [
+          'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
+        ],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'inactive hidden window does not list before release',
+      rules: [
+        {
+          active: false,
+          showClosedAssessment: false,
+          startDate: '2024-01-01T00:00:00',
+        },
+        {
+          credit: 100,
+          startDate: '2024-02-01T00:00:00',
+          endDate: '2024-06-01T00:00:00',
+        },
+      ],
+      expected: {
+        accessControl: {
+          dateControl: {
+            release: { date: '2024-02-01T00:00:00' },
+            due: { date: '2024-06-01T00:00:00' },
+          },
+        },
+        errors: [],
+        notes: [],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'PrairieTest with inactive viewing rule',
+      rules: [
+        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
+        { startDate: '2024-01-01T00:00:00', active: false },
+      ],
+      expected: {
+        accessControl: {
+          integrations: {
+            prairieTest: { exams: [{ examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' }] },
+          },
+        },
+        errors: [],
+        notes: [
+          'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
+        ],
+        hasUidRules: false,
+      },
+    },
+    {
+      name: 'inactive positive-credit rule ignored for active credit monotonicity',
+      rules: [
+        {
+          credit: 50,
+          startDate: '2026-01-01T23:55:01',
+          endDate: '2026-06-01T23:59:59',
+        },
+        {
+          active: false,
+          credit: 100,
+          startDate: '2026-07-01T23:55:01',
+          endDate: '2026-12-25T23:59:59',
+        },
+      ],
+      expected: {
+        accessControl: {
+          dateControl: {
+            release: { date: '2026-01-01T23:55:01' },
+            due: { date: '2026-06-01T23:59:59', credit: 50 },
+          },
+          afterComplete: {
+            questions: {
+              hidden: true,
+              visibleFromDate: '2026-07-01T23:55:01',
+              visibleUntilDate: '2026-12-25T23:59:59',
+            },
+          },
+        },
+        errors: [],
+        notes: [],
+        hasUidRules: false,
+      },
+    },
+    {
       name: 'filters non-Student role rules and treats mode:Public as no-op',
       rules: [
         { role: 'TA', endDate: '2019-12-20T23:59:59' },
@@ -1559,134 +1715,6 @@ describe('migrateAllowAccess', () => {
 
     const { errors } = validateAccessControlRules({ rules: [result.accessControl] });
     assert.deepEqual(errors, []);
-  });
-
-  describe('inactive legacy rules without date-control access', () => {
-    const inactiveDatedRule = {
-      active: false,
-      showClosedAssessment: true,
-      startDate: '2026-01-01T23:55:01',
-      endDate: '2026-12-25T23:59:59',
-    } satisfies AssessmentAccessRuleJson;
-
-    it.each([
-      {
-        name: 'view-only dated rule',
-        rules: [inactiveDatedRule],
-        notes: [INACTIVE_WINDOW_NOTE],
-      },
-      {
-        name: 'inactive rule with submission-only fields',
-        rules: [{ ...inactiveDatedRule, credit: 100, timeLimitMin: 90 }],
-        notes: [INACTIVE_WINDOW_NOTE],
-      },
-      {
-        name: 'inactive password rule',
-        rules: [{ ...inactiveDatedRule, credit: 0, password: 'foo' }],
-        notes: [INACTIVE_PASSWORD_NOTE, INACTIVE_WINDOW_NOTE],
-      },
-      {
-        name: 'hidden inactive rule',
-        rules: [
-          {
-            active: false,
-            showClosedAssessment: false,
-            showClosedAssessmentScore: false,
-          },
-        ],
-        notes: [INACTIVE_WINDOW_NOTE],
-      },
-    ] satisfies { name: string; rules: AssessmentAccessRuleJson[]; notes: string[] }[])(
-      '$name',
-      ({ rules, notes }) => {
-        assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
-          accessControl: {},
-          errors: [],
-          notes,
-          hasUidRules: false,
-        });
-      },
-    );
-
-    it('does not list before release for inactive windows that hide the assessment', () => {
-      const rules: AssessmentAccessRuleJson[] = [
-        {
-          active: false,
-          showClosedAssessment: false,
-          startDate: '2024-01-01T00:00:00',
-        },
-        {
-          credit: 100,
-          startDate: '2024-02-01T00:00:00',
-          endDate: '2024-06-01T00:00:00',
-        },
-      ];
-
-      assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
-        accessControl: {
-          dateControl: {
-            release: { date: '2024-02-01T00:00:00' },
-            due: { date: '2024-06-01T00:00:00' },
-          },
-        },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      });
-    });
-
-    it('keeps PrairieTest integration without turning inactive viewing into a release date', () => {
-      const rules: AssessmentAccessRuleJson[] = [
-        { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },
-        { startDate: '2024-01-01T00:00:00', active: false },
-      ];
-
-      assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
-        accessControl: {
-          integrations: {
-            prairieTest: { exams: [{ examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34' }] },
-          },
-        },
-        errors: [],
-        notes: [INACTIVE_WINDOW_NOTE],
-        hasUidRules: false,
-      });
-    });
-
-    it('ignores inactive positive-credit rules for active credit monotonicity', () => {
-      const rules: AssessmentAccessRuleJson[] = [
-        {
-          credit: 50,
-          startDate: '2026-01-01T23:55:01',
-          endDate: '2026-06-01T23:59:59',
-        },
-        {
-          active: false,
-          credit: 100,
-          startDate: '2026-07-01T23:55:01',
-          endDate: '2026-12-25T23:59:59',
-        },
-      ];
-
-      assert.deepEqual(migrateAllowAccess(rules, FALLBACK_RELEASE), {
-        accessControl: {
-          dateControl: {
-            release: { date: '2026-01-01T23:55:01' },
-            due: { date: '2026-06-01T23:59:59', credit: 50 },
-          },
-          afterComplete: {
-            questions: {
-              hidden: true,
-              visibleFromDate: '2026-07-01T23:55:01',
-              visibleUntilDate: '2026-12-25T23:59:59',
-            },
-          },
-        },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      });
-    });
   });
 });
 

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.test.ts
@@ -1610,32 +1610,6 @@ describe('migrateAllowAccess', () => {
       },
     },
     {
-      name: 'inactive hidden window does not list before release',
-      rules: [
-        {
-          active: false,
-          showClosedAssessment: false,
-          startDate: '2024-01-01T00:00:00',
-        },
-        {
-          credit: 100,
-          startDate: '2024-02-01T00:00:00',
-          endDate: '2024-06-01T00:00:00',
-        },
-      ],
-      expected: {
-        accessControl: {
-          dateControl: {
-            release: { date: '2024-02-01T00:00:00' },
-            due: { date: '2024-06-01T00:00:00' },
-          },
-        },
-        errors: [],
-        notes: [],
-        hasUidRules: false,
-      },
-    },
-    {
       name: 'PrairieTest with inactive viewing rule',
       rules: [
         { examUuid: '8d38a804-7858-49a6-abe7-7a057604dd34', credit: 100 },

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -27,6 +27,15 @@ import { formatJsonWithPrettier } from '../prettier.js';
 
 import { getAfterCompleteCrossFieldIssue, validateAccessControlRules } from './validation.js';
 
+export const INACTIVE_WINDOW_NOTE =
+  'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.';
+
+function inactivePasswordNote(count: number): string {
+  return `${count} password${count === 1 ? '' : 's'} on inactive legacy access rule${
+    count === 1 ? '' : 's'
+  } discarded because inactive rules do not allow submissions.`;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -74,7 +83,7 @@ interface VisibilityMigration {
 
 function getCreditRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
   return rules
-    .filter((r) => (r.credit ?? 0) > 0)
+    .filter((r) => (r.active ?? true) && (r.credit ?? 0) > 0)
     .sort((a, b) => {
       const creditDiff = (b.credit ?? 0) - (a.credit ?? 0);
       if (creditDiff !== 0) return creditDiff;
@@ -82,8 +91,12 @@ function getCreditRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRule
     });
 }
 
+function getInactiveRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
+  return rules.filter((r) => (r.active ?? true) === false && !r.examUuid);
+}
+
 function getVisibilityRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
-  return rules.filter((r) => (r.active ?? true) === false && !r.examUuid && !r.password);
+  return getInactiveRules(rules).filter((r) => !r.password);
 }
 
 function findFirstCreditStartDate(rules: AssessmentAccessRuleJson[]): string | undefined {
@@ -144,14 +157,7 @@ function findReleaseDate(rules: AssessmentAccessRuleJson[]): string | undefined 
   // — otherwise the resolver would treat any earlier visibility-rule startDate
   // as a submittable 100%-credit window. Pre-credit visibility is preserved
   // separately via `beforeRelease.listed`.
-  const firstCreditStartDate = findFirstCreditStartDate(rules);
-  if (firstCreditStartDate) return firstCreditStartDate;
-
-  const visibilityDates = getVisibilityRules(rules)
-    .map((r) => r.startDate)
-    .filter((date): date is string => !!date)
-    .sort();
-  return visibilityDates[0];
+  return findFirstCreditStartDate(rules);
 }
 
 // ---------------------------------------------------------------------------
@@ -216,7 +222,7 @@ function hasAccessGaps(rules: AssessmentAccessRuleJson[]): boolean {
 }
 
 function hasNonMonotonicCredit(rules: AssessmentAccessRuleJson[]): boolean {
-  const creditRules = rules.filter((r) => (r.credit ?? 0) > 0);
+  const creditRules = getCreditRules(rules);
   if (creditRules.length === 0) return false;
 
   const dates = new Set<string>();
@@ -815,6 +821,23 @@ function extractPassword(rules: AssessmentAccessRuleJson[]): {
   };
 }
 
+function stripPasswordsFromInactiveRules(rules: AssessmentAccessRuleJson[]): {
+  rules: AssessmentAccessRuleJson[];
+  notes: string[];
+} {
+  const inactivePasswordRules = getInactiveRules(rules).filter((r) => r.password);
+  if (inactivePasswordRules.length === 0) return { rules, notes: [] };
+
+  return {
+    rules: rules.map((r) => {
+      if (!r.password || (r.active ?? true) !== false) return r;
+      const { password: _password, ...rest } = r;
+      return rest;
+    }),
+    notes: [inactivePasswordNote(inactivePasswordRules.length)],
+  };
+}
+
 function extractPrairieTest(rules: AssessmentAccessRuleJson[]): {
   integrations: AccessControlJsonInput['integrations'];
   remainingRules: AssessmentAccessRuleJson[];
@@ -852,14 +875,12 @@ function extractPrairieTest(rules: AssessmentAccessRuleJson[]): {
 // ---------------------------------------------------------------------------
 
 function assembleAccessControl({
-  schedulingRules,
   ptExtract,
   pwExtract,
   dateControl,
   visibilityMigration,
   fallbackReleaseDate,
 }: {
-  schedulingRules: AssessmentAccessRuleJson[];
   ptExtract: ReturnType<typeof extractPrairieTest>;
   pwExtract: ReturnType<typeof extractPassword>;
   dateControl: AccessControlJsonInput['dateControl'];
@@ -870,14 +891,6 @@ function assembleAccessControl({
 
   if (dateControl) {
     accessControl.dateControl = dateControl;
-  } else {
-    // No credit rules produced a dateControl. Check for view-only rules
-    // (active: false with dates) that indicate a release date.
-    const viewOnlyRules = getVisibilityRules(schedulingRules).filter((r) => r.startDate);
-    if (viewOnlyRules.length > 0) {
-      const releaseDate = viewOnlyRules.map((r) => r.startDate!).sort()[0];
-      accessControl.dateControl = { release: { date: releaseDate } };
-    }
   }
 
   if (pwExtract) {
@@ -885,7 +898,9 @@ function assembleAccessControl({
     accessControl.dateControl.password = pwExtract.password;
   }
 
-  applyVisibilityMigration(accessControl, visibilityMigration);
+  if (dateControl || ptExtract || pwExtract) {
+    applyVisibilityMigration(accessControl, visibilityMigration);
+  }
 
   if (ptExtract) {
     accessControl.integrations = ptExtract.integrations;
@@ -940,6 +955,10 @@ export function migrateAllowAccess(
     schedulingRules = ptExtract.remainingRules;
     notes.push(...ptExtract.notes);
   }
+
+  const inactivePasswordResult = stripPasswordsFromInactiveRules(schedulingRules);
+  schedulingRules = inactivePasswordResult.rules;
+  notes.push(...inactivePasswordResult.notes);
 
   const pwExtract = extractPassword(schedulingRules);
   if (pwExtract) {
@@ -1012,6 +1031,10 @@ export function migrateAllowAccess(
     );
   }
 
+  const hasInactiveRulesWithoutDateControl =
+    !dateControl && getInactiveRules(schedulingRules).length > 0;
+  if (hasInactiveRulesWithoutDateControl && !pwExtract) notes.push(INACTIVE_WINDOW_NOTE);
+
   // No-op detection: when nothing produced a dateControl, password, or
   // PrairieTest config, the rules collapse to a no-op. Suppress the note if
   // the rules were intentionally hidden via `active: false`.
@@ -1026,7 +1049,6 @@ export function migrateAllowAccess(
   notes.push(...visibilityMigration.notes);
 
   const accessControl = assembleAccessControl({
-    schedulingRules,
     ptExtract,
     pwExtract,
     dateControl,

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -825,16 +825,16 @@ function stripPasswordsFromInactiveRules(rules: AssessmentAccessRuleJson[]): {
   rules: AssessmentAccessRuleJson[];
   notes: string[];
 } {
-  const inactivePasswordRules = getInactiveRules(rules).filter((r) => r.password);
-  if (inactivePasswordRules.length === 0) return { rules, notes: [] };
+  const inactivePasswordRules = new Set(getInactiveRules(rules).filter((r) => r.password));
+  if (inactivePasswordRules.size === 0) return { rules, notes: [] };
 
   return {
     rules: rules.map((r) => {
-      if (!r.password || (r.active ?? true) !== false) return r;
+      if (!inactivePasswordRules.has(r)) return r;
       const { password: _password, ...rest } = r;
       return rest;
     }),
-    notes: [inactivePasswordNote(inactivePasswordRules.length)],
+    notes: [inactivePasswordNote(inactivePasswordRules.size)],
   };
 }
 

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -72,7 +72,7 @@ interface VisibilityMigration {
 // Rule helpers
 // ---------------------------------------------------------------------------
 
-function getCreditRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
+function getActiveCreditRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
   return rules
     .filter((r) => (r.active ?? true) && (r.credit ?? 0) > 0)
     .sort((a, b) => {
@@ -82,24 +82,24 @@ function getCreditRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRule
     });
 }
 
-function getInactiveRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
+function getInactiveSchedulingRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
   return rules.filter((r) => (r.active ?? true) === false && !r.examUuid);
 }
 
 function getVisibilityRules(rules: AssessmentAccessRuleJson[]): AssessmentAccessRuleJson[] {
-  return getInactiveRules(rules).filter((r) => !r.password);
+  return getInactiveSchedulingRules(rules).filter((r) => !r.password);
 }
 
-function findFirstCreditStartDate(rules: AssessmentAccessRuleJson[]): string | undefined {
-  const startDates = getCreditRules(rules)
+function findFirstActiveCreditStartDate(rules: AssessmentAccessRuleJson[]): string | undefined {
+  const startDates = getActiveCreditRules(rules)
     .map((r) => r.startDate)
     .filter(Boolean)
     .sort() as string[];
   return startDates[0];
 }
 
-function findLastCreditEndDate(rules: AssessmentAccessRuleJson[]): string | undefined {
-  const endDates = getCreditRules(rules)
+function findLastActiveCreditEndDate(rules: AssessmentAccessRuleJson[]): string | undefined {
+  const endDates = getActiveCreditRules(rules)
     .map((r) => r.endDate)
     .filter(Boolean)
     .sort() as string[];
@@ -140,15 +140,6 @@ function ruleCovers(outer: AssessmentAccessRuleJson, inner: AssessmentAccessRule
     if (outer.startDate > inner.startDate) return false;
   }
   return true;
-}
-
-function findReleaseDate(rules: AssessmentAccessRuleJson[]): string | undefined {
-  // The new format's `release` is the start of submittability, not visibility.
-  // When credit rules exist, release must coincide with the first credit window
-  // — otherwise the resolver would treat any earlier visibility-rule startDate
-  // as a submittable 100%-credit window. Pre-credit visibility is preserved
-  // separately via `beforeRelease.listed`.
-  return findFirstCreditStartDate(rules);
 }
 
 // ---------------------------------------------------------------------------
@@ -213,7 +204,7 @@ function hasAccessGaps(rules: AssessmentAccessRuleJson[]): boolean {
 }
 
 function hasNonMonotonicCredit(rules: AssessmentAccessRuleJson[]): boolean {
-  const creditRules = getCreditRules(rules);
+  const creditRules = getActiveCreditRules(rules);
   if (creditRules.length === 0) return false;
 
   const dates = new Set<string>();
@@ -253,7 +244,7 @@ function hasNonMonotonicCredit(rules: AssessmentAccessRuleJson[]): boolean {
 }
 
 function hasPracticeBeforeRelease(rules: AssessmentAccessRuleJson[]): boolean {
-  const firstCreditStartDate = findFirstCreditStartDate(rules);
+  const firstCreditStartDate = findFirstActiveCreditStartDate(rules);
   if (!firstCreditStartDate) return false;
 
   return rules.some(
@@ -285,7 +276,7 @@ function buildAfterComplete(rules: AssessmentAccessRuleJson[]): {
   if (hidesAssessment || questionReviewWindows.length > 0) result.questions = { hidden: true };
   if (hidesScore) result.score = { hidden: true };
 
-  const lastCreditEndDate = findLastCreditEndDate(rules);
+  const lastCreditEndDate = findLastActiveCreditEndDate(rules);
   const visibilityRules = getVisibilityRules(rules);
   const questionReviewWindow = questionReviewWindows[0];
   const visibleUntilDate =
@@ -365,7 +356,7 @@ function getQuestionReviewWindows(rules: AssessmentAccessRuleJson[]): QuestionRe
   // last deadline. In accessControl, completed questions are hidden by default,
   // so model that window as hidden except visible starting at that window. If
   // there is exactly one bounded review window, preserve its end date too.
-  const lastCreditEndDate = findLastCreditEndDate(rules);
+  const lastCreditEndDate = findLastActiveCreditEndDate(rules);
   if (lastCreditEndDate == null) return [];
 
   const windows = getVisibilityRules(rules)
@@ -423,7 +414,7 @@ function mergeQuestionReviewWindows(windows: QuestionReviewWindow[]): QuestionRe
 }
 
 function shouldListBeforeRelease(rules: AssessmentAccessRuleJson[]): boolean {
-  const firstCreditStartDate = findFirstCreditStartDate(rules);
+  const firstCreditStartDate = findFirstActiveCreditStartDate(rules);
   if (!firstCreditStartDate) return false;
 
   // Any visibility rule that covers some pre-release time is enough to list
@@ -565,7 +556,7 @@ function buildCreditTimeline(rules: AssessmentAccessRuleJson[]): BuilderResult {
   const errors: string[] = [];
   const notes: string[] = [];
 
-  const creditRules = getCreditRules(rules);
+  const creditRules = getActiveCreditRules(rules);
   const allClosedCreditRules = creditRules.filter((r) => r.endDate);
   const openEndedCreditRules = creditRules.filter((r) => !r.endDate);
 
@@ -588,8 +579,8 @@ function buildCreditTimeline(rules: AssessmentAccessRuleJson[]): BuilderResult {
   }
   const closedCreditRules = allClosedCreditRules.filter((r) => !dominatedRules.has(r));
 
-  // No positive credit rules. If there are credit:0 rules with dates, treat
-  // them as a credit-0 due window using `due.credit: 0`.
+  // No active positive-credit rules. If there are active credit:0 rules with
+  // dates, treat them as a credit-0 due window using `due.credit: 0`.
   if (creditRules.length === 0) {
     const zeroCreditRules = rules.filter(
       (r) => (r.credit ?? 0) === 0 && (r.active ?? true) && (r.startDate || r.endDate),
@@ -623,14 +614,14 @@ function buildCreditTimeline(rules: AssessmentAccessRuleJson[]): BuilderResult {
     return { dateControl, errors, notes };
   }
 
-  // All credit rules are open-ended (no endDate).
+  // All active positive-credit rules are open-ended (no endDate).
   if (closedCreditRules.length === 0) {
     const allFull = openEndedCreditRules.every((r) => (r.credit ?? 0) === 100);
     if (!allFull) {
       errors.push('Open-ended credit windows without a 100% credit rule cannot be migrated.');
       return { dateControl: undefined, errors, notes };
     }
-    const releaseDate = findReleaseDate(rules);
+    const releaseDate = findFirstActiveCreditStartDate(rules);
     const dateControl: NonNullable<AccessControlJsonInput['dateControl']> = {};
     if (releaseDate) dateControl.release = { date: releaseDate };
     const openTimedRule = creditRules.find((r) => r.timeLimitMin);
@@ -675,7 +666,9 @@ function buildCreditTimeline(rules: AssessmentAccessRuleJson[]): BuilderResult {
   }
 
   // --- Build dateControl ---
-  const releaseDate = findReleaseDate(rules);
+  // `release` is the start of submittability, not visibility. Earlier
+  // inactive visibility windows are handled by `beforeRelease.listed`.
+  const releaseDate = findFirstActiveCreditStartDate(rules);
   const dateControl: NonNullable<AccessControlJsonInput['dateControl']> = {};
   if (releaseDate) dateControl.release = { date: releaseDate };
   if (dueDate) {
@@ -739,7 +732,7 @@ function buildCreditTimeline(rules: AssessmentAccessRuleJson[]): BuilderResult {
   // treating them as practice would silently grant submission rights they
   // never had.
   if (!dateControl.afterLastDeadline) {
-    const lastDeadline = findLastCreditEndDate(rules) ?? dueDate;
+    const lastDeadline = findLastActiveCreditEndDate(rules) ?? dueDate;
     if (lastDeadline) {
       const hasPracticeWindow = rules.some(
         (r) => (r.credit ?? 0) === 0 && (r.active ?? true) && r.endDate && r.endDate > lastDeadline,
@@ -816,7 +809,9 @@ function stripPasswordsFromInactiveRules(rules: AssessmentAccessRuleJson[]): {
   rules: AssessmentAccessRuleJson[];
   notes: string[];
 } {
-  const inactivePasswordRules = new Set(getInactiveRules(rules).filter((r) => r.password));
+  const inactivePasswordRules = new Set(
+    getInactiveSchedulingRules(rules).filter((r) => r.password),
+  );
   const count = inactivePasswordRules.size;
   if (count === 0) return { rules, notes: [] };
 
@@ -989,14 +984,14 @@ export function migrateAllowAccess(
     };
   }
 
-  const hasCreditRules = schedulingRules.some((r) => (r.credit ?? 0) > 0);
+  const activeSchedulingRules = schedulingRules.filter((r) => r.active ?? true);
+  const hasCreditRules = getActiveCreditRules(schedulingRules).length > 0;
   const hasModeOnly =
     !hasCreditRules &&
-    schedulingRules.some((r) => r.mode) &&
-    schedulingRules.every(
+    activeSchedulingRules.some((r) => r.mode) &&
+    activeSchedulingRules.every(
       (r) =>
         (r.credit ?? 0) === 0 &&
-        (r.active ?? true) &&
         !r.startDate &&
         !r.endDate &&
         !r.showClosedAssessment &&
@@ -1025,7 +1020,7 @@ export function migrateAllowAccess(
     );
   }
 
-  if (!dateControl && !pwExtract && getInactiveRules(schedulingRules).length > 0) {
+  if (!dateControl && !pwExtract && getInactiveSchedulingRules(schedulingRules).length > 0) {
     notes.push(
       'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
     );

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -27,9 +27,6 @@ import { formatJsonWithPrettier } from '../prettier.js';
 
 import { getAfterCompleteCrossFieldIssue, validateAccessControlRules } from './validation.js';
 
-export const INACTIVE_WINDOW_NOTE =
-  'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.';
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -1029,7 +1026,9 @@ export function migrateAllowAccess(
   }
 
   if (!dateControl && !pwExtract && getInactiveRules(schedulingRules).length > 0) {
-    notes.push(INACTIVE_WINDOW_NOTE);
+    notes.push(
+      'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.',
+    );
   }
 
   // No-op detection: when nothing produced a dateControl, password, or

--- a/apps/prairielearn/src/lib/assessment-access-control/migration.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/migration.ts
@@ -30,12 +30,6 @@ import { getAfterCompleteCrossFieldIssue, validateAccessControlRules } from './v
 export const INACTIVE_WINDOW_NOTE =
   'Inactive legacy access rules without a date-control access window cannot be faithfully migrated because modern access control cannot represent bounded view-only windows.';
 
-function inactivePasswordNote(count: number): string {
-  return `${count} password${count === 1 ? '' : 's'} on inactive legacy access rule${
-    count === 1 ? '' : 's'
-  } discarded because inactive rules do not allow submissions.`;
-}
-
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -826,7 +820,8 @@ function stripPasswordsFromInactiveRules(rules: AssessmentAccessRuleJson[]): {
   notes: string[];
 } {
   const inactivePasswordRules = new Set(getInactiveRules(rules).filter((r) => r.password));
-  if (inactivePasswordRules.size === 0) return { rules, notes: [] };
+  const count = inactivePasswordRules.size;
+  if (count === 0) return { rules, notes: [] };
 
   return {
     rules: rules.map((r) => {
@@ -834,7 +829,9 @@ function stripPasswordsFromInactiveRules(rules: AssessmentAccessRuleJson[]): {
       const { password: _password, ...rest } = r;
       return rest;
     }),
-    notes: [inactivePasswordNote(inactivePasswordRules.size)],
+    notes: [
+      `${count} password${count === 1 ? '' : 's'} on inactive legacy access rule${count === 1 ? '' : 's'} discarded because inactive rules do not allow submissions.`,
+    ],
   };
 }
 
@@ -1031,9 +1028,9 @@ export function migrateAllowAccess(
     );
   }
 
-  const hasInactiveRulesWithoutDateControl =
-    !dateControl && getInactiveRules(schedulingRules).length > 0;
-  if (hasInactiveRulesWithoutDateControl && !pwExtract) notes.push(INACTIVE_WINDOW_NOTE);
+  if (!dateControl && !pwExtract && getInactiveRules(schedulingRules).length > 0) {
+    notes.push(INACTIVE_WINDOW_NOTE);
+  }
 
   // No-op detection: when nothing produced a dateControl, password, or
   // PrairieTest config, the rules collapse to a no-op. Suppress the note if

--- a/scripts/migration-harness.mts
+++ b/scripts/migration-harness.mts
@@ -3,13 +3,16 @@
  * migrateAllowAccess(), normalizes shapes and error signatures, and generates
  * an HTML report comparing old vs new for each unique (shape, outcome) pair.
  *
- * Run from the root of the repository with `./node_modules/.bin/tsx scripts/migration-harness.mts`
+ * Run from the root of the repository with
+ * `pnpm --dir apps/prairielearn exec tsx ../../scripts/migration-harness.mts`
+ * or add `--inactive-window-summary` for a targeted summary of inactive legacy access rules.
  */
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import {
+  INACTIVE_WINDOW_NOTE,
   migrateAllowAccess,
   normalizeRules,
 } from '../apps/prairielearn/src/lib/assessment-access-control/migration.js';
@@ -167,6 +170,27 @@ interface OutcomeGroup {
   filePaths: string[];
 }
 
+interface InactiveWindowClassification {
+  singleInactiveRule: boolean;
+  inactiveOnly: boolean;
+  prairieTestPlusInactive: boolean;
+  hasInactiveDates: boolean;
+  hasInactiveTimeLimit: boolean;
+  hasInactivePassword: boolean;
+  hasInactiveExplicitZeroCredit: boolean;
+  hasInactivePositiveCredit: boolean;
+  hasInactiveShowClosedAssessment: boolean;
+  hasInactiveShowClosedAssessmentScore: boolean;
+  shape: string;
+  normalized: NormalizedRule[];
+}
+
+interface InactiveWindowShapeGroup {
+  count: number;
+  classification: InactiveWindowClassification;
+  filePaths: string[];
+}
+
 // ---------------------------------------------------------------------------
 // Generate HTML report
 // ---------------------------------------------------------------------------
@@ -287,6 +311,154 @@ function filterRows() {
 }
 
 // ---------------------------------------------------------------------------
+// Inactive-only legacy rule summary
+// ---------------------------------------------------------------------------
+
+function classifyInactiveWindowRules(
+  rules: AssessmentAccessRuleJson[],
+): InactiveWindowClassification | null {
+  const migrationResult = migrateAllowAccess(rules, FALLBACK_RELEASE);
+  if (!migrationResult.notes.includes(INACTIVE_WINDOW_NOTE)) return null;
+
+  const { shape, normalized } = normalizeRulesForHarness(rules);
+  const normalizedRules = normalizeRules(rules);
+  const inactiveRules = normalizedRules.filter((rule) => rule.active === false && !rule.examUuid);
+  const nonPrairieTestRules = normalizedRules.filter((rule) => !rule.examUuid);
+
+  return {
+    singleInactiveRule: normalizedRules.length === 1 && inactiveRules.length === 1,
+    inactiveOnly: inactiveRules.length > 0 && nonPrairieTestRules.length === inactiveRules.length,
+    prairieTestPlusInactive:
+      normalizedRules.some((rule) => rule.examUuid) && inactiveRules.length > 0,
+    hasInactiveDates: inactiveRules.some((rule) => rule.startDate != null || rule.endDate != null),
+    hasInactiveTimeLimit: inactiveRules.some((rule) => rule.timeLimitMin != null),
+    hasInactivePassword: inactiveRules.some((rule) => rule.password != null),
+    hasInactiveExplicitZeroCredit: inactiveRules.some((rule) => rule.credit === 0),
+    hasInactivePositiveCredit: inactiveRules.some((rule) => (rule.credit ?? 0) > 0),
+    hasInactiveShowClosedAssessment: inactiveRules.some(
+      (rule) => rule.showClosedAssessment != null,
+    ),
+    hasInactiveShowClosedAssessmentScore: inactiveRules.some(
+      (rule) => rule.showClosedAssessmentScore != null,
+    ),
+    shape,
+    normalized,
+  };
+}
+
+function incrementIf(map: Map<string, number>, key: string, condition: boolean) {
+  if (!condition) return;
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function printCount(label: string, count: number, denominator: number) {
+  const pct = denominator === 0 ? '0.00' : ((count / denominator) * 100).toFixed(2);
+  console.log(`  ${label}: ${count.toLocaleString()} (${pct}%)`);
+}
+
+async function printInactiveWindowSummary(files: string[]) {
+  const shapeGroups = new Map<string, InactiveWindowShapeGroup>();
+  const counters = new Map<string, number>();
+  let withAccess = 0;
+  let processed = 0;
+  let affected = 0;
+
+  for (const filePath of files) {
+    processed++;
+    if (processed % 10000 === 0) {
+      console.log(`  Processed ${processed}/${files.length}...`);
+    }
+
+    let content: string;
+    try {
+      content = await fs.readFile(filePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    let json: any;
+    try {
+      json = JSON.parse(content);
+    } catch {
+      continue;
+    }
+
+    const allowAccess: AssessmentAccessRuleJson[] | undefined = json.allowAccess;
+    if (!allowAccess || !Array.isArray(allowAccess) || allowAccess.length === 0) continue;
+    withAccess++;
+
+    const classification = classifyInactiveWindowRules(allowAccess);
+    if (!classification) continue;
+
+    affected++;
+    incrementIf(counters, 'single inactive rule', classification.singleInactiveRule);
+    incrementIf(counters, 'inactive-only after normalization', classification.inactiveOnly);
+    incrementIf(
+      counters,
+      'PrairieTest plus inactive viewing rule',
+      classification.prairieTestPlusInactive,
+    );
+    incrementIf(counters, 'inactive rule has start/end date', classification.hasInactiveDates);
+    incrementIf(counters, 'inactive rule has timeLimitMin', classification.hasInactiveTimeLimit);
+    incrementIf(counters, 'inactive rule has password', classification.hasInactivePassword);
+    incrementIf(
+      counters,
+      'inactive rule has explicit credit 0',
+      classification.hasInactiveExplicitZeroCredit,
+    );
+    incrementIf(
+      counters,
+      'inactive rule has positive credit',
+      classification.hasInactivePositiveCredit,
+    );
+    incrementIf(
+      counters,
+      'inactive rule has showClosedAssessment',
+      classification.hasInactiveShowClosedAssessment,
+    );
+    incrementIf(
+      counters,
+      'inactive rule has showClosedAssessmentScore',
+      classification.hasInactiveShowClosedAssessmentScore,
+    );
+
+    const existing = shapeGroups.get(classification.shape);
+    if (existing) {
+      existing.count++;
+      if (existing.filePaths.length < 3) existing.filePaths.push(filePath);
+    } else {
+      shapeGroups.set(classification.shape, {
+        count: 1,
+        classification,
+        filePaths: [filePath],
+      });
+    }
+  }
+
+  console.log('\nInactive legacy access-rule summary');
+  console.log(`${files.length.toLocaleString()} total files scanned`);
+  console.log(`${withAccess.toLocaleString()} assessments with allowAccess`);
+  printCount('affected assessments', affected, withAccess);
+  console.log('\nBreakdown among affected assessments:');
+  for (const [label, count] of [...counters.entries()].sort((a, b) => b[1] - a[1])) {
+    printCount(label, count, affected);
+  }
+
+  console.log('\nTop affected normalized shapes:');
+  const topGroups = [...shapeGroups.values()].sort((a, b) => b.count - a.count).slice(0, 20);
+  topGroups.forEach((group, index) => {
+    console.log(
+      `\n#${index + 1}: ${group.count.toLocaleString()} assessment${group.count === 1 ? '' : 's'}`,
+    );
+    console.log(JSON.stringify(group.classification.normalized, null, 2));
+    console.log('Example files:');
+    for (const filePath of group.filePaths) {
+      console.log(`  ${filePath.replace(REPOS_DIR + '/', '')}`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -294,6 +466,11 @@ async function main() {
   console.log('Scanning for infoAssessment.json files...');
   const files = await findInfoAssessmentFiles(REPOS_DIR);
   console.log(`Found ${files.length} files`);
+
+  if (process.argv.includes('--inactive-window-summary')) {
+    await printInactiveWindowSummary(files);
+    return;
+  }
 
   // Group by (shape, outcome) where outcome = normalized errors/notes.
   const groupMap = new Map<string, OutcomeGroup>();

--- a/scripts/migration-harness.mts
+++ b/scripts/migration-harness.mts
@@ -3,16 +3,13 @@
  * migrateAllowAccess(), normalizes shapes and error signatures, and generates
  * an HTML report comparing old vs new for each unique (shape, outcome) pair.
  *
- * Run from the root of the repository with
- * `pnpm --dir apps/prairielearn exec tsx ../../scripts/migration-harness.mts`
- * or add `--inactive-window-summary` for a targeted summary of inactive legacy access rules.
+ * Run from the root of the repository with `./node_modules/.bin/tsx scripts/migration-harness.mts`
  */
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import {
-  INACTIVE_WINDOW_NOTE,
   migrateAllowAccess,
   normalizeRules,
 } from '../apps/prairielearn/src/lib/assessment-access-control/migration.js';
@@ -170,27 +167,6 @@ interface OutcomeGroup {
   filePaths: string[];
 }
 
-interface InactiveWindowClassification {
-  singleInactiveRule: boolean;
-  inactiveOnly: boolean;
-  prairieTestPlusInactive: boolean;
-  hasInactiveDates: boolean;
-  hasInactiveTimeLimit: boolean;
-  hasInactivePassword: boolean;
-  hasInactiveExplicitZeroCredit: boolean;
-  hasInactivePositiveCredit: boolean;
-  hasInactiveShowClosedAssessment: boolean;
-  hasInactiveShowClosedAssessmentScore: boolean;
-  shape: string;
-  normalized: NormalizedRule[];
-}
-
-interface InactiveWindowShapeGroup {
-  count: number;
-  classification: InactiveWindowClassification;
-  filePaths: string[];
-}
-
 // ---------------------------------------------------------------------------
 // Generate HTML report
 // ---------------------------------------------------------------------------
@@ -311,154 +287,6 @@ function filterRows() {
 }
 
 // ---------------------------------------------------------------------------
-// Inactive-only legacy rule summary
-// ---------------------------------------------------------------------------
-
-function classifyInactiveWindowRules(
-  rules: AssessmentAccessRuleJson[],
-): InactiveWindowClassification | null {
-  const migrationResult = migrateAllowAccess(rules, FALLBACK_RELEASE);
-  if (!migrationResult.notes.includes(INACTIVE_WINDOW_NOTE)) return null;
-
-  const { shape, normalized } = normalizeRulesForHarness(rules);
-  const normalizedRules = normalizeRules(rules);
-  const inactiveRules = normalizedRules.filter((rule) => rule.active === false && !rule.examUuid);
-  const nonPrairieTestRules = normalizedRules.filter((rule) => !rule.examUuid);
-
-  return {
-    singleInactiveRule: normalizedRules.length === 1 && inactiveRules.length === 1,
-    inactiveOnly: inactiveRules.length > 0 && nonPrairieTestRules.length === inactiveRules.length,
-    prairieTestPlusInactive:
-      normalizedRules.some((rule) => rule.examUuid) && inactiveRules.length > 0,
-    hasInactiveDates: inactiveRules.some((rule) => rule.startDate != null || rule.endDate != null),
-    hasInactiveTimeLimit: inactiveRules.some((rule) => rule.timeLimitMin != null),
-    hasInactivePassword: inactiveRules.some((rule) => rule.password != null),
-    hasInactiveExplicitZeroCredit: inactiveRules.some((rule) => rule.credit === 0),
-    hasInactivePositiveCredit: inactiveRules.some((rule) => (rule.credit ?? 0) > 0),
-    hasInactiveShowClosedAssessment: inactiveRules.some(
-      (rule) => rule.showClosedAssessment != null,
-    ),
-    hasInactiveShowClosedAssessmentScore: inactiveRules.some(
-      (rule) => rule.showClosedAssessmentScore != null,
-    ),
-    shape,
-    normalized,
-  };
-}
-
-function incrementIf(map: Map<string, number>, key: string, condition: boolean) {
-  if (!condition) return;
-  map.set(key, (map.get(key) ?? 0) + 1);
-}
-
-function printCount(label: string, count: number, denominator: number) {
-  const pct = denominator === 0 ? '0.00' : ((count / denominator) * 100).toFixed(2);
-  console.log(`  ${label}: ${count.toLocaleString()} (${pct}%)`);
-}
-
-async function printInactiveWindowSummary(files: string[]) {
-  const shapeGroups = new Map<string, InactiveWindowShapeGroup>();
-  const counters = new Map<string, number>();
-  let withAccess = 0;
-  let processed = 0;
-  let affected = 0;
-
-  for (const filePath of files) {
-    processed++;
-    if (processed % 10000 === 0) {
-      console.log(`  Processed ${processed}/${files.length}...`);
-    }
-
-    let content: string;
-    try {
-      content = await fs.readFile(filePath, 'utf-8');
-    } catch {
-      continue;
-    }
-
-    let json: any;
-    try {
-      json = JSON.parse(content);
-    } catch {
-      continue;
-    }
-
-    const allowAccess: AssessmentAccessRuleJson[] | undefined = json.allowAccess;
-    if (!allowAccess || !Array.isArray(allowAccess) || allowAccess.length === 0) continue;
-    withAccess++;
-
-    const classification = classifyInactiveWindowRules(allowAccess);
-    if (!classification) continue;
-
-    affected++;
-    incrementIf(counters, 'single inactive rule', classification.singleInactiveRule);
-    incrementIf(counters, 'inactive-only after normalization', classification.inactiveOnly);
-    incrementIf(
-      counters,
-      'PrairieTest plus inactive viewing rule',
-      classification.prairieTestPlusInactive,
-    );
-    incrementIf(counters, 'inactive rule has start/end date', classification.hasInactiveDates);
-    incrementIf(counters, 'inactive rule has timeLimitMin', classification.hasInactiveTimeLimit);
-    incrementIf(counters, 'inactive rule has password', classification.hasInactivePassword);
-    incrementIf(
-      counters,
-      'inactive rule has explicit credit 0',
-      classification.hasInactiveExplicitZeroCredit,
-    );
-    incrementIf(
-      counters,
-      'inactive rule has positive credit',
-      classification.hasInactivePositiveCredit,
-    );
-    incrementIf(
-      counters,
-      'inactive rule has showClosedAssessment',
-      classification.hasInactiveShowClosedAssessment,
-    );
-    incrementIf(
-      counters,
-      'inactive rule has showClosedAssessmentScore',
-      classification.hasInactiveShowClosedAssessmentScore,
-    );
-
-    const existing = shapeGroups.get(classification.shape);
-    if (existing) {
-      existing.count++;
-      if (existing.filePaths.length < 3) existing.filePaths.push(filePath);
-    } else {
-      shapeGroups.set(classification.shape, {
-        count: 1,
-        classification,
-        filePaths: [filePath],
-      });
-    }
-  }
-
-  console.log('\nInactive legacy access-rule summary');
-  console.log(`${files.length.toLocaleString()} total files scanned`);
-  console.log(`${withAccess.toLocaleString()} assessments with allowAccess`);
-  printCount('affected assessments', affected, withAccess);
-  console.log('\nBreakdown among affected assessments:');
-  for (const [label, count] of [...counters.entries()].sort((a, b) => b[1] - a[1])) {
-    printCount(label, count, affected);
-  }
-
-  console.log('\nTop affected normalized shapes:');
-  const topGroups = [...shapeGroups.values()].sort((a, b) => b.count - a.count).slice(0, 20);
-  topGroups.forEach((group, index) => {
-    console.log(
-      `\n#${index + 1}: ${group.count.toLocaleString()} assessment${group.count === 1 ? '' : 's'}`,
-    );
-    console.log(JSON.stringify(group.classification.normalized, null, 2));
-    console.log('Example files:');
-    for (const filePath of group.filePaths) {
-      console.log(`  ${filePath.replace(REPOS_DIR + '/', '')}`);
-    }
-  });
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -466,11 +294,6 @@ async function main() {
   console.log('Scanning for infoAssessment.json files...');
   const files = await findInfoAssessmentFiles(REPOS_DIR);
   console.log(`Found ${files.length} files`);
-
-  if (process.argv.includes('--inactive-window-summary')) {
-    await printInactiveWindowSummary(files);
-    return;
-  }
 
   // Group by (shape, outcome) where outcome = normalized errors/notes.
   const groupMap = new Map<string, OutcomeGroup>();


### PR DESCRIPTION
# Description

Fixes #15305.

Legacy `active: false` access rules now migrate as non-submittable view-only rules instead of contributing release dates, credit deadlines, passwords, or time limits, which avoids turning inactive-only rules into open assessments.

When inactive-only rules cannot be represented as bounded view-only windows in modern access control, the migration emits an empty default access rule with a note rather than loosening access, while still preserving inactive rules as before-release listing or after-complete review visibility when they are anchored to a real submittable window.

The implementation now treats inactive rules consistently across credit timeline construction, password extraction, release-date selection, and mode-only precondition checks.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation was produced with AI assistance under human direction.

# Testing

Ran the focused access-control migration Vitest suite after the latest cleanup; it passes with 110 tests.
