### PR TITLE
Normalize pl-drawing boolean flag reads

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/elements.py
+++ b/apps/prairielearn/elements/pl-drawing/elements.py
@@ -255,8 +255,8 @@ class Roller(BaseElement):
             "strokeWidth": pl.get_float_attrib(
                 el, "stroke-width", drawing_defaults["stroke-width"]
             ),
-            "drawPin": json.loads(pl.get_string_attrib(el, "draw-pin", "true")),
-            "drawGround": json.loads(pl.get_string_attrib(el, "draw-ground", "true")),
+            "drawPin": pl.get_boolean_attrib(el, "draw-pin", True),
+            "drawGround": pl.get_boolean_attrib(el, "draw-ground", True),
             "selectable": drawing_defaults["selectable"],
             "evented": drawing_defaults["selectable"],
         }
@@ -337,8 +337,8 @@ class FixedPin(BaseElement):
             "strokeWidth": pl.get_float_attrib(
                 el, "stroke-width", drawing_defaults["stroke-width"]
             ),
-            "drawPin": json.loads(pl.get_string_attrib(el, "draw-pin", "true")),
-            "drawGround": json.loads(pl.get_string_attrib(el, "draw-ground", "true")),
+            "drawPin": pl.get_boolean_attrib(el, "draw-pin", True),
+            "drawGround": pl.get_boolean_attrib(el, "draw-ground", True),
             "selectable": drawing_defaults["selectable"],
             "evented": drawing_defaults["selectable"],
         }
@@ -393,7 +393,7 @@ class Rod(BaseElement):
             "strokeWidth": pl.get_float_attrib(
                 el, "stroke-width", drawing_defaults["stroke-width"]
             ),
-            "drawPin": json.loads(pl.get_string_attrib(el, "draw-pin", "true")),
+            "drawPin": pl.get_boolean_attrib(el, "draw-pin", True),
             "selectable": drawing_defaults["selectable"],
             "evented": drawing_defaults["selectable"],
         }
@@ -448,7 +448,7 @@ class CollarRod(BaseElement):
             "strokeWidth": pl.get_float_attrib(
                 el, "stroke-width", drawing_defaults["stroke-width"]
             ),
-            "drawPin": json.loads(pl.get_string_attrib(el, "draw-pin", "true")),
+            "drawPin": pl.get_boolean_attrib(el, "draw-pin", True),
             "selectable": drawing_defaults["selectable"],
             "evented": drawing_defaults["selectable"],
         }
@@ -513,7 +513,7 @@ class ThreePointRod(BaseElement):
             "strokeWidth": pl.get_float_attrib(
                 el, "stroke-width", drawing_defaults["stroke-width"]
             ),
-            "drawPin": json.loads(pl.get_string_attrib(el, "draw-pin", "true")),
+            "drawPin": pl.get_boolean_attrib(el, "draw-pin", True),
             "selectable": drawing_defaults["selectable"],
             "evented": drawing_defaults["selectable"],
         }
@@ -585,7 +585,7 @@ class FourPointRod(BaseElement):
             "strokeWidth": pl.get_float_attrib(
                 el, "stroke-width", drawing_defaults["stroke-width"]
             ),
-            "drawPin": json.loads(pl.get_string_attrib(el, "draw-pin", "true")),
+            "drawPin": pl.get_boolean_attrib(el, "draw-pin", True),
             "selectable": drawing_defaults["selectable"],
             "evented": drawing_defaults["selectable"],
         }
@@ -1055,9 +1055,7 @@ class ArcVector(BaseElement):
             "radius": pl.get_float_attrib(el, "radius", 30),
             "startAngle": pl.get_float_attrib(el, "start-angle", 0),
             "endAngle": pl.get_float_attrib(el, "end-angle", 210),
-            "drawCenterPoint": json.loads(
-                pl.get_string_attrib(el, "draw-center", "true")
-            ),
+            "drawCenterPoint": pl.get_boolean_attrib(el, "draw-center", True),
             "drawStartArrow": draw_start_arrow,
             "drawEndArrow": draw_end_arrow,
             "label": pl.get_string_attrib(el, "label", ""),
@@ -1191,7 +1189,7 @@ class DistributedLoad(BaseElement):
             "arrowheadOffsetRatio": pl.get_float_attrib(el, "arrow-head-length", 3),
             "drawStartArrow": False,
             "drawEndArrow": True,
-            "anchor_is_tail": pl.get_string_attrib(el, "anchor-is-tail", "true"),
+            "anchor_is_tail": anchor_is_tail,
             "trueHandles": ["mtr"],
             "disregard_sense": disregard_sense,
             "optional_grading": pl.get_boolean_attrib(el, "optional-grading", False),
@@ -1464,12 +1462,8 @@ class Dimensions(BaseElement):
             "offsety": pl.get_float_attrib(el, "offsety", 0),
             "xlabel": float(rlabel[0]),
             "ylabel": float(rlabel[1]),
