### PR TITLE
Honor pl-drawing pulley labels and switch label offsets

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -2803,6 +2803,32 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
     obj.evented = false;
     canvas.add(obj);
 
+    let textObj = null;
+    const updateLabel = function () {
+      if (textObj) {
+        textObj.left = obj.left + obj.offsetx;
+        textObj.top = obj.top + obj.offsety;
+        textObj.setCoords();
+      }
+    };
+    const removeLabel = function () {
+      if (textObj) {
+        canvas.remove(textObj);
+      }
+    };
+    if (obj.label) {
+      textObj = new mechanicsObjects.LatexText(obj.label, {
+        left: obj.left + obj.offsetx,
+        top: obj.top + obj.offsety,
+        fontSize: 16,
+        textAlign: 'left',
+        selectable: false,
+        originX: 'center',
+        originY: 'center',
+      });
+      canvas.add(textObj);
+    }
+
     if (options.selectable) {
       const cc = mechanicsObjects.makeControlHandle(options.x1, options.y1, 5, 2);
       const c1 = mechanicsObjects.makeControlHandle(options.x2, options.y2, 5, 2);
@@ -2824,11 +2850,13 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(c1);
           canvas.remove(c2);
+          removeLabel();
         },
       );
       cc.on('moving', function () {
         obj.set({ x1: cc.left, y1: cc.top });
         obj.fire('update_visuals');
+        updateLabel();
       });
 
       // c1
@@ -2845,6 +2873,7 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(cc);
           canvas.remove(c2);
+          removeLabel();
         },
       );
       c1.on('moving', function () {
@@ -2866,6 +2895,7 @@ mechanicsObjects.byType['pl-pulley'] = class extends PLDrawingBaseElement {
           // Removed
           canvas.remove(cc);
           canvas.remove(c1);
+          removeLabel();
         },
       );
       c2.on('moving', function () {
@@ -4181,8 +4211,16 @@ mechanicsObjects.byType['pl-switch'] = class extends PLDrawingBaseElement {
     if (options.label) {
       const offsetlabel = 10;
       const textObj = new mechanicsObjects.LatexText(options.label, {
-        left: xm1 + (l / 2) * Math.cos(theta2 + theta) - offsetlabel * Math.sin(theta2 + theta),
-        top: ym1 + (l / 2) * Math.sin(theta2 + theta) + offsetlabel * Math.cos(theta2 + theta),
+        left:
+          xm1 +
+          (l / 2) * Math.cos(theta2 + theta) -
+          offsetlabel * Math.sin(theta2 + theta) +
+          options.offsetx,
+        top:
+          ym1 +
+          (l / 2) * Math.sin(theta2 + theta) +
+          offsetlabel * Math.cos(theta2 + theta) +
+          options.offsety,
         textAlign: 'left',
         fontSize: options.fontSize,
         selectable: false,


### PR DESCRIPTION
# Description

Fixes `pl-drawing` rendering mismatches where `pl-pulley` accepted and documented label offsets but never rendered its label, and where `pl-switch` accepted offsets without applying them to the label position.

`pl-pulley` now creates a nonselectable `LatexText` label at the pulley center plus `offsetx`/`offsety` and keeps it aligned when the selectable center handle moves; `pl-switch` now adds `offsetx`/`offsety` to its existing default label location.

- [x] I have disclosed the level of AI assistance used (majority of implementation).

# Testing

Verified with Playwright against the local dev server using a temporary `pl-drawing` question that reproduced the missing pulley label and ignored switch offsets, then rechecked existing pulley and resistor-capacitor circuit demo questions.

Reviewers can test manually by placing this markup in a temporary v3 question's `question.html` and previewing it; the pulley label `P` should render at the pulley center plus `(45, -35)`, and `S_1` should be shifted by `(45, -25)` from the default switch label position shown by `S_0`.

```html
<pl-question-panel>
  <pl-drawing width="360" height="220" grid-size="0" gradable="false" aria-label="pl-drawing label offset test">
    <pl-drawing-initial>
      <pl-pulley x1="80" y1="80" x2="30" y2="160" x3="150" y3="160" radius="28" label="P" offsetx="45" offsety="-35"></pl-pulley>
      <pl-switch x1="210" y1="70" x2="330" y2="70" label="S_0" offsetx="0" offsety="0"></pl-switch>
      <pl-switch x1="210" y1="150" x2="330" y2="150" label="S_1" offsetx="45" offsety="-25"></pl-switch>
    </pl-drawing-initial>
  </pl-drawing>
</pl-question-panel>
```
