### PR TITLE
Fix missing exam timer for modern access control CBTF exams

### DIFF
--- a/apps/prairielearn/src/lib/assessment.shared.test.ts
+++ b/apps/prairielearn/src/lib/assessment.shared.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAssessmentInstanceTimeLimit } from './assessment.shared.js';
+
+describe('getAssessmentInstanceTimeLimit', () => {
+  const reqDate = new Date('2026-01-01T12:00:00Z');
+  const date = new Date('2026-01-01T11:00:00Z');
+
+  it('is untimed when there is neither an exam access end nor a date limit', () => {
+    expect(
+      getAssessmentInstanceTimeLimit({ examAccessEnd: null, date, dateLimit: null, reqDate }),
+    ).toEqual({
+      assessment_instance_remaining_ms: null,
+      assessment_instance_time_limit_ms: null,
+      assessment_instance_time_limit_expired: false,
+    });
+  });
+
+  it('uses the exam access end when there is no date limit (CBTF exam)', () => {
+    // A PrairieTest reservation governs timing and the instance has no
+    // date_limit. This is the case that was broken for modern access control.
+    const examAccessEnd = new Date('2026-01-01T12:30:00Z');
+    expect(
+      getAssessmentInstanceTimeLimit({ examAccessEnd, date, dateLimit: null, reqDate }),
+    ).toEqual({
+      assessment_instance_remaining_ms: 30 * 60 * 1000,
+      assessment_instance_time_limit_ms: 90 * 60 * 1000,
+      assessment_instance_time_limit_expired: false,
+    });
+  });
+
+  it('uses the date limit when there is no exam access end', () => {
+    const dateLimit = new Date('2026-01-01T12:30:00Z');
+    expect(
+      getAssessmentInstanceTimeLimit({ examAccessEnd: null, date, dateLimit, reqDate }),
+    ).toEqual({
+      assessment_instance_remaining_ms: 30 * 60 * 1000,
+      assessment_instance_time_limit_ms: 90 * 60 * 1000,
+      assessment_instance_time_limit_expired: false,
+    });
+  });
+
+  it('uses the earlier of the exam access end and the date limit', () => {
+    const earlier = new Date('2026-01-01T12:20:00Z');
+    const later = new Date('2026-01-01T12:40:00Z');
+    expect(
+      getAssessmentInstanceTimeLimit({ examAccessEnd: later, date, dateLimit: earlier, reqDate }),
+    ).toMatchObject({ assessment_instance_remaining_ms: 20 * 60 * 1000 });
+    expect(
+      getAssessmentInstanceTimeLimit({ examAccessEnd: earlier, date, dateLimit: later, reqDate }),
+    ).toMatchObject({ assessment_instance_remaining_ms: 20 * 60 * 1000 });
+  });
+
+  it('reports a negative remaining time once the effective end has passed', () => {
+    const examAccessEnd = new Date('2026-01-01T11:30:00Z');
+    expect(
+      getAssessmentInstanceTimeLimit({ examAccessEnd, date, dateLimit: null, reqDate }),
+    ).toMatchObject({ assessment_instance_remaining_ms: -30 * 60 * 1000 });
+  });
+
+  it('marks the time limit expired only once date_limit is at or before the request date', () => {
+    // Boundary: date_limit exactly equal to req_date is expired (SQL used `<=`).
+    expect(
+      getAssessmentInstanceTimeLimit({
+        examAccessEnd: null,
+        date,
+        dateLimit: new Date(reqDate),
+        reqDate,
+      }).assessment_instance_time_limit_expired,
+    ).toBe(true);
+
+    expect(
+      getAssessmentInstanceTimeLimit({
+        examAccessEnd: null,
+        date,
+        dateLimit: new Date('2026-01-01T11:59:59Z'),
+        reqDate,
+      }).assessment_instance_time_limit_expired,
+    ).toBe(true);
+
+    expect(
+      getAssessmentInstanceTimeLimit({
+        examAccessEnd: null,
+        date,
+        dateLimit: new Date('2026-01-01T12:00:01Z'),
+        reqDate,
+      }).assessment_instance_time_limit_expired,
+    ).toBe(false);
+
+    // An exam access end alone never expires the time limit; only date_limit does.
+    expect(
+      getAssessmentInstanceTimeLimit({
+        examAccessEnd: new Date('2026-01-01T11:00:00Z'),
+        date,
+        dateLimit: null,
+        reqDate,
+      }).assessment_instance_time_limit_expired,
+    ).toBe(false);
+  });
+
+  it('has no time limit duration when the instance has no start date', () => {
+    expect(
+      getAssessmentInstanceTimeLimit({
+        examAccessEnd: new Date('2026-01-01T12:30:00Z'),
+        date: null,
+        dateLimit: null,
+        reqDate,
+      }),
+    ).toMatchObject({
+      assessment_instance_remaining_ms: 30 * 60 * 1000,
+      assessment_instance_time_limit_ms: null,
+    });
+  });
+});

