### PR TITLE
Fail fast when no workspace host can be launched

### DIFF
--- a/apps/prairielearn/src/lib/workspace.test.ts
+++ b/apps/prairielearn/src/lib/workspace.test.ts
@@ -1,6 +1,7 @@
-import { assert, describe, it } from 'vitest';
+import { afterEach, assert, describe, it } from 'vitest';
 
-import { decideStartupAction } from './workspace.js';
+import { config } from './config.js';
+import { canLaunchAdditionalHosts, decideStartupAction } from './workspace.js';
 
 describe('decideStartupAction', () => {
   it('initializes and launches when uninit→uninit and the version still matches', () => {
@@ -82,5 +83,33 @@ describe('decideStartupAction', () => {
       }),
       'noop',
     );
+  });
+});
+
+describe('canLaunchAdditionalHosts', () => {
+  const originalAutoscalingEnabled = config.workspaceAutoscalingEnabled;
+  const originalLaunchTemplateId = config.workspaceLoadLaunchTemplateId;
+
+  afterEach(() => {
+    config.workspaceAutoscalingEnabled = originalAutoscalingEnabled;
+    config.workspaceLoadLaunchTemplateId = originalLaunchTemplateId;
+  });
+
+  it('can launch hosts when autoscaling is enabled and a launch template is configured', () => {
+    config.workspaceAutoscalingEnabled = true;
+    config.workspaceLoadLaunchTemplateId = 'lt-1234';
+    assert.isTrue(canLaunchAdditionalHosts());
+  });
+
+  it('cannot launch hosts when no launch template is configured (e.g. local development)', () => {
+    config.workspaceAutoscalingEnabled = true;
+    config.workspaceLoadLaunchTemplateId = null;
+    assert.isFalse(canLaunchAdditionalHosts());
+  });
+
+  it('cannot launch hosts when autoscaling is disabled', () => {
+    config.workspaceAutoscalingEnabled = false;
+    config.workspaceLoadLaunchTemplateId = 'lt-1234';
+    assert.isFalse(canLaunchAdditionalHosts());
   });
 });

--- a/apps/prairielearn/src/lib/workspace.test.ts
+++ b/apps/prairielearn/src/lib/workspace.test.ts
@@ -1,7 +1,6 @@
-import { afterEach, assert, describe, it } from 'vitest';
+import { assert, describe, it } from 'vitest';
 
