### PR TITLE
Replace jQuery in manual grading page

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -1,8 +1,8 @@
-import { decodeData } from '@prairielearn/browser-utils';
+import { decodeData, onDocumentReady } from '@prairielearn/browser-utils';
 
 import { mathjaxTypeset } from '../../src/lib/client/mathjax.js';
 
-$(() => {
+onDocumentReady(() => {
   resetInstructorGradingPanel();
 
   document.addEventListener('keypress', (event) => {
@@ -24,13 +24,12 @@ $(() => {
   });
   const modal = document.querySelector('#conflictGradingJobModal');
   if (modal) {
-    $(modal)
-      .on('shown.bs.modal', function () {
-        modal
-          .querySelectorAll('.js-submission-feedback')
-          .forEach((item) => item.dispatchEvent(new Event('input')));
-      })
-      .modal('show');
+    modal.addEventListener('shown.bs.modal', () =>
+      modal
+        .querySelectorAll('.js-submission-feedback')
+        .forEach((item) => item.dispatchEvent(new Event('input'))),
+    );
+    window.bootstrap.Modal.getOrCreateInstance(modal).show();
   }
 });
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Replace use of jQuery in manual grading instance question page.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Tested locally with a conflicting grading job to trigger the modal. Modal is triggered as expected, with feedback text box resized according to content (meaning the input events were triggered).

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
