### PR TITLE
Replace jQuery with native JS in administrator and edit error pages

### DIFF
--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
@@ -30,6 +30,24 @@ export function AdministratorSettings({
     options: {
       fullWidth: true,
     },
+    headContent: html`
+      <script type="module">
+        // This script has type="module" so it's deferred until after the DOM is loaded.
+        const invalidateButton = document.getElementById('invalidate-render-cache');
+        const confirmInvalidateContainer = document.getElementById(
+          'confirm-invalidate-cache-container',
+        );
+        const cancelInvalidateButton = document.getElementById('cancel-invalidate-render-cache');
+        invalidateButton.addEventListener('click', () => {
+          confirmInvalidateContainer.classList.remove('d-none');
+          invalidateButton.classList.add('d-none');
+        });
+        cancelInvalidateButton.addEventListener('click', () => {
+          invalidateButton.classList.remove('d-none');
+          confirmInvalidateContainer.classList.add('d-none');
+        });
+      </script>
+    `,
     content: html`
       <h1 class="visually-hidden">Administrator Settings</h1>
       <!-- Chunk generation -->
@@ -68,11 +86,7 @@ export function AdministratorSettings({
             <button id="invalidate-render-cache" type="button" class="btn btn-danger">
               Invalidate question render cache
             </button>
-            <div
-              id="confirm-invalidate-cache-container"
-              class="confirm-invalidate-cache"
-              style="display: none;"
-            >
+            <div id="confirm-invalidate-cache-container" class="confirm-invalidate-cache d-none">
               <button id="confirm-invalidate-render-cache" type="submit" class="btn btn-danger">
                 Confirm invalidate cache
               </button>
@@ -81,21 +95,6 @@ export function AdministratorSettings({
               </button>
             </div>
           </form>
-          <script>
-            $(function () {
-              var invalidateButton = $('#invalidate-render-cache');
-              var confirmInvalidateContainer = $('#confirm-invalidate-cache-container');
-              var cancelInvalidateButton = $('#cancel-invalidate-render-cache');
-              invalidateButton.click(function () {
-                confirmInvalidateContainer.show();
-                invalidateButton.hide();
-              });
-              cancelInvalidateButton.click(function () {
-                invalidateButton.show();
-                confirmInvalidateContainer.hide();
-              });
-            });
-          </script>
           ${config.newsFeedUrl
             ? html`
                 <hr />

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
@@ -46,15 +46,21 @@ export function AdministratorWorkspaces({
       subPage: 'workspaces',
     },
     preContent: html`
-      <script>
-        $(() => {
-          const toggleButton = document.querySelector('#toggle-all-workspaces');
-          toggleButton.addEventListener('click', () => {
-            const state = toggleButton.dataset.state;
-            $('#content .collapse').collapse(state === 'collapsed' ? 'show' : 'hide');
-            toggleButton.dataset.state = state === 'collapsed' ? 'expanded' : 'collapsed';
-            toggleButton.textContent = state === 'collapsed' ? 'Collapse all' : 'Expand all';
+      <script type="module">
+        // This script has type="module" so it's deferred until after the DOM is loaded.
+        const toggleButton = document.querySelector('#toggle-all-workspaces');
+        toggleButton.addEventListener('click', () => {
+          const state = toggleButton.dataset.state;
+          document.querySelectorAll('#content .collapse').forEach((element) => {
+            const collapse = window.bootstrap.Collapse.getOrCreateInstance(element);
+            if (state === 'collapsed') {
+              collapse.show();
+            } else {
+              collapse.hide();
+            }
           });
+          toggleButton.dataset.state = state === 'collapsed' ? 'expanded' : 'collapsed';
+          toggleButton.textContent = state === 'collapsed' ? 'Collapse all' : 'Expand all';
         });
       </script>
     `,

--- a/apps/prairielearn/src/pages/editError/editError.html.ts
+++ b/apps/prairielearn/src/pages/editError/editError.html.ts
@@ -25,20 +25,20 @@ export function EditError({
       type: 'plain',
       page: 'error',
     },
-    content: html`
-      <script>
-        $(function () {
-          const button = document.querySelector('#job-sequence-results-button');
-          $('#job-sequence-results')
-            .on('show.bs.collapse', () => {
-              button.textContent = 'Hide detail';
-            })
-            .on('hide.bs.collapse', () => {
-              button.textContent = 'Show detail';
-            });
+    headContent: html`
+      <script type="module">
+        // This script has type="module" so it's deferred until after the DOM is loaded.
+        const button = document.getElementById('job-sequence-results-button');
+        const results = document.getElementById('job-sequence-results');
+        results.addEventListener('show.bs.collapse', () => {
+          button.textContent = 'Hide detail';
+        });
+        results.addEventListener('hide.bs.collapse', () => {
+          button.textContent = 'Show detail';
         });
       </script>
-
+    `,
+    content: html`
       <div class="card mb-4">
         <div
           class="card-header ${isWarning


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Replaces jQuery with native JS and Bootstrap APIs in two administrator pages: settings (cache handling buttons) and workspaces. The edit error page was also changed as it had similar context. jQuery was being used for:

* Run after DOM is loaded. This was replaced with `type="module"`, which [always defers to after the DOM is loaded](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#other_differences_between_modules_and_classic_scripts). Using `<script defer>` was considered, but [it doesn't work with inline scripts](https://html.spec.whatwg.org/multipage/scripting.html#the-script-element).
* Querying elements and adding event handlers, which have direct replacements in vanilla JS.
* Show/hide, replaced with adding/removing `d-none` class.
* Trigger bootstrap collapse, replaced with a direct call to `window.bootstrap` API.

If the use of `type="module"` is objected, an alternative is to create a small asset for these pages, but I wanted to avoid that given the relatively short code in these pages.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: auto-complete only.

# Testing

All three pages have the same functionality as before. For edit error, the easiest way to trigger it is to introduce a sync error (e.g., a wrong key in any json file), then edit the settings of a different question.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
