### PR TITLE
Validate GitHub usernames for course requests

### DIFF
--- a/apps/prairielearn/src/lib/github-utils.ts
+++ b/apps/prairielearn/src/lib/github-utils.ts
@@ -1,9 +1,19 @@
 const GITHUB_REPOSITORY_REGEX =
   /^(?:git@github\.com:\/?|https?:\/\/github\.com\/)([^/]+)\/([^/]+?)(?:\.git)?\/?$/i;
 
+export const GITHUB_USERNAME_MAX_LENGTH = 39;
+export const GITHUB_USERNAME_PATTERN = '[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}';
+export const GITHUB_USERNAME_VALIDATION_MESSAGE = 'Enter a valid GitHub username.';
+
+const GITHUB_USERNAME_REGEX = new RegExp(`^${GITHUB_USERNAME_PATTERN}$`);
+
 /** Parses a stored course `repository` string into its GitHub owner and repo, or null if it is not a recognized GitHub URL. */
 export function parseGithubRepository(repository: string): { owner: string; repo: string } | null {
   const match = GITHUB_REPOSITORY_REGEX.exec(repository.trim());
   if (match === null) return null;
   return { owner: match[1], repo: match[2] };
+}
+
+export function isValidGithubUsername(username: string): boolean {
+  return GITHUB_USERNAME_REGEX.test(username);
 }

--- a/apps/prairielearn/src/lib/github.test.ts
+++ b/apps/prairielearn/src/lib/github.test.ts
@@ -2,7 +2,7 @@ import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { withConfig } from '../tests/utils/config.js';
 
