### PR TITLE
Limit docs table of contents depth

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,7 @@ markdown_extensions:
 
   - toc:
       permalink: true
+      toc_depth: 3
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/?h=pymdownx+blocks+caption#caption
   - pymdownx.blocks.caption
   # https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown/?h=attribute+list#attribute-lists


### PR DESCRIPTION
# Description

This sets the Markdown `toc` extension's `toc_depth` to `3`, limiting the generated page-local table of contents to H1-H3 headings while keeping heading permalinks enabled.

This is related to #15049, where the `pl-drawing` docs page was called out as hard to navigate because repeated H4 entries like `Sample element`, `Customizations`, and `Example implementations` dominate the right-side TOC.

The tradeoff is that this is a global docs setting, so H4 entries disappear from the page TOC on every docs page, not just `pl-drawing`. The main pages affected outside `pl-drawing` are the API endpoint list, `pl-sketch` grading criteria, C grader options, and assessment access-control details.

The H4 headings themselves, generated IDs, and permalink anchors remain in the rendered page content, so existing deep links to those headings should continue to work; only page-TOC discoverability changes.

An alternative would be to restructure only `pl-drawing` by replacing repeated H4 labels with bold text or another local pattern. This PR chooses the smaller global config change so reviewers can evaluate whether the site-wide TOC behavior is acceptable.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation and analysis was performed by Codex under Nathan's direction.

# Testing

Built the docs with `uv run mkdocs build --strict`; the build completed successfully and only emitted the existing Material/MkDocs 2.0 warning from the docs toolchain.