### PR TITLE
Add Conductor docs preview run script

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,4 +2,12 @@
 
 [scripts]
 setup = "./scripts/conductor-setup.sh"
-run = "make dev"
+
+[scripts.run.app]
+command = "make dev"
+default = true
+icon = "play"
+
+[scripts.run.docs]
+command = "make dev-docs"
+icon = "book-open"

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ lint-docs: lint-d2 lint-links lint-markdown lint-docs-links
 build-docs:
 	@NO_MKDOCS_2_WARNING=1 DISABLE_MKDOCS_2_WARNING=true uv run mkdocs build --strict
 dev-docs:
-	@NO_MKDOCS_2_WARNING=1 DISABLE_MKDOCS_2_WARNING=true uv run mkdocs serve --livereload
+	@NO_MKDOCS_2_WARNING=1 DISABLE_MKDOCS_2_WARNING=true uv run mkdocs serve --livereload --dev-addr "127.0.0.1:$$(( $${CONDUCTOR_PORT:-7999} + 1 ))"
 
 format-d2:
 	@d2 fmt docs/**/*.d2


### PR DESCRIPTION
# Description

Adds named Conductor run scripts so the existing PrairieLearn app runner remains the default and a new docs runner is available with a book icon.

Updates `make dev-docs` to bind MkDocs to `127.0.0.1:$(( ${CONDUCTOR_PORT:-7999} + 1 ))`, which keeps normal local use on port 8000 while using the next Conductor-allocated port inside a workspace.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Majority of implementation by Codex.

# Testing

Verified the Conductor settings TOML parses, `make -n dev-docs` keeps the expected MkDocs command, and the shell port expression resolves to `8000` without `CONDUCTOR_PORT` and `55021` with `CONDUCTOR_PORT=55020`.