--- a/apps/prairielearn/src/lib/assessment.shared.ts
+++ b/apps/prairielearn/src/lib/assessment.shared.ts
@@ -1,6 +1,52 @@
 import type { Assessment, AssessmentInstance, AssessmentSet } from './db-types.js';
 import type { UntypedResLocals } from './res-locals.types.js';
 
+export interface AssessmentInstanceTimeLimit {
+  /** Milliseconds remaining until the instance's time runs out; null if untimed. */
+  assessment_instance_remaining_ms: number | null;
+  /** Total duration of the instance's time limit in milliseconds; null if untimed. */
+  assessment_instance_time_limit_ms: number | null;
+  /** Whether the instance's `date_limit` has passed. */
+  assessment_instance_time_limit_expired: boolean;
+}
+
+/**
+ * Computes the time-limit display values for an assessment instance from its
+ * resolved access result. The effective end is the earlier of the PrairieTest
+ * exam access end (`exam_access_end`, null when not in a reservation) and the
+ * instance's own `date_limit` (null when untimed).
+ *
+ * This is the single source of truth for these values, called after access
+ * control is resolved. Both the legacy (sproc) and modern (TypeScript resolver)
+ * paths feed their resolved `exam_access_end` through here, so the timer can't
+ * diverge from the access decision that produced it.
+ */
+export function getAssessmentInstanceTimeLimit({
+  examAccessEnd,
+  date,
+  dateLimit,
+  reqDate,
+}: {
+  examAccessEnd: Date | null;
+  date: Date | null;
+  dateLimit: Date | null;
+  reqDate: Date;
+}): AssessmentInstanceTimeLimit {
+  // The earlier of the two ends, ignoring nulls; null only if both are null.
+  const effectiveEnd =
+    examAccessEnd === null || (dateLimit !== null && dateLimit < examAccessEnd)
+      ? dateLimit
+      : examAccessEnd;
+
+  return {
+    assessment_instance_remaining_ms:
+      effectiveEnd === null ? null : effectiveEnd.getTime() - reqDate.getTime(),
+    assessment_instance_time_limit_ms:
+      effectiveEnd === null || date === null ? null : effectiveEnd.getTime() - date.getTime(),
+    assessment_instance_time_limit_expired: dateLimit !== null && dateLimit <= reqDate,
+  };
+}
+
 export function assessmentLabel(
   assessment: { number: string },
   assessmentSet: { abbreviation: string },

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.sql
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.sql
@@ -19,26 +19,6 @@ WITH
   )
 SELECT
   to_jsonb(ai) AS assessment_instance,
-  CASE
-    WHEN COALESCE(aai.exam_access_end, ai.date_limit) IS NOT NULL THEN floor(
-      DATE_PART(
-        'epoch',
-        LEAST(aai.exam_access_end, ai.date_limit) - $req_date::timestamptz
-      ) * 1000
-    )
-  END AS assessment_instance_remaining_ms,
-  CASE
-    WHEN COALESCE(aai.exam_access_end, ai.date_limit) IS NOT NULL THEN floor(
-      DATE_PART(
-        'epoch',
-        LEAST(aai.exam_access_end, ai.date_limit) - ai.date
-      ) * 1000
-    )
-  END AS assessment_instance_time_limit_ms,
-  (
-    ai.date_limit IS NOT NULL
-    AND ai.date_limit <= $req_date::timestamptz
-  ) AS assessment_instance_time_limit_expired,
   to_jsonb(u) AS instance_user,
   users_get_displayed_role (u.id, ci.id) AS instance_role,
   to_jsonb(a) AS assessment,

--- a/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.ts
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzAssessmentInstance.ts
@@ -6,7 +6,12 @@ import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 
 import { resolveModernAssessmentInstanceAccess } from '../lib/assessment-access-control/authz.js';
