### PR TITLE
Validate institution UID regexps

### DIFF
--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.html.ts
@@ -145,7 +145,8 @@ export function AdministratorInstitutionGeneral({
           />
           <small id="uid_regexp_help" class="form-text text-muted">
             Should match the non-username part of user UIDs, e.g. <code>@example\\.com$</code>. This
-            should be set for institution-based access restrictions to work correctly.
+            must be a valid regular expression and should be set for institution-based access
+            restrictions to work correctly.
           </small>
         </div>
         <h2 class="h4">Limits</h2>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.html.ts
@@ -145,8 +145,9 @@ export function AdministratorInstitutionGeneral({
           />
           <small id="uid_regexp_help" class="form-text text-muted">
             Should match the non-username part of user UIDs, e.g. <code>@example\\.com$</code>. This
-            must be a valid regular expression and should be set for institution-based access
-            restrictions to work correctly.
+            must be a valid regular expression that starts with <code>@</code> and ends with
+            <code>$</code>. Periods must be escaped as <code>\\.</code>. This should be set for
+            institution-based access restrictions to work correctly.
           </small>
         </div>
         <h2 class="h4">Limits</h2>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
@@ -79,7 +79,6 @@ router.post(
         res.redirect(req.originalUrl);
         return;
       }
-      const uidRegexp = uidRegexpResult.data || null;
 
       await runInTransactionAsync(async () => {
         const institution = await getInstitution(req.params.institution_id);
@@ -90,7 +89,7 @@ router.post(
             short_name: req.body.short_name,
             long_name: req.body.long_name,
             display_timezone: req.body.display_timezone,
-            uid_regexp: uidRegexp,
+            uid_regexp: uidRegexpResult.data || null,
             yearly_enrollment_limit: req.body.yearly_enrollment_limit || null,
             course_instance_enrollment_limit: req.body.course_instance_enrollment_limit || null,
           },

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionGeneral/administratorInstitutionGeneral.ts
@@ -10,6 +10,7 @@ import { InstitutionSchema } from '../../../lib/db-types.js';
 import { validateGithubCourseOwner } from '../../../lib/github.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalTimezones } from '../../../lib/timezones.js';
+import { UidRegexpSchema } from '../../../lib/uid-regexp.js';
 import { insertAuditLog } from '../../../models/audit-log.js';
 import {
   COURSE_REQUEST_MESSAGE_MAX_LENGTH,
@@ -72,6 +73,14 @@ router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
     if (req.body.__action === 'update_enrollment_limits') {
+      const uidRegexpResult = UidRegexpSchema.safeParse(req.body.uid_regexp || '');
+      if (!uidRegexpResult.success) {
+        flash('error', uidRegexpResult.error.issues[0].message);
+        res.redirect(req.originalUrl);
+        return;
+      }
+      const uidRegexp = uidRegexpResult.data || null;
+
       await runInTransactionAsync(async () => {
         const institution = await getInstitution(req.params.institution_id);
         const updatedInstitution = await queryRow(
@@ -81,7 +90,7 @@ router.post(
             short_name: req.body.short_name,
             long_name: req.body.long_name,
             display_timezone: req.body.display_timezone,
-            uid_regexp: req.body.uid_regexp,
+            uid_regexp: uidRegexp,
             yearly_enrollment_limit: req.body.yearly_enrollment_limit || null,
             course_instance_enrollment_limit: req.body.course_instance_enrollment_limit || null,
           },

--- a/apps/prairielearn/src/lib/uid-regexp.test.ts
+++ b/apps/prairielearn/src/lib/uid-regexp.test.ts
@@ -1,0 +1,19 @@
+import { assert, describe, it } from 'vitest';
+
+import { UidRegexpSchema } from './uid-regexp.js';
+
+describe('UID regexp validation', () => {
+  it('accepts blank UID regexps', () => {
+    assert.isTrue(UidRegexpSchema.safeParse('').success);
+    assert.deepEqual(UidRegexpSchema.parse('   '), '');
+  });
+
+  it('accepts valid UID regexps', () => {
+    assert.deepEqual(UidRegexpSchema.parse('  @example\\.com$  '), '@example\\.com$');
+  });
+
+  it('rejects invalid UID regexps', () => {
+    const result = UidRegexpSchema.safeParse('@uot\\.edu.\\ly$');
+    assert.isFalse(result.success);
+  });
+});

--- a/apps/prairielearn/src/lib/uid-regexp.test.ts
+++ b/apps/prairielearn/src/lib/uid-regexp.test.ts
@@ -10,10 +10,25 @@ describe('UID regexp validation', () => {
 
   it('accepts valid UID regexps', () => {
     assert.deepEqual(UidRegexpSchema.parse('  @example\\.com$  '), '@example\\.com$');
+    assert.deepEqual(
+      UidRegexpSchema.parse('@(student\\.|)example\\.edu$'),
+      '@(student\\.|)example\\.edu$',
+    );
   });
 
   it('rejects invalid UID regexps', () => {
     const result = UidRegexpSchema.safeParse('@uot\\.edu.\\ly$');
     assert.isFalse(result.success);
+  });
+
+  it('rejects UID regexps that do not start with @ and end with $', () => {
+    assert.isFalse(UidRegexpSchema.safeParse('example.edu').success);
+    assert.isFalse(UidRegexpSchema.safeParse('@example\\.edu@').success);
+  });
+
+  it('rejects UID regexps with unescaped periods', () => {
+    assert.isFalse(UidRegexpSchema.safeParse('@example.com$').success);
+    assert.isFalse(UidRegexpSchema.safeParse('@example.\\edu$').success);
+    assert.isFalse(UidRegexpSchema.safeParse('@(student\\.|)example.edu$').success);
   });
 });

--- a/apps/prairielearn/src/lib/uid-regexp.ts
+++ b/apps/prairielearn/src/lib/uid-regexp.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const INVALID_UID_REGEXP_MESSAGE = 'UID regexp must be a valid regular expression.';
+const UNESCAPED_DOT_REGEXP = /(^|[^\\])(?:\\\\)*\./u;
 
 export const UidRegexpSchema = z
   .string()
@@ -17,5 +17,12 @@ export const UidRegexpSchema = z
 
       return true;
     },
-    { message: INVALID_UID_REGEXP_MESSAGE },
-  );
+    { message: 'UID regexp must be a valid regular expression.' },
+  )
+  .refine(
+    (uidRegexp) => uidRegexp.length === 0 || (uidRegexp.startsWith('@') && uidRegexp.endsWith('$')),
+    { message: 'UID regexp must start with @ and end with $.' },
+  )
+  .refine((uidRegexp) => !UNESCAPED_DOT_REGEXP.test(uidRegexp), {
+    message: 'Periods in UID regexp must be escaped as \\.',
+  });

--- a/apps/prairielearn/src/lib/uid-regexp.ts
+++ b/apps/prairielearn/src/lib/uid-regexp.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const INVALID_UID_REGEXP_MESSAGE = 'UID regexp must be a valid regular expression.';
+
+export const UidRegexpSchema = z
+  .string()
+  .trim()
+  .refine(
+    (uidRegexp) => {
+      if (uidRegexp.length === 0) return true;
+
+      try {
+        new RegExp(uidRegexp, 'u');
+      } catch {
+        return false;
+      }
+
+      return true;
+    },
+    { message: INVALID_UID_REGEXP_MESSAGE },
+  );

--- a/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
+++ b/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
@@ -244,8 +244,9 @@ export function AddInstitutionModal({
             )}
             <small id="uid_regexp_help" className="form-text text-muted">
               Should match the non-username part of user UIDs, e.g. <code>@example\.com$</code>.
-              This must be a valid regular expression and should be set for institution-based access
-              restrictions to work correctly.
+              This must be a valid regular expression that starts with <code>@</code> and ends with{' '}
+              <code>$</code>. Periods must be escaped as <code>\.</code>. This should be set for
+              institution-based access restrictions to work correctly.
             </small>
           </div>
           {supportedAuthenticationProviders.length > 0 ? (

--- a/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
+++ b/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
@@ -9,6 +9,7 @@ import { OverlayTrigger } from '@prairielearn/ui';
 import { AppErrorAlert, getAppError } from '../../../lib/client/errors.js';
 import type { StaffAuthnProvider } from '../../../lib/client/safe-db-types.js';
 import { type Timezone, formatTimezone } from '../../../lib/timezone.shared.js';
+import { UidRegexpSchema } from '../../../lib/uid-regexp.js';
 import { useTRPC } from '../../../trpc/administrator/context.js';
 import type { AdministratorInstitutionsError } from '../../../trpc/administrator/institutions.js';
 
@@ -223,14 +224,28 @@ export function AddInstitutionModal({
             </label>
             <input
               type="text"
-              className="form-control"
+              className={clsx('form-control', errors.uid_regexp && 'is-invalid')}
               id="uid_regexp"
               aria-describedby="uid_regexp_help"
-              {...register('uid_regexp')}
+              aria-invalid={errors.uid_regexp ? true : undefined}
+              aria-errormessage={errors.uid_regexp ? 'uid_regexp-error' : undefined}
+              defaultValue=""
+              {...register('uid_regexp', {
+                validate: (value) => {
+                  const result = UidRegexpSchema.safeParse(value);
+                  return result.success || result.error.issues[0].message;
+                },
+              })}
             />
+            {errors.uid_regexp && (
+              <div id="uid_regexp-error" className="invalid-feedback">
+                {errors.uid_regexp.message}
+              </div>
+            )}
             <small id="uid_regexp_help" className="form-text text-muted">
               Should match the non-username part of user UIDs, e.g. <code>@example\.com$</code>.
-              This should be set for institution-based access restrictions to work correctly.
+              This must be a valid regular expression and should be set for institution-based access
+              restrictions to work correctly.
             </small>
           </div>
           {supportedAuthenticationProviders.length > 0 ? (

--- a/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
+++ b/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
@@ -229,7 +229,6 @@ export function AddInstitutionModal({
               aria-describedby="uid_regexp_help"
               aria-invalid={errors.uid_regexp ? true : undefined}
               aria-errormessage={errors.uid_regexp ? 'uid_regexp-error' : undefined}
-              defaultValue=""
               {...register('uid_regexp', {
                 validate: (value) => {
                   const result = UidRegexpSchema.safeParse(value);

--- a/apps/prairielearn/src/trpc/administrator/institutions.ts
+++ b/apps/prairielearn/src/trpc/administrator/institutions.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { getSupportedAuthenticationProviders } from '../../lib/authn-providers.js';
 import { suggestTimezone as suggestTimezoneImpl } from '../../lib/course-request-ai.js';
+import { UidRegexpSchema } from '../../lib/uid-regexp.js';
 import { updateInstitutionAuthnProviders } from '../../models/institution-authn-provider.js';
 import { insertInstitution } from '../../models/institution.js';
 
@@ -36,7 +37,7 @@ const addInstitution = t.procedure
       shortName: z.string().trim().min(1),
       longName: z.string().trim().min(1),
       displayTimezone: z.string().trim().min(1),
-      uidRegexp: z.string().trim(),
+      uidRegexp: UidRegexpSchema,
       enabledAuthnProviderIds: z.array(z.string()),
     }),
   )


### PR DESCRIPTION
# Description

Adds shared Zod validation for institution UID regexps so malformed patterns are caught when creating or editing institutions instead of being saved and later breaking PostgreSQL regexp matching. Nonblank UID regexps must now start with `@`, end with `$`, and escape literal periods as `\.`.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Added unit coverage for blank, valid, syntactically invalid, incorrectly bounded, and unescaped-period UID regexps in `apps/prairielearn/src/lib/uid-regexp.test.ts`.
