### PR TITLE
Show inline validation instead of raw Zod errors in admin/instructor forms

### DIFF
--- a/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
+++ b/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
@@ -19,10 +19,6 @@ export interface CourseFormFieldValues {
   repository_short_name: string;
 }
 
-const SHORT_NAME_PATTERN = /^[A-Z]+ [A-Z0-9]+$/;
-const SHORT_NAME_PATTERN_MESSAGE =
-  'The course rubric and number should be a series of upper case letters, followed by a space, followed by a series of numbers and/or letters.';
-
 export function buildRepoShortName(prefix: string | null | undefined, shortName: string): string {
   const slug = shortName.replaceAll(' ', '').toLowerCase();
   return prefix ? `pl-${prefix}-${slug}` : `pl-${slug}`;
@@ -75,7 +71,6 @@ export function AdministratorCourseFormFields({
   aiSecretsConfigured,
   autoFilledInstitutionId,
   repositoryRequired,
-  enforceShortNamePattern = false,
   onInstitutionChange,
 }: {
   institutions: AdminInstitution[];
@@ -86,7 +81,6 @@ export function AdministratorCourseFormFields({
   aiSecretsConfigured: boolean;
   autoFilledInstitutionId?: string | null;
   repositoryRequired: boolean;
-  enforceShortNamePattern?: boolean;
   onInstitutionChange?: (institution: AdminInstitution) => void;
 }) {
   const trpc = useTRPC();
@@ -267,12 +261,7 @@ export function AdministratorCourseFormFields({
           placeholder="XC 101"
           aria-invalid={errors.short_name ? true : undefined}
           aria-errormessage={errors.short_name ? 'courseFormShortName-error' : undefined}
-          {...register('short_name', {
-            required: 'Enter a short name',
-            pattern: enforceShortNamePattern
-              ? { value: SHORT_NAME_PATTERN, message: SHORT_NAME_PATTERN_MESSAGE }
-              : undefined,
-          })}
+          {...register('short_name', { required: 'Enter a short name' })}
         />
         {errors.short_name && (
           <div id="courseFormShortName-error" className="invalid-feedback">
@@ -280,10 +269,11 @@ export function AdministratorCourseFormFields({
           </div>
         )}
         <div aria-live="polite" aria-atomic="true">
-          {shortName && !SHORT_NAME_PATTERN.test(shortName) && !errors.short_name && (
+          {shortName && !/^[A-Z]+ [A-Z0-9]+$/.test(shortName) && (
             <div className="form-text text-warning">
-              <i className="fa fa-exclamation-triangle" aria-hidden="true" />{' '}
-              {SHORT_NAME_PATTERN_MESSAGE}
+              <i className="fa fa-exclamation-triangle" aria-hidden="true" /> The course rubric and
+              number should be a series of upper case letters, followed by a space, followed by a
+              series of numbers and/or letters.
             </div>
           )}
         </div>

--- a/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
+++ b/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
@@ -19,6 +19,10 @@ export interface CourseFormFieldValues {
   repository_short_name: string;
 }
 
+const SHORT_NAME_PATTERN = /^[A-Z]+ [A-Z0-9]+$/;
+const SHORT_NAME_PATTERN_MESSAGE =
+  'The course rubric and number should be a series of upper case letters, followed by a space, followed by a series of numbers and/or letters.';
+
 export function buildRepoShortName(prefix: string | null | undefined, shortName: string): string {
   const slug = shortName.replaceAll(' ', '').toLowerCase();
   return prefix ? `pl-${prefix}-${slug}` : `pl-${slug}`;
@@ -71,6 +75,7 @@ export function AdministratorCourseFormFields({
   aiSecretsConfigured,
   autoFilledInstitutionId,
   repositoryRequired,
+  enforceShortNamePattern = false,
   onInstitutionChange,
 }: {
   institutions: AdminInstitution[];
@@ -81,6 +86,7 @@ export function AdministratorCourseFormFields({
   aiSecretsConfigured: boolean;
   autoFilledInstitutionId?: string | null;
   repositoryRequired: boolean;
+  enforceShortNamePattern?: boolean;
   onInstitutionChange?: (institution: AdminInstitution) => void;
 }) {
   const trpc = useTRPC();
@@ -261,7 +267,12 @@ export function AdministratorCourseFormFields({
           placeholder="XC 101"
           aria-invalid={errors.short_name ? true : undefined}
           aria-errormessage={errors.short_name ? 'courseFormShortName-error' : undefined}
-          {...register('short_name', { required: 'Enter a short name' })}
+          {...register('short_name', {
+            required: 'Enter a short name',
+            pattern: enforceShortNamePattern
+              ? { value: SHORT_NAME_PATTERN, message: SHORT_NAME_PATTERN_MESSAGE }
+              : undefined,
+          })}
         />
         {errors.short_name && (
           <div id="courseFormShortName-error" className="invalid-feedback">
@@ -269,11 +280,10 @@ export function AdministratorCourseFormFields({
           </div>
         )}
         <div aria-live="polite" aria-atomic="true">
-          {shortName && !/^[A-Z]+ [A-Z0-9]+$/.test(shortName) && (
+          {shortName && !SHORT_NAME_PATTERN.test(shortName) && !errors.short_name && (
             <div className="form-text text-warning">
-              <i className="fa fa-exclamation-triangle" aria-hidden="true" /> The course rubric and
-              number should be a series of upper case letters, followed by a space, followed by a
-              series of numbers and/or letters.
+              <i className="fa fa-exclamation-triangle" aria-hidden="true" />{' '}
+              {SHORT_NAME_PATTERN_MESSAGE}
             </div>
           )}
         </div>

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
@@ -357,7 +357,6 @@ function CourseInsertModal({
               prefixState={prefixState}
               aiSecretsConfigured={aiSecretsConfigured}
               repositoryRequired={false}
-              enforceShortNamePattern
             />
             <div className="mb-3">
               <label className="form-label" htmlFor="courseAddInputBranch">
@@ -499,14 +498,6 @@ function CourseUpdateColumnForm({
           aria-label={label}
           {...register('value', {
             required: required && `Enter a ${label}`,
-            pattern:
-              columnName === 'short_name'
-                ? {
-                    value: /^[A-Z]+ [A-Z0-9]+$/,
-                    message:
-                      'The course rubric and number should be a series of upper case letters, followed by a space, followed by a series of numbers and/or letters.',
-                  }
-                : undefined,
           })}
         />
         {errors.value && <div className="invalid-feedback">{errors.value.message}</div>}

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
@@ -248,7 +248,11 @@ function CourseDeleteForm({
           id={`inputConfirm${id}`}
           aria-invalid={errors.short_name ? true : undefined}
           aria-errormessage={errors.short_name ? `inputConfirm${id}-error` : undefined}
-          {...register('short_name')}
+          {...register('short_name', {
+            validate: (value) =>
+              value === row.course.short_name ||
+              `Type "${row.course.short_name}" exactly to confirm deletion.`,
+          })}
         />
         {errors.short_name && (
           <div id={`inputConfirm${id}-error`} className="invalid-feedback">
@@ -353,6 +357,7 @@ function CourseInsertModal({
               prefixState={prefixState}
               aiSecretsConfigured={aiSecretsConfigured}
               repositoryRequired={false}
+              enforceShortNamePattern
             />
             <div className="mb-3">
               <label className="form-label" htmlFor="courseAddInputBranch">

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -169,10 +169,13 @@ export function TimeLimitEditForm({
   function handleSubmit() {
     const reopenWithoutLimit = showReopenRadios && form.reopen_without_limit;
     const action = reopenWithoutLimit ? 'reopen_without_limit' : form.action;
+    const actionUsesTimeAdd =
+      action === 'set_total' || action === 'set_rem' || action === 'add' || action === 'subtract';
+    if (actionUsesTimeAdd && !Number.isFinite(form.time_add)) return;
     mutation.mutate({
       assessmentInstanceIds,
       action,
-      time_add: form.time_add,
+      time_add: actionUsesTimeAdd ? form.time_add : undefined,
       date: form.date,
       // In single mode we always re-open the targeted instance (matching the
       // legacy ✎ behavior). In bulk mode this is the explicit checkbox.

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -1,5 +1,6 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { useMutation } from '@tanstack/react-query';
+import clsx from 'clsx';
 import { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 
@@ -122,6 +123,12 @@ export function TimeLimitEditForm({
   // "re-open without time limit" hides the time-limit options entirely.
   const showReopenRadios = mode === 'single' && singleRow != null && !singleRow.open;
   const showTimeLimitOptions = mode === 'bulk' || singleRow?.open || !form.reopen_without_limit;
+  const showTimeAddInput =
+    showTimeLimitOptions &&
+    form.action !== 'set_exact' &&
+    form.action !== 'remove' &&
+    form.action !== 'expire';
+  const timeAddInvalid = showTimeAddInput && !Number.isFinite(form.time_add);
 
   const showRemove =
     mode === 'bulk' ||
@@ -259,20 +266,24 @@ export function TimeLimitEditForm({
           <TimeLimitExplanation action={form.action} />
         </p>
       ) : null}
-      {showTimeLimitOptions &&
-      form.action !== 'set_exact' &&
-      form.action !== 'remove' &&
-      form.action !== 'expire' ? (
-        <div className="input-group mb-2">
+      {showTimeAddInput ? (
+        <div className={clsx('input-group mb-2', timeAddInvalid && 'has-validation')}>
           <input
-            className="form-control time-limit-field"
+            className={clsx('form-control time-limit-field', timeAddInvalid && 'is-invalid')}
             type="number"
             name="time_add"
             aria-label="Time value"
-            value={form.time_add}
+            aria-invalid={timeAddInvalid ? true : undefined}
+            aria-errormessage={timeAddInvalid ? 'time-add-error' : undefined}
+            value={Number.isNaN(form.time_add) ? '' : form.time_add}
             onChange={(e) => updateFormState('time_add', Number.parseFloat(e.currentTarget.value))}
           />
           <span className="input-group-text time-limit-field">minutes</span>
+          {timeAddInvalid && (
+            <div id="time-add-error" className="invalid-feedback">
+              Enter a number of minutes.
+            </div>
+          )}
         </div>
       ) : null}
       {showTimeLimitOptions && form.action === 'set_exact' ? (
@@ -314,7 +325,7 @@ export function TimeLimitEditForm({
         <Button type="button" variant="secondary" className="me-2" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" variant="primary" disabled={mutation.isPending}>
+        <Button type="submit" variant="primary" disabled={mutation.isPending || timeAddInvalid}>
           {mutation.isPending ? 'Saving...' : 'Set'}
         </Button>
       </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -1,6 +1,5 @@
 import { Temporal } from '@js-temporal/polyfill';
 import { useMutation } from '@tanstack/react-query';
-import clsx from 'clsx';
 import { useState } from 'react';
 import { Alert, Button } from 'react-bootstrap';
 
@@ -133,7 +132,6 @@ export function TimeLimitEditForm({
     form.action !== 'set_exact' &&
     form.action !== 'remove' &&
     form.action !== 'expire';
-  const timeAddInvalid = showTimeAddInput && !Number.isFinite(timeAddValue);
 
   const showRemove =
     mode === 'bulk' ||
@@ -176,7 +174,6 @@ export function TimeLimitEditForm({
     const action = reopenWithoutLimit ? 'reopen_without_limit' : form.action;
     const actionUsesTimeAdd =
       action === 'set_total' || action === 'set_rem' || action === 'add' || action === 'subtract';
-    if (actionUsesTimeAdd && !Number.isFinite(timeAddValue)) return;
     mutation.mutate({
       assessmentInstanceIds,
       action,
@@ -275,23 +272,17 @@ export function TimeLimitEditForm({
         </p>
       ) : null}
       {showTimeAddInput ? (
-        <div className={clsx('input-group mb-2', timeAddInvalid && 'has-validation')}>
+        <div className="input-group mb-2">
           <input
-            className={clsx('form-control time-limit-field', timeAddInvalid && 'is-invalid')}
+            className="form-control time-limit-field"
             type="number"
             name="time_add"
             aria-label="Time value"
-            aria-invalid={timeAddInvalid ? true : undefined}
-            aria-errormessage={timeAddInvalid ? 'time-add-error' : undefined}
             value={form.time_add}
+            required
             onChange={(e) => updateFormState('time_add', e.currentTarget.value)}
           />
           <span className="input-group-text time-limit-field">minutes</span>
-          {timeAddInvalid && (
-            <div id="time-add-error" className="invalid-feedback">
-              Enter a number of minutes.
-            </div>
-          )}
         </div>
       ) : null}
       {showTimeLimitOptions && form.action === 'set_exact' ? (
@@ -333,7 +324,7 @@ export function TimeLimitEditForm({
         <Button type="button" variant="secondary" className="me-2" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" variant="primary" disabled={mutation.isPending || timeAddInvalid}>
+        <Button type="submit" variant="primary" disabled={mutation.isPending}>
           {mutation.isPending ? 'Saving...' : 'Set'}
         </Button>
       </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -107,17 +107,22 @@ export function TimeLimitEditForm({
 
   const [form, setForm] = useState<{
     action: TimeLimitAction;
-    time_add: number;
+    /**
+     * Kept as the raw input string so in-progress edits (empty, trailing dot)
+     * aren't collapsed to NaN; parsed to a number only when used.
+     */
+    time_add: string;
     date: string;
     reopen_closed: boolean;
     reopen_without_limit: boolean;
   }>(() => ({
     action: canAddSubtract ? 'add' : 'set_total',
-    time_add: 5,
+    time_add: '5',
     date: Temporal.Now.zonedDateTimeISO(timezone).toPlainDateTime().toString().slice(0, 16),
     reopen_closed: false,
     reopen_without_limit: true,
   }));
+  const timeAddValue = Number.parseFloat(form.time_add);
 
   // In single mode a closed instance shows the re-open radios; choosing
   // "re-open without time limit" hides the time-limit options entirely.
@@ -128,7 +133,7 @@ export function TimeLimitEditForm({
     form.action !== 'set_exact' &&
     form.action !== 'remove' &&
     form.action !== 'expire';
-  const timeAddInvalid = showTimeAddInput && !Number.isFinite(form.time_add);
+  const timeAddInvalid = showTimeAddInput && !Number.isFinite(timeAddValue);
 
   const showRemove =
     mode === 'bulk' ||
@@ -143,19 +148,19 @@ export function TimeLimitEditForm({
   }
 
   function proposedClosingTime() {
-    if (singleRow == null || !Number.isFinite(form.time_add)) return null;
+    if (singleRow == null || !Number.isFinite(timeAddValue)) return null;
     const totalTime = Math.round(singleRow.total_time_sec ?? 0);
 
     try {
       let startDate = Temporal.Instant.from(singleRow.date).toZonedDateTimeISO(timezone);
       if (form.action === 'set_total') {
-        startDate = startDate.add({ minutes: form.time_add });
+        startDate = startDate.add({ minutes: timeAddValue });
       } else if (form.action === 'set_rem') {
-        startDate = Temporal.Now.zonedDateTimeISO(timezone).add({ minutes: form.time_add });
+        startDate = Temporal.Now.zonedDateTimeISO(timezone).add({ minutes: timeAddValue });
       } else if (form.action === 'add') {
-        startDate = startDate.add({ seconds: totalTime }).add({ minutes: form.time_add });
+        startDate = startDate.add({ seconds: totalTime }).add({ minutes: timeAddValue });
       } else if (form.action === 'subtract') {
-        startDate = startDate.add({ seconds: totalTime }).subtract({ minutes: form.time_add });
+        startDate = startDate.add({ seconds: totalTime }).subtract({ minutes: timeAddValue });
       }
 
       return formatDate(new Date(startDate.epochMilliseconds), timezone);
@@ -171,11 +176,11 @@ export function TimeLimitEditForm({
     const action = reopenWithoutLimit ? 'reopen_without_limit' : form.action;
     const actionUsesTimeAdd =
       action === 'set_total' || action === 'set_rem' || action === 'add' || action === 'subtract';
-    if (actionUsesTimeAdd && !Number.isFinite(form.time_add)) return;
+    if (actionUsesTimeAdd && !Number.isFinite(timeAddValue)) return;
     mutation.mutate({
       assessmentInstanceIds,
       action,
-      time_add: actionUsesTimeAdd ? form.time_add : undefined,
+      time_add: actionUsesTimeAdd ? timeAddValue : undefined,
       date: form.date,
       // In single mode we always re-open the targeted instance (matching the
       // legacy ✎ behavior). In bulk mode this is the explicit checkbox.
@@ -278,8 +283,8 @@ export function TimeLimitEditForm({
             aria-label="Time value"
             aria-invalid={timeAddInvalid ? true : undefined}
             aria-errormessage={timeAddInvalid ? 'time-add-error' : undefined}
-            value={Number.isNaN(form.time_add) ? '' : form.time_add}
-            onChange={(e) => updateFormState('time_add', Number.parseFloat(e.currentTarget.value))}
+            value={form.time_add}
+            onChange={(e) => updateFormState('time_add', e.currentTarget.value)}
           />
           <span className="input-group-text time-limit-field">minutes</span>
           {timeAddInvalid && (

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -390,12 +390,14 @@ function AddUsersModal({
   const [courseRole, setCourseRole] = useState<CourseRole>('None');
   const [instanceRoles, setInstanceRoles] = useState<Record<string, string>>({});
   const [warnings, setWarnings] = useState<string[]>([]);
+  const [uidError, setUidError] = useState<string | null>(null);
 
   const resetState = () => {
     setUidText('');
     setCourseRole('None');
     setInstanceRoles({});
     setWarnings([]);
+    setUidError(null);
     mutation.reset();
   };
 
@@ -418,6 +420,16 @@ function AddUsersModal({
     e.preventDefault();
     setWarnings([]);
     const uids = uidText.split(/[,;\s]+/).filter(Boolean);
+
+    if (uids.length === 0) {
+      setUidError('Enter at least one UID.');
+      return;
+    }
+    if (uids.length > uidsLimit) {
+      setUidError(`Enter at most ${uidsLimit} UIDs at a time. You entered ${uids.length}.`);
+      return;
+    }
+    setUidError(null);
 
     const courseInstanceChanges = Object.entries(instanceRoles)
       .filter((entry): entry is [string, 'Student Data Viewer' | 'Student Data Editor'] =>
@@ -450,14 +462,23 @@ function AddUsersModal({
               UIDs:
             </label>
             <textarea
-              className="form-control"
+              className={clsx('form-control', uidError && 'is-invalid')}
               id="addUsersInputUid"
               placeholder="staff1@example.com, staff2@example.com"
               aria-describedby="addUsersInputUidHelp"
+              aria-invalid={uidError ? true : undefined}
+              aria-errormessage={uidError ? 'addUsersInputUid-error' : undefined}
               value={uidText}
-              required
-              onChange={(e) => setUidText(e.target.value)}
+              onChange={(e) => {
+                setUidText(e.target.value);
+                setUidError(null);
+              }}
             />
+            {uidError && (
+              <div id="addUsersInputUid-error" className="invalid-feedback">
+                {uidError}
+              </div>
+            )}
             <small id="addUsersInputUidHelp" className="form-text text-muted">
               Enter up to {uidsLimit} UIDs separated by commas, semicolons, or whitespace.
             </small>

--- a/apps/prairielearn/src/pages/instructorStudentsLabels/components/LabelModifyModal.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentsLabels/components/LabelModifyModal.tsx
@@ -12,6 +12,7 @@ import { getAppError } from '../../../lib/client/errors.js';
 import { getCourseInstanceJobSequenceUrl } from '../../../lib/client/url.js';
 import { parseUniqueValuesFromString } from '../../../lib/string-util.js';
 import { ColorJsonSchema } from '../../../schemas/infoCourse.js';
+import { MAX_STUDENT_LABEL_NAME_LENGTH } from '../../../schemas/infoCourseInstance.js';
 import { useTRPC } from '../../../trpc/courseInstance/context.js';
 import type { StudentLabelError } from '../../../trpc/courseInstance/student-labels.js';
 import { MAX_LABEL_UIDS } from '../instructorStudentsLabels.types.js';
@@ -226,7 +227,16 @@ export function LabelModifyModal({
               className={clsx('form-control', errors.name && 'is-invalid')}
               aria-invalid={!!errors.name}
               aria-errormessage={errors.name ? 'label-name-error' : undefined}
-              {...register('name', { required: 'Label name is required' })}
+              {...register('name', {
+                validate: (value) => {
+                  const trimmed = value.trim();
+                  if (trimmed.length === 0) return 'Label name is required';
+                  if (trimmed.length > MAX_STUDENT_LABEL_NAME_LENGTH) {
+                    return `Label name must be at most ${MAX_STUDENT_LABEL_NAME_LENGTH} characters.`;
+                  }
+                  return true;
+                },
+              })}
             />
             {errors.name && (
               <div id="label-name-error" className="invalid-feedback d-block">

--- a/apps/prairielearn/src/trpc/administrator/courses.ts
+++ b/apps/prairielearn/src/trpc/administrator/courses.ts
@@ -25,12 +25,16 @@ const insert = t.procedure
   .input(
     z.object({
       institutionId: IdSchema,
-      shortName: z.string().min(1, 'Short name is required'),
-      title: z.string().min(1, 'Title is required').max(75, 'Title must be at most 75 characters'),
-      displayTimezone: z.string().min(1, 'Timezone is required'),
-      path: z.string().min(1, 'Path is required'),
-      repository: z.string().nullable(),
-      branch: z.string().min(1, 'Branch is required'),
+      shortName: z.string().trim().min(1, 'Short name is required'),
+      title: z
+        .string()
+        .trim()
+        .min(1, 'Title is required')
+        .max(75, 'Title must be at most 75 characters'),
+      displayTimezone: z.string().trim().min(1, 'Timezone is required'),
+      path: z.string().trim().min(1, 'Path is required'),
+      repository: z.string().trim().nullable(),
+      branch: z.string().trim().min(1, 'Branch is required'),
     }),
   )
   .mutation(async ({ input, ctx }) => {
@@ -96,11 +100,11 @@ const updateColumn = t.procedure
       z.discriminatedUnion('columnName', [
         z.object({
           columnName: z.enum(['short_name', 'title', 'display_timezone', 'path', 'branch']),
-          value: z.string().min(1, 'Value is required'),
+          value: z.string().trim().min(1, 'Value is required'),
         }),
         z.object({
           columnName: z.literal('repository'),
-          value: z.string(), // Optional
+          value: z.string().trim(), // Optional
         }),
       ]),
     ),

--- a/apps/prairielearn/src/trpc/administrator/courses.ts
+++ b/apps/prairielearn/src/trpc/administrator/courses.ts
@@ -25,13 +25,7 @@ const insert = t.procedure
   .input(
     z.object({
       institutionId: IdSchema,
-      shortName: z
-        .string()
-        .min(1, 'Short name is required')
-        .regex(
-          /^[A-Z]+ [A-Z0-9]+$/,
-          'The course rubric and number should be a series of letters, followed by a space, followed by a series of numbers and/or letters.',
-        ),
+      shortName: z.string().min(1, 'Short name is required'),
       title: z.string().min(1, 'Title is required').max(75, 'Title must be at most 75 characters'),
       displayTimezone: z.string().min(1, 'Timezone is required'),
       path: z.string().min(1, 'Path is required'),


### PR DESCRIPTION
# Description

Some tRPC-backed forms could submit input that failed the server's Zod schema, rendering the raw `ZodError` JSON in the error alert (e.g. the admin course-delete modal). Each form now validates client-side so users see a clean inline message instead. Affected: course delete, admin course insert, add course staff, student labels, and time-limit edit.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). — majority of implementation.

# Testing

Reproduced on the admin courses page: deleting with an empty/mismatched confirmation previously showed raw ZodError JSON, now shows an inline message. Spot-checked the other forms with boundary input (empty UIDs, over-length label name, cleared minutes field).