### PR TITLE
Allow public access to shared assessments without sharing course instance

### DIFF
--- a/apps/prairielearn/src/middlewares/authzPublicCourseOrInstance.tsx
+++ b/apps/prairielearn/src/middlewares/authzPublicCourseOrInstance.tsx
@@ -25,8 +25,12 @@ function MissingCourseSharingNameCard({ courseId }: { courseId: string }) {
 /**
  * Middleware to authorize access to public course or course instance routes.
  * Checks if the course or course instance exists, if question sharing is enabled,
- * if the course has a sharing name, and if the course instance is shared publicly
- * (if applicable).
+ * and if the course has a sharing name.
+ *
+ * It does not check whether the course instance itself is shared publicly, since
+ * individual assessments can be shared publicly without sharing the entire course
+ * instance. Pages that expose course-instance-level content (e.g. the list of all
+ * assessments) must additionally use `authzPublicCourseInstanceSource`.
  *
  * If authorization fails, responds with a 404 Not Found error.
  *
@@ -68,10 +72,6 @@ export default typedAsyncHandler<'public-course' | 'public-course-instance'>(
       throw new HttpStatusError(404, 'Not Found');
     }
 
-    if (course_instance && !course_instance.share_source_publicly) {
-      throw new HttpStatusError(404, 'Not Found');
-    }
-
     res.locals.course = course;
     if (course_instance) res.locals.course_instance = course_instance;
 
@@ -90,6 +90,25 @@ export default typedAsyncHandler<'public-course' | 'public-course-instance'>(
         }),
       );
       return;
+    }
+
+    next();
+  },
+);
+
+/**
+ * Middleware that gates pages exposing course-instance-level content (e.g. the
+ * list of all of an instance's publicly shared assessments) on the course
+ * instance itself being shared publicly.
+ *
+ * Must run after `authzPublicCourseOrInstance`, which sets res.locals.course_instance.
+ *
+ * If the course instance is not shared publicly, responds with a 404 Not Found error.
+ */
+export const authzPublicCourseInstanceSource = typedAsyncHandler<'public-course-instance'>(
+  async (req, res, next) => {
+    if (!res.locals.course_instance.share_source_publicly) {
+      throw new HttpStatusError(404, 'Not Found');
     }
 
     next();

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -1905,10 +1905,10 @@ export async function initExpress(): Promise<Express> {
     },
     (await import('./middlewares/authzPublicCourseOrInstance.js')).default,
   ]);
-  app.use(
-    '/pl/public/course_instance/:course_instance_id(\\d+)/assessments',
+  app.use('/pl/public/course_instance/:course_instance_id(\\d+)/assessments', [
+    (await import('./middlewares/authzPublicCourseOrInstance.js')).authzPublicCourseInstanceSource,
     (await import('./pages/publicAssessments/publicAssessments.js')).default,
-  );
+  ]);
   app.use(/^(\/pl\/public\/course_instance\/[0-9]+\/assessment\/[0-9]+)\/?$/, (req, res, _next) => {
     res.redirect(`${req.params[0]}/questions`);
   });

--- a/apps/prairielearn/src/tests/questionSharing.test.ts
+++ b/apps/prairielearn/src/tests/questionSharing.test.ts
@@ -1092,6 +1092,26 @@ describe('Question Sharing', { timeout: 60_000 }, function () {
     });
 
     test.sequential(
+      'Access a publicly shared assessment whose course instance is not shared publicly',
+      async () => {
+        const sharedAssessmentId = (
+          await selectAssessmentByTid({
+            tid: 'test',
+            course_instance_id: sharingCourseInstanceId,
+          })
+        ).id;
+
+        const sharedAssessmentUrl = `${baseUrl}/public/course_instance/${sharingCourseInstanceId}/assessment/${sharedAssessmentId}/questions`;
+        const sharedAssessmentPage = await fetchCheerio(sharedAssessmentUrl);
+        assert(sharedAssessmentPage.ok);
+
+        const courseInstanceAssessmentsUrl = `${baseUrl}/public/course_instance/${sharingCourseInstanceId}/assessments`;
+        const courseInstanceAssessmentsPage = await fetchCheerio(courseInstanceAssessmentsUrl);
+        assert.equal(courseInstanceAssessmentsPage.status, 404);
+      },
+    );
+
+    test.sequential(
       'Fail to unshare a publicly shared question that is in a publicly shared assessment in the same course',
       async () => {
         sharingCourseData.questions[ASSESSMENT_ONLY_PUBLICLY_SHARED_QUESTION_QID].sharePublicly =


### PR DESCRIPTION
# Description

Closes #14242

The public sharing middleware `authzPublicCourseOrInstance`) required the entire course instance to be shared publicly, so a publicly shared assessment whose course instance was not shared returned a 404 at its own public link (e.g. `/pl/public/course_instance/XXX/assessment/YYY/questions`), even though the instructor settings page advertises that link. This loosens the shared middleware to no longer enforce course-instance-level sharing and instead gates only the pages that actually expose course-instance-level content (the assessments listing) with a new `authzPublicCourseInstanceSource` middleware; the per-assessment questions page already enforces its own `assessment.share_source_publicly` check. 

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation.

# Testing

Added an integration test in `questionSharing.test.ts` covering the issue scenario