### PR TITLE
UI/UX: Missing focus-visible styles for interactive elements

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.css
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.css
@@ -5,6 +5,11 @@
   background-repeat: no-repeat;
 }
 
+.pl-drawing-button:focus-visible {
+  outline: 2px solid var(--bs-primary, #0d6efd);
+  outline-offset: 2px;
+}
+
 .pl-drawing-button img {
   filter: invert(100%);
 }


### PR DESCRIPTION
## Summary

UI/UX: Missing focus-visible styles for interactive elements

## Problem

**Severity**: `High` | **File**: `apps/prairielearn/elements/pl-drawing/pl-drawing.css:L1`

Several CSS files define interactive elements badge styles but lack consistent focus-visible indicators. The pl-drawing.css file has buttons with only background image styling but no visible focus state. The pl-external-grader-results.css has a card header interaction without visible focus indicators for keyboard users.

## Solution

Add explicit :focus-visible styles to all interactive elements. For drawing buttons, add outline or box-shadow on focus. Ensure all interactive elements have a visible focus indicator that meets WCAG 2.2 requirements (minimum 2px outline with 3:1 contrast ratio).

## Changes

- `apps/prairielearn/elements/pl-drawing/pl-drawing.css` (modified)