### PR TITLE
Remove deprecated checkbox answer hiding

### DIFF
--- a/exampleCourse/questions/demo/randomCheckbox/question.html
+++ b/exampleCourse/questions/demo/randomCheckbox/question.html
@@ -3,7 +3,7 @@
     Select the matrices below with dimensions ${{params.N}}\times{{params.N}}$:
   </p>
 </pl-question-panel>
-<pl-checkbox answers-name="students" hide-answer-panel="true">
+<pl-checkbox answers-name="students">
   <pl-answer correct="true">
     $<pl-matrix-latex params-name="N1"></pl-matrix-latex>$
   </pl-answer>


### PR DESCRIPTION
# Description

The random checkbox demo still used the deprecated `hide-answer-panel` attribute that was originally added while demonstrating `pl-checkbox` answer-panel hiding.

Since this question does not need to suppress correct answers, this removes the deprecated attribute instead of preserving the behavior with `<pl-hide-in-panel>`.

# Testing

`make lint-mustache`
