### PR TITLE
Ability to view and edit saved text notes

### DIFF
--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -5,7 +5,6 @@ import { escapeHtml, html } from '@prairielearn/html';
 import { config } from '../lib/config.js';
 import type { AssessmentInstance, File } from '../lib/db-types.js';
 
-/** Extensions whose contents can safely be opened and edited as plain text. */
 const TEXT_NOTE_EXTENSIONS = new Set([
   'txt',
   'text',
@@ -35,7 +34,6 @@ const TEXT_NOTE_EXTENSIONS = new Set([
   'sh',
 ]);
 
-/** A note is editable in-browser if it is a student-authored upload with a text-like extension. */
 function isEditableTextNote(file: File): boolean {
   if (file.type !== 'student_upload') return false;
   const parts = file.display_filename.split('.');
@@ -219,8 +217,7 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
         <form method="POST" class="attach-text-form">
           <p class="small mt-3">
             Attached personal notes will be saved here for your reference. These notes can be used
-            for your own review purposes. They are not used for grading. Click a saved text note
-            above to open and edit it here.
+            for your own review purposes. They are not used for grading.
           </p>
           <input
             type="text"
@@ -257,7 +254,6 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
     </div>
 
     <script type="module">
-      // This script is type="module" so that it is deferred and runs after the DOM is ready.
       const collapseEl = document.getElementById('attachTextCollapse');
       const toggleLabel = document.getElementById('attachTextToggleLabel');
       const filenameInput = document.getElementById('attachTextFilename');

--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -5,6 +5,44 @@ import { escapeHtml, html } from '@prairielearn/html';
 import { config } from '../lib/config.js';
 import type { AssessmentInstance, File } from '../lib/db-types.js';
 
+/** Extensions whose contents can safely be opened and edited as plain text. */
+const TEXT_NOTE_EXTENSIONS = new Set([
+  'txt',
+  'text',
+  'md',
+  'markdown',
+  'csv',
+  'tsv',
+  'json',
+  'log',
+  'yml',
+  'yaml',
+  'xml',
+  'html',
+  'htm',
+  'css',
+  'js',
+  'ts',
+  'py',
+  'c',
+  'cpp',
+  'h',
+  'java',
+  'r',
+  'sql',
+  'ini',
+  'conf',
+  'sh',
+]);
+
+/** A note is editable in-browser if it is a student-authored upload with a text-like extension. */
+function isEditableTextNote(file: File): boolean {
+  if (file.type !== 'student_upload') return false;
+  const parts = file.display_filename.split('.');
+  if (parts.length < 2) return false;
+  return TEXT_NOTE_EXTENSIONS.has(parts[parts.length - 1].toLowerCase());
+}
+
 export function PersonalNotesPanel({
   fileList,
   courseInstanceId,
@@ -27,6 +65,11 @@ export function PersonalNotesPanel({
   csrfToken: string;
   context: 'question' | 'assessment';
 }) {
+  const canEditNotes =
+    allowNewUploads &&
+    assessment_instance.open &&
+    authz_result.active &&
+    authz_result.authorized_edit;
   return html`
     <div class="card mb-4" id="attach-file-panel">
       <div class="card-header bg-secondary text-white d-flex align-items-center">
@@ -37,16 +80,28 @@ export function PersonalNotesPanel({
         ? html`<div class="card-body"><i>No attached notes</i></div>`
         : html`
             <ul class="list-group list-group-flush">
-              ${fileList.map(
-                (file) => html`
+              ${fileList.map((file) => {
+                const fileUrl = `/pl/course_instance/${courseInstanceId}/assessment_instance/${assessment_instance.id}/file/${file.id}/${file.display_filename}`;
+                return html`
                   <li class="list-group-item d-flex align-items-center">
-                    <a
-                      class="text-break me-2"
-                      href="/pl/course_instance/${courseInstanceId}/assessment_instance/${assessment_instance.id}/file/${file.id}/${file.display_filename}"
-                      data-testid="attached-file"
-                    >
-                      ${file.display_filename}
-                    </a>
+                    ${canEditNotes && isEditableTextNote(file)
+                      ? html`
+                          <button
+                            type="button"
+                            class="btn btn-link p-0 text-break text-start me-2 edit-text-note"
+                            data-file-id="${file.id}"
+                            data-file-name="${file.display_filename}"
+                            data-file-url="${fileUrl}"
+                            data-testid="attached-file"
+                          >
+                            ${file.display_filename}
+                          </button>
+                        `
+                      : html`
+                          <a class="text-break me-2" href="${fileUrl}" data-testid="attached-file">
+                            ${file.display_filename}
+                          </a>
+                        `}
                     ${assessment_instance.open &&
                     authz_result.active &&
                     authz_result.authorized_edit &&
@@ -59,8 +114,8 @@ export function PersonalNotesPanel({
                         `
                       : ''}
                   </li>
-                `,
-              )}
+                `;
+              })}
             </ul>
           `}
       ${allowNewUploads
@@ -157,19 +212,22 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
         aria-expanded="false"
         aria-controls="attachTextCollapse"
       >
-        Add text note <i class="far fa-caret-square-down"></i>
+        <span id="attachTextToggleLabel">Add text note</span>
+        <i class="far fa-caret-square-down"></i>
       </button>
       <div class="collapse" id="attachTextCollapse">
         <form method="POST" class="attach-text-form">
           <p class="small mt-3">
             Attached personal notes will be saved here for your reference. These notes can be used
-            for your own review purposes. They are not used for grading.
+            for your own review purposes. They are not used for grading. Click a saved text note
+            above to open and edit it here.
           </p>
           <input
             type="text"
             class="form-control"
             aria-label="Text filename"
             name="filename"
+            id="attachTextFilename"
             value="notes.txt"
           />
           <div class="mb-3">
@@ -178,6 +236,7 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
               rows="5"
               aria-label="Text contents"
               name="contents"
+              id="attachTextContents"
               placeholder="Type or paste text here"
             ></textarea>
           </div>
@@ -185,12 +244,64 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
             ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
             : ''}
           <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-          <button type="submit" class="btn btn-sm btn-primary" name="__action" value="attach_text">
+          <input type="hidden" name="__action" id="attachTextAction" value="attach_text" />
+          <input type="hidden" name="file_id" id="attachTextFileId" value="" />
+          <button type="submit" class="btn btn-sm btn-primary" id="attachTextSubmit">
             Add note
+          </button>
+          <button type="button" class="btn btn-sm btn-link d-none" id="attachTextCancel">
+            Cancel edit
           </button>
         </form>
       </div>
     </div>
+
+    <script type="module">
+      // This script is type="module" so that it is deferred and runs after the DOM is ready.
+      const collapseEl = document.getElementById('attachTextCollapse');
+      const toggleLabel = document.getElementById('attachTextToggleLabel');
+      const filenameInput = document.getElementById('attachTextFilename');
+      const contentsInput = document.getElementById('attachTextContents');
+      const actionInput = document.getElementById('attachTextAction');
+      const fileIdInput = document.getElementById('attachTextFileId');
+      const submitButton = document.getElementById('attachTextSubmit');
+      const cancelButton = document.getElementById('attachTextCancel');
+
+      function setAddMode() {
+        actionInput.value = 'attach_text';
+        fileIdInput.value = '';
+        filenameInput.value = 'notes.txt';
+        contentsInput.value = '';
+        toggleLabel.textContent = 'Add text note';
+        submitButton.textContent = 'Add note';
+        cancelButton.classList.add('d-none');
+      }
+
+      cancelButton.addEventListener('click', setAddMode);
+
+      for (const button of document.querySelectorAll('.edit-text-note')) {
+        button.addEventListener('click', async () => {
+          const { fileId, fileName, fileUrl } = button.dataset;
+          const response = await fetch(fileUrl);
+          if (!response.ok) {
+            window.location.href = fileUrl;
+            return;
+          }
+          const contents = await response.text();
+
+          actionInput.value = 'edit_text';
+          fileIdInput.value = fileId;
+          filenameInput.value = fileName;
+          contentsInput.value = contents;
+          toggleLabel.textContent = 'Edit text note';
+          submitButton.textContent = 'Save note';
+          cancelButton.classList.remove('d-none');
+
+          window.bootstrap.Collapse.getOrCreateInstance(collapseEl).show();
+          contentsInput.focus();
+        });
+      }
+    </script>
   `;
 }
 

--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -277,7 +277,10 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
         cancelButton.classList.add('d-none');
       }
 
-      cancelButton.addEventListener('click', setAddMode);
+      cancelButton.addEventListener('click', () => {
+        setAddMode();
+        window.bootstrap.Collapse.getOrCreateInstance(collapseEl).hide();
+      });
 
       for (const button of document.querySelectorAll('.edit-text-note')) {
         button.addEventListener('click', async () => {

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
@@ -110,7 +110,6 @@ async function processTextEdit(req: Request, res: Response) {
     throw new HttpStatusError(403, 'This assessment is not accepting submissions at this time.');
   }
 
-  // Check the requested file belongs to the current assessment instance
   const validFiles = (res.locals.file_list ?? []).filter((file: File) =>
     idsEqual(file.id, req.body.file_id),
   );
@@ -123,8 +122,7 @@ async function processTextEdit(req: Request, res: Response) {
     throw new HttpStatusError(403, `Cannot edit file type ${file.type} for file_id=${file.id}`);
   }
 
-  // The file store treats files as immutable, so replace the note by uploading a
-  // new file and deleting the old one within a single transaction.
+  // upload the new file and delete the old one
   await runInTransactionAsync(async () => {
     await uploadFile({
       display_filename: req.body.filename,

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.ts
@@ -2,7 +2,7 @@ import { type Request, type Response, Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { HttpStatusError } from '@prairielearn/error';
-import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
 import {
@@ -99,6 +99,47 @@ async function processTextUpload(req: Request, res: Response) {
   });
 }
 
+async function processTextEdit(req: Request, res: Response) {
+  if (!res.locals.assessment_instance.open) {
+    throw new HttpStatusError(403, 'Assessment is not open');
+  }
+  if (!res.locals.assessment.allow_personal_notes) {
+    throw new HttpStatusError(403, 'This assessment does not allow personal notes.');
+  }
+  if (!res.locals.authz_result.active) {
+    throw new HttpStatusError(403, 'This assessment is not accepting submissions at this time.');
+  }
+
+  // Check the requested file belongs to the current assessment instance
+  const validFiles = (res.locals.file_list ?? []).filter((file: File) =>
+    idsEqual(file.id, req.body.file_id),
+  );
+  if (validFiles.length === 0) {
+    throw new HttpStatusError(404, `No such file_id: ${req.body.file_id}`);
+  }
+  const file = validFiles[0];
+
+  if (file.type !== 'student_upload') {
+    throw new HttpStatusError(403, `Cannot edit file type ${file.type} for file_id=${file.id}`);
+  }
+
+  // The file store treats files as immutable, so replace the note by uploading a
+  // new file and deleting the old one within a single transaction.
+  await runInTransactionAsync(async () => {
+    await uploadFile({
+      display_filename: req.body.filename,
+      contents: Buffer.from(req.body.contents),
+      type: 'student_upload',
+      assessment_id: res.locals.assessment.id,
+      assessment_instance_id: res.locals.assessment_instance.id,
+      instance_question_id: null,
+      user_id: res.locals.user.id,
+      authn_user_id: res.locals.authn_user.id,
+    });
+    await deleteFile(file.id, res.locals.authn_user.id);
+  });
+}
+
 async function processDeleteFile(req: Request, res: Response) {
   if (!res.locals.assessment_instance.open) {
     throw new HttpStatusError(403, 'Assessment is not open');
@@ -137,9 +178,14 @@ router.post(
     }
     if (
       !res.locals.authz_result.authorized_edit &&
-      ['attach_file', 'attach_text', 'delete_file', 'timeLimitFinish', 'leave_group'].includes(
-        req.body.__action,
-      )
+      [
+        'attach_file',
+        'attach_text',
+        'edit_text',
+        'delete_file',
+        'timeLimitFinish',
+        'leave_group',
+      ].includes(req.body.__action)
     ) {
       throw new HttpStatusError(403, 'Action is only permitted to students, not staff');
     }
@@ -149,6 +195,9 @@ router.post(
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'attach_text') {
       await processTextUpload(req, res);
+      res.redirect(req.originalUrl);
+    } else if (req.body.__action === 'edit_text') {
+      await processTextEdit(req, res);
       res.redirect(req.originalUrl);
     } else if (req.body.__action === 'delete_file') {
       await processDeleteFile(req, res);

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -194,7 +194,6 @@ async function processTextEdit(req: Request, res: Response) {
     is_administrator: res.locals.is_administrator,
   });
 
-  // Check the requested file belongs to the current instance question
   const validFiles =
     res.locals.file_list?.filter((file: File) => idsEqual(file.id, req.body.file_id)) ?? [];
   if (validFiles.length === 0) {
@@ -206,8 +205,7 @@ async function processTextEdit(req: Request, res: Response) {
     throw new HttpStatusError(403, `Cannot edit file type ${file.type} for file_id=${file.id}`);
   }
 
-  // The file store treats files as immutable, so replace the note by uploading a
-  // new file and deleting the old one within a single transaction.
+  // upload the new file and delete the old one
   await runInTransactionAsync(async () => {
     await uploadFile({
       display_filename: req.body.filename,

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import { type Request, type Response, Router } from 'express';
 
 import { HttpStatusError } from '@prairielearn/error';
-import { loadSqlEquiv, queryOptionalScalar } from '@prairielearn/postgres';
+import { loadSqlEquiv, queryOptionalScalar, runInTransactionAsync } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
 import checkPlanGrantsForQuestion from '../../ee/middlewares/checkPlanGrantsForQuestion.js';
@@ -171,6 +171,60 @@ async function processDeleteFile(req: Request, res: Response) {
   return variant.id;
 }
 
+async function processTextEdit(req: Request, res: Response) {
+  if (!res.locals.assessment_instance.open) {
+    throw new HttpStatusError(403, 'Assessment is not open');
+  }
+  if (!res.locals.assessment.allow_personal_notes) {
+    throw new HttpStatusError(403, 'This assessment does not allow personal notes.');
+  }
+  if (!res.locals.authz_result.active) {
+    throw new HttpStatusError(403, 'This assessment is not accepting submissions at this time.');
+  }
+
+  const variant = await selectAndAuthzVariant({
+    unsafe_variant_id: req.body.__variant_id,
+    variant_course: res.locals.course,
+    question_id: res.locals.question.id,
+    course_instance_id: res.locals.course_instance.id,
+    instance_question_id: res.locals.instance_question.id,
+    authz_data: res.locals.authz_data,
+    authn_user: res.locals.authn_user,
+    user: res.locals.user,
+    is_administrator: res.locals.is_administrator,
+  });
+
+  // Check the requested file belongs to the current instance question
+  const validFiles =
+    res.locals.file_list?.filter((file: File) => idsEqual(file.id, req.body.file_id)) ?? [];
+  if (validFiles.length === 0) {
+    throw new HttpStatusError(404, `No such file_id: ${req.body.file_id}`);
+  }
+  const file = validFiles[0];
+
+  if (file.type !== 'student_upload') {
+    throw new HttpStatusError(403, `Cannot edit file type ${file.type} for file_id=${file.id}`);
+  }
+
+  // The file store treats files as immutable, so replace the note by uploading a
+  // new file and deleting the old one within a single transaction.
+  await runInTransactionAsync(async () => {
+    await uploadFile({
+      display_filename: req.body.filename,
+      contents: Buffer.from(req.body.contents),
+      type: 'student_upload',
+      assessment_id: res.locals.assessment.id,
+      assessment_instance_id: res.locals.assessment_instance.id,
+      instance_question_id: res.locals.instance_question.id,
+      user_id: res.locals.user.id,
+      authn_user_id: res.locals.authn_user.id,
+    });
+    await deleteFile(file.id, res.locals.authn_user.id);
+  });
+
+  return variant.id;
+}
+
 async function validateAndProcessSubmission(req: Request, res: Response) {
   if (!res.locals.assessment_instance.open) {
     throw new HttpStatusError(400, 'assessment_instance is closed');
@@ -253,6 +307,11 @@ router.post(
       );
     } else if (req.body.__action === 'attach_text') {
       const variant_id = await processTextUpload(req, res);
+      res.redirect(
+        `${res.locals.urlPrefix}/instance_question/${res.locals.instance_question.id}/?variant_id=${variant_id}`,
+      );
+    } else if (req.body.__action === 'edit_text') {
+      const variant_id = await processTextEdit(req, res);
       res.redirect(
         `${res.locals.urlPrefix}/instance_question/${res.locals.instance_question.id}/?variant_id=${variant_id}`,
       );

--- a/apps/prairielearn/src/tests/helperAttachFiles.ts
+++ b/apps/prairielearn/src/tests/helperAttachFiles.ts
@@ -39,7 +39,7 @@ export function attachFile(locals: AttachFileLocals, textFile: boolean) {
     });
     it('should have an action', () => {
       if (textFile) {
-        elemList = locals.$('.attach-text-form button[name="__action"]');
+        elemList = locals.$('.attach-text-form input[name="__action"]');
       } else {
         elemList = locals.$('.attach-file-form input[name="__action"]');
       }
@@ -95,6 +95,64 @@ export function attachFile(locals: AttachFileLocals, textFile: boolean) {
   });
 }
 
+export function editAttachedFile(locals: AttachFileLocals & { file_id?: string; siteUrl: string }) {
+  describe('editAttachedFile-1. GET to assessment_instance URL', () => {
+    it('should load successfully', async () => {
+      const res = await fetch(locals.attachFilesUrl);
+      assert.isOk(res.ok);
+      locals.$ = cheerio.load(await res.text());
+    });
+    it('should render the text note as an editable button', () => {
+      elemList = locals.$('.edit-text-note');
+      assert.lengthOf(elemList, 1);
+      assert.nestedProperty(elemList[0], 'attribs.data-file-id');
+      locals.file_id = elemList[0].attribs['data-file-id'];
+    });
+    it('should have a CSRF token', () => {
+      elemList = locals.$('.attach-text-form input[name="__csrf_token"]');
+      assert.lengthOf(elemList, 1);
+      locals.__csrf_token = elemList[0].attribs.value;
+    });
+    it('might have a variant', () => {
+      elemList = locals.$('.attach-text-form input[name="__variant_id"]');
+      delete locals.__variant_id;
+      if (elemList.length === 0) return; // assessment_instance page does not have variant_id
+      locals.__variant_id = elemList[0].attribs.value;
+    });
+  });
+
+  describe('editAttachedFile-2. POST to edit the text note', () => {
+    it('should load successfully', async () => {
+      const body = new URLSearchParams({
+        __action: 'edit_text',
+        __csrf_token: locals.__csrf_token,
+        filename: 'testfile.txt',
+        contents: 'This is the edited text',
+        file_id: locals.file_id!,
+      });
+      if (locals.__variant_id) {
+        body.append('__variant_id', locals.__variant_id);
+      }
+      const res = await fetch(locals.attachFilesUrl, { method: 'POST', body });
+      assert.isOk(res.ok);
+      locals.$ = cheerio.load(await res.text());
+    });
+    it('should result in exactly one attached file', async () => {
+      locals.file = await sqldb.queryRow(sql.select_files, FileSchema);
+      assert.equal(locals.file.display_filename, 'testfile.txt');
+    });
+    it('should serve the edited contents', async () => {
+      elemList = locals.$('#attach-file-panel [data-testid="attached-file"]');
+      assert.lengthOf(elemList, 1);
+      const { attribs } = elemList[0];
+      const href = 'href' in attribs ? attribs.href : attribs['data-file-url'];
+      const res = await fetch(locals.siteUrl + href);
+      assert.isOk(res.ok);
+      assert.equal(await res.text(), 'This is the edited text');
+    });
+  });
+}
+
 export interface DownloadAttachedFileLocals {
   $?: cheerio.CheerioAPI;
   attachFilesUrl: string;
@@ -109,10 +167,12 @@ export function downloadAttachedFile(locals: DownloadAttachedFileLocals) {
       locals.$ = cheerio.load(await res.text());
     });
     it('should have a file URL', () => {
-      elemList = locals.$!('#attach-file-panel a[data-testid="attached-file"]');
+      // Editable text notes render as a button carrying the URL in data-file-url;
+      // other files render as a plain download anchor.
+      elemList = locals.$!('#attach-file-panel [data-testid="attached-file"]');
       assert.lengthOf(elemList, 1);
-      assert.nestedProperty(elemList[0], 'attribs.href');
-      locals.fileHref = elemList[0].attribs.href;
+      const { attribs } = elemList[0];
+      locals.fileHref = 'href' in attribs ? attribs.href : attribs['data-file-url'];
       assert.isString(locals.fileHref);
     });
   });
@@ -214,7 +274,7 @@ export function checkNoAttachedFiles(locals: { $: cheerio.CheerioAPI; attachFile
       locals.$ = cheerio.load(await res.text());
     });
     it('should not have a file URL', () => {
-      elemList = locals.$('#attach-file-panel a[data-testid="attached-file"]');
+      elemList = locals.$('#attach-file-panel [data-testid="attached-file"]');
       assert.lengthOf(elemList, 0);
     });
   });

--- a/apps/prairielearn/src/tests/homework.test.ts
+++ b/apps/prairielearn/src/tests/homework.test.ts
@@ -380,6 +380,10 @@ describe('Homework assessment', { timeout: 60_000 }, function () {
     helperAttachFiles.downloadAttachedFile(locals);
   });
 
+  describe('assessment_instance: edit attached text file', function () {
+    helperAttachFiles.editAttachedFile(locals);
+  });
+
   describe('assessment_instance: delete attached text file', function () {
     helperAttachFiles.deleteAttachedFile(locals);
     helperAttachFiles.checkNoAttachedFiles(locals);
@@ -415,6 +419,10 @@ describe('Homework assessment', { timeout: 60_000 }, function () {
     const textFile = true;
     helperAttachFiles.attachFile(locals, textFile);
     helperAttachFiles.downloadAttachedFile(locals);
+  });
+
+  describe('instance_question: edit attached text file', function () {
+    helperAttachFiles.editAttachedFile(locals);
   });
 
   describe('instance_question: delete attached text file', function () {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Saving a new note from the ui should also be viewable and editable from the ui. Currently to view the note, it needs to be downloaded and lacks editing. This PR add those features.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
ai wrote the initial code and then modified by me.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

https://github.com/user-attachments/assets/474e996a-9c47-4ac7-9b9d-5a0dccabaa58

