### PR TITLE
Fix overlapping input border in personal notes

### DIFF
--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -172,7 +172,7 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
             name="filename"
             value="notes.txt"
           />
-          <div class="mb-3">
+          <div class="mt-1 mb-3">
             <textarea
               class="form-control"
               rows="5"


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

The file name input border when adding a notes.txt is overlapping with the description.
Adding a margin fixes it.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
no AI used.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

**before**

<img width="1457" height="271" alt="image" src="https://github.com/user-attachments/assets/42c35296-9991-4411-8954-ab7a23bb6b14" />


**after**

<img width="1420" height="395" alt="image" src="https://github.com/user-attachments/assets/b1cce1b5-58a1-48a6-af4b-502977834cd6" />
