### PR TITLE
Move client code for grading job page to asset

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorGradingJobClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradingJobClient.ts
@@ -16,10 +16,11 @@ onDocumentReady(async () => {
       try {
         const outputJson = JSON.parse(outputText);
         if (typeof outputJson === 'object' && outputJson !== null && 'error' in outputJson) {
-          outputText = `Error: ${outputJson.error}`;
+          outputText = `Error: ${outputJson.error || 'Unknown error'}`;
         }
       } catch {
-        // Ignore JSON parse errors
+        // In case of JSON parse errors, use original text
+        outputText = `Error: ${outputText || 'Unknown error'}`;
       }
     }
 

--- a/apps/prairielearn/assets/scripts/instructorGradingJobClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradingJobClient.ts
@@ -1,0 +1,33 @@
+import { onDocumentReady } from '@prairielearn/browser-utils';
+
+onDocumentReady(async () => {
+  const outputUrl = document.getElementById('job-output')?.dataset.outputUrl;
+
+  // If the output URL is not defined, the output is already included in the
+  // page, so we don't need to fetch it.
+  if (outputUrl) {
+    const output = await fetch(outputUrl, {
+      // If the load triggers an error, we want the error in JSON format.
+      headers: { accept: 'text/plain, application/json' },
+    }).catch(() => ({ ok: true, text: async () => 'Unable to load grader results' }));
+
+    let outputText = await output.text();
+    if (!output.ok) {
+      try {
+        const outputJson = JSON.parse(outputText);
+        if (typeof outputJson === 'object' && outputJson !== null && 'error' in outputJson) {
+          outputText = `Error: ${outputJson.error}`;
+        }
+      } catch {
+        // Ignore JSON parse errors
+      }
+    }
+
+    document.getElementById('job-output-loading')?.classList.add('d-none');
+    const jobOutputElement = document.getElementById('job-output');
+    if (jobOutputElement != null) {
+      jobOutputElement.textContent = outputText;
+      jobOutputElement.classList.remove('d-none');
+    }
+  }
+});

--- a/apps/prairielearn/assets/scripts/instructorGradingJobClient.ts
+++ b/apps/prairielearn/assets/scripts/instructorGradingJobClient.ts
@@ -16,12 +16,12 @@ onDocumentReady(async () => {
       try {
         const outputJson = JSON.parse(outputText);
         if (typeof outputJson === 'object' && outputJson !== null && 'error' in outputJson) {
-          outputText = `Error: ${outputJson.error || 'Unknown error'}`;
+          outputText = outputJson.error;
         }
       } catch {
         // In case of JSON parse errors, use original text
-        outputText = `Error: ${outputText || 'Unknown error'}`;
       }
+      outputText = `Error: ${outputText || 'Unknown error'}`;
     }
 
     document.getElementById('job-output-loading')?.classList.add('d-none');

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -4,7 +4,7 @@ import { formatDate } from '@prairielearn/formatter';
 import { html } from '@prairielearn/html';
 
 import { PageLayout } from '../../components/PageLayout.js';
-import { compiledScriptTag } from '../../lib/assets.ts';
+import { compiledScriptTag } from '../../lib/assets.js';
 import { GradingJobSchema, QuestionSchema, UserSchema, VariantSchema } from '../../lib/db-types.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -4,6 +4,7 @@ import { formatDate } from '@prairielearn/formatter';
 import { html } from '@prairielearn/html';
 
 import { PageLayout } from '../../components/PageLayout.js';
+import { compiledScriptTag } from '../../lib/assets.ts';
 import { GradingJobSchema, QuestionSchema, UserSchema, VariantSchema } from '../../lib/db-types.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 
@@ -46,6 +47,7 @@ export function InstructorGradingJob({
       type: 'instructor',
       page: 'course_instance' in resLocals ? 'instance_admin' : 'course_admin',
     },
+    headContent: compiledScriptTag('instructorGradingJobClient.ts'),
     content: html`
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">
@@ -175,27 +177,9 @@ export function InstructorGradingJob({
         <div class="card-body">
           ${gradingJobRow.grading_job.s3_bucket && gradingJobRow.grading_job.s3_root_key
             ? html`
-                <script>
-                  $(() => {
-                    const outputUrl = document.getElementById('job-output').dataset.outputUrl;
-
-                    $.get(outputUrl)
-                      .done(function (data) {
-                        $('#job-output-loading').hide();
-                        $('#job-output').text(data);
-                        $('#job-output').show();
-                      })
-                      .fail(function () {
-                        $('#job-output-loading').hide();
-                        $('#job-output').text('Unable to load grader results');
-                        $('#job-output').show();
-                      });
-                  });
-                </script>
                 <pre
-                  class="bg-dark text-white rounded p-3 mb-0"
+                  class="bg-dark text-white rounded p-3 mb-0 d-none"
                   id="job-output"
-                  style="display: none;"
                   data-output-url="${resLocals.urlPrefix}/grading_job/${gradingJobRow.grading_job
                     .id}/file/output.log"
                 ></pre>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Improvements to client-side functionality for grading job page.
* Dynamic loading of job output moved from a script tag to an asset.
* Use of jQuery for dynamic loading replaced with a call to fetch.
* Improved handling of errors in loading job output, particularly if request causes a 4xx or 5xx response.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none

# Testing

Given dynamic loading is only used when grading stores info in S3, it makes things trickier to test. I made temporary changes to the code to trigger the s3 branch in html.ts, which resulted in an expected error message that loading doesn't work for non-S3 grading job, which was properly shown in the output log. I also temporarily changed the router to return the grading job output if a request was done for output.log, and the dynamic loading retrieved the content correctly in that case. CI does not include a test for this page (and I don't think it would be easy to create one with the S3 functionality), so manual testing is all that's available for now.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
