### PR TITLE
Use pnpm 11 floor instead of exact pin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,7 @@
 !pnpm-workspace.yaml
 !pyproject.toml
 !tsconfig.json
-!turbo.json
+!turbo.jsonc
 !vitest.config.ts
 !vitest.shared.ts
 !pyproject.toml

--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -30,6 +30,8 @@ runs:
         sudo apt-get install -y --no-install-recommends graphviz libgraphviz-dev
 
     - uses: pnpm/action-setup@v4
+      with:
+        version: 11
     - name: Set up Node
       uses: actions/setup-node@v6
       with:

--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -29,7 +29,7 @@ runs:
         sudo apt-get purge -y man-db
         sudo apt-get install -y --no-install-recommends graphviz libgraphviz-dev
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
       with:
         version: 11
     - name: Set up Node

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,8 @@ jobs:
           sudo curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | sudo bash -s -- latest /bin
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -197,6 +199,8 @@ jobs:
         run: make python-deps
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -33,6 +33,8 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -79,6 +79,8 @@ jobs:
           OUTPUT_PATH: ${{ runner.temp }}/image-sizes.json
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
+        with:
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,6 +248,8 @@ jobs:
         with:
           show-progress: false
       - uses: pnpm/action-setup@v6
+        with:
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=11.5.0 <12.0.0"
+    "pnpm": "^11.5.0"
   },
   "scripts": {
     "capture-access-control-screenshots": "CAPTURE_SCREENSHOTS=1 pnpm --filter @prairielearn/prairielearn test:e2e src/tests/e2e/captureAccessControlScreenshots.spec.ts",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "apps/*",
     "packages/*"
   ],
-  "packageManager": "pnpm@11.5.0",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=24.0.0",
+    "pnpm": ">=11.5.0 <12.0.0"
   },
   "scripts": {
     "capture-access-control-screenshots": "CAPTURE_SCREENSHOTS=1 pnpm --filter @prairielearn/prairielearn test:e2e src/tests/e2e/captureAccessControlScreenshots.spec.ts",

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -40,6 +40,7 @@ nvm install 24
 nvm alias default 24
 
 corepack enable pnpm
+corepack prepare pnpm@latest-11 --activate
 
 # uv is already installed in the default Claude Code environment, but we need to update it to the latest version.
 # Self-update w/o using pip fails: https://github.com/astral-sh/uv/issues/14016#issuecomment-2969548188

--- a/scripts/pl-install.sh
+++ b/scripts/pl-install.sh
@@ -46,8 +46,8 @@ git checkout "$(git describe --abbrev=0 --tags --match "v[0-9]*" "$(git rev-list
 source /nvm/nvm.sh
 export NVM_SYMLINK_CURRENT=true
 nvm install 24
-# Pinned to the packageManager version in package.json.
-npm install -g pnpm@11.5.0
+# Install the latest pnpm 11; package.json enforces the minimum supported version.
+npm install -g pnpm@latest-11
 for f in /nvm/current/bin/*; do ln -s $f "/usr/local/bin/$(basename $f)"; done
 
 echo "setting up postgres..."

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://turbo.build/schema.json",
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", "public/build/**"]
-    }
-  }
-}

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  // Remove this once Turborepo supports semver ranges in devEngines.packageManager:
+  // https://github.com/vercel/turborepo/issues/13163
+  "dangerouslyDisablePackageManagerCheck": true,
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "public/build/**"]
+    }
+  }
+}


### PR DESCRIPTION
# Description

This removes the exact `packageManager` pnpm 11.5.0 pin and replaces it with an `engines.pnpm` floor of `>=11.5.0 <12.0.0`, while configuring CI and bootstrap scripts to install pnpm 11 explicitly so they no longer rely on the removed packageManager field.

The motivation is to avoid forcing local tooling, including Codex sandboxed runs, through an older pnpm handoff path while still keeping PrairieLearn on pnpm 11.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

A nested `codex exec` run in `workspace-write` sandbox completed the prior hanging checks successfully: plain `pnpm --version` returned `11.9.0`, `pnpm exec prettier --version` returned `3.8.3`, `corepack pnpm --version` returned `11.7.0`, and `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts` reported the lockfile was already up to date.