-import { config } from './config.js';
-import { canLaunchAdditionalHosts, decideStartupAction } from './workspace.js';
+import { decideStartupAction } from './workspace.js';
 
 describe('decideStartupAction', () => {
   it('initializes and launches when uninit→uninit and the version still matches', () => {
@@ -83,33 +82,5 @@ describe('decideStartupAction', () => {
       }),
       'noop',
     );
-  });
-});
-
-describe('canLaunchAdditionalHosts', () => {
-  const originalAutoscalingEnabled = config.workspaceAutoscalingEnabled;
-  const originalLaunchTemplateId = config.workspaceLoadLaunchTemplateId;
-
-  afterEach(() => {
-    config.workspaceAutoscalingEnabled = originalAutoscalingEnabled;
-    config.workspaceLoadLaunchTemplateId = originalLaunchTemplateId;
-  });
-
-  it('can launch hosts when autoscaling is enabled and a launch template is configured', () => {
-    config.workspaceAutoscalingEnabled = true;
-    config.workspaceLoadLaunchTemplateId = 'lt-1234';
-    assert.isTrue(canLaunchAdditionalHosts());
-  });
-
-  it('cannot launch hosts when no launch template is configured (e.g. local development)', () => {
-    config.workspaceAutoscalingEnabled = true;
-    config.workspaceLoadLaunchTemplateId = null;
-    assert.isFalse(canLaunchAdditionalHosts());
-  });
-
-  it('cannot launch hosts when autoscaling is disabled', () => {
-    config.workspaceAutoscalingEnabled = false;
-    config.workspaceLoadLaunchTemplateId = 'lt-1234';
-    assert.isFalse(canLaunchAdditionalHosts());
   });
 });

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -371,6 +371,16 @@ async function startup(workspace_id: string): Promise<void> {
     if (workspace_host_id != null) {
       break; // success, we got a host
     }
+    if (!canLaunchAdditionalHosts()) {
+      // No autoscaler is configured to launch new hosts (e.g. local
+      // development), so if no host is available now, none will become
+      // available by retrying. Fail fast with an actionable message instead
+      // of spinning on the retry loop for several minutes.
+      throw new Error(
+        'No workspace host is available. Ensure the workspace-host process is running ' +
+          '(when running in Docker, mount /var/run/docker.sock so that workspaces are started).',
+      );
+    }
     const t = attempt * config.workspaceLaunchingRetryIntervalSec;
     await workspaceUtils.updateWorkspaceMessage(
       workspace_id,
@@ -667,6 +677,16 @@ export async function generateWorkspaceFiles({
   }
 
   return { fileGenerationErrors };
+}
+
+/**
+ * Whether the deployment is able to launch additional workspace hosts on
+ * demand. This is only true when autoscaling is enabled and a launch template
+ * is configured; in local development neither is set, so the set of available
+ * hosts is fixed and retrying host assignment can never succeed.
+ */
+export function canLaunchAdditionalHosts(): boolean {
+  return config.workspaceAutoscalingEnabled && config.workspaceLoadLaunchTemplateId != null;
 }
 
 /**

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -371,12 +371,11 @@ async function startup(workspace_id: string): Promise<void> {
     if (workspace_host_id != null) {
       break; // success, we got a host
     }
-    if (!canLaunchAdditionalHosts()) {
+    if (!config.workspaceAutoscalingEnabled || !config.workspaceLoadLaunchTemplateId) {
       // in local development, when no autoscaler is configured
       // to launch new hosts, none will become available after retrying
       throw new Error(
-        'No workspace host is available. Ensure the workspace-host process is running ' +
-          '(when running in Docker, mount /var/run/docker.sock so that workspaces are started).',
+        'No workspace host is available. Ensure the workspace-host process is running ',
       );
     }
     const t = attempt * config.workspaceLaunchingRetryIntervalSec;
@@ -675,10 +674,6 @@ export async function generateWorkspaceFiles({
   }
 
   return { fileGenerationErrors };
-}
-
-export function canLaunchAdditionalHosts(): boolean {
-  return config.workspaceAutoscalingEnabled && config.workspaceLoadLaunchTemplateId != null;
 }
 
 /**

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -372,10 +372,8 @@ async function startup(workspace_id: string): Promise<void> {
       break; // success, we got a host
     }
     if (!canLaunchAdditionalHosts()) {
-      // No autoscaler is configured to launch new hosts (e.g. local
-      // development), so if no host is available now, none will become
-      // available by retrying. Fail fast with an actionable message instead
-      // of spinning on the retry loop for several minutes.
+      // in local development, when no autoscaler is configured
+      // to launch new hosts, none will become available after retrying
       throw new Error(
         'No workspace host is available. Ensure the workspace-host process is running ' +
           '(when running in Docker, mount /var/run/docker.sock so that workspaces are started).',
@@ -679,12 +677,6 @@ export async function generateWorkspaceFiles({
   return { fileGenerationErrors };
 }
 
-/**
- * Whether the deployment is able to launch additional workspace hosts on
- * demand. This is only true when autoscaling is enabled and a launch template
- * is configured; in local development neither is set, so the set of available
- * hosts is fixed and retrying host assignment can never succeed.
- */
 export function canLaunchAdditionalHosts(): boolean {
   return config.workspaceAutoscalingEnabled && config.workspaceLoadLaunchTemplateId != null;
 }


### PR DESCRIPTION

<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

The worksapce host shows loading for a very long time and finally failing when running with `docker run -it --rm -p 3000:3000 prairielearn/prairielearn`. This happens because this command only starts the web app and not the workspace host.

In this type of environment, it should be detectable and should fail fast.



- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

I used ai for writing the code based on my specs - I gave specs of how I want the functions to look. AI added all the tests in this pull request. 

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

<img width="2266" height="1045" alt="image" src="https://github.com/user-attachments/assets/861f4192-0504-4323-9516-ca7614c2a7b6" />
