### PR TITLE
Fix missing spaces before inline elements in JSX warnings

### DIFF
--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -56,7 +56,7 @@ export function StudentCoursesCard({
           </div>
         ) : isDevMode ? (
           <div className="card-body">
-            No courses loaded. Click <strong>"Load from disk"</strong> above and then click
+            No courses loaded. Click <strong>"Load from disk"</strong> above and then click{' '}
             <strong>"PrairieLearn"</strong> in the top left corner to come back to this page.
           </div>
         ) : (

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -81,9 +81,8 @@ function DevModeCard({ isDevMode }: { isDevMode: boolean }) {
       </div>
       <div className="card-body">
         <p>
-          PrairieLearn is running in Development Mode. Click the
-          <strong>"Load from disk"</strong> button above to load question and assessment definitions
-          from JSON files on disk.
+          PrairieLearn is running in Development Mode. Click the <strong>"Load from disk"</strong>{' '}
+          button above to load question and assessment definitions from JSON files on disk.
         </p>
         <p>
           You need to click "Load from disk" every time that a JSON file is changed on disk. Changes

--- a/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSettings/instructorCourseAdminSettings.html.tsx
@@ -304,14 +304,14 @@ function CourseDirectoryMissingAlert({
   if (!coursePathExists) {
     return (
       <div className="alert alert-danger">
-        Course directory not found. You must
+        Course directory not found. You must{' '}
         <a href={`${urlPrefix}/course_admin/syncs`}>sync your course</a>.
       </div>
     );
   } else if (!courseInfoExists) {
     return (
       <form name="add-configuration-form" method="POST" className="alert alert-danger">
-        <code>infoCourse.json</code> is missing. You must
+        <code>infoCourse.json</code> is missing. You must{' '}
         <input type="hidden" name="__csrf_token" value={csrfToken} />
         <button
           name="__action"
@@ -319,7 +319,7 @@ function CourseDirectoryMissingAlert({
           className="btn btn-link btn-link-inline mt-n1 p-0 border-0"
         >
           create this file
-        </button>
+        </button>{' '}
         to edit your course settings.
       </form>
     );

--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/LegacyAccessRuleCard.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/LegacyAccessRuleCard.tsx
@@ -18,7 +18,7 @@ export function LegacyAccessRuleCard({
   return (
     <>
       <div className="alert alert-warning" role="alert">
-        <strong>Legacy Access Rules Active:</strong> This course instance is using the legacy
+        <strong>Legacy Access Rules Active:</strong> This course instance is using the legacy{' '}
         <code>allowAccess</code> system. To use the new publishing system, you must first remove the{' '}
         <code>allowAccess</code> section from your course instance configuration. For more
         information, please see the{' '}


### PR DESCRIPTION
# Description

Some JSX warning/info messages had a word glued directly to an adjacent inline element (`<a>`, `<button>`, `<code>`, `<strong>`) because JSX collapses the newline + indentation between a text node and an element to nothing rather than a space. This made messages render as e.g. "You must**sync your course**". Each case now uses an explicit `{' '}` so the space renders. Affected: the course settings sync/`infoCourse.json` warnings, the home page Development Mode banner, the "no courses loaded" dev message, and the legacy `allowAccess` publishing warning.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). — majority of implementation

# Testing

Verified the home page Development Mode banner in a local dev server with Playwright: the rendered text content is exactly `Click the "Load from disk" button` (single space, no doubling). The other three follow the identical `{' '}` pattern.