-            "drawStartArrow": json.loads(
-                pl.get_string_attrib(el, "draw-start-arrow", "true")
-            ),
-            "drawEndArrow": json.loads(
-                pl.get_string_attrib(el, "draw-end-arrow", "true")
-            ),
+            "drawStartArrow": pl.get_boolean_attrib(el, "draw-start-arrow", True),
+            "drawEndArrow": pl.get_boolean_attrib(el, "draw-end-arrow", True),
             "startSupportLine": pl.get_boolean_attrib(el, "start-support-line", False),
             "endSupportLine": pl.get_boolean_attrib(el, "end-support-line", False),
             "originY": "center",

--- a/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
+++ b/apps/prairielearn/elements/pl-drawing/mechanicsObjects.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-alert, unicorn/no-immediate-mutation */
+/* eslint-disable no-alert */
 /* global _, fabric, Sylvester, PLDrawingBaseElement, MathJax */
 
 const $V = Sylvester.Vector.create;
@@ -20,6 +20,11 @@ const vec2pt = function (v) {
 };
 
 const mechanicsObjects = {};
+
+const isTrueBooleanOption = function (value) {
+  // Existing saved submissions may contain string booleans; new generated options use booleans.
+  return value === true || value === 'true';
+};
 
 /**
  * New object types.
@@ -1074,7 +1079,7 @@ mechanicsObjects.DistTrianLoad = fabric.util.createClass(fabric.Object, {
   initialize(options) {
     this.callSuper('initialize', options);
     this.spacing = options.spacing;
-    this.anchor_is_tail = options.anchor_is_tail === 'true';
+    this.anchor_is_tail = isTrueBooleanOption(options.anchor_is_tail);
     this.w1 = options.w1;
     this.w2 = options.w2;
     this.width = options.range;
@@ -3330,20 +3335,20 @@ mechanicsObjects.byType['pl-distributed-load'] = class extends PLDrawingBaseElem
   }
 
   static get_button_icon(options) {
-    const wdef = { w1: 60, w2: 60, anchor_is_tail: false };
+    const wdef = { w1: 60, w2: 60 };
     const opts = { ...wdef, ...options };
     const w1 = opts['w1'];
     const w2 = opts['w2'];
-    const anchor = opts['anchor_is_tail'];
+    const anchor = isTrueBooleanOption(opts['anchor_is_tail']);
 
     let file_name;
     if (w1 === w2) {
       file_name = 'DUD';
-    } else if (w1 < w2 && anchor === 'true') {
+    } else if (w1 < w2 && anchor) {
       file_name = 'DTDA';
     } else if (w1 < w2) {
       file_name = 'DTUD';
-    } else if (w1 > w2 && anchor === 'true') {
+    } else if (w1 > w2 && anchor) {
       file_name = 'DTUA';
     } else {
       file_name = 'DTDD';

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -157,28 +157,13 @@ window.PLDrawingApi = {
     const canvas_height = Number.parseFloat(elem_options.height);
     const html_input = $(root_elem).find('input');
 
-    const parseElemOptions = function (elem) {
-      const opts = JSON.parse(elem.getAttribute('opts'));
-
-      // Parse any numerical options from string to floating point
-      for (const key in opts) {
-        if (/^type$|^label|color|^plist$/.test(key)) continue; // skip parsing for string-only options
-        if (typeof opts[key] !== 'string') continue;
-        const parsed = Number(opts[key]);
-        if (!Number.isNaN(parsed)) {
-          opts[key] = parsed;
-        }
-      }
-      return opts;
-    };
-
     // Set all button icons
     const drawing_btns = $(root_elem).find('button');
     const element_base_url = elem_options['element_client_files'];
     const clientFilesBase = this.clientFilesBase;
     drawing_btns.each(function (i, btn) {
       const img = btn.children[0];
-      const opts = parseElemOptions(img.parentNode);
+      const opts = JSON.parse(btn.getAttribute('opts'));
       const elem = window.PLDrawingApi.getElement(opts.type);
       const elem_name = opts.type;
       if (elem !== null) {

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -162,7 +162,8 @@ window.PLDrawingApi = {
 
       // Parse any numerical options from string to floating point
       for (const key in opts) {
-        if (/^type$|^label|color|^plist$/.test(key)) continue; // skip parsing for string-only options
+        if (/^type$|^label|color|^plist$/.test(key)) continue;
+        if (typeof opts[key] !== 'string') continue;
         const parsed = Number(opts[key]);
         if (!Number.isNaN(parsed)) {
           opts[key] = parsed;

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.js
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.js
@@ -162,7 +162,7 @@ window.PLDrawingApi = {
 
       // Parse any numerical options from string to floating point
       for (const key in opts) {
-        if (/^type$|^label|color|^plist$/.test(key)) continue;
+        if (/^type$|^label|color|^plist$/.test(key)) continue; // skip parsing for string-only options
         if (typeof opts[key] !== 'string') continue;
         const parsed = Number(opts[key]);
         if (!Number.isNaN(parsed)) {


### PR DESCRIPTION
# Description

Normalize `pl-drawing` boolean flag reads to use `pl.get_boolean_attrib`, and keep distributed-load `anchor_is_tail` compatible with legacy string-valued saved submissions while new generated options use booleans.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). AI assistance: majority of implementation.

# Testing

No manual browser testing; the change is limited to controller option parsing/serialization and distributed-load compatibility handling.