-import { parseGithubRepository } from './github-utils.js';
+import { isValidGithubUsername, parseGithubRepository } from './github-utils.js';
 import {
   addMachineAccessToRepo,
   checkGithubOrgAccess,
@@ -179,6 +179,29 @@ describe('parseGithubRepository', () => {
   it('returns null for non-GitHub URLs', () => {
     assert.isNull(parseGithubRepository('git@gitlab.com:u/r.git'));
     assert.isNull(parseGithubRepository(''));
+  });
+});
+
+describe('isValidGithubUsername', () => {
+  it('accepts GitHub username syntax', () => {
+    for (const username of ['nathan', 'EduardoMVAz', 'pl-user1', 'a', 'a'.repeat(39)]) {
+      assert.isTrue(isValidGithubUsername(username));
+    }
+  });
+
+  it('rejects values that GitHub will not accept as usernames', () => {
+    for (const username of [
+      '',
+      'test@example.com',
+      '-leading',
+      'trailing-',
+      'double--hyphen',
+      'has space',
+      'has_underscore',
+      'a'.repeat(40),
+    ]) {
+      assert.isFalse(isValidGithubUsername(username));
+    }
   });
 });
 

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -24,6 +24,10 @@ import {
   getAdministratorJobSequenceUrl,
 } from '../../../lib/client/url.js';
 import type { CourseRequestRow } from '../../../lib/course-request.js';
+import {
+  GITHUB_USERNAME_VALIDATION_MESSAGE,
+  isValidGithubUsername,
+} from '../../../lib/github-utils.js';
 import { type Timezone } from '../../../lib/timezone.shared.js';
 import { useTRPC } from '../../../trpc/administrator/context.js';
 import type { AdminCourseRequestError } from '../../../trpc/administrator/course-requests.js';
@@ -398,7 +402,7 @@ function CourseRequestApproveModalContent({
         path: data.path,
         repoShortName: data.repository_short_name,
         githubCourseOwner: data.github_course_owner.trim(),
-        githubUser: data.github_user,
+        githubUser: data.github_user.trim(),
       },
       {
         onSuccess: ({ jobSequenceId }) => {
@@ -611,10 +615,25 @@ function CourseRequestApproveModalContent({
             </label>
             <input
               type="text"
-              className="form-control"
+              className={clsx('form-control', errors.github_user && 'is-invalid')}
               id="courseRequestAddInputGithubUser"
-              {...register('github_user')}
+              defaultValue={request.github_user ?? ''}
+              aria-invalid={errors.github_user ? true : undefined}
+              aria-errormessage={
+                errors.github_user ? 'courseRequestAddInputGithubUser-error' : undefined
+              }
+              {...register('github_user', {
+                validate: (value) =>
+                  value.trim().length === 0 ||
+                  isValidGithubUsername(value.trim()) ||
+                  GITHUB_USERNAME_VALIDATION_MESSAGE,
+              })}
             />
+            {errors.github_user && (
+              <div id="courseRequestAddInputGithubUser-error" className="invalid-feedback">
+                {errors.github_user.message}
+              </div>
+            )}
           </div>
           <MutationError appError={appError} onDismiss={() => mutation.reset()} />
         </Modal.Body>

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -6,6 +6,11 @@ import { Modal } from '../../components/Modal.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { compiledScriptTag } from '../../lib/assets.js';
 import { type CourseRequest } from '../../lib/db-types.js';
+import {
+  GITHUB_USERNAME_MAX_LENGTH,
+  GITHUB_USERNAME_PATTERN,
+  GITHUB_USERNAME_VALIDATION_MESSAGE,
+} from '../../lib/github-utils.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 import { DEFAULT_INSTITUTION_SHORT_NAME } from '../../models/institution.js';
 
@@ -338,9 +343,18 @@ function CourseNewRequestForm({
         </div>
       </div>
       <div class="mb-3">
-        <label class="form-label" for="cr-ghuser">GitHub Username (optional)</label>
-        <input type="text" class="form-control" name="cr-ghuser" id="cr-ghuser" />
-        <small class="form-text text-muted">
+        <label class="form-label" for="cr-ghuser">GitHub username (optional)</label>
+        <input
+          type="text"
+          class="form-control"
+          name="cr-ghuser"
+          id="cr-ghuser"
+          maxlength="${GITHUB_USERNAME_MAX_LENGTH}"
+          pattern="${GITHUB_USERNAME_PATTERN}"
+          title="${GITHUB_USERNAME_VALIDATION_MESSAGE}"
+          aria-describedby="cr-ghuser-help"
+        />
+        <small class="form-text text-muted" id="cr-ghuser-help">
           Providing your GitHub username will grant you access to your course's GitHub repository.
           This access allows you to edit your code in a
           <a

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
@@ -9,6 +9,10 @@ import * as Sentry from '@prairielearn/sentry';
 
 import { Lti13Claim } from '../../ee/lib/lti13.js';
 import { insertCourseRequest } from '../../lib/course-request.js';
+import {
+  GITHUB_USERNAME_VALIDATION_MESSAGE,
+  isValidGithubUsername,
+} from '../../lib/github-utils.js';
 import { isEnterprise } from '../../lib/license.js';
 import * as opsbot from '../../lib/opsbot.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
@@ -98,7 +102,7 @@ router.post(
   typedAsyncHandler<'plain'>(async (req, res) => {
     const short_name = req.body['cr-shortname'].toUpperCase() || '';
     const title = req.body['cr-title'] || '';
-    const github_user = req.body['cr-ghuser'] || null;
+    const github_user = req.body['cr-ghuser']?.trim() || null;
     const first_name = req.body['cr-firstname'] || '';
     const last_name = req.body['cr-lastname'] || '';
     const referral_source_option = req.body['cr-referral-source'] || '';
@@ -138,6 +142,10 @@ router.post(
     }
     if (last_name.length === 0) {
       flash('error', 'The last name should not be empty.');
+      error = true;
+    }
+    if (github_user !== null && !isValidGithubUsername(github_user)) {
+      flash('error', GITHUB_USERNAME_VALIDATION_MESSAGE);
       error = true;
     }
 

--- a/apps/prairielearn/src/tests/courseRequest.test.ts
+++ b/apps/prairielearn/src/tests/courseRequest.test.ts
@@ -1,10 +1,9 @@
-import { afterAll, assert, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
 import { insertCourseRequest, selectAllCourseRequests } from '../lib/course-request.js';
-import { GITHUB_USERNAME_VALIDATION_MESSAGE } from '../lib/github-utils.js';
 import { createAdministratorTrpcClient } from '../trpc/administrator/client.js';
 
 import * as helperClient from './helperClient.js';
@@ -15,7 +14,6 @@ const baseUrl = `${siteUrl}/pl`;
 const coursesAdminUrl = `${baseUrl}/administrator/courses`;
 const courseRequestsAdminUrl = `${baseUrl}/administrator/courseRequests`;
 const allCourseRequestsAdminUrl = `${courseRequestsAdminUrl}?status=all`;
-const requestCourseUrl = `${baseUrl}/request_course`;
 
 describe('Course requests', { timeout: 60_000, concurrent: false }, function () {
   let trpcClient: ReturnType<typeof createAdministratorTrpcClient>;
@@ -35,51 +33,6 @@ describe('Course requests', { timeout: 60_000, concurrent: false }, function () 
   let courseRequestId: string;
   const shortName = 'TEST 101';
   const title = 'Course Request Test Course';
-
-  test('rejects invalid GitHub usernames submitted with a course request', async () => {
-    const requestPage = await helperClient.fetchCheerio(requestCourseUrl);
-    assert.isTrue(requestPage.ok);
-
-    const invalidGithubUsernameShortName = 'CR TEST 100';
-    const response = await helperClient.fetchCheerio(requestCourseUrl, {
-      method: 'POST',
-      redirect: 'manual',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        __csrf_token: helperClient.getCSRFToken(requestPage.$),
-        'cr-firstname': 'Test',
-        'cr-lastname': 'User',
-        'cr-institution': 'Test Institution',
-        'cr-email': 'test@example.com',
-        'cr-shortname': invalidGithubUsernameShortName,
-        'cr-title': 'Invalid GitHub Username Test Course',
-        'cr-ghuser': 'test@example.com',
-        'cr-referral-source': "I've used PrairieLearn before",
-        'cr-role': 'instructor',
-      }).toString(),
-    });
-
-    assert.equal(response.status, 302);
-
-    const allRequests = await selectAllCourseRequests();
-    assert.isUndefined(allRequests.find((r) => r.short_name === invalidGithubUsernameShortName));
-  });
-
-  test('rejects invalid GitHub usernames when approving a course request', async () => {
-    await expect(
-      trpcClient.courseRequests.createCourse.mutate({
-        courseRequestId: '1',
-        shortName,
-        title,
-        institutionId: '1',
-        displayTimezone: 'America/Chicago',
-        path: '/tmp/course-request-test',
-        repoShortName: 'pl-test101',
-        githubCourseOwner: 'PrairieLearn',
-        githubUser: 'test@example.com',
-      }),
-    ).rejects.toThrow(GITHUB_USERNAME_VALIDATION_MESSAGE);
-  });
 
   test('insert a course request', async () => {
     courseRequestId = await insertCourseRequest({

--- a/apps/prairielearn/src/tests/courseRequest.test.ts
+++ b/apps/prairielearn/src/tests/courseRequest.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, assert, beforeAll, describe, expect, test } from 'vitest';
 
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
 import { insertCourseRequest, selectAllCourseRequests } from '../lib/course-request.js';
+import { GITHUB_USERNAME_VALIDATION_MESSAGE } from '../lib/github-utils.js';
 import { createAdministratorTrpcClient } from '../trpc/administrator/client.js';
 
 import * as helperClient from './helperClient.js';
@@ -14,6 +15,7 @@ const baseUrl = `${siteUrl}/pl`;
 const coursesAdminUrl = `${baseUrl}/administrator/courses`;
 const courseRequestsAdminUrl = `${baseUrl}/administrator/courseRequests`;
 const allCourseRequestsAdminUrl = `${courseRequestsAdminUrl}?status=all`;
+const requestCourseUrl = `${baseUrl}/request_course`;
 
 describe('Course requests', { timeout: 60_000, concurrent: false }, function () {
   let trpcClient: ReturnType<typeof createAdministratorTrpcClient>;
@@ -33,6 +35,51 @@ describe('Course requests', { timeout: 60_000, concurrent: false }, function () 
   let courseRequestId: string;
   const shortName = 'TEST 101';
   const title = 'Course Request Test Course';
+
+  test('rejects invalid GitHub usernames submitted with a course request', async () => {
+    const requestPage = await helperClient.fetchCheerio(requestCourseUrl);
+    assert.isTrue(requestPage.ok);
+
+    const invalidGithubUsernameShortName = 'CR TEST 100';
+    const response = await helperClient.fetchCheerio(requestCourseUrl, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        __csrf_token: helperClient.getCSRFToken(requestPage.$),
+        'cr-firstname': 'Test',
+        'cr-lastname': 'User',
+        'cr-institution': 'Test Institution',
+        'cr-email': 'test@example.com',
+        'cr-shortname': invalidGithubUsernameShortName,
+        'cr-title': 'Invalid GitHub Username Test Course',
+        'cr-ghuser': 'test@example.com',
+        'cr-referral-source': "I've used PrairieLearn before",
+        'cr-role': 'instructor',
+      }).toString(),
+    });
+
+    assert.equal(response.status, 302);
+
+    const allRequests = await selectAllCourseRequests();
+    assert.isUndefined(allRequests.find((r) => r.short_name === invalidGithubUsernameShortName));
+  });
+
+  test('rejects invalid GitHub usernames when approving a course request', async () => {
+    await expect(
+      trpcClient.courseRequests.createCourse.mutate({
+        courseRequestId: '1',
+        shortName,
+        title,
+        institutionId: '1',
+        displayTimezone: 'America/Chicago',
+        path: '/tmp/course-request-test',
+        repoShortName: 'pl-test101',
+        githubCourseOwner: 'PrairieLearn',
+        githubUser: 'test@example.com',
+      }),
+    ).rejects.toThrow(GITHUB_USERNAME_VALIDATION_MESSAGE);
+  });
 
   test('insert a course request', async () => {
     courseRequestId = await insertCourseRequest({

--- a/apps/prairielearn/src/trpc/administrator/course-requests.ts
+++ b/apps/prairielearn/src/trpc/administrator/course-requests.ts
@@ -15,6 +15,10 @@ import {
   selectInstitutionPrefix,
   updateCourseRequestNote,
 } from '../../lib/course-request.js';
+import {
+  GITHUB_USERNAME_VALIDATION_MESSAGE,
+  isValidGithubUsername,
+} from '../../lib/github-utils.js';
 import { checkGithubRepositoryExists, validateGithubCourseOwner } from '../../lib/github.js';
 import {
   selectOptionalCourseByGithubRepository,
@@ -72,7 +76,12 @@ const createCourse = t.procedure
       path: z.string().min(1, 'Path is required'),
       repoShortName: z.string().min(1, 'Repository name is required'),
       githubCourseOwner: z.string().min(1, 'GitHub organization is required'),
-      githubUser: z.string(),
+      githubUser: z
+        .string()
+        .trim()
+        .refine((value) => value.length === 0 || isValidGithubUsername(value), {
+          message: GITHUB_USERNAME_VALIDATION_MESSAGE,
+        }),
     }),
   )
   .output(z.object({ jobSequenceId: z.string() }))
@@ -117,7 +126,7 @@ const createCourse = t.procedure
       path: normalizedPath,
       repoShortName: input.repoShortName,
       githubCourseOwner: input.githubCourseOwner,
-      githubUser: input.githubUser.trim().length > 0 ? input.githubUser.trim() : null,
+      githubUser: input.githubUser.length > 0 ? input.githubUser : null,
       authnUser: ctx.authn_user,
     });
     return { jobSequenceId };

--- a/apps/prairielearn/src/trpc/administrator/course-requests.ts
+++ b/apps/prairielearn/src/trpc/administrator/course-requests.ts
@@ -81,7 +81,8 @@ const createCourse = t.procedure
         .trim()
         .refine((value) => value.length === 0 || isValidGithubUsername(value), {
           message: GITHUB_USERNAME_VALIDATION_MESSAGE,
-        }),
+        })
+        .transform((value) => (value.length > 0 ? value : null)),
     }),
   )
   .output(z.object({ jobSequenceId: z.string() }))
@@ -126,7 +127,7 @@ const createCourse = t.procedure
       path: normalizedPath,
       repoShortName: input.repoShortName,
       githubCourseOwner: input.githubCourseOwner,
-      githubUser: input.githubUser.length > 0 ? input.githubUser : null,
+      githubUser: input.githubUser,
       authnUser: ctx.authn_user,
     });
     return { jobSequenceId };


### PR DESCRIPTION
# Description

We've seen a few people submitting weird things as GitHub usernames, e.g. email addresses or links to their profile. This PR adds validation in the instructor course request flow and administrator approval modal so invalid values cannot be stored or sent into GitHub repository setup.

- [x] I have disclosed the level of AI assistance used: majority of implementation by Codex.

# Testing

Added unit coverage for GitHub username syntax. Manually tested the course requests page and confirmed that it rejects invalid usernames.
