### PR TITLE
Fix question README expansion

### DIFF
--- a/apps/prairielearn/assets/scripts/question.ts
+++ b/apps/prairielearn/assets/scripts/question.ts
@@ -27,13 +27,19 @@ onDocumentReady(() => {
     constructor: HTMLDivElement,
     initialize(container) {
       void mathjaxTypeset([container]);
-      initializeReadmeExpansion(container);
       setupDisableOnSubmit(container);
 
       if (container.dataset.gradingMethod === 'External') {
         const externalGrading = initializeExternalGrading({ container });
         return { remove: () => externalGrading?.close() };
       }
+    },
+  });
+
+  observe('.js-readme-card', {
+    constructor: HTMLDivElement,
+    initialize(readmeCard) {
+      initializeReadmeExpansion(readmeCard);
     },
   });
 


### PR DESCRIPTION
# Description

Closes #15219.

This fixes instructor question README cards so their expand/collapse behavior initializes from the README card itself, instead of only from `.question-container`, which left long README content clipped at 150px with no visible expansion control.

- [x] I have disclosed the level of AI assistance used: majority of implementation by Codex.

# Testing

Manually verified by adding a very long `README.md` to a question: it initially shows an Expand button, expands from 150px to its full content height, and collapses back.