### PR TITLE
Fix manual grading group fetch URL

### DIFF
--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -279,7 +279,8 @@ function ensureElementsExist(elements) {
 }
 
 function addInstanceQuestionGroupSelectionDropdownListeners() {
-  const { instanceQuestionId, instanceQuestionGroupsExist } = decodeData('instance-question-data');
+  const { instanceQuestionGroupsExist, manualInstanceQuestionGroupUrl } =
+    decodeData('instance-question-data');
 
   if (!instanceQuestionGroupsExist) {
     // Instance question grouping has not been run yet for the assessment question,
@@ -313,7 +314,7 @@ function addInstanceQuestionGroupSelectionDropdownListeners() {
       description: selectedGroupDescription,
     } = selectedGroupDropdownItem.dataset;
 
-    await fetch(`${instanceQuestionId}/manual_instance_question_group`, {
+    await fetch(manualInstanceQuestionGroupUrl, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -16,6 +16,7 @@ import type {
 } from '../../../ee/lib/ai-grading/types.js';
 import { assetPath, compiledScriptTag, nodeModulesAssetPath } from '../../../lib/assets.js';
 import { StaffAssessmentQuestionSchema } from '../../../lib/client/safe-db-types.js';
+import { getAssessmentManualGradingUrl } from '../../../lib/client/url.js';
 import { GradingJobSchema, type InstanceQuestionGroup, type User } from '../../../lib/db-types.js';
 import type { ResLocalsInstanceQuestionRender } from '../../../lib/question-render.types.js';
 import type { ResLocalsForPage } from '../../../lib/res-locals.js';
@@ -130,7 +131,10 @@ export function InstanceQuestion({
       ${EncodedData(
         {
           instanceQuestionGroupsExist,
-          manualInstanceQuestionGroupUrl: `${resLocals.urlPrefix}/assessment/${resLocals.assessment.id}/manual_grading/instance_question/${resLocals.instance_question.id}/manual_instance_question_group`,
+          manualInstanceQuestionGroupUrl: `${getAssessmentManualGradingUrl({
+            courseInstanceId: resLocals.course_instance.id,
+            assessmentId: resLocals.assessment.id,
+          })}/instance_question/${resLocals.instance_question.id}/manual_instance_question_group`,
         },
         'instance-question-data',
       )}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -129,8 +129,8 @@ export function InstanceQuestion({
       ${compiledScriptTag('instructorAssessmentManualGradingInstanceQuestion.js')}
       ${EncodedData(
         {
-          instanceQuestionId: resLocals.instance_question.id,
           instanceQuestionGroupsExist,
+          manualInstanceQuestionGroupUrl: `${resLocals.urlPrefix}/assessment/${resLocals.assessment.id}/manual_grading/instance_question/${resLocals.instance_question.id}/manual_instance_question_group`,
         },
         'instance-question-data',
       )}


### PR DESCRIPTION
# Description

Fixes #15314 by passing the manual instance-question group update endpoint from the server-rendered page data to the manual grading script, then fetching that rooted URL instead of constructing it relative to the current page path.
This prevents AI submission grouping updates from breaking when the manual grading page is loaded with a trailing slash.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation completed with Codex.

# Testing

Verified the PR diff no longer constructs the manual group update request from the current page path; targeted formatting, linting, TypeScript checking, and whitespace validation passed for the changed files.
