### PR TITLE
Improve layout of output and data in issue card

### DIFF
--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -431,7 +431,7 @@ function IssueDataCollapse({
   // A `position: sticky` header inside the scrollable box keeps the show/hide
   // button reachable even when scrolled midway through a large payload.
   return html`
-    <div class="border rounded mb-2" style="max-height: 400px; overflow-y: auto;">
+    <div class="border rounded mb-2" style="max-height: 60vh; overflow-y: auto;">
       <p
         class="mb-0 p-2 border-bottom"
         style="position: sticky; top: 0; z-index: 1; background-color: var(--bs-card-bg);"

--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -399,49 +399,58 @@ ${unsafeHtml(ansiToHtml(issue.system_data.courseErrData.outputBoth))}</pre
                     >
                   `
                 : ''}
-              <p>
-                <strong>Associated data:</strong>
-                <button
-                  type="button"
-                  class="btn btn-xs btn-secondary"
-                  data-bs-toggle="collapse"
-                  href="#issue-course-data-${issue.id}"
-                  aria-expanded="false"
-                  aria-controls="#issue-course-data-${issue.id}"
-                >
-                  Show/hide
-                </button>
-              </p>
-              <div class="collapse" id="issue-course-data-${issue.id}">
-                <pre class="bg-dark text-white rounded p-3">
-${JSON.stringify(issue.course_data, null, '    ')}</pre
-                >
-              </div>
+              ${IssueDataCollapse({
+                label: 'Associated data',
+                collapseId: `issue-course-data-${issue.id}`,
+                data: issue.course_data,
+              })}
               ${is_administrator
-                ? html`
-                    <p>
-                      <strong>System data:</strong>
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-secondary"
-                        data-bs-toggle="collapse"
-                        href="#issue-system-data-${issue.id}"
-                        aria-expanded="false"
-                        aria-controls="#issue-system-data-${issue.id}"
-                      >
-                        Show/hide
-                      </button>
-                    </p>
-                    <div class="collapse" id="issue-system-data-${issue.id}">
-                      <pre class="bg-dark text-white rounded p-3">
-${JSON.stringify(issue.system_data, null, '    ')}</pre
-                      >
-                    </div>
-                  `
+                ? IssueDataCollapse({
+                    label: 'System data',
+                    collapseId: `issue-system-data-${issue.id}`,
+                    data: issue.system_data,
+                  })
                 : ''}
             </div>
           `
         : ''}
+    </div>
+  `;
+}
+
+function IssueDataCollapse({
+  label,
+  collapseId,
+  data,
+}: {
+  label: string;
+  collapseId: string;
+  data: unknown;
+}) {
+  // The header stays visible while the collapsible JSON body scrolls beneath it.
+  // A `position: sticky` header inside the scrollable box keeps the show/hide
+  // button reachable even when scrolled midway through a large payload.
+  return html`
+    <div class="border rounded mb-2" style="max-height: 400px; overflow-y: auto;">
+      <p
+        class="mb-0 p-2 border-bottom"
+        style="position: sticky; top: 0; z-index: 1; background-color: var(--bs-card-bg);"
+      >
+        <strong>${label}:</strong>
+        <button
+          type="button"
+          class="btn btn-xs btn-secondary"
+          data-bs-toggle="collapse"
+          href="#${collapseId}"
+          aria-expanded="false"
+          aria-controls="${collapseId}"
+        >
+          Show/hide
+        </button>
+      </p>
+      <div class="collapse" id="${collapseId}">
+        <pre class="bg-dark text-white p-3 mb-0">${JSON.stringify(data, null, '    ')}</pre>
+      </div>
     </div>
   `;
 }

--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -427,9 +427,6 @@ function IssueDataCollapse({
   collapseId: string;
   data: unknown;
 }) {
-  // The header stays visible while the collapsible JSON body scrolls beneath it.
-  // A `position: sticky` header inside the scrollable box keeps the show/hide
-  // button reachable even when scrolled midway through a large payload.
   return html`
     <div class="border rounded mb-2" style="max-height: 60vh; overflow-y: auto;">
       <p

--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -390,13 +390,18 @@ function IssuePanel({
 
       ${config.devMode || authz_data.has_course_permission_view
         ? html`
-            <div class="card-body border border-bottom-0 border-start-0 border-end-0">
+            <ul
+              class="list-group list-group-flush border-top"
+              style="--bs-list-group-item-padding-x: 1.25rem; --bs-list-group-item-padding-y: 0.25rem;"
+            >
               ${issue.system_data?.courseErrData
                 ? html`
-                    <p><strong>Console log:</strong></p>
-                    <pre class="bg-dark text-white rounded p-3">
+                    <li class="list-group-item">
+                      <p class="mb-2"><strong>Console log:</strong></p>
+                      <pre class="bg-dark text-white rounded p-3 mb-0" style="max-height: 60vh;">
 ${unsafeHtml(ansiToHtml(issue.system_data.courseErrData.outputBoth))}</pre
-                    >
+                      >
+                    </li>
                   `
                 : ''}
               ${IssueDataCollapse({
@@ -411,7 +416,7 @@ ${unsafeHtml(ansiToHtml(issue.system_data.courseErrData.outputBoth))}</pre
                     data: issue.system_data,
                   })
                 : ''}
-            </div>
+            </ul>
           `
         : ''}
     </div>
@@ -428,11 +433,8 @@ function IssueDataCollapse({
   data: unknown;
 }) {
   return html`
-    <div class="border rounded mb-2" style="max-height: 60vh; overflow-y: auto;">
-      <p
-        class="mb-0 p-2 border-bottom"
-        style="position: sticky; top: 0; z-index: 1; background-color: var(--bs-card-bg);"
-      >
+    <li class="list-group-item">
+      <p class="mb-0">
         <strong>${label}:</strong>
         <button
           type="button"
@@ -446,9 +448,11 @@ function IssueDataCollapse({
         </button>
       </p>
       <div class="collapse" id="${collapseId}">
-        <pre class="bg-dark text-white p-3 mb-0">${JSON.stringify(data, null, '    ')}</pre>
+        <pre class="bg-dark text-white rounded p-3 mt-2 mb-0" style="max-height: 60vh;">
+${JSON.stringify(data, null, '    ')}</pre
+        >
       </div>
-    </div>
+    </li>
   `;
 }
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

The show/hide button gets lost after scrolling a bit when seeing the associated data/system data in an issue.
We need to scroll all the way up to click on the button to collapse the div.

This PR introduces a sticky header div with max height so that the button does not get lost

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
ai used at the initial commit only. rest done by me


# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

**before**

<img width="1304" height="1301" alt="image" src="https://github.com/user-attachments/assets/0ddb94c1-a089-44f3-bd6f-a9b35bae0d26" />



**after**

<img width="1077" height="1166" alt="image" src="https://github.com/user-attachments/assets/0cdb72b6-0bf2-444e-8373-887daa64b739" />
