### PR TITLE
Fix assessment heading missing in student assessments page

### DIFF
--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.tsx
@@ -17,7 +17,7 @@ import {
   AssessmentSchema,
   AssessmentSetSchema,
 } from '../../lib/db-types.js';
-import { idsEqual } from '../../lib/id.ts';
+import { idsEqual } from '../../lib/id.js';
 import { type ResLocalsForPage } from '../../lib/res-locals.js';
 
 export const StudentAssessmentsRowSchema = z.object({

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.tsx
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { html } from '@prairielearn/html';
+import { IdSchema } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { ScorebarHtml } from '../../components/Scorebar.js';
@@ -16,6 +17,7 @@ import {
   AssessmentSchema,
   AssessmentSetSchema,
 } from '../../lib/db-types.js';
+import { idsEqual } from '../../lib/id.ts';
 import { type ResLocalsForPage } from '../../lib/res-locals.js';
 
 export const StudentAssessmentsRowSchema = z.object({
@@ -39,7 +41,7 @@ export const StudentAssessmentsRowSchema = z.object({
   assessment_instance_open: AssessmentInstanceSchema.shape.open.nullable(),
   assessment_instance_date_limit: AssessmentInstanceSchema.shape.date_limit.nullable(),
   link: z.string(),
-  start_new_assessment_group: z.boolean(),
+  assessment_group_id: IdSchema,
   assessment_group_heading: z.string(),
   show_before_release: z.boolean().optional(),
   will_release_at: z.string().nullable().optional(),
@@ -79,8 +81,9 @@ export function StudentAssessments({
             </thead>
             <tbody>
               ${rows.map(
-                (row) => html`
-                  ${row.start_new_assessment_group
+                (row, index) => html`
+                  ${index === 0 ||
+                  !idsEqual(row.assessment_group_id, rows[index - 1].assessment_group_id)
                     ? html`
                         <tr>
                           <th colspan="4" scope="row" data-testid="assessment-group-heading">

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.sql
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.sql
@@ -174,29 +174,11 @@ SELECT
     ELSE '/assessment_instance/' || assessment_instance_id || '/'
   END AS link,
   (
-    LAG(
-      CASE
-        WHEN $assessments_group_by = 'Set' THEN assessment_set_id
-        ELSE assessment_module_id
-      END
-    ) OVER (
-      PARTITION BY
-        (
-          CASE
-            WHEN $assessments_group_by = 'Set' THEN assessment_set_id
-            ELSE assessment_module_id
-          END
-        )
-        -- Note that we set `NULLS FIRST` to ensure that the rows from
-        -- `multiple_instance_assessments` are always first, as they have a
-        -- null `assessment_instance_number`.
-      ORDER BY
-        assessment_set_number,
-        assessment_order_by,
-        assessment_id,
-        assessment_instance_number NULLS FIRST
-    ) IS NULL
-  ) AS start_new_assessment_group,
+    CASE
+      WHEN $assessments_group_by = 'Set' THEN assessment_set_id
+      ELSE assessment_module_id
+    END
+  ) AS assessment_group_id,
   (
     CASE
       WHEN $assessments_group_by = 'Set' THEN assessment_set_heading


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes an issue with the student assessments page where the set/module heading is not shown when the first assessment is not available due to new access control rules.

This is the test course in student view:

<img width="667" height="100" alt="image" src="https://github.com/user-attachments/assets/1f40a2a0-4443-4318-ae68-f34af3c89525" />

Note that no heading is shown. This is because the `start_new_assessment_group` flag is based on the assessment list before filtering by modern access control. This PR changes the check to verify when the assessment group (set or module) changes.

I considered using groupBy, but that does not guarantee group ordering. This implementation keeps the same order as the original query.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Tested in the test course in pure student view (with no overrides). Heading works fine in this PR, fails in master.

<img width="356" height="111" alt="image" src="https://github.com/user-attachments/assets/6cd3766c-25b1-454d-a38c-3677dd340a29" />


<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
