### PR TITLE
Persist LTI 1.3 course-nav resource link and add admin roster inspector

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -1030,6 +1030,9 @@ export async function updateLti13Scores({
 const RosterMemberSchema = z
   .object({
     user_id: z.string(),
+    // NRPS flattens the lis sourcedid onto the member rather than nesting it under
+    // the lis claim the way a launch id_token does.
+    lis_person_sourcedid: z.string().optional(),
     // Present only when the roster is fetched with a resource link id (`?rlid=`).
     message: z.array(z.record(z.string(), z.unknown())).optional(),
   })
@@ -1037,25 +1040,34 @@ const RosterMemberSchema = z
 type RosterMember = z.infer<typeof RosterMemberSchema>;
 
 /**
- * Resolves the UIN for a roster member from its per-message custom claims using
- * the instance's configured `uin_attribute` path. Returns null if the attribute
- * isn't configured or no message resolves a non-empty value.
+ * Resolves the UIN for a roster member using the instance's configured
+ * `uin_attribute` path. That path is written against the launch id_token, but NRPS
+ * represents a member differently: standard claims and the lis sourcedid are
+ * flattened onto the member, while per-resource-link claims (e.g. custom) live in
+ * `message[]`. We rebuild a launch-claim-shaped object so the same path resolves
+ * for the configurations seen in practice — both `…/claim/custom` and
+ * `…/claim/lis`. Returns null when the attribute isn't configured or nothing
+ * resolves to a non-empty value.
  */
 function resolveRosterMemberUin(member: RosterMember, uin_attribute: string | null): string | null {
-  if (!uin_attribute || !member.message) return null;
-  for (const message of member.message) {
-    // Each `message[]` entry holds its own `…/claim/custom` block at the same
-    // top-level position the launch id_token holds it, so a `uin_attribute` that
-    // targets the custom claim resolves when applied to an entry. es-toolkit's
-    // `get` expands a path like 'a[0].b.c'. Note this only works for custom-claim
-    // paths: attributes sourced from other launch claims (e.g. the `lis` claim,
-    // which NRPS flattens directly onto the member) won't resolve from a message.
-    const value = get(message, uin_attribute);
-    if (typeof value === 'string' && value.length > 0) {
-      return value;
-    }
-  }
-  return null;
+  if (!uin_attribute) return null;
+
+  // `message[]` is typed as an array (each entry tagged with a message_type) and is
+  // only present with `?rlid=`. Canvas only ever emits a single LtiResourceLinkRequest
+  // entry, but merge any entries so a custom claim resolves regardless of position.
+  // The lis sourcedid is the one claim NRPS flattens onto the member, so nest it back
+  // under its claim. es-toolkit's `get` expands a path like 'a[0].b.c'.
+  const claims = {
+    ...member,
+    ...Object.assign({}, ...(member.message ?? [])),
+    'https://purl.imsglobal.org/spec/lti/claim/lis':
+      member.lis_person_sourcedid != null
+        ? { person_sourcedid: member.lis_person_sourcedid }
+        : undefined,
+  };
+
+  const value = get(claims, uin_attribute);
+  return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
 /**

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -791,10 +791,10 @@ const ContextMembershipContainerSchema = z.object({
 
 /**
  * Appends a resource link id to a NRPS `context_memberships_url` so that the
- * platform resolves per-member `message[].custom` claims for that resource link.
- * Returns the URL unchanged when no rlid is provided.
+ * platform resolves per-member `message[]` claims (including custom claims) for
+ * that resource link. Returns the URL unchanged when no rlid is provided.
  *
- * https://www.imsglobal.org/spec/lti-nrps/v2p0/#access-to-extended-personal-data-via-message-property
+ * https://www.imsglobal.org/spec/lti-nrps/v2p0/#resource-link-membership-service
  */
 function appendRlidToMembershipsUrl(context_memberships_url: string, rlid: string | null): string {
   if (!rlid) return context_memberships_url;
@@ -1044,9 +1044,12 @@ type RosterMember = z.infer<typeof RosterMemberSchema>;
 function resolveRosterMemberUin(member: RosterMember, uin_attribute: string | null): string | null {
   if (!uin_attribute || !member.message) return null;
   for (const message of member.message) {
-    // es-toolkit's `get` expands a path representation like 'a[0].b.c'. The same
-    // `uin_attribute` path used at launch applies here because the message mirrors
-    // the launch claim's custom block.
+    // Each `message[]` entry holds its own `…/claim/custom` block at the same
+    // top-level position the launch id_token holds it, so a `uin_attribute` that
+    // targets the custom claim resolves when applied to an entry. es-toolkit's
+    // `get` expands a path like 'a[0].b.c'. Note this only works for custom-claim
+    // paths: attributes sourced from other launch claims (e.g. the `lis` claim,
+    // which NRPS flattens directly onto the member) won't resolve from a message.
     const value = get(message, uin_attribute);
     if (typeof value === 'string' && value.length > 0) {
       return value;
@@ -1100,29 +1103,25 @@ export async function inspectRoster({
     },
   });
 
-  const rawMembers = fetchArray.flatMap((container) => {
-    const parsed = z.object({ members: z.array(z.unknown()).optional() }).safeParse(container);
-    return parsed.success ? (parsed.data.members ?? []) : [];
-  });
+  const members = fetchArray
+    .flatMap((container) => {
+      const parsed = z.object({ members: z.array(z.unknown()).optional() }).safeParse(container);
+      return parsed.success ? (parsed.data.members ?? []) : [];
+    })
+    .map((raw) => ({ raw, parsed: RosterMemberSchema.safeParse(raw) }));
 
-  job.info(`\nFound ${rawMembers.length} member${rawMembers.length === 1 ? '' : 's'}.\n`);
+  job.info(`\nFound ${members.length} member${members.length === 1 ? '' : 's'}.\n`);
 
   const counts = { by_sub: 0, by_uin: 0, unmatched: 0 };
-  let anyMessage = false;
 
-  for (const rawMember of rawMembers) {
-    job.info(JSON.stringify(rawMember, null, 2));
+  for (const { raw, parsed } of members) {
+    job.info(JSON.stringify(raw, null, 2));
 
-    const parsed = RosterMemberSchema.safeParse(rawMember);
     if (!parsed.success) {
       job.warn('  Could not parse member; skipping match annotation.');
       continue;
     }
     const member = parsed.data;
-
-    if (member.message && member.message.length > 0) {
-      anyMessage = true;
-    }
 
     const userBySub = await selectOptionalUserByLti13Sub({
       lti13_instance_id: lti13_instance.id,
@@ -1155,6 +1154,12 @@ export async function inspectRoster({
   job.info(`${counts.by_sub} matched by LTI sub.`);
   job.info(`${counts.by_uin} matched by UIN.`);
   job.info(`${counts.unmatched} unmatched.`);
+
+  // Whether the platform returned any per-member custom data (`message`). If a
+  // resource link was requested but none came back, the rlid is likely stale.
+  const anyMessage = members.some(
+    ({ parsed }) => parsed.success && (parsed.data.message?.length ?? 0) > 0,
+  );
 
   if (rlid && !anyMessage) {
     job.warn(

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -29,6 +29,8 @@ import {
 } from '../../lib/db-types.js';
 import { type ServerJob } from '../../lib/server-jobs.js';
 import { selectUsersWithCourseInstanceAccess } from '../../models/course-instances.js';
+import { selectOptionalUserByUin } from '../../models/user.js';
+import { selectOptionalUserByLti13Sub } from '../models/lti13-user.js';
 import { selectLti13Instance } from '../models/lti13Instance.js';
 
 const sql = loadSqlEquiv(import.meta.url);
@@ -280,6 +282,22 @@ export class Lti13Claim {
     this.assertValid();
     return this.claims['https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice']
       ?.context_memberships_url;
+  }
+
+  /**
+   * The resource link id for the launch. Only present on resource link requests
+   * (e.g. the course-navigation launch), not deep linking requests. Returns null
+   * when absent.
+   */
+  get resource_link_id(): string | null {
+    this.assertValid();
+    if (
+      this.claims['https://purl.imsglobal.org/spec/lti/claim/message_type'] !==
+      'LtiResourceLinkRequest'
+    ) {
+      return null;
+    }
+    return this.claims['https://purl.imsglobal.org/spec/lti/claim/resource_link'].id;
   }
 
   // Functions
@@ -771,6 +789,20 @@ const ContextMembershipContainerSchema = z.object({
   members: ContextMembershipSchema.array(),
 });
 
+/**
+ * Appends a resource link id to a NRPS `context_memberships_url` so that the
+ * platform resolves per-member `message[].custom` claims for that resource link.
+ * Returns the URL unchanged when no rlid is provided.
+ *
+ * https://www.imsglobal.org/spec/lti-nrps/v2p0/#access-to-extended-personal-data-via-message-property
+ */
+function appendRlidToMembershipsUrl(context_memberships_url: string, rlid: string | null): string {
+  if (!rlid) return context_memberships_url;
+  const url = new URL(context_memberships_url);
+  url.searchParams.set('rlid', rlid);
+  return url.toString();
+}
+
 class Lti13ContextMembership {
   #membershipsByEmail: Record<string, ContextMembership[]> = {};
   #membershipsBySub: Record<string, ContextMembership> = {};
@@ -991,4 +1023,145 @@ export async function updateLti13Scores({
     );
   }
   job.info(`${counts.not_sent} score${counts.not_sent === 1 ? '' : 's'} skipped (not sent).`);
+}
+
+// Loose schema for the inspector: we want to dump members verbatim, so we only
+// parse the few fields needed for match annotation and keep everything else.
+const RosterMemberSchema = z
+  .object({
+    user_id: z.string(),
+    // Present only when the roster is fetched with a resource link id (`?rlid=`).
+    message: z.array(z.record(z.string(), z.unknown())).optional(),
+  })
+  .loose();
+type RosterMember = z.infer<typeof RosterMemberSchema>;
+
+/**
+ * Resolves the UIN for a roster member from its per-message custom claims using
+ * the instance's configured `uin_attribute` path. Returns null if the attribute
+ * isn't configured or no message resolves a non-empty value.
+ */
+function resolveRosterMemberUin(member: RosterMember, uin_attribute: string | null): string | null {
+  if (!uin_attribute || !member.message) return null;
+  for (const message of member.message) {
+    // es-toolkit's `get` expands a path representation like 'a[0].b.c'. The same
+    // `uin_attribute` path used at launch applies here because the message mirrors
+    // the launch claim's custom block.
+    const value = get(message, uin_attribute);
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Read-only NRPS roster inspector. Fetches the membership roster (optionally with
+ * a resource link id so the platform resolves per-member custom claims), dumps the
+ * raw per-member payloads, and annotates each member with how it could be matched
+ * to a PrairieLearn user. Does not create or modify any enrollments or users.
+ */
+export async function inspectRoster({
+  instance,
+  rlid,
+  job,
+}: {
+  instance: Lti13CombinedInstance;
+  rlid: string | null;
+  job: ServerJob;
+}) {
+  const { lti13_instance, lti13_course_instance } = instance;
+
+  if (lti13_course_instance.context_memberships_url === null) {
+    throw new HttpStatusError(
+      403,
+      'LTI 1.3 course instance context_memberships_url not configured',
+    );
+  }
+
+  const url = appendRlidToMembershipsUrl(lti13_course_instance.context_memberships_url, rlid);
+
+  job.info(
+    `Fetching roster for ${lti13_instance.name}: ${lti13_course_instance.context_label ?? '(no context label)'}`,
+  );
+  job.info(`NRPS URL: ${url}`);
+  if (rlid) {
+    job.info(`Requesting per-member custom data for resource link id: ${rlid}`);
+  } else {
+    job.info('No resource link id selected; fetching a plain roster (no custom claims).');
+  }
+
+  const token = await getAccessToken(lti13_instance.id);
+  const fetchArray = await fetchRetryPaginated(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-type': 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
+    },
+  });
+
+  const rawMembers = fetchArray.flatMap((container) => {
+    const parsed = z.object({ members: z.array(z.unknown()).optional() }).safeParse(container);
+    return parsed.success ? (parsed.data.members ?? []) : [];
+  });
+
+  job.info(`\nFound ${rawMembers.length} member${rawMembers.length === 1 ? '' : 's'}.\n`);
+
+  const counts = { by_sub: 0, by_uin: 0, unmatched: 0 };
+  let anyMessage = false;
+
+  for (const rawMember of rawMembers) {
+    job.info(JSON.stringify(rawMember, null, 2));
+
+    const parsed = RosterMemberSchema.safeParse(rawMember);
+    if (!parsed.success) {
+      job.warn('  Could not parse member; skipping match annotation.');
+      continue;
+    }
+    const member = parsed.data;
+
+    if (member.message && member.message.length > 0) {
+      anyMessage = true;
+    }
+
+    const userBySub = await selectOptionalUserByLti13Sub({
+      lti13_instance_id: lti13_instance.id,
+      sub: member.user_id,
+    });
+
+    const uin = resolveRosterMemberUin(member, lti13_instance.uin_attribute);
+    const userByUin =
+      !userBySub && uin
+        ? await selectOptionalUserByUin({ uin, institution_id: lti13_instance.institution_id })
+        : null;
+
+    if (userBySub) {
+      counts.by_sub++;
+      job.info(
+        `  Matched by sub to PrairieLearn user ${userBySub.uid} (UIN ${userBySub.uin ?? 'none'}).`,
+      );
+    } else if (userByUin) {
+      counts.by_uin++;
+      job.info(`  Matched by UIN ${uin} to PrairieLearn user ${userByUin.uid}.`);
+    } else {
+      counts.unmatched++;
+      job.info(
+        `  No PrairieLearn user matched${uin ? ` (UIN ${uin} resolved but no user found)` : ''}.`,
+      );
+    }
+  }
+
+  job.info('\nDone.\n\nSummary:');
+  job.info(`${counts.by_sub} matched by LTI sub.`);
+  job.info(`${counts.by_uin} matched by UIN.`);
+  job.info(`${counts.unmatched} unmatched.`);
+
+  if (rlid && !anyMessage) {
+    job.warn(
+      '\nThe platform returned no per-member custom data (`message`). The selected resource link id may be stale.',
+    );
+    job.warn(
+      'Have an instructor re-launch from the course navigation link to refresh custom data.',
+    );
+  }
 }

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -837,7 +837,7 @@ class Lti13ContextMembership {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
-        'Content-type': 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
+        Accept: 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
       },
     });
 
@@ -1111,7 +1111,7 @@ export async function inspectRoster({
     method: 'GET',
     headers: {
       Authorization: `Bearer ${token}`,
-      'Content-type': 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
+      Accept: 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json',
     },
   });
 
@@ -1124,12 +1124,13 @@ export async function inspectRoster({
 
   job.info(`\nFound ${members.length} member${members.length === 1 ? '' : 's'}.\n`);
 
-  const counts = { by_sub: 0, by_uin: 0, unmatched: 0 };
+  const counts = { by_sub: 0, by_uin: 0, unmatched: 0, unparseable: 0 };
 
   for (const { raw, parsed } of members) {
     job.info(JSON.stringify(raw, null, 2));
 
     if (!parsed.success) {
+      counts.unparseable++;
       job.warn('  Could not parse member; skipping match annotation.');
       continue;
     }
@@ -1166,6 +1167,7 @@ export async function inspectRoster({
   job.info(`${counts.by_sub} matched by LTI sub.`);
   job.info(`${counts.by_uin} matched by UIN.`);
   job.info(`${counts.unmatched} unmatched.`);
+  job.info(`${counts.unparseable} could not be parsed.`);
 
   // Whether the platform returned any per-member custom data (`message`). If a
   // resource link was requested but none came back, the rlid is likely stale.

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
@@ -17,7 +17,6 @@ import { type LTI13InstancePlatforms } from './administratorInstitutionLti13.typ
 export const LinkedCourseInstanceSchema = z.object({
   lti13_course_instance: Lti13CourseInstanceSchema,
   course_instance_short_name: z.string().nullable(),
-  course_instance_long_name: z.string().nullable(),
   course_short_name: z.string().nullable(),
   lineitem_resource_links: z
     .object({
@@ -487,7 +486,13 @@ function RosterInspectorForm({
     <div class="card mb-2">
       <div class="card-body">
         <h6 class="card-title mb-1">
-          ${courseLabel}
+          <a
+            href="/pl/course_instance/${lci.course_instance_id}/instructor/instance_admin/lti13_instance/${lci.id}"
+            target="_blank"
+            rel="noreferrer"
+          >
+            ${courseLabel}
+          </a>
           <span class="text-muted fw-normal">(${lci.context_label ?? 'no context label'})</span>
         </h6>
         ${lci.context_memberships_url === null

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
@@ -91,26 +91,32 @@ export function AdministratorInstitutionLti13({
         </div>
 
         <div class="col-9">
-          ${LTI13Instance(
+          ${LTI13Instance({
             instance,
             linkedCourseInstances,
             resLocals,
             platform_defaults,
             canonicalHost,
-          )}
+          })}
         </div>
       </div>
     `,
   });
 }
 
-function LTI13Instance(
-  instance: Lti13Instance | null,
-  linkedCourseInstances: LinkedCourseInstance[],
-  resLocals: ResLocalsForPage<'plain'>,
-  platform_defaults: LTI13InstancePlatforms,
-  canonicalHost: string,
-) {
+function LTI13Instance({
+  instance,
+  linkedCourseInstances,
+  resLocals,
+  platform_defaults,
+  canonicalHost,
+}: {
+  instance: Lti13Instance | null;
+  linkedCourseInstances: LinkedCourseInstance[];
+  resLocals: ResLocalsForPage<'plain'>;
+  platform_defaults: LTI13InstancePlatforms;
+  canonicalHost: string;
+}) {
   if (instance) {
     return html`
       <h3>${instance.name} (ID #${instance.id})</h3>
@@ -417,7 +423,7 @@ ${JSON.stringify(instance.custom_fields, null, 3)}</textarea
       </form>
 
       <hr />
-      ${RosterInspector(linkedCourseInstances, resLocals)}
+      ${RosterInspector({ linkedCourseInstances, resLocals })}
 
       <hr />
       <p>
@@ -444,10 +450,13 @@ ${JSON.stringify(instance.custom_fields, null, 3)}</textarea
   }
 }
 
-function RosterInspector(
-  linkedCourseInstances: LinkedCourseInstance[],
-  resLocals: ResLocalsForPage<'plain'>,
-) {
+function RosterInspector({
+  linkedCourseInstances,
+  resLocals,
+}: {
+  linkedCourseInstances: LinkedCourseInstance[];
+  resLocals: ResLocalsForPage<'plain'>;
+}) {
   return html`
     <h5>NRPS roster inspector</h5>
     <p class="text-muted">
@@ -458,11 +467,17 @@ function RosterInspector(
     </p>
     ${linkedCourseInstances.length === 0
       ? html`<p>No course instances are linked to this LTI 1.3 instance yet.</p>`
-      : linkedCourseInstances.map((linked) => RosterInspectorForm(linked, resLocals))}
+      : linkedCourseInstances.map((linked) => RosterInspectorForm({ linked, resLocals }))}
   `;
 }
 
-function RosterInspectorForm(linked: LinkedCourseInstance, resLocals: ResLocalsForPage<'plain'>) {
+function RosterInspectorForm({
+  linked,
+  resLocals,
+}: {
+  linked: LinkedCourseInstance;
+  resLocals: ResLocalsForPage<'plain'>;
+}) {
   const lci = linked.lti13_course_instance;
   const courseLabel =
     `${linked.course_short_name ?? ''} ${linked.course_instance_short_name ?? ''}`.trim() ||

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
@@ -1,17 +1,39 @@
+import { z } from 'zod';
+
 import { EncodedData } from '@prairielearn/browser-utils';
 import { html } from '@prairielearn/html';
 
 import { PageLayout } from '../../../components/PageLayout.js';
 import { compiledScriptTag } from '../../../lib/assets.js';
-import { type Institution, type Lti13Instance } from '../../../lib/db-types.js';
+import {
+  type Institution,
+  Lti13CourseInstanceSchema,
+  type Lti13Instance,
+} from '../../../lib/db-types.js';
 import type { ResLocalsForPage } from '../../../lib/res-locals.js';
 
 import { type LTI13InstancePlatforms } from './administratorInstitutionLti13.types.js';
+
+export const LinkedCourseInstanceSchema = z.object({
+  lti13_course_instance: Lti13CourseInstanceSchema,
+  course_instance_short_name: z.string().nullable(),
+  course_instance_long_name: z.string().nullable(),
+  course_short_name: z.string().nullable(),
+  lineitem_resource_links: z
+    .object({
+      resource_link_id: z.string(),
+      label: z.string().nullable(),
+      assessment_title: z.string().nullable(),
+    })
+    .array(),
+});
+type LinkedCourseInstance = z.infer<typeof LinkedCourseInstanceSchema>;
 
 export function AdministratorInstitutionLti13({
   institution,
   lti13Instances,
   instance,
+  linkedCourseInstances,
   resLocals,
   platform_defaults,
   canonicalHost,
@@ -19,6 +41,7 @@ export function AdministratorInstitutionLti13({
   institution: Institution;
   lti13Instances: Lti13Instance[];
   instance: Lti13Instance | null;
+  linkedCourseInstances: LinkedCourseInstance[];
   resLocals: ResLocalsForPage<'plain'>;
   platform_defaults: LTI13InstancePlatforms;
   canonicalHost: string;
@@ -68,7 +91,13 @@ export function AdministratorInstitutionLti13({
         </div>
 
         <div class="col-9">
-          ${LTI13Instance(instance, resLocals, platform_defaults, canonicalHost)}
+          ${LTI13Instance(
+            instance,
+            linkedCourseInstances,
+            resLocals,
+            platform_defaults,
+            canonicalHost,
+          )}
         </div>
       </div>
     `,
@@ -77,6 +106,7 @@ export function AdministratorInstitutionLti13({
 
 function LTI13Instance(
   instance: Lti13Instance | null,
+  linkedCourseInstances: LinkedCourseInstance[],
   resLocals: ResLocalsForPage<'plain'>,
   platform_defaults: LTI13InstancePlatforms,
   canonicalHost: string,
@@ -387,6 +417,9 @@ ${JSON.stringify(instance.custom_fields, null, 3)}</textarea
       </form>
 
       <hr />
+      ${RosterInspector(linkedCourseInstances, resLocals)}
+
+      <hr />
       <p>
         For testing, have the LMS admin configure their OpenID Connect Initiation URL to
         <a href="${canonicalHost}/pl/lti13_instance/${instance.id}/auth/login?test">
@@ -409,4 +442,78 @@ ${JSON.stringify(instance.custom_fields, null, 3)}</textarea
   } else {
     return html`Please select an instance on the left.`;
   }
+}
+
+function RosterInspector(
+  linkedCourseInstances: LinkedCourseInstance[],
+  resLocals: ResLocalsForPage<'plain'>,
+) {
+  return html`
+    <h5>NRPS roster inspector</h5>
+    <p class="text-muted">
+      Read-only diagnostic. Dumps the raw Names and Role Provisioning Service (NRPS) roster for a
+      linked course instance, optionally requesting per-member custom claims for a chosen resource
+      link. This exposes every member's <code>sub</code>, email, and UIN. No enrollments or users
+      are created or modified.
+    </p>
+    ${linkedCourseInstances.length === 0
+      ? html`<p>No course instances are linked to this LTI 1.3 instance yet.</p>`
+      : linkedCourseInstances.map((linked) => RosterInspectorForm(linked, resLocals))}
+  `;
+}
+
+function RosterInspectorForm(linked: LinkedCourseInstance, resLocals: ResLocalsForPage<'plain'>) {
+  const lci = linked.lti13_course_instance;
+  const courseLabel =
+    `${linked.course_short_name ?? ''} ${linked.course_instance_short_name ?? ''}`.trim() ||
+    `Course instance ${lci.course_instance_id}`;
+
+  return html`
+    <div class="card mb-2">
+      <div class="card-body">
+        <h6 class="card-title mb-1">
+          ${courseLabel}
+          <span class="text-muted fw-normal">(${lci.context_label ?? 'no context label'})</span>
+        </h6>
+        ${lci.context_memberships_url === null
+          ? html`
+              <p class="text-muted mb-0">
+                No <code>context_memberships_url</code> stored yet. Have an instructor launch
+                PrairieLearn from this course in the LMS to populate it.
+              </p>
+            `
+          : html`
+              <form method="POST" class="row g-2 align-items-end">
+                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                <input type="hidden" name="__action" value="inspect_roster" />
+                <input type="hidden" name="lti13_course_instance_id" value="${lci.id}" />
+                <div class="col-md-9">
+                  <label class="form-label" for="rlid-${lci.id}">Resource link</label>
+                  <select class="form-select" id="rlid-${lci.id}" name="rlid">
+                    <option value="">None (plain roster, no custom claims)</option>
+                    ${lci.resource_link_id
+                      ? html`
+                          <option value="${lci.resource_link_id}">
+                            Course navigation (${lci.resource_link_id})
+                          </option>
+                        `
+                      : ''}
+                    ${linked.lineitem_resource_links.map(
+                      (li) => html`
+                        <option value="${li.resource_link_id}">
+                          Assessment: ${li.assessment_title ?? li.label ?? li.resource_link_id}
+                          (${li.resource_link_id})
+                        </option>
+                      `,
+                    )}
+                  </select>
+                </div>
+                <div class="col-md-3">
+                  <button type="submit" class="btn btn-primary w-100">Dump roster</button>
+                </div>
+              </form>
+            `}
+      </div>
+    </div>
+  `;
 }

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.sql
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.sql
@@ -13,7 +13,6 @@ ORDER BY
 SELECT
   to_jsonb(lci) AS lti13_course_instance,
   ci.short_name AS course_instance_short_name,
-  ci.long_name AS course_instance_long_name,
   c.short_name AS course_short_name,
   COALESCE(
     (

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.sql
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.sql
@@ -9,6 +9,58 @@ WHERE
 ORDER BY
   id;
 
+-- BLOCK select_linked_course_instances
+SELECT
+  to_jsonb(lci) AS lti13_course_instance,
+  ci.short_name AS course_instance_short_name,
+  ci.long_name AS course_instance_long_name,
+  c.short_name AS course_short_name,
+  COALESCE(
+    (
+      SELECT
+        jsonb_agg(
+          jsonb_build_object(
+            'resource_link_id',
+            la.lineitem ->> 'resourceLinkId',
+            'label',
+            la.lineitem ->> 'label',
+            'assessment_title',
+            a.title
+          )
+          ORDER BY
+            la.id
+        )
+      FROM
+        lti13_assessments AS la
+        JOIN assessments AS a ON a.id = la.assessment_id
+      WHERE
+        la.lti13_course_instance_id = lci.id
+        AND la.lineitem ->> 'resourceLinkId' IS NOT NULL
+    ),
+    '[]'::jsonb
+  ) AS lineitem_resource_links
+FROM
+  lti13_course_instances AS lci
+  JOIN course_instances AS ci ON ci.id = lci.course_instance_id
+  JOIN courses AS c ON c.id = ci.course_id
+WHERE
+  lci.lti13_instance_id = $lti13_instance_id
+ORDER BY
+  lci.id;
+
+-- BLOCK select_combined_lti13_instance
+SELECT
+  to_jsonb(lci) AS lti13_course_instance,
+  to_jsonb(li) AS lti13_instance
+FROM
+  lti13_course_instances AS lci
+  JOIN lti13_instances AS li ON li.id = lci.lti13_instance_id
+WHERE
+  lci.id = $lti13_course_instance_id
+  AND li.id = $lti13_instance_id
+  AND li.institution_id = $institution_id
+  AND li.deleted_at IS NULL;
+
 -- BLOCK select_keystore
 SELECT
   keystore

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -9,6 +9,7 @@ import {
   execute,
   loadSqlEquiv,
   queryOptionalScalar,
+  queryRow,
   queryRows,
   queryScalar,
 } from '@prairielearn/postgres';
@@ -16,10 +17,15 @@ import {
 import { config } from '../../../lib/config.js';
 import { type Lti13Instance, Lti13InstanceSchema } from '../../../lib/db-types.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { createServerJob } from '../../../lib/server-jobs.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import { getInstitution } from '../../lib/institution.js';
+import { Lti13CombinedInstanceSchema, inspectRoster } from '../../lib/lti13.js';
 
-import { AdministratorInstitutionLti13 } from './administratorInstitutionLti13.html.js';
+import {
+  AdministratorInstitutionLti13,
+  LinkedCourseInstanceSchema,
+} from './administratorInstitutionLti13.html.js';
 import { type LTI13InstancePlatforms } from './administratorInstitutionLti13.types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
@@ -92,11 +98,20 @@ router.get(
       }
     }
 
+    const linkedCourseInstances = paramInstance
+      ? await queryRows(
+          sql.select_linked_course_instances,
+          { lti13_instance_id: paramInstance.id },
+          LinkedCourseInstanceSchema,
+        )
+      : [];
+
     res.send(
       AdministratorInstitutionLti13({
         institution,
         lti13Instances,
         instance: paramInstance ?? null,
+        linkedCourseInstances,
         resLocals: res.locals,
         platform_defaults,
         canonicalHost: getCanonicalHost(req),
@@ -234,6 +249,32 @@ router.post(
       });
       flash('success', 'Instance deleted.');
       return res.redirect(`/pl/administrator/institution/${req.params.institution_id}/lti13`);
+    } else if (req.body.__action === 'inspect_roster') {
+      const instance = await queryRow(
+        sql.select_combined_lti13_instance,
+        {
+          institution_id: req.params.institution_id,
+          lti13_instance_id: req.params.unsafe_lti13_instance_id,
+          lti13_course_instance_id: req.body.lti13_course_instance_id,
+        },
+        Lti13CombinedInstanceSchema,
+      );
+
+      // An empty selection means a plain roster with no custom claims.
+      const rlid = String(req.body.rlid ?? '').trim() || null;
+
+      const serverJob = await createServerJob({
+        type: 'lti13',
+        description: 'Inspect LTI 1.3 NRPS roster',
+        userId: res.locals.authn_user.id,
+        authnUserId: res.locals.authn_user.id,
+      });
+
+      serverJob.executeInBackground(async (job) => {
+        await inspectRoster({ instance, rlid, job });
+      });
+
+      return res.redirect(`/pl/administrator/jobSequence/${serverJob.jobSequenceId}`);
     } else {
       throw new error.HttpStatusError(400, `unknown __action: ${req.body.__action}`);
     }

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.ts
@@ -260,9 +260,12 @@ router.post(
         Lti13CombinedInstanceSchema,
       );
 
-      // An empty selection means a plain roster with no custom claims.
-      const rlid = String(req.body.rlid ?? '').trim() || null;
-
+      // Intentionally not associated with a course or course instance. The roster
+      // dump contains every member's sub/email/UIN, so it must stay viewable only
+      // via the administrator job sequence page (gated by authzIsAdministrator).
+      // Setting courseId/courseInstanceId would both expose it to that course's
+      // student data viewers and hide its output from the admin view (which fetches
+      // jobs scoped to course_id IS NULL).
       const serverJob = await createServerJob({
         type: 'lti13',
         description: 'Inspect LTI 1.3 NRPS roster',
@@ -271,7 +274,12 @@ router.post(
       });
 
       serverJob.executeInBackground(async (job) => {
-        await inspectRoster({ instance, rlid, job });
+        await inspectRoster({
+          instance,
+          // An empty selection means a plain roster with no custom claims.
+          rlid: String(req.body.rlid ?? '').trim() || null,
+          job,
+        });
       });
 
       return res.redirect(`/pl/administrator/jobSequence/${serverJob.jobSequenceId}`);

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.sql
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.sql
@@ -21,7 +21,7 @@ WHERE
   AND lti13_instances.id = $lti13_instance_id
   AND lti13_instances.id = $authn_lti13_instance_id;
 
--- BLOCK insert_lci
+-- BLOCK insert_lti13_course_instance
 INSERT INTO
   lti13_course_instances (
     lti13_instance_id,
@@ -29,7 +29,8 @@ INSERT INTO
     context_id,
     context_label,
     context_title,
-    course_instance_id
+    course_instance_id,
+    resource_link_id
   )
 VALUES
   (
@@ -38,7 +39,8 @@ VALUES
     $context_id,
     $context_label,
     $context_title,
-    $course_instance_id
+    $course_instance_id,
+    $resource_link_id
   );
 
 -- BLOCK update_lti13_course_instance
@@ -47,7 +49,8 @@ SET
   context_label = $context_label,
   context_title = $context_title,
   lineitems_url = $lineitems_url,
-  context_memberships_url = $context_memberships_url
+  context_memberships_url = $context_memberships_url,
+  resource_link_id = $resource_link_id
 WHERE
   lti13_instance_id = $lti13_instance_id
   AND course_instance_id = $course_instance_id

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.sql
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.sql
@@ -30,6 +30,8 @@ INSERT INTO
     context_label,
     context_title,
     course_instance_id,
+    lineitems_url,
+    context_memberships_url,
     resource_link_id
   )
 VALUES
@@ -40,6 +42,8 @@ VALUES
     $context_label,
     $context_title,
     $course_instance_id,
+    $lineitems_url,
+    $context_memberships_url,
     $resource_link_id
   );
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -232,6 +232,8 @@ router.post(
         context_label: ltiClaim.context?.label,
         context_title: ltiClaim.context?.title,
         course_instance_id: course_instance.id,
+        lineitems_url: ltiClaim.lineitems,
+        context_memberships_url: ltiClaim.context_memberships_url,
         resource_link_id: ltiClaim.resource_link_id,
       });
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -146,6 +146,7 @@ router.get(
           context_title: ltiClaim.context?.title,
           lineitems_url: ltiClaim.lineitems,
           context_memberships_url: ltiClaim.context_memberships_url,
+          resource_link_id: ltiClaim.resource_link_id,
         });
 
         // TODO: Set course/instance staff permissions for LMS course staff here?
@@ -224,13 +225,14 @@ router.post(
 
     const ltiClaim = new Lti13Claim(req);
     if (ltiClaim.isRoleInstructor()) {
-      await execute(sql.insert_lci, {
+      await execute(sql.insert_lti13_course_instance, {
         lti13_instance_id: req.params.lti13_instance_id,
         deployment_id: ltiClaim.deployment_id,
         context_id: ltiClaim.context?.id,
         context_label: ltiClaim.context?.label,
         context_title: ltiClaim.context?.title,
         course_instance_id: course_instance.id,
+        resource_link_id: ltiClaim.resource_link_id,
       });
 
       res.redirect(`/pl/lti13_instance/${req.params.lti13_instance_id}/course_navigation?done`);

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -1269,6 +1269,7 @@ export const Lti13CourseInstanceSchema = z.object({
   id: IdSchema,
   lineitems_url: z.string().nullable(),
   lti13_instance_id: IdSchema,
+  resource_link_id: z.string().nullable(),
 });
 export type Lti13CourseInstance = z.infer<typeof Lti13CourseInstanceSchema>;
 

--- a/apps/prairielearn/src/migrations/20260630002812_lti13_course_instances__resource_link_id__add.sql
+++ b/apps/prairielearn/src/migrations/20260630002812_lti13_course_instances__resource_link_id__add.sql
@@ -1,0 +1,4 @@
+-- The course-navigation resource link is captured on every instructor launch so
+-- that we can request per-member custom claims from NRPS via `?rlid=`.
+ALTER TABLE lti13_course_instances
+ADD COLUMN resource_link_id text;

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -579,7 +579,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   });
 
   describe('LTI 1.3 NRPS roster inspector', () => {
-    test('inspectRoster appends rlid, dumps members, and annotates matches', async () => {
+    test('inspectRoster appends rlid, dumps members, and annotates sub/custom/lis matches', async () => {
       // Ensure course instance 1 is linked to LTI instance 1.
       await execute(
         `DELETE FROM lti13_course_instances
@@ -648,7 +648,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         Lti13CombinedInstanceSchema,
       );
 
-      let capturedRlid: string | undefined;
+      const capturedRlids: (string | undefined)[] = [];
       const app = express();
       app.use(express.urlencoded({ extended: true }));
       app.post('/token', (_req, res) => {
@@ -660,7 +660,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         });
       });
       app.get('/memberships', (req, res) => {
-        capturedRlid = typeof req.query.rlid === 'string' ? req.query.rlid : undefined;
+        capturedRlids.push(typeof req.query.rlid === 'string' ? req.query.rlid : undefined);
         res.setHeader('Content-Type', 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
         res.json({
           id: membershipsUrl,
@@ -697,35 +697,70 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
               user_id: 'nrps-unknown-sub-no-match',
               roles: ['http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'],
               email: 'nrps-none@example.com',
+              // NRPS flattens the lis sourcedid onto the member (no `message`),
+              // which exercises lis-based uin_attribute resolution below.
+              lis_person_sourcedid: knownUin,
             },
           ],
         });
       });
 
-      const serverJob = await createServerJob({
+      // Instance 1 resolves UIN from a custom claim; clone it to also cover an
+      // instance configured to read UIN from the lis person_sourcedid claim.
+      const lisInstance = {
+        ...instance,
+        lti13_instance: {
+          ...instance.lti13_instance,
+          uin_attribute: '["https://purl.imsglobal.org/spec/lti/claim/lis"]["person_sourcedid"]',
+        },
+      };
+
+      const customJob = await createServerJob({
         type: 'lti13',
-        description: 'Inspect LTI 1.3 NRPS roster (test)',
+        description: 'Inspect LTI 1.3 NRPS roster (test, custom)',
+        userId: null,
+        authnUserId: null,
+      });
+      const lisJob = await createServerJob({
+        type: 'lti13',
+        description: 'Inspect LTI 1.3 NRPS roster (test, lis)',
         userId: null,
         authnUserId: null,
       });
 
       await withServer(app, oidcProviderPort, async () => {
-        await serverJob.executeUnsafe(async (job) => {
+        await customJob.executeUnsafe(async (job) => {
           await inspectRoster({ instance, rlid: 'rl-course-nav', job });
+        });
+        await lisJob.executeUnsafe(async (job) => {
+          await inspectRoster({ instance: lisInstance, rlid: null, job });
         });
       });
 
-      // The chosen resource link id was appended to the NRPS request.
-      assert.equal(capturedRlid, 'rl-course-nav');
+      // The custom run appended the chosen rlid; the lis run requested a plain roster.
+      assert.deepEqual(capturedRlids, ['rl-course-nav', undefined]);
 
-      const jobs = await selectJobsByJobSequenceId(serverJob.jobSequenceId);
-      assert.lengthOf(jobs, 1);
-      const output = jobs[0].output ?? '';
-      assert.include(output, 'Found 3 members.');
-      assert.include(output, 'roster-inspector@example.com');
-      assert.include(output, 'Matched by sub');
-      assert.include(output, 'Matched by UIN');
-      assert.include(output, 'No PrairieLearn user matched');
+      const customJobs = await selectJobsByJobSequenceId(customJob.jobSequenceId);
+      assert.lengthOf(customJobs, 1);
+      const customOutput = customJobs[0].output ?? '';
+      assert.include(customOutput, 'Found 3 members.');
+      assert.include(customOutput, 'roster-inspector@example.com');
+      assert.include(customOutput, 'Matched by sub');
+      assert.include(
+        customOutput,
+        `Matched by UIN ${knownUin} to PrairieLearn user roster-inspector@example.com`,
+      );
+      assert.include(customOutput, 'No PrairieLearn user matched');
+
+      // With no rlid (no custom claims), the lis-configured instance still resolves
+      // the UIN from the lis sourcedid that NRPS flattens onto the member.
+      const lisJobs = await selectJobsByJobSequenceId(lisJob.jobSequenceId);
+      assert.lengthOf(lisJobs, 1);
+      const lisOutput = lisJobs[0].output ?? '';
+      assert.include(
+        lisOutput,
+        `Matched by UIN ${knownUin} to PrairieLearn user roster-inspector@example.com`,
+      );
     });
   });
 });

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -2,15 +2,18 @@
  * Tests for LTI 1.3 course instance linking and admin page.
  */
 import * as cheerio from 'cheerio';
+import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
-import { execute, queryOptionalRow } from '@prairielearn/postgres';
+import { execute, queryOptionalRow, queryRow } from '@prairielearn/postgres';
 
+import { Lti13CombinedInstanceSchema, inspectRoster } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
 import { Lti13CourseInstanceSchema } from '../lib/db-types.js';
+import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
 import { selectOptionalUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
@@ -23,6 +26,7 @@ import {
   grantCoursePermissions,
   linkLtiContext,
   makeLoginExecutor,
+  withServer,
 } from './lti13TestHelpers.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
@@ -261,6 +265,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
     assert.ok(linkRecord);
     assert.equal(linkRecord.course_instance_id, '1');
+    // The course-navigation resource link from the launch claim is persisted.
+    assert.equal(linkRecord.resource_link_id, LTI_CONTEXT_ID);
   });
 
   test('already linked context redirects instructor to course instance', async () => {
@@ -569,6 +575,157 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const location = adminPageRes.headers.get('location');
       assert.ok(location);
       assert.include(location, 'lti13_instance/');
+    });
+  });
+
+  describe('LTI 1.3 NRPS roster inspector', () => {
+    test('inspectRoster appends rlid, dumps members, and annotates matches', async () => {
+      // Ensure course instance 1 is linked to LTI instance 1.
+      await execute(
+        `DELETE FROM lti13_course_instances
+         WHERE lti13_instance_id = '1'
+         AND deployment_id = $deployment_id
+         AND context_id = $context_id`,
+        { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+      );
+      await linkLtiContext({
+        lti13InstanceId: '1',
+        deploymentId: LTI_DEPLOYMENT_ID,
+        contextId: LTI_CONTEXT_ID,
+        courseInstanceId: '1',
+      });
+
+      // Create a user with a known sub and UIN to exercise both match paths.
+      const knownSub = 'roster-inspector-sub-1';
+      const knownUin = '555000555';
+      await grantCoursePermissions({
+        uid: 'roster-inspector@example.com',
+        courseId: '1',
+        courseRole: 'Editor',
+        courseInstanceId: '1',
+        courseInstanceRole: 'Student Data Editor',
+        authnUserId: '1',
+      });
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Roster Inspector User',
+          email: 'roster-inspector@example.com',
+          uin: knownUin,
+          sub: knownSub,
+        },
+        fetchWithCookies: fetchCookie(fetch),
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri: `${siteUrl}/pl/lti13_instance/1/course_navigation`,
+        isInstructor: true,
+      });
+      const loginRes = await executor.login();
+      assert.equal(loginRes.status, 200);
+
+      // Point the linked course instance's NRPS endpoint at our mock platform.
+      // This must happen after login, since the instructor launch overwrites
+      // context_memberships_url from the (membership-less) launch claim.
+      const membershipsUrl = `http://localhost:${oidcProviderPort}/memberships`;
+      await execute(
+        `UPDATE lti13_course_instances
+         SET context_memberships_url = $url, resource_link_id = 'rl-course-nav'
+         WHERE lti13_instance_id = '1'
+         AND deployment_id = $deployment_id
+         AND context_id = $context_id`,
+        { url: membershipsUrl, deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+      );
+
+      const instance = await queryRow(
+        `SELECT to_jsonb(lci) AS lti13_course_instance, to_jsonb(li) AS lti13_instance
+         FROM lti13_course_instances AS lci
+         JOIN lti13_instances AS li ON li.id = lci.lti13_instance_id
+         WHERE lci.lti13_instance_id = '1'
+         AND lci.deployment_id = $deployment_id
+         AND lci.context_id = $context_id`,
+        { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+        Lti13CombinedInstanceSchema,
+      );
+
+      let capturedRlid: string | undefined;
+      const app = express();
+      app.use(express.urlencoded({ extended: true }));
+      app.post('/token', (_req, res) => {
+        res.json({
+          access_token: 'roster-inspector-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          scope: 'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly',
+        });
+      });
+      app.get('/memberships', (req, res) => {
+        capturedRlid = typeof req.query.rlid === 'string' ? req.query.rlid : undefined;
+        res.setHeader('Content-Type', 'application/vnd.ims.lti-nrps.v2.membershipcontainer+json');
+        res.json({
+          id: membershipsUrl,
+          context: { id: LTI_CONTEXT_ID },
+          members: [
+            {
+              status: 'Active',
+              user_id: knownSub,
+              roles: ['http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor'],
+              email: 'roster-inspector@example.com',
+              message: [
+                {
+                  'https://purl.imsglobal.org/spec/lti/claim/message_type':
+                    'LtiResourceLinkRequest',
+                  'https://purl.imsglobal.org/spec/lti/claim/custom': { uin: knownUin },
+                },
+              ],
+            },
+            {
+              status: 'Active',
+              user_id: 'nrps-unknown-sub-with-uin',
+              roles: ['http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'],
+              email: 'nrps-uin@example.com',
+              message: [
+                {
+                  'https://purl.imsglobal.org/spec/lti/claim/message_type':
+                    'LtiResourceLinkRequest',
+                  'https://purl.imsglobal.org/spec/lti/claim/custom': { uin: knownUin },
+                },
+              ],
+            },
+            {
+              status: 'Active',
+              user_id: 'nrps-unknown-sub-no-match',
+              roles: ['http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'],
+              email: 'nrps-none@example.com',
+            },
+          ],
+        });
+      });
+
+      const serverJob = await createServerJob({
+        type: 'lti13',
+        description: 'Inspect LTI 1.3 NRPS roster (test)',
+        userId: null,
+        authnUserId: null,
+      });
+
+      await withServer(app, oidcProviderPort, async () => {
+        await serverJob.executeUnsafe(async (job) => {
+          await inspectRoster({ instance, rlid: 'rl-course-nav', job });
+        });
+      });
+
+      // The chosen resource link id was appended to the NRPS request.
+      assert.equal(capturedRlid, 'rl-course-nav');
+
+      const jobs = await selectJobsByJobSequenceId(serverJob.jobSequenceId);
+      assert.lengthOf(jobs, 1);
+      const output = jobs[0].output ?? '';
+      assert.include(output, 'Found 3 members.');
+      assert.include(output, 'roster-inspector@example.com');
+      assert.include(output, 'Matched by sub');
+      assert.include(output, 'Matched by UIN');
+      assert.include(output, 'No PrairieLearn user matched');
     });
   });
 });

--- a/database/tables/lti13_course_instances.pg
+++ b/database/tables/lti13_course_instances.pg
@@ -11,6 +11,7 @@ columns
     id: bigint not null default nextval('lti13_course_instances_id_seq'::regclass)
     lineitems_url: text
     lti13_instance_id: bigint
+    resource_link_id: text
 
 indexes
     lti13_course_instances_pkey: PRIMARY KEY (id) USING btree (id)


### PR DESCRIPTION
# Description

We want to read the per-member UIN that the LMS resolves into NRPS responses via the `?rlid=` mechanism (per-member `message[].custom` claims), which first requires capturing a resource link id and being able to inspect the raw roster to confirm what identifiers each institution actually provides.

This PR captures the course-navigation `resource_link_id` (new nullable column on `lti13_course_instances`) on every instructor launch, and refreshes it on login since a course copy or tool re-add can mint a new one).

It also adds a read-only NRPS roster inspector to the global-admin institution LTI page that dumps the raw membership roster — optionally with per-member custom claims for a chosen resource link (course navigation, a linked assessment's lineitem, or none) — and annotates each member as matchable by `sub`, by UIN, or not at all. It is hosted on the global-admin page rather than the instructor instance-admin page because the raw dump exposes every member's `sub`/email/UIN. This is a diagnostic foundation for later roster-sync/identity work: no enrollment creation, identity-resolution, or auth-flow changes are included.

AI assistance: majority of implementation (Claude Code), reviewed by me.

# Testing

- Added integration coverage in `lti13Linking.test.ts`: `resource_link_id` is persisted on a real instructor course-nav launch; the chosen `rlid` is appended to the NRPS request URL (verified by a mock platform that captures the query param); and the server job dumps members and annotates by-sub / by-UIN / unmatched against the job output.
- Manually verified the inspector end-to-end against a local mock NRPS endpoint: the resource picker renders, "Dump roster" produces a job sequence with the raw per-member payload and match summary, and the stale-rlid degradation warning fires when the platform returns no `message`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
