### PR TITLE
Improve generated admin queries

### DIFF
--- a/apps/prairielearn/src/admin_queries/generate_and_enroll_users.ts
+++ b/apps/prairielearn/src/admin_queries/generate_and_enroll_users.ts
@@ -1,5 +1,6 @@
 import { runInTransactionAsync } from '@prairielearn/postgres';
 
+import { config } from '../lib/config.js';
 import type { Course, CourseInstance } from '../lib/db-types.js';
 import { selectOptionalCourseInstanceById } from '../models/course-instances.js';
 import { selectCourseById } from '../models/course.js';
@@ -10,6 +11,7 @@ import type { AdministratorQueryResult, AdministratorQuerySpecs } from './lib/ut
 
 export const specs: AdministratorQuerySpecs = {
   description: 'Generate random users and enroll them in a course instance',
+  enabled: config.devMode,
   params: [
     {
       name: 'count',

--- a/apps/prairielearn/src/admin_queries/generate_assessment_instances.ts
+++ b/apps/prairielearn/src/admin_queries/generate_assessment_instances.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { loadSqlEquiv, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
 
 import { makeAssessmentInstance } from '../lib/assessment.js';
+import { config } from '../lib/config.js';
 import {
   type AssessmentInstance,
   CourseInstanceSchema,
@@ -17,6 +18,7 @@ import { type AdministratorQueryResult, type AdministratorQuerySpecs } from './l
 export const specs: AdministratorQuerySpecs = {
   description:
     'Simulates all students enrolled in a course starting an assessment. For group assessments, groups must have been created.',
+  enabled: config.devMode,
   params: [
     {
       name: 'assessment_id',

--- a/apps/prairielearn/src/admin_queries/generate_submissions.ts
+++ b/apps/prairielearn/src/admin_queries/generate_submissions.ts
@@ -11,7 +11,12 @@ import {
   UserSchema,
 } from '../lib/db-types.js';
 import { saveSubmission } from '../lib/grading.js';
-import { TEST_TYPES, type TestType, createTestSubmissionData } from '../lib/question-testing.js';
+import {
+  TEST_TYPES,
+  type TestType,
+  createTestSubmissionData,
+  questionSupportsTesting,
+} from '../lib/question-testing.js';
 import { ensureVariant } from '../lib/question-variant.js';
 import { selectOptionalAssessmentById } from '../models/assessment.js';
 import { selectOptionalCourseInstanceById } from '../models/course-instances.js';
@@ -78,14 +83,16 @@ export default async function ({
     InstanceQuestionQuerySchema,
   );
 
-  const rows = await mapSeries(
+  const submissionRows = await mapSeries(
     instanceQuestions,
     async ({
       question,
       instance_question,
       user,
       question_course,
-    }: InstanceQuestionQuery): Promise<ResultRow> => {
+    }: InstanceQuestionQuery): Promise<ResultRow | null> => {
+      if (!questionSupportsTesting(question)) return null;
+
       // Select an existing open variant, or create a new one if none exists.
       const variant = await ensureVariant({
         question_id: question.id,
@@ -142,6 +149,7 @@ export default async function ({
       };
     },
   );
+  const rows = submissionRows.filter((row) => row != null);
 
   return { rows, columns };
 }

--- a/apps/prairielearn/src/lib/question-testing.ts
+++ b/apps/prairielearn/src/lib/question-testing.ts
@@ -133,6 +133,10 @@ interface TestQuestionResults {
 export const TEST_TYPES = ['correct', 'incorrect', 'invalid'] as const;
 export type TestType = (typeof TEST_TYPES)[number];
 
+export function questionSupportsTesting(question: Question): boolean {
+  return questionServers.getModule(question.type).test != null;
+}
+
 /**
  * Creates the data for a test submission.
  *
@@ -153,7 +157,7 @@ export async function createTestSubmissionData(
   authn_user_id: string,
 ): Promise<{ data: questionServers.TestResultData; hasFatalIssue: boolean }> {
   const questionModule = questionServers.getModule(question.type);
-  if (!questionModule.test) {
+  if (questionModule.test == null) {
     throw new Error('Question type does not support testing, must be Freeform');
   }
 


### PR DESCRIPTION
# Description

The `generate_submissions` admin query used the question testing helper for every open instance question, which made mixed assessments abort when a non-Freeform question server lacked `test()` support.

It now skips unsupported questions and still creates submissions for supported questions.

The other mutating `generate_*` admin queries are restricted to dev mode to match `generate_submissions`.

- [x] I have disclosed the level of AI assistance used: majority of implementation by Codex.

# Testing

Targeted static validation passed; no automated regression test was added because this is a small dev-only admin-query behavior change.
