### PR TITLE
Reject unitless pl-excalidraw sizes

### DIFF
--- a/apps/prairielearn/elements/pl-excalidraw/pl-excalidraw.py
+++ b/apps/prairielearn/elements/pl-excalidraw/pl-excalidraw.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import re
 from pathlib import Path
 
 import chevron
@@ -7,12 +8,7 @@ import lxml.html
 import prairielearn as pl
 from lxml.html import HtmlElement
 
-ATTR_ANSWER_NAME = "answers-name"
-ATTR_WIDTH = "width"
-ATTR_HEIGHT = "height"
-ATTR_SOURCE_FILE_NAME = "source-file-name"
-ATTR_SOURCE_DIRECTORY = "directory"
-ATTR_GRADABLE = "gradable"
+UNITLESS_NUMBER_RE = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$")
 
 
 SOURCE_DIRECTORY_MAP = {
@@ -21,6 +17,16 @@ SOURCE_DIRECTORY_MAP = {
     "clientFilesQuestion": "client_files_question_path",
     ".": "question_path",
 }
+
+
+def check_css_size_attrib(element: HtmlElement, attrib: str) -> None:
+    value = pl.get_string_attrib(element, attrib, None)
+    if value is not None and UNITLESS_NUMBER_RE.match(value.strip()):
+        raise ValueError(
+            f'Attribute "{attrib}" must be a CSS size value, not the unitless number '
+            f'"{value}". Use a value with units, such as "900px" for pixels.'
+        )
+
 
 # -----------------------------------------------------------------------------
 # The logic below is derived from the combinations at
@@ -51,27 +57,29 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     element = lxml.html.fragment_fromstring(element_html)
     required_attrs = []
     optional_attrs = [
-        ATTR_GRADABLE,
-        ATTR_ANSWER_NAME,
-        ATTR_WIDTH,
-        ATTR_HEIGHT,
-        ATTR_SOURCE_FILE_NAME,
-        ATTR_SOURCE_DIRECTORY,
+        "gradable",
+        "answers-name",
+        "width",
+        "height",
+        "source-file-name",
+        "directory",
     ]
     pl.check_attribs(element, required_attrs, optional_attrs)
+    check_css_size_attrib(element, "width")
+    check_css_size_attrib(element, "height")
 
-    gradable = pl.get_boolean_attrib(element, ATTR_GRADABLE, True)
+    gradable = pl.get_boolean_attrib(element, "gradable", True)
 
-    name = pl.get_string_attrib(element, ATTR_ANSWER_NAME, None)
+    name = pl.get_string_attrib(element, "answers-name", None)
     if name:
         pl.check_answers_names(data, name)
 
     if is_answer_name_required(gradable) and name is None:
         raise RuntimeError(
-            f"Missing required attribute {ATTR_ANSWER_NAME} (Required when `{ATTR_GRADABLE}` is set)"
+            "Missing required attribute answers-name (Required when `gradable` is set)"
         )
 
-    source_dir = pl.get_string_attrib(element, ATTR_SOURCE_DIRECTORY, ".")
+    source_dir = pl.get_string_attrib(element, "directory", ".")
     if source_dir not in SOURCE_DIRECTORY_MAP:
         raise RuntimeError(
             f"{source_dir=} must be one of {list(SOURCE_DIRECTORY_MAP.keys())}"
@@ -79,11 +87,9 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
 
 
 def load_file_content(element: HtmlElement, data: pl.QuestionData) -> str:
-    file_dir = SOURCE_DIRECTORY_MAP[
-        pl.get_string_attrib(element, ATTR_SOURCE_DIRECTORY, ".")
-    ]
+    file_dir = SOURCE_DIRECTORY_MAP[pl.get_string_attrib(element, "directory", ".")]
     file = Path(data["options"][file_dir]) / pl.get_string_attrib(
-        element, ATTR_SOURCE_FILE_NAME
+        element, "source-file-name"
     )
     if not file.exists():
         raise RuntimeError(f"Unknown file path: {file}")
@@ -93,18 +99,18 @@ def load_file_content(element: HtmlElement, data: pl.QuestionData) -> str:
 def render(element_html: str, data: pl.QuestionData) -> str:
     empty_diagram = ""  # pick a default representation
     element = lxml.html.fragment_fromstring(element_html)
-    drawing_name = pl.get_string_attrib(element, ATTR_ANSWER_NAME, None)
+    drawing_name = pl.get_string_attrib(element, "answers-name", None)
 
-    gradable = pl.get_boolean_attrib(element, ATTR_GRADABLE, True)
+    gradable = pl.get_boolean_attrib(element, "gradable", True)
     fresh = drawing_name not in data["submitted_answers"]
     panel = data["panel"]
-    source_available = pl.has_attrib(element, ATTR_SOURCE_FILE_NAME)
+    source_available = pl.has_attrib(element, "source-file-name")
 
     # the state space (for debugging)
     matrix = f"{gradable=} {fresh=} {panel=} {source_available=}"
 
     if is_source_file_name_required(panel, gradable, fresh) and not source_available:
-        raise RuntimeError(f"Missing required attribute `{ATTR_SOURCE_FILE_NAME}`")
+        raise RuntimeError("Missing required attribute `source-file-name`")
 
     initial_content: str = empty_diagram
 
@@ -156,8 +162,8 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     content_bytes = json.dumps({
         "read_only": not is_widget_editable(panel, gradable, data["editable"]),
         "initial_content": initial_content,
-        "width": pl.get_string_attrib(element, ATTR_WIDTH, "100%"),
-        "height": pl.get_string_attrib(element, ATTR_HEIGHT, "800px"),
+        "width": pl.get_string_attrib(element, "width", "100%"),
+        "height": pl.get_string_attrib(element, "height", "800px"),
     }).encode()
 
     errors: list[str] = []
@@ -178,7 +184,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
 
 def parse(element_html: str, data: pl.QuestionData) -> None:
     element = lxml.html.fragment_fromstring(element_html)
-    drawing_name = pl.get_string_attrib(element, ATTR_ANSWER_NAME, None)
+    drawing_name = pl.get_string_attrib(element, "answers-name", None)
 
     if drawing_name:
         try:
@@ -195,11 +201,11 @@ def parse(element_html: str, data: pl.QuestionData) -> None:
 
 def test(element_html: str, data: pl.ElementTestData) -> None:
     element = lxml.html.fragment_fromstring(element_html)
-    gradable = pl.get_boolean_attrib(element, ATTR_GRADABLE, True)
+    gradable = pl.get_boolean_attrib(element, "gradable", True)
     if not gradable:
         return
 
-    drawing_name = pl.get_string_attrib(element, ATTR_ANSWER_NAME)
+    drawing_name = pl.get_string_attrib(element, "answers-name")
     result = data["test_type"]
 
     if result in {"correct", "incorrect"}:

--- a/apps/prairielearn/elements/pl-excalidraw/pl_excalidraw_test.py
+++ b/apps/prairielearn/elements/pl-excalidraw/pl_excalidraw_test.py
@@ -1,0 +1,28 @@
+import importlib
+from typing import Any
+
+import pytest
+
+pl_excalidraw = importlib.import_module("pl-excalidraw")
+
+
+def make_question_data() -> dict[str, Any]:
+    return {"answers_names": {}}
+
+
+@pytest.mark.parametrize(("attrib", "value"), [("width", "900"), ("height", "900")])
+def test_prepare_rejects_unitless_size(attrib: str, value: str) -> None:
+    element_html = (
+        f'<pl-excalidraw answers-name="drawing" {attrib}="{value}"></pl-excalidraw>'
+    )
+
+    with pytest.raises(
+        ValueError, match=f'Attribute "{attrib}" must be a CSS size value'
+    ):
+        pl_excalidraw.prepare(element_html, make_question_data())
+
+
+def test_prepare_accepts_css_size_values() -> None:
+    element_html = '<pl-excalidraw answers-name="drawing" width="100%" height="900px"></pl-excalidraw>'
+
+    pl_excalidraw.prepare(element_html, make_question_data())

--- a/docs/elements/pl-excalidraw.md
+++ b/docs/elements/pl-excalidraw.md
@@ -26,8 +26,11 @@ Note that only manual grading is supported. For auto-gradable drawings, consider
 | `answers-name`     | string                                                                         | —         | Unique name to identify the widget with. Drawing submissions are saved with this name. Required when `gradable` is set. |
 | `directory`        | `"serverFilesCourse"`, `"clientFilesCourse"`, `"clientFilesQuestion"` or `"."` | `"."`     | Directory where the `"source-file-name"` is loaded from. By default, it refers to the question directory `"."`.         |
 | `gradable`         | boolean                                                                        | "true"    | Whether a diagram accepts input from the user.                                                                          |
-| `height`           | string                                                                         | `"800px"` | Height of the widget, compatible with the [CSS width][css-width-mdn] specification.                                     |
+| `height`           | string                                                                         | `"800px"` | Height of the widget, compatible with the [CSS height][css-height-mdn] specification.                                   |
 | `source-file-name` | string                                                                         | —         | Optional file to load as the starter diagram.                                                                           |
 | `width`            | string                                                                         | `"100%"`  | Width of the widget, compatible with the [CSS width][css-width-mdn] specification.                                      |
 
+The `width` and `height` attributes are used as CSS property values. Unitless numbers such as `height="900"` are invalid; use `height="900px"` for pixels.
+
+[css-height-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/height
 [css-width-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/width

--- a/exampleCourse/questions/element/excalidraw/question.html
+++ b/exampleCourse/questions/element/excalidraw/question.html
@@ -5,7 +5,7 @@
 </pl-question-panel>
 
 <p><b>Draw something</b></p>
-<pl-excalidraw answers-name="vector" width="100%" height="900"></pl-excalidraw>
+<pl-excalidraw answers-name="vector" width="100%" height="900px"></pl-excalidraw>
 <pl-answer-panel>Answer 1</pl-answer-panel>
 
 <hr>


### PR DESCRIPTION
# Description

`pl-excalidraw` now rejects unitless `width` and `height` values during `prepare` so invalid CSS sizes fail clearly instead of silently producing a collapsed widget. The example course now uses `height="900px"`, and the docs now link `height` to CSS height and call out that sizing attributes are CSS property values. Closes #14837.

- [x] I have disclosed the level of AI assistance used: majority of implementation by Codex, guided by Nathan's review feedback.

# Testing

Added a focused Python element test covering unitless-size rejection and valid CSS size values.