### PR TITLE
Use unique stable key in rubric item component

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -16,6 +16,7 @@ type RubricItemData = Omit<RenderedRubricItem, 'rubric_item' | 'num_submissions'
     id?: string;
     points: number | null;
   };
+  unique_key: string;
   disagreement_count: number | null;
   num_submissions: number | null;
 };
@@ -90,6 +91,7 @@ export function RubricSettings({
   const rubricItemDataMerged =
     rubricData?.rubric_items.map((item) => ({
       ...item,
+      unique_key: `rubric-item-${item.rubric_item.id}`,
       disagreement_count:
         item.rubric_item.id in rubricItemsWithDisagreementCount
           ? rubricItemsWithDisagreementCount[item.rubric_item.id]
@@ -213,6 +215,10 @@ export function RubricSettings({
           key_binding: null,
           points: 1,
         },
+        // Use a stable ID for the new row so that it can be used as a key in
+        // the list. This is important for React to correctly identify and
+        // manage the list items, especially when reordering or deleting rows.
+        unique_key: `new-row-${crypto.randomUUID()}`,
         num_submissions: null,
         disagreement_count: null,
       },
@@ -394,6 +400,7 @@ export function RubricSettings({
             key_binding: null,
             points: roundPoints(rubricItem.points * scaleFactor),
           },
+          unique_key: `imported-row-${crypto.randomUUID()}`,
           num_submissions: null,
           disagreement_count: null,
         });
@@ -553,6 +560,7 @@ export function RubricSettings({
         const rubricItemsWithDisagreementCount = data.aiGradingStats?.rubric_stats ?? {};
         const rubricItemDataMerged = rubricItemsWithSelectionCount.map((item) => ({
           ...item,
+          unique_key: `rubric-item-${item.rubric_item.id}`,
           disagreement_count:
             item.rubric_item.id in rubricItemsWithDisagreementCount
               ? rubricItemsWithDisagreementCount[item.rubric_item.id]
@@ -827,7 +835,7 @@ export function RubricSettings({
                 {rubricItems.length > 0 ? (
                   rubricItems.map((it, idx) => (
                     <RubricRow
-                      key={it.rubric_item.id ?? `row-${idx}`}
+                      key={it.unique_key}
                       item={it}
                       showAiGradingStats={showAiGradingStats}
                       submissionCount={aiGradingStats?.submission_rubric_count ?? 0}


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Fixes #15384. Creates a stable key to be used as react key instead of the array index. Done in anticipation of an update of eslint that causes a warning in this case.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: auto-complete only.

# Testing

Page still works as expected.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