-import { assessmentInstanceLabel, assessmentLabel } from '../lib/assessment.shared.js';
+import {
+  type AssessmentInstanceTimeLimit,
+  assessmentInstanceLabel,
+  assessmentLabel,
+  getAssessmentInstanceTimeLimit,
+} from '../lib/assessment.shared.js';
 import {
   AssessmentInstanceSchema,
   AssessmentSchema,
@@ -22,9 +27,6 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 
 const SelectAndAuthzAssessmentInstanceBaseSchema = z.object({
   assessment_instance: AssessmentInstanceSchema,
-  assessment_instance_remaining_ms: z.number().nullable(),
-  assessment_instance_time_limit_ms: z.number().nullable(),
-  assessment_instance_time_limit_expired: z.boolean(),
   instance_role: SprocUsersGetDisplayedRoleSchema,
   assessment: AssessmentSchema,
   assessment_set: AssessmentSetSchema,
@@ -45,10 +47,11 @@ const SelectAndAuthzAssessmentInstanceSchema = z.union([
   }),
 ]);
 
-export type ResLocalsAssessmentInstance = z.infer<typeof SelectAndAuthzAssessmentInstanceSchema> & {
-  assessment_instance_label: string;
-  assessment_label: string;
-};
+export type ResLocalsAssessmentInstance = z.infer<typeof SelectAndAuthzAssessmentInstanceSchema> &
+  AssessmentInstanceTimeLimit & {
+    assessment_instance_label: string;
+    assessment_label: string;
+  };
 
 async function selectAndAuthzAssessmentInstance(req: Request, res: Response) {
   const row = await sqldb.queryOptionalRow(
@@ -79,6 +82,12 @@ async function selectAndAuthzAssessmentInstance(req: Request, res: Response) {
     throw new error.HttpStatusError(403, 'Access denied');
   }
   Object.assign(res.locals, row, {
+    ...getAssessmentInstanceTimeLimit({
+      examAccessEnd: row.authz_result.exam_access_end,
+      date: row.assessment_instance.date,
+      dateLimit: row.assessment_instance.date_limit,
+      reqDate: res.locals.req_date,
+    }),
     assessment_instance_label: assessmentInstanceLabel(
       row.assessment_instance,
       row.assessment,

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.sql
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.sql
@@ -46,26 +46,6 @@ WITH
   )
 SELECT
   to_jsonb(ai) AS assessment_instance,
-  CASE
-    WHEN COALESCE(aai.exam_access_end, ai.date_limit) IS NOT NULL THEN floor(
-      DATE_PART(
-        'epoch',
-        LEAST(aai.exam_access_end, ai.date_limit) - $req_date::timestamptz
-      ) * 1000
-    )
-  END AS assessment_instance_remaining_ms,
-  CASE
-    WHEN COALESCE(aai.exam_access_end, ai.date_limit) IS NOT NULL THEN floor(
-      DATE_PART(
-        'epoch',
-        LEAST(aai.exam_access_end, ai.date_limit) - ai.date
-      ) * 1000
-    )
-  END AS assessment_instance_time_limit_ms,
-  (
-    ai.date_limit IS NOT NULL
-    AND ai.date_limit <= $req_date::timestamptz
-  ) AS assessment_instance_time_limit_expired,
   to_jsonb(u) AS instance_user,
   users_get_displayed_role (u.id, ci.id) AS instance_role,
   to_jsonb(g) AS instance_group,

--- a/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.ts
+++ b/apps/prairielearn/src/middlewares/selectAndAuthzInstanceQuestion.ts
@@ -7,7 +7,11 @@ import * as sqldb from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
 import { resolveModernAssessmentInstanceAccess } from '../lib/assessment-access-control/authz.js';
-import { assessmentInstanceLabel } from '../lib/assessment.shared.js';
+import {
+  type AssessmentInstanceTimeLimit,
+  assessmentInstanceLabel,
+  getAssessmentInstanceTimeLimit,
+} from '../lib/assessment.shared.js';
 import {
   AssessmentInstanceSchema,
   AssessmentQuestionSchema,
@@ -52,9 +56,6 @@ type InstanceQuestionInfo = z.infer<typeof InstanceQuestionInfoSchema>;
 
 const SelectAndAuthzInstanceQuestionSchema = z.object({
   assessment_instance: AssessmentInstanceSchema,
-  assessment_instance_remaining_ms: z.number().nullable(),
-  assessment_instance_time_limit_ms: z.number().nullable(),
-  assessment_instance_time_limit_expired: z.boolean(),
   instance_user: UserSchema.nullable(),
   instance_role: SprocUsersGetDisplayedRoleSchema,
   instance_group: GroupSchema.nullable(),
@@ -69,20 +70,21 @@ const SelectAndAuthzInstanceQuestionSchema = z.object({
   file_list: z.array(FileSchema),
 });
 
-export type ResLocalsInstanceQuestion = z.infer<typeof SelectAndAuthzInstanceQuestionSchema> & {
-  assessment_instance_label: string;
+export type ResLocalsInstanceQuestion = z.infer<typeof SelectAndAuthzInstanceQuestionSchema> &
+  AssessmentInstanceTimeLimit & {
+    assessment_instance_label: string;
 
-  instance_question_info: InstanceQuestionInfo & {
-    previous_variants?: SimpleVariantWithScore[];
+    instance_question_info: InstanceQuestionInfo & {
+      previous_variants?: SimpleVariantWithScore[];
+    };
+
+    /** These are only set if the assessment has group work. */
+    prev_instance_question_role_permissions?: QuestionGroupPermissions;
+    next_instance_question_role_permissions?: QuestionGroupPermissions;
+    group_config?: GroupConfig;
+    group_info?: GroupInfo;
+    group_role_permissions?: QuestionGroupPermissions;
   };
-
-  /** These are only set if the assessment has group work. */
-  prev_instance_question_role_permissions?: QuestionGroupPermissions;
-  next_instance_question_role_permissions?: QuestionGroupPermissions;
-  group_config?: GroupConfig;
-  group_info?: GroupInfo;
-  group_role_permissions?: QuestionGroupPermissions;
-};
 
 export async function selectAndAuthzInstanceQuestion(req: Request, res: Response) {
   const row = await sqldb.queryOptionalRow(
@@ -125,6 +127,12 @@ export async function selectAndAuthzInstanceQuestion(req: Request, res: Response
   if (!row.authz_result.authorized) throw new error.HttpStatusError(403, 'Access denied');
 
   Object.assign(res.locals, row, {
+    ...getAssessmentInstanceTimeLimit({
+      examAccessEnd: row.authz_result.exam_access_end,
+      date: row.assessment_instance.date,
+      dateLimit: row.assessment_instance.date_limit,
+      reqDate: res.locals.req_date,
+    }),
     assessment_instance_label: assessmentInstanceLabel(
       row.assessment_instance,
       row.assessment,


### PR DESCRIPTION
# Description

Students taking a CBTF exam under **modern access control** saw no "time remaining" countdown — on both the assessment instance page and the per-question page. The timer values (`remaining_ms`, `time_limit_ms`, `time_limit_expired`) were computed in SQL from the legacy `authz_assessment_instance` sproc's `exam_access_end`, which is always null for modern-access-control assessments (the sproc reads the legacy `assessment_access_rules` table, not the modern rules / PrairieTest reservation), and modern Exam mode sets no `date_limit`; meanwhile the modern resolver that *does* produce the correct `exam_access_end` runs in TypeScript afterward and only overwrote `authz_result`, leaving the timer values null. This change computes the timer values once in TypeScript from the resolved `authz_result.exam_access_end` via a shared `getAssessmentInstanceTimeLimit` helper called by both middlewares after access control is finalized, which is behavior-preserving for the legacy path and removes the split between the timer math and the access decision that produced it (the three derived columns are dropped from both SQL files). Reported in Slack for CPSC 221.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). _Majority of implementation, with human review._

# Testing

Added unit tests for `getAssessmentInstanceTimeLimit` covering the previously-broken CBTF case (exam access end set, no date limit), the legacy date-limit path, the earlier-of-two-ends and expiry boundary semantics, and null inputs. Manually verified end-to-end against a modern-access-control CBTF exam with an active PrairieTest reservation: the "Time remaining" countdown now renders on the open assessment instance page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assessment timing is now calculated consistently in the app, improving remaining-time and expiration display across assessment pages.
  * Time-limit status now handles boundary cases more accurately, including untimed assessments and cases where one end date is missing.
  * Expiration is now determined from the effective deadline, helping prevent incorrect “expired” states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->