### PR TITLE
Upgrade prettier to 3.9.4

### DIFF
--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -212,7 +212,7 @@
     "pem": "^1.14.8",
     "pg": "^8.21.0",
     "popper.js": "^1.16.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.4",
     "prosemirror-model": "^1.25.7",
     "prosemirror-state": "^1.4.4",
     "prosemirror-view": "^1.41.8",

--- a/apps/prairielearn/src/components/AssessmentNavigation.tsx
+++ b/apps/prairielearn/src/components/AssessmentNavigation.tsx
@@ -37,9 +37,9 @@ export function AssessmentNavigation({
         aria-label="Change assessment"
         aria-haspopup="true"
         aria-expanded="false"
-        hx-get="/pl/navbar/course_instance/${courseInstanceId}/assessment/${assessment.id}/switcher${subPage
-          ? `?subPage=${subPage}`
-          : ''}"
+        hx-get="/pl/navbar/course_instance/${courseInstanceId}/assessment/${assessment.id}/switcher${
+          subPage ? `?subPage=${subPage}` : ''
+        }"
         hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
         data-bs-toggle="modal"
         data-bs-target="#assessmentNavigationModal"

--- a/apps/prairielearn/src/components/CalculatorDrawer.ts
+++ b/apps/prairielearn/src/components/CalculatorDrawer.ts
@@ -42,22 +42,24 @@ export function CalculatorDrawerToggle({
     <div class="card mb-4">
       <div class="card-header bg-secondary text-white d-flex align-items-center">
         <span>Tools</span>
-        ${showInfoPopover
-          ? html`
-              <button
-                type="button"
-                class="btn btn-link btn-sm ms-auto text-white border-0 p-0"
-                data-bs-toggle="popover"
-                data-bs-container="body"
-                data-bs-html="true"
-                data-bs-title="${escapeHtml(toolsTitleContent)}"
-                data-bs-content="${escapeHtml(toolsPopoverContent)}"
-                data-bs-placement="auto"
-              >
-                <i class="bi bi-question-circle" aria-hidden="true"></i>
-              </button>
-            `
-          : ''}
+        ${
+          showInfoPopover
+            ? html`
+                <button
+                  type="button"
+                  class="btn btn-link btn-sm ms-auto text-white border-0 p-0"
+                  data-bs-toggle="popover"
+                  data-bs-container="body"
+                  data-bs-html="true"
+                  data-bs-title="${escapeHtml(toolsTitleContent)}"
+                  data-bs-content="${escapeHtml(toolsPopoverContent)}"
+                  data-bs-placement="auto"
+                >
+                  <i class="bi bi-question-circle" aria-hidden="true"></i>
+                </button>
+              `
+            : ''
+        }
       </div>
       <div class="card-body">
         <button type="button" class="btn btn-outline-secondary w-100" id="calculatorDrawerToggle">

--- a/apps/prairielearn/src/components/EditQuestionPointsScore.tsx
+++ b/apps/prairielearn/src/components/EditQuestionPointsScore.tsx
@@ -132,10 +132,12 @@ function EditQuestionPointsScoreFormHtml({
         <small>
           This will also recalculate the total points and total score at 100% credit. This change
           will be overwritten if the question is answered again by the student.
-          ${instance_question.status !== 'unanswered'
-            ? html`You may also update the score
-                <a href="${manualGradingUrl}">via the manual grading page</a>.`
-            : ''}
+          ${
+            instance_question.status !== 'unanswered'
+              ? html`You may also update the score
+                  <a href="${manualGradingUrl}">via the manual grading page</a>.`
+              : ''
+          }
         </small>
       </p>
       <div class="text-end">

--- a/apps/prairielearn/src/components/EnrollmentPage.tsx
+++ b/apps/prairielearn/src/components/EnrollmentPage.tsx
@@ -5,10 +5,7 @@ import { PageLayout } from './PageLayout.js';
 interface EnrollmentPageProps {
   resLocals: UntypedResLocals;
   type:
-    | 'blocked'
-    | 'self-enrollment-disabled'
-    | 'self-enrollment-expired'
-    | 'institution-restriction';
+    'blocked' | 'self-enrollment-disabled' | 'self-enrollment-expired' | 'institution-restriction';
 }
 
 function BlockedEnrollment() {

--- a/apps/prairielearn/src/components/ExamQuestionAvailablePoints.tsx
+++ b/apps/prairielearn/src/components/ExamQuestionAvailablePoints.tsx
@@ -25,34 +25,38 @@ export function ExamQuestionAvailablePoints({
       If you score 100% on your next submission, then you will be awarded an additional
       ${formatPoints(pointsList[0])} points.
     </p>
-    ${bestScore > 0
-      ? html`
-          <p>
-            If you score less than ${bestScore}% on your next submission, then you will be awarded
-            no additional points, but you will keep any awarded points that you already have.
-          </p>
-          <p class="mb-0">
-            If you score between ${bestScore}% and 100% on your next submission, then you will be
-            awarded an additional
-            <code>(${formatPoints(currentWeight)} * (score - ${bestScore})/100)</code>
-            points.
-          </p>
-        `
-      : html`
-          <p class="mb-0">
-            If you score less than 100% on your next submission, then you will be awarded an
-            additional
-            <code>(${formatPoints(currentWeight)} * score / 100)</code>
-            points.
-          </p>
-        `}
+    ${
+      bestScore > 0
+        ? html`
+            <p>
+              If you score less than ${bestScore}% on your next submission, then you will be awarded
+              no additional points, but you will keep any awarded points that you already have.
+            </p>
+            <p class="mb-0">
+              If you score between ${bestScore}% and 100% on your next submission, then you will be
+              awarded an additional
+              <code>(${formatPoints(currentWeight)} * (score - ${bestScore})/100)</code>
+              points.
+            </p>
+          `
+        : html`
+            <p class="mb-0">
+              If you score less than 100% on your next submission, then you will be awarded an
+              additional
+              <code>(${formatPoints(currentWeight)} * score / 100)</code>
+              points.
+            </p>
+          `
+    }
   `;
 
   return html`
-    ${pointsList.length === 1
-      ? formatPoints(pointsList[0])
-      : html`${formatPoints(pointsList[0])},
-          <span class="text-muted">${formatPointsOrList(pointsList.slice(1))}</span>`}
+    ${
+      pointsList.length === 1
+        ? formatPoints(pointsList[0])
+        : html`${formatPoints(pointsList[0])},
+            <span class="text-muted">${formatPointsOrList(pointsList.slice(1))}</span>`
+    }
     <button
       type="button"
       class="btn btn-xs btn-ghost js-available-points-popover"

--- a/apps/prairielearn/src/components/ExamQuestionStatus.tsx
+++ b/apps/prairielearn/src/components/ExamQuestionStatus.tsx
@@ -66,23 +66,25 @@ export function ExamQuestionStatus({
 
   return html`
     <span class="badge text-bg-${badgeColor}">${badgeText}</span>
-    ${allowGradeLeftMs > 0
-      ? html`
-          <button
-            type="button"
-            class="grade-rate-limit-popover btn btn-xs"
-            data-bs-toggle="popover"
-            data-bs-container="body"
-            data-bs-html="true"
-            data-bs-content="This question limits the rate of submissions. Further grade allowed in ${formatInterval(
+    ${
+      allowGradeLeftMs > 0
+        ? html`
+            <button
+              type="button"
+              class="grade-rate-limit-popover btn btn-xs"
+              data-bs-toggle="popover"
+              data-bs-container="body"
+              data-bs-html="true"
+              data-bs-content="This question limits the rate of submissions. Further grade allowed in ${formatInterval(
               allowGradeLeftMs,
               { fullPartNames: true, firstOnly: true },
             )} (as of the loading of this page)."
-            data-bs-placement="auto"
-          >
-            <i class="fa fa-hourglass-half" aria-hidden="true"></i>
-          </button>
-        `
-      : ''}
+              data-bs-placement="auto"
+            >
+              <i class="fa fa-hourglass-half" aria-hidden="true"></i>
+            </button>
+          `
+        : ''
+    }
   `;
 }

--- a/apps/prairielearn/src/components/FileBrowser.tsx
+++ b/apps/prairielearn/src/components/FileBrowser.tsx
@@ -318,34 +318,40 @@ function FileBrowser({
               ${joinHtml(
                 breadcrumbPaths.map(
                   (dir) => html`
-                    ${dir.canView
-                      ? html`
-                          <a
-                            class="text-white"
-                            href="${paths.urlPrefix}/file_view/${encodePath(dir.path)}"
-                          >
-                            ${dir.name}
-                          </a>
-                        `
-                      : html`<span>${dir.name}</span>`}
+                    ${
+                      dir.canView
+                        ? html`
+                            <a
+                              class="text-white"
+                              href="${paths.urlPrefix}/file_view/${encodePath(dir.path)}"
+                            >
+                              ${dir.name}
+                            </a>
+                          `
+                        : html`<span>${dir.name}</span>`
+                    }
                   `,
                 ),
                 html`<span class="mx-2">/</span>`,
               )}
             </div>
             <div class="col-auto">
-              ${isFile
-                ? FileBrowserActions({ paths, fileInfo, isReadOnly, csrfToken })
-                : paths.hasEditPermission && !isReadOnly
-                  ? DirectoryBrowserActions({ paths, csrfToken })
-                  : ''}
+              ${
+                isFile
+                  ? FileBrowserActions({ paths, fileInfo, isReadOnly, csrfToken })
+                  : paths.hasEditPermission && !isReadOnly
+                    ? DirectoryBrowserActions({ paths, csrfToken })
+                    : ''
+              }
             </div>
           </div>
         </div>
 
-        ${isFile
-          ? html`<div class="card-body">${FileContentPreview({ paths, fileInfo })}</div>`
-          : DirectoryBrowserBody({ paths, directoryListings, isReadOnly, csrfToken })}
+        ${
+          isFile
+            ? html`<div class="card-body">${FileContentPreview({ paths, fileInfo })}</div>`
+            : DirectoryBrowserBody({ paths, directoryListings, isReadOnly, csrfToken })
+        }
       </div>
     `,
   });
@@ -365,32 +371,34 @@ function FileBrowserActions({
   const encodedPath = encodePath(fileInfo.path);
   return html`
     <div class="d-flex flex-wrap gap-2">
-      ${isReadOnly
-        ? ''
-        : html`
-            <a
-              tabindex="0"
-              class="btn btn-sm btn-light ${fileInfo.canEdit ? '' : 'disabled'}"
-              href="${paths.urlPrefix}/file_edit/${encodedPath}"
-            >
-              <i class="fa fa-edit"></i>
-              <span>Edit</span>
-            </a>
-            <button
-              type="button"
-              class="btn btn-sm btn-light"
-              data-bs-toggle="popover"
-              data-bs-container="body"
-              data-bs-html="true"
-              data-bs-placement="auto"
-              data-bs-title="Upload file"
-              data-bs-content="${escapeHtml(FileUploadForm({ file: fileInfo, csrfToken }))}"
-              ${fileInfo.canUpload ? '' : 'disabled'}
-            >
-              <i class="fa fa-arrow-up"></i>
-              <span>Upload</span>
-            </button>
-          `}
+      ${
+        isReadOnly
+          ? ''
+          : html`
+              <a
+                tabindex="0"
+                class="btn btn-sm btn-light ${fileInfo.canEdit ? '' : 'disabled'}"
+                href="${paths.urlPrefix}/file_edit/${encodedPath}"
+              >
+                <i class="fa fa-edit"></i>
+                <span>Edit</span>
+              </a>
+              <button
+                type="button"
+                class="btn btn-sm btn-light"
+                data-bs-toggle="popover"
+                data-bs-container="body"
+                data-bs-html="true"
+                data-bs-placement="auto"
+                data-bs-title="Upload file"
+                data-bs-content="${escapeHtml(FileUploadForm({ file: fileInfo, csrfToken }))}"
+                ${fileInfo.canUpload ? '' : 'disabled'}
+              >
+                <i class="fa fa-arrow-up"></i>
+                <span>Upload</span>
+              </button>
+            `
+      }
       <a
         class="btn btn-sm btn-light ${fileInfo.canDownload ? '' : 'disabled'}"
         href="${paths.urlPrefix}/file_download/${encodedPath}?attachment=${encodeURIComponent(
@@ -400,40 +408,42 @@ function FileBrowserActions({
         <i class="fa fa-arrow-down"></i>
         <span>Download</span>
       </a>
-      ${isReadOnly
-        ? ''
-        : html`
-            <button
-              type="button"
-              class="btn btn-sm btn-light"
-              data-bs-toggle="popover"
-              data-bs-container="body"
-              data-bs-html="true"
-              data-bs-placement="auto"
-              data-bs-title="Rename file"
-              data-bs-content="${escapeHtml(
+      ${
+        isReadOnly
+          ? ''
+          : html`
+              <button
+                type="button"
+                class="btn btn-sm btn-light"
+                data-bs-toggle="popover"
+                data-bs-container="body"
+                data-bs-html="true"
+                data-bs-placement="auto"
+                data-bs-title="Rename file"
+                data-bs-content="${escapeHtml(
                 FileRenameForm({ file: fileInfo, csrfToken, isViewingFile: true }),
               )}"
-              ${fileInfo.canRename ? '' : 'disabled'}
-            >
-              <i class="fa fa-i-cursor"></i>
-              <span>Rename</span>
-            </button>
-            <button
-              type="button"
-              class="btn btn-sm btn-light"
-              data-bs-toggle="popover"
-              data-bs-container="body"
-              data-bs-html="true"
-              data-bs-placement="auto"
-              data-bs-title="Confirm delete"
-              data-bs-content="${escapeHtml(FileDeleteForm({ file: fileInfo, csrfToken }))}"
-              ${fileInfo.canDelete ? '' : 'disabled'}
-            >
-              <i class="far fa-trash-alt"></i>
-              <span>Delete</span>
-            </button>
-          `}
+                ${fileInfo.canRename ? '' : 'disabled'}
+              >
+                <i class="fa fa-i-cursor"></i>
+                <span>Rename</span>
+              </button>
+              <button
+                type="button"
+                class="btn btn-sm btn-light"
+                data-bs-toggle="popover"
+                data-bs-container="body"
+                data-bs-html="true"
+                data-bs-placement="auto"
+                data-bs-title="Confirm delete"
+                data-bs-content="${escapeHtml(FileDeleteForm({ file: fileInfo, csrfToken }))}"
+                ${fileInfo.canDelete ? '' : 'disabled'}
+              >
+                <i class="far fa-trash-alt"></i>
+                <span>Delete</span>
+              </button>
+            `
+      }
     </div>
   `;
 }
@@ -555,59 +565,65 @@ function DirectoryBrowserBody({
                 <td class="align-middle">
                   <div class="d-flex align-items-center">
                     <i class="far fa-file-alt"></i>
-                    ${f.sync_errors
-                      ? SyncProblemButtonHtml({
-                          type: 'error',
-                          output: f.sync_errors,
-                        })
-                      : f.sync_warnings
+                    ${
+                      f.sync_errors
                         ? SyncProblemButtonHtml({
-                            type: 'warning',
-                            output: f.sync_warnings,
+                            type: 'error',
+                            output: f.sync_errors,
                           })
-                        : ''}
-                    ${f.canView
-                      ? html`<a href="${paths.urlPrefix}/file_view/${encodePath(f.path)}"
-                          >${f.name}</a
-                        >`
-                      : html`<span>${f.name}</span>`}
+                        : f.sync_warnings
+                          ? SyncProblemButtonHtml({
+                              type: 'warning',
+                              output: f.sync_warnings,
+                            })
+                          : ''
+                    }
+                    ${
+                      f.canView
+                        ? html`<a href="${paths.urlPrefix}/file_view/${encodePath(f.path)}"
+                            >${f.name}</a
+                          >`
+                        : html`<span>${f.name}</span>`
+                    }
                   </div>
                 </td>
                 <td class="align-middle">
                   <div class="d-flex gap-2">
-                    ${isReadOnly
-                      ? ''
-                      : html`
-                          <a
-                            class="btn btn-xs btn-secondary text-nowrap ${f.canEdit
-                              ? ''
-                              : 'disabled'}"
-                            href="${paths.urlPrefix}/file_edit/${encodePath(f.path)}"
-                          >
-                            <i class="fa fa-edit"></i>
-                            <span>Edit</span>
-                          </a>
-                          <button
-                            type="button"
-                            id="instructorFileUploadForm-${f.id}"
-                            class="btn btn-xs btn-secondary text-nowrap"
-                            data-bs-toggle="popover"
-                            data-bs-container="body"
-                            data-bs-html="true"
-                            data-bs-placement="auto"
-                            data-bs-title="Upload file"
-                            data-bs-content="
-                  ${escapeHtml(FileUploadForm({ file: f, csrfToken }))}"
-                            ${f.canUpload ? '' : 'disabled'}
-                          >
-                            <i class="fa fa-arrow-up"></i>
-                            <span>Upload</span>
-                          </button>
-                        `}
-                    <a
-                      class="btn btn-xs btn-secondary text-nowrap ${f.canDownload
+                    ${
+                      isReadOnly
                         ? ''
-                        : 'disabled'}"
+                        : html`
+                            <a
+                              class="btn btn-xs btn-secondary text-nowrap ${
+                              f.canEdit ? '' : 'disabled'
+                            }"
+                              href="${paths.urlPrefix}/file_edit/${encodePath(f.path)}"
+                            >
+                              <i class="fa fa-edit"></i>
+                              <span>Edit</span>
+                            </a>
+                            <button
+                              type="button"
+                              id="instructorFileUploadForm-${f.id}"
+                              class="btn btn-xs btn-secondary text-nowrap"
+                              data-bs-toggle="popover"
+                              data-bs-container="body"
+                              data-bs-html="true"
+                              data-bs-placement="auto"
+                              data-bs-title="Upload file"
+                              data-bs-content="
+                  ${escapeHtml(FileUploadForm({ file: f, csrfToken }))}"
+                              ${f.canUpload ? '' : 'disabled'}
+                            >
+                              <i class="fa fa-arrow-up"></i>
+                              <span>Upload</span>
+                            </button>
+                          `
+                    }
+                    <a
+                      class="btn btn-xs btn-secondary text-nowrap ${
+                        f.canDownload ? '' : 'disabled'
+                      }"
                       href="${paths.urlPrefix}/file_download/${encodePath(
                         f.path,
                       )}?attachment=${encodeURIComponent(f.name)}"
@@ -615,42 +631,44 @@ function DirectoryBrowserBody({
                       <i class="fa fa-arrow-down"></i>
                       <span>Download</span>
                     </a>
-                    ${isReadOnly
-                      ? ''
-                      : html`
-                          <button
-                            type="button"
-                            class="btn btn-xs btn-secondary text-nowrap"
-                            data-bs-toggle="popover"
-                            data-bs-container="body"
-                            data-bs-html="true"
-                            data-bs-placement="auto"
-                            data-bs-title="Rename file"
-                            data-bs-content="${escapeHtml(
+                    ${
+                      isReadOnly
+                        ? ''
+                        : html`
+                            <button
+                              type="button"
+                              class="btn btn-xs btn-secondary text-nowrap"
+                              data-bs-toggle="popover"
+                              data-bs-container="body"
+                              data-bs-html="true"
+                              data-bs-placement="auto"
+                              data-bs-title="Rename file"
+                              data-bs-content="${escapeHtml(
                               FileRenameForm({ file: f, csrfToken, isViewingFile: false }),
                             )}"
-                            data-testid="rename-file-button"
-                            ${f.canRename ? '' : 'disabled'}
-                          >
-                            <i class="fa fa-i-cursor"></i>
-                            <span>Rename</span>
-                          </button>
-                          <button
-                            type="button"
-                            class="btn btn-xs btn-secondary text-nowrap"
-                            data-bs-toggle="popover"
-                            data-bs-container="body"
-                            data-bs-html="true"
-                            data-bs-placement="auto"
-                            data-bs-title="Confirm delete"
-                            data-bs-content="${escapeHtml(FileDeleteForm({ file: f, csrfToken }))}"
-                            data-testid="delete-file-button"
-                            ${f.canDelete ? '' : 'disabled'}
-                          >
-                            <i class="far fa-trash-alt"></i>
-                            <span>Delete</span>
-                          </button>
-                        `}
+                              data-testid="rename-file-button"
+                              ${f.canRename ? '' : 'disabled'}
+                            >
+                              <i class="fa fa-i-cursor"></i>
+                              <span>Rename</span>
+                            </button>
+                            <button
+                              type="button"
+                              class="btn btn-xs btn-secondary text-nowrap"
+                              data-bs-toggle="popover"
+                              data-bs-container="body"
+                              data-bs-html="true"
+                              data-bs-placement="auto"
+                              data-bs-title="Confirm delete"
+                              data-bs-content="${escapeHtml(FileDeleteForm({ file: f, csrfToken }))}"
+                              data-testid="delete-file-button"
+                              ${f.canDelete ? '' : 'disabled'}
+                            >
+                              <i class="far fa-trash-alt"></i>
+                              <span>Delete</span>
+                            </button>
+                          `
+                    }
                   </div>
                 </td>
               </tr>
@@ -661,11 +679,13 @@ function DirectoryBrowserBody({
               <tr>
                 <td colspan="2">
                   <i class="fa fa-folder"></i>
-                  ${d.canView
-                    ? html`<a href="${paths.urlPrefix}/file_view/${encodePath(d.path)}"
-                        >${d.name}</a
-                      >`
-                    : html`<span>${d.name}</span>`}
+                  ${
+                    d.canView
+                      ? html`<a href="${paths.urlPrefix}/file_view/${encodePath(d.path)}"
+                          >${d.name}</a
+                        >`
+                      : html`<span>${d.name}</span>`
+                  }
                 </td>
               </tr>
             `,
@@ -695,9 +715,11 @@ function FileUploadForm({ file, csrfToken }: { file: FileUploadInfo; csrfToken: 
         <input
           type="file"
           name="files"
-          ${file.path == null
-            ? html`multiple data-max-file-count="${config.fileUploadMaxFiles}"`
-            : ''}
+          ${
+            file.path == null
+              ? html`multiple data-max-file-count="${config.fileUploadMaxFiles}"`
+              : ''
+          }
           data-max-file-size="${config.fileUploadMaxBytes}"
           data-max-file-size-formatted="${maxFileSizeFormatted}"
           class="form-control"
@@ -713,9 +735,11 @@ function FileUploadForm({ file, csrfToken }: { file: FileUploadInfo; csrfToken: 
       <div class="mb-3">
         <input type="hidden" name="__action" value="upload_file" />
         <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-        ${file.path != null
-          ? html`<input type="hidden" name="file_path" value="${file.path}" />`
-          : html`<input type="hidden" name="working_path" value="${file.working_path}" />`}
+        ${
+          file.path != null
+            ? html`<input type="hidden" name="file_path" value="${file.path}" />`
+            : html`<input type="hidden" name="working_path" value="${file.working_path}" />`
+        }
         <div class="text-end justify-content-end gap-2 d-flex flex-wrap">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="popover">Cancel</button>
           <button type="submit" class="btn btn-primary">

--- a/apps/prairielearn/src/components/GroupWorkInfoContainer.tsx
+++ b/apps/prairielearn/src/components/GroupWorkInfoContainer.tsx
@@ -24,59 +24,71 @@ export function GroupWorkInfoContainer({
           <div>
             <strong>Group name:</strong> <span id="group-name">${groupInfo.groupName}</span>
           </div>
-          ${groupConfig.student_authz_join
-            ? html`
-                <div>
-                  <strong>Join code:</strong> <span id="join-code">${groupInfo.joinCode}</span>
-                </div>
-                <div class="mt-3">
-                  ${(groupConfig.minimum ?? 0) > 1
-                    ? html`
-                        This is a group assessment. Use your join code to invite others to join the
-                        group. A group must have
-                        ${groupConfig.minimum === groupConfig.maximum
-                          ? groupConfig.minimum
-                          : groupConfig.maximum
-                            ? `between ${groupConfig.minimum} and ${groupConfig.maximum}`
-                            : `at least ${groupConfig.minimum}`}
-                        students.
-                      `
-                    : html`
-                        This assessment can be done individually or in groups. Use your join code if
-                        you wish to invite others to join the group.
-                        ${groupConfig.maximum
-                          ? `A group must have no more than ${groupConfig.maximum} students.`
-                          : ''}
-                      `}
-                </div>
-              `
-            : ''}
+          ${
+            groupConfig.student_authz_join
+              ? html`
+                  <div>
+                    <strong>Join code:</strong> <span id="join-code">${groupInfo.joinCode}</span>
+                  </div>
+                  <div class="mt-3">
+                    ${
+                    (groupConfig.minimum ?? 0) > 1
+                      ? html`
+                          This is a group assessment. Use your join code to invite others to join
+                          the group. A group must have
+                          ${
+                          groupConfig.minimum === groupConfig.maximum
+                            ? groupConfig.minimum
+                            : groupConfig.maximum
+                              ? `between ${groupConfig.minimum} and ${groupConfig.maximum}`
+                              : `at least ${groupConfig.minimum}`
+                        }
+                          students.
+                        `
+                      : html`
+                          This assessment can be done individually or in groups. Use your join code
+                          if you wish to invite others to join the group.
+                          ${
+                          groupConfig.maximum
+                            ? `A group must have no more than ${groupConfig.maximum} students.`
+                            : ''
+                        }
+                        `
+                  }
+                  </div>
+                `
+              : ''
+          }
         </div>
         <div class="col-sm bg-light py-4 px-4 border">
-          ${groupConfig.student_authz_leave
-            ? html`
-                <div class="text-end">
-                  <button
-                    type="button"
-                    class="btn btn-danger"
-                    data-bs-toggle="modal"
-                    data-bs-target="#leaveGroupModal"
-                  >
-                    Leave the group
-                  </button>
-                </div>
-                ${LeaveGroupModal({ csrfToken })}
-              `
-            : ''}
+          ${
+            groupConfig.student_authz_leave
+              ? html`
+                  <div class="text-end">
+                    <button
+                      type="button"
+                      class="btn btn-danger"
+                      data-bs-toggle="modal"
+                      data-bs-target="#leaveGroupModal"
+                    >
+                      Leave the group
+                    </button>
+                  </div>
+                  ${LeaveGroupModal({ csrfToken })}
+                `
+              : ''
+          }
           <span id="group-member"><b>Group members: </b></span>
           ${groupInfo.groupMembers.map((user) =>
             groupConfig.has_roles
               ? html`
                   <li>
                     ${user.uid} -
-                    ${groupInfo.rolesInfo?.roleAssignments[user.uid]
-                      ?.map((a) => a.role_name)
-                      .join(', ') || 'No role assigned'}
+                    ${
+                      groupInfo.rolesInfo?.roleAssignments[user.uid]
+                        ?.map((a) => a.role_name)
+                        .join(', ') || 'No role assigned'
+                    }
                   </li>
                 `
               : html`<li>${user.uid}</li>`,
@@ -124,31 +136,37 @@ function GroupRoleTable({
     (rolesInfo.usersWithoutRoles.length > 0 ? 1 : 0) +
     (rolesInfo.rolesAreBalanced ? 0 : 1);
   return html`
-    ${roleConfigProblems > 0
-      ? html`
-          <div class="alert alert-danger mt-2" role="alert">
-            Your group's role configuration is currently invalid. Please review the role
-            requirements and
-            ${userCanAssignRoles
-              ? 'assign a valid role configuration'
-              : 'ask a user with an assigner role to update the role configuration'}.
-            Question submissions are disabled until the role configuration is valid.
-          </div>
-        `
-      : ''}
+    ${
+      roleConfigProblems > 0
+        ? html`
+            <div class="alert alert-danger mt-2" role="alert">
+              Your group's role configuration is currently invalid. Please review the role
+              requirements and
+              ${
+              userCanAssignRoles
+                ? 'assign a valid role configuration'
+                : 'ask a user with an assigner role to update the role configuration'
+            }.
+              Question submissions are disabled until the role configuration is valid.
+            </div>
+          `
+        : ''
+    }
     <details class="card mb-2">
       <summary class="card-header bg-secondary text-light">
         ${userCanAssignRoles ? 'Manage group roles' : 'View group roles'}
-        ${roleConfigProblems > 0
-          ? html`
-              <span
-                class="badge rounded-pill text-bg-danger"
-                data-testid="group-role-config-problems"
-              >
-                ${roleConfigProblems}
-              </span>
-            `
-          : ''}
+        ${
+          roleConfigProblems > 0
+            ? html`
+                <span
+                  class="badge rounded-pill text-bg-danger"
+                  data-testid="group-role-config-problems"
+                >
+                  ${roleConfigProblems}
+                </span>
+              `
+            : ''
+        }
       </summary>
       <div class="card-body">
         ${GroupRoleErrors({ rolesInfo, groupSize })}
@@ -179,20 +197,22 @@ function GroupRoleTable({
                           ${rolesInfo.groupRoles.map(
                             (role) => html`
                               <label
-                                class="d-inline-flex gap-1 ${rolesInfo.disabledRoles.includes(
-                                  role.role_name,
-                                )
-                                  ? 'text-muted'
-                                  : ''}"
+                                class="d-inline-flex gap-1 ${
+                                  rolesInfo.disabledRoles.includes(role.role_name)
+                                    ? 'text-muted'
+                                    : ''
+                                }"
                               >
                                 <input
                                   type="checkbox"
                                   id="user_role_${role.id}-${user.id}"
                                   name="user_role_${role.id}-${user.id}"
-                                  ${rolesInfo.disabledRoles.includes(role.role_name) ||
-                                  !userCanAssignRoles
-                                    ? 'disabled'
-                                    : ''}
+                                  ${
+                                    rolesInfo.disabledRoles.includes(role.role_name) ||
+                                    !userCanAssignRoles
+                                      ? 'disabled'
+                                      : ''
+                                  }
                                   ${
                                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                                     rolesInfo.roleAssignments[user.uid]?.some((a) =>
@@ -214,15 +234,17 @@ function GroupRoleTable({
               </tbody>
             </table>
           </div>
-          ${userCanAssignRoles
-            ? html`
-                <div class="d-flex justify-content-center">
-                  <input type="hidden" name="__action" value="update_group_roles" />
-                  <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-                  <button type="submit" class="btn btn-primary">Update Roles</button>
-                </div>
-              `
-            : ''}
+          ${
+            userCanAssignRoles
+              ? html`
+                  <div class="d-flex justify-content-center">
+                    <input type="hidden" name="__action" value="update_group_roles" />
+                    <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+                    <button type="submit" class="btn btn-primary">Update Roles</button>
+                  </div>
+                `
+              : ''
+          }
         </form>
       </div>
       <div class="card-footer small">
@@ -266,43 +288,52 @@ function GroupRoleErrors({
   groupSize: number;
 }) {
   return html`
-    ${!rolesInfo.rolesAreBalanced
-      ? html`
-          <div class="alert alert-danger" role="alert">
-            At least one student has too many roles. In a group with ${groupSize} students, every
-            student must be assigned to exactly <strong>one</strong> role.
-          </div>
-        `
-      : ''}
+    ${
+      !rolesInfo.rolesAreBalanced
+        ? html`
+            <div class="alert alert-danger" role="alert">
+              At least one student has too many roles. In a group with ${groupSize} students, every
+              student must be assigned to exactly <strong>one</strong> role.
+            </div>
+          `
+        : ''
+    }
     ${rolesInfo.validationErrors.map(
       ({ role_name, count, minimum, maximum }) => html`
         <div class="alert alert-danger" role="alert">
-          ${minimum != null && count < minimum
-            ? html`
-                ${minimum - count} more ${minimum - count === 1 ? 'student needs' : 'students need'}
-                to be assigned to the role "${role_name}"
-              `
-            : maximum != null && count > maximum
+          ${
+            minimum != null && count < minimum
               ? html`
-                  ${count - maximum} less
-                  ${count - maximum === 1 ? 'student needs' : 'students need'} to be assigned to the
+                  ${minimum - count} more
+                  ${minimum - count === 1 ? 'student needs' : 'students need'} to be assigned to the
                   role "${role_name}"
                 `
-              : ''}
-          ${maximum === minimum
-            ? html` (${count} assigned, ${minimum} expected). `
-            : maximum == null
-              ? html` (${count} assigned, at least ${minimum} expected). `
-              : html` (${count} assigned, between ${minimum ?? 0} and ${maximum} expected). `}
+              : maximum != null && count > maximum
+                ? html`
+                    ${count - maximum} less
+                    ${count - maximum === 1 ? 'student needs' : 'students need'} to be assigned to
+                    the role "${role_name}"
+                  `
+                : ''
+          }
+          ${
+            maximum === minimum
+              ? html` (${count} assigned, ${minimum} expected). `
+              : maximum == null
+                ? html` (${count} assigned, at least ${minimum} expected). `
+                : html` (${count} assigned, between ${minimum ?? 0} and ${maximum} expected). `
+          }
         </div>
       `,
     )}
-    ${rolesInfo.usersWithoutRoles.length > 0
-      ? html`
-          <div class="alert alert-danger" role="alert">
-            At least one user does not have a role. All users must have a role.
-          </div>
-        `
-      : ''}
+    ${
+      rolesInfo.usersWithoutRoles.length > 0
+        ? html`
+            <div class="alert alert-danger" role="alert">
+              At least one user does not have a role. All users must have a role.
+            </div>
+          `
+        : ''
+    }
   `;
 }

--- a/apps/prairielearn/src/components/HeadContents.tsx
+++ b/apps/prairielearn/src/components/HeadContents.tsx
@@ -34,9 +34,11 @@ export function HeadContents(titleOptions: TitleOptions) {
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    ${config.cookieDomain
-      ? html`<meta name="cookie-domain" content="${config.cookieDomain}" />`
-      : ''}
+    ${
+      config.cookieDomain
+        ? html`<meta name="cookie-domain" content="${config.cookieDomain}" />`
+        : ''
+    }
     <title>${getTitle(titleOptions)}</title>
     <link href="${nodeModulesAssetPath('bootstrap/dist/css/bootstrap.min.css')}" rel="stylesheet" />
     <link

--- a/apps/prairielearn/src/components/InstructorInfoPanel.tsx
+++ b/apps/prairielearn/src/components/InstructorInfoPanel.tsx
@@ -127,19 +127,21 @@ function InstanceUserInfo({
             ${instance_group != null ? 'Group details' : 'Student details'}
           </h3>
         </summary>
-        ${instance_group != null
-          ? html`
-              <div class="d-flex flex-wrap">
-                <div class="pe-1">${instance_group.name}</div>
-                <div class="pe-1">(${instance_group_uid_list?.join(', ')})</div>
-              </div>
-            `
-          : html`
-              <div class="d-flex flex-wrap mt-2">
-                <div class="pe-1">${instance_user?.name}</div>
-                <div class="pe-1">${instance_user?.uid}</div>
-              </div>
-            `}
+        ${
+          instance_group != null
+            ? html`
+                <div class="d-flex flex-wrap">
+                  <div class="pe-1">${instance_group.name}</div>
+                  <div class="pe-1">(${instance_group_uid_list?.join(', ')})</div>
+                </div>
+              `
+            : html`
+                <div class="d-flex flex-wrap mt-2">
+                  <div class="pe-1">${instance_user?.name}</div>
+                  <div class="pe-1">${instance_user?.uid}</div>
+                </div>
+              `
+        }
       </details>
     </div>
   `;
@@ -186,36 +188,44 @@ function QuestionInfo({
     <div class="d-flex flex-wrap">
       <div class="pe-1">QID:</div>
       <div>
-        ${questionContext === 'public'
-          ? html`<a href="${publicPreviewUrl}?variant_seed=${variant.variant_seed}">
-              ${sharingQid}
-            </a>`
-          : html`<a href="${questionPreviewUrl}">${question.qid}</a>`}
+        ${
+          questionContext === 'public'
+            ? html`<a href="${publicPreviewUrl}?variant_seed=${variant.variant_seed}">
+                ${sharingQid}
+              </a>`
+            : html`<a href="${questionPreviewUrl}">${question.qid}</a>`
+        }
       </div>
     </div>
 
-    ${question_is_shared && course.sharing_name && questionContext !== 'public'
-      ? html`
-          <div class="d-flex flex-wrap">
-            <div class="pe-1">Shared As:</div>
-            ${question.share_publicly || question.share_source_publicly
-              ? html`
-                  <div>
-                    <a href="${publicPreviewUrl}">${sharingQid}</a>
-                  </div>
-                `
-              : html`<div>${sharingQid}</div>`}
-          </div>
-        `
-      : ''}
-    ${question.title?.trim()
-      ? html`
-          <div class="d-flex flex-wrap">
-            <div class="pe-1">Title:</div>
-            <div>${question.title}</div>
-          </div>
-        `
-      : ''}
+    ${
+      question_is_shared && course.sharing_name && questionContext !== 'public'
+        ? html`
+            <div class="d-flex flex-wrap">
+              <div class="pe-1">Shared As:</div>
+              ${
+              question.share_publicly || question.share_source_publicly
+                ? html`
+                    <div>
+                      <a href="${publicPreviewUrl}">${sharingQid}</a>
+                    </div>
+                  `
+                : html`<div>${sharingQid}</div>`
+            }
+            </div>
+          `
+        : ''
+    }
+    ${
+      question.title?.trim()
+        ? html`
+            <div class="d-flex flex-wrap">
+              <div class="pe-1">Title:</div>
+              <div>${question.title}</div>
+            </div>
+          `
+        : ''
+    }
   `;
 }
 
@@ -240,18 +250,20 @@ function VariantInfo({
 
   return html`
     <h3 class="card-title h5">Variant</h3>
-    ${questionContext !== 'public'
-      ? html`
-          <div class="d-flex flex-wrap">
-            <div class="pe-1">Started at:</div>
-            <div>${date ? formatDate(date, timeZone) : '(unknown)'}</div>
-          </div>
-          <div class="d-flex flex-wrap">
-            <div class="pe-1">Duration:</div>
-            <div>${formatInterval(duration)}</div>
-          </div>
-        `
-      : ''}
+    ${
+      questionContext !== 'public'
+        ? html`
+            <div class="d-flex flex-wrap">
+              <div class="pe-1">Started at:</div>
+              <div>${date ? formatDate(date, timeZone) : '(unknown)'}</div>
+            </div>
+            <div class="d-flex flex-wrap">
+              <div class="pe-1">Duration:</div>
+              <div>${formatInterval(duration)}</div>
+            </div>
+          `
+        : ''
+    }
     <div class="d-flex flex-wrap">
       <details class="pe-1">
         <summary>Show/Hide answer</summary>
@@ -340,35 +352,43 @@ function ManualGradingInfo({
       <div>${instance_question.requires_manual_grading ? 'Requires grading' : 'Graded'}</div>
     </div>
 
-    ${instance_question.requires_manual_grading
-      ? html`
-          <div class="d-flex flex-wrap">
-            <div class="pe-1">Assigned to:</div>
-            <div>
-              ${assignedGrader?.name
-                ? `${assignedGrader.name} (${assignedGrader.uid})`
-                : (assignedGrader?.uid ?? 'Unassigned')}
+    ${
+      instance_question.requires_manual_grading
+        ? html`
+            <div class="d-flex flex-wrap">
+              <div class="pe-1">Assigned to:</div>
+              <div>
+                ${
+                assignedGrader?.name
+                  ? `${assignedGrader.name} (${assignedGrader.uid})`
+                  : (assignedGrader?.uid ?? 'Unassigned')
+              }
+              </div>
             </div>
-          </div>
-        `
-      : ''}
-    ${lastGrader
-      ? html`
-          <div class="d-flex flex-wrap">
-            <div class="pe-1">Graded by:</div>
-            <div>
-              ${lastGrader.name ? `${lastGrader.name} (${lastGrader.uid})` : lastGrader.uid}
+          `
+        : ''
+    }
+    ${
+      lastGrader
+        ? html`
+            <div class="d-flex flex-wrap">
+              <div class="pe-1">Graded by:</div>
+              <div>
+                ${lastGrader.name ? `${lastGrader.name} (${lastGrader.uid})` : lastGrader.uid}
+              </div>
             </div>
-          </div>
-        `
-      : ''}
-    ${questionContext !== 'manual_grading'
-      ? html`
-          <div class="pb-2">
-            <a href="${manualGradingUrl}">Grade</a>
-          </div>
-        `
-      : ''}
+          `
+        : ''
+    }
+    ${
+      questionContext !== 'manual_grading'
+        ? html`
+            <div class="pb-2">
+              <a href="${manualGradingUrl}">Grade</a>
+            </div>
+          `
+        : ''
+    }
   `;
 }
 

--- a/apps/prairielearn/src/components/InsufficientCoursePermissionsCard.ts
+++ b/apps/prairielearn/src/components/InsufficientCoursePermissionsCard.ts
@@ -55,21 +55,23 @@ function InsufficientCoursePermissionsCard({
         You don't have permission to view this page. It requires at least
         &quot;${requiredPermissions}&quot; permissions for this course.
       </p>
-      ${hasCoursePermissionOwn
-        ? html`<p>
-            You can grant yourself the necessary permissions on the course's
-            <a href="${urlPrefix}/course_admin/staff">Staff page</a>.
-          </p>`
-        : courseOwners.length > 0
-          ? html`
-              <p>Contact one of the below course owners to request access.</p>
-              <ul>
-                ${courseOwners.map(
+      ${
+        hasCoursePermissionOwn
+          ? html`<p>
+              You can grant yourself the necessary permissions on the course's
+              <a href="${urlPrefix}/course_admin/staff">Staff page</a>.
+            </p>`
+          : courseOwners.length > 0
+            ? html`
+                <p>Contact one of the below course owners to request access.</p>
+                <ul>
+                  ${courseOwners.map(
                   (owner) => html` <li>${owner.uid} ${owner.name ? `(${owner.name})` : ''}</li> `,
                 )}
-              </ul>
-            `
-          : ''}
+                </ul>
+              `
+            : ''
+      }
     </div>
   </div>`;
 }

--- a/apps/prairielearn/src/components/Navbar.tsx
+++ b/apps/prairielearn/src/components/Navbar.tsx
@@ -32,17 +32,19 @@ export function Navbar({
   navbarType ??= resLocals.navbarType;
 
   return html`
-    ${config.devMode && __csrf_token
-      ? // Unit tests often need access to the CSRF token even when the page contains
-        // no form - for example, to confirm that a POST with a prohibited
-        // action is denied. For convenience, we include the CSRF token here, on
-        // all pages. We do this only in devMode and only for the purpose of
-        // testing.
-        html`
-          <!-- DO NOT RELY ON OR USE THIS CSRF TOKEN FOR ANYTHING OTHER THAN UNIT TESTS! -->
-          <span id="test_csrf_token" hidden>${__csrf_token}</span>
-        `
-      : ''}
+    ${
+      config.devMode && __csrf_token
+        ? // Unit tests often need access to the CSRF token even when the page contains
+          // no form - for example, to confirm that a POST with a prohibited
+          // action is denied. For convenience, we include the CSRF token here, on
+          // all pages. We do this only in devMode and only for the purpose of
+          // testing.
+          html`
+            <!-- DO NOT RELY ON OR USE THIS CSRF TOKEN FOR ANYTHING OTHER THAN UNIT TESTS! -->
+            <span id="test_csrf_token" hidden>${__csrf_token}</span>
+          `
+        : ''
+    }
 
     <nav
       class="container-fluid bg-primary visually-hidden-focusable"
@@ -59,31 +61,35 @@ export function Navbar({
       </a>
     </nav>
 
-    ${config.announcementHtml
-      ? html`
-          <div
-            class="alert alert-${config.announcementColor ?? 'primary'} mb-0 rounded-0 text-center"
-          >
-            ${unsafeHtml(config.announcementHtml)}
-          </div>
-        `
-      : ''}
+    ${
+      config.announcementHtml
+        ? html`
+            <div
+              class="alert alert-${config.announcementColor ?? 'primary'} mb-0 rounded-0 text-center"
+            >
+              ${unsafeHtml(config.announcementHtml)}
+            </div>
+          `
+        : ''
+    }
 
     <nav class="navbar navbar-dark bg-dark navbar-expand-md" aria-label="Global navigation">
       <div class="container-fluid position-relative">
-        ${sideNavEnabled
-          ? html`
-              <button
-                id="side-nav-mobile-toggler"
-                class="navbar-toggler"
-                type="button"
-                aria-expanded="false"
-                aria-label="Toggle side nav"
-              >
-                <span class="navbar-toggler-icon"></span>
-              </button>
-            `
-          : ''}
+        ${
+          sideNavEnabled
+            ? html`
+                <button
+                  id="side-nav-mobile-toggler"
+                  class="navbar-toggler"
+                  type="button"
+                  aria-expanded="false"
+                  aria-label="Toggle side nav"
+                >
+                  <span class="navbar-toggler-icon"></span>
+                </button>
+              `
+            : ''
+        }
         <a class="navbar-brand" href="/" aria-label="Homepage">
           <span class="navbar-brand-label">PrairieLearn</span>
           <span class="navbar-brand-hover-label">
@@ -111,29 +117,33 @@ export function Navbar({
             })}
           </ul>
 
-          ${config.devMode
-            ? html`
-                <a
-                  id="navbar-load-from-disk"
-                  class="btn btn-success btn-sm"
-                  href="/pl/loadFromDisk"
-                >
-                  Load from disk
-                </a>
-              `
-            : ''}
+          ${
+            config.devMode
+              ? html`
+                  <a
+                    id="navbar-load-from-disk"
+                    class="btn btn-success btn-sm"
+                    href="/pl/loadFromDisk"
+                  >
+                    Load from disk
+                  </a>
+                `
+              : ''
+          }
           ${EndExamControl({ resLocals })} ${UserDropdownMenu({ resLocals, navPage, navbarType })}
         </div>
       </div>
     </nav>
 
-    ${navbarType === 'instructor' && course?.announcement_html && course.announcement_color
-      ? html`
-          <div class="alert alert-${course.announcement_color} mb-0 rounded-0 text-center">
-            ${unsafeHtml(course.announcement_html)}
-          </div>
-        `
-      : ''}
+    ${
+      navbarType === 'instructor' && course?.announcement_html && course.announcement_color
+        ? html`
+            <div class="alert alert-${course.announcement_color} mb-0 rounded-0 text-center">
+              ${unsafeHtml(course.announcement_html)}
+            </div>
+          `
+        : ''
+    }
     ${FlashMessages()}
   `;
 }
@@ -307,31 +317,39 @@ function UserDropdownMenu({
           ${displayedName}
         </a>
         <div class="dropdown-menu dropdown-menu-end">
-          ${authn_is_administrator
-            ? html`
-                <button type="button" class="dropdown-item" id="navbar-administrator-toggle">
-                  ${access_as_administrator
-                    ? 'Turn off administrator access'
-                    : 'Turn on administrator access'}
-                </button>
+          ${
+            authn_is_administrator
+              ? html`
+                  <button type="button" class="dropdown-item" id="navbar-administrator-toggle">
+                    ${
+                    access_as_administrator
+                      ? 'Turn off administrator access'
+                      : 'Turn on administrator access'
+                  }
+                  </button>
 
-                <div class="dropdown-divider"></div>
-              `
-            : ''}
+                  <div class="dropdown-divider"></div>
+                `
+              : ''
+          }
           ${ViewTypeMenu({ resLocals })} ${AuthnOverrides({ resLocals, navbarType })}
-          ${authz_data?.mode === 'Exam'
-            ? html`
-                <div class="dropdown-item-text">
-                  Exam mode means you have a checked-in reservation on PrairieTest. Your
-                  interactions with PrairieLearn are limited to your checked-in exam for the
-                  duration of your reservation.
-                </div>
-                <div class="dropdown-divider"></div>
-              `
-            : ''}
-          ${!authz_data || authz_data?.mode === 'Public'
-            ? html`<a class="dropdown-item" href="/pl/request_course">Course Requests</a>`
-            : ''}
+          ${
+            authz_data?.mode === 'Exam'
+              ? html`
+                  <div class="dropdown-item-text">
+                    Exam mode means you have a checked-in reservation on PrairieTest. Your
+                    interactions with PrairieLearn are limited to your checked-in exam for the
+                    duration of your reservation.
+                  </div>
+                  <div class="dropdown-divider"></div>
+                `
+              : ''
+          }
+          ${
+            !authz_data || authz_data?.mode === 'Public'
+              ? html`<a class="dropdown-item" href="/pl/request_course">Course Requests</a>`
+              : ''
+          }
           <a class="dropdown-item" href="/pl/settings">Settings</a>
           <a class="dropdown-item" href="/pl/logout">Log out</a>
         </div>
@@ -362,9 +380,9 @@ function FlashMessages() {
   return flashMessages.map(
     ({ type, message }) => html`
       <div
-        class="alert alert-${globalFlashColors[
-          type
-        ]} border-start-0 border-end-0 rounded-0 mt-0 mb-0 alert-dismissible fade show"
+        class="alert alert-${
+          globalFlashColors[type]
+        } border-start-0 border-end-0 rounded-0 mt-0 mb-0 alert-dismissible fade show"
         role="alert"
       >
         ${unsafeHtml(message)}
@@ -487,16 +505,18 @@ function ViewTypeMenu({ resLocals }: { resLocals: UntypedResLocals }) {
   }
 
   return html`
-    ${authz_data?.overrides?.length > 0 && authnViewTypeMenuChecked === 'instructor'
-      ? html`
-          <a class="dropdown-item" href="${instructorLink}" id="navbar-reset-view">
-            Reset to default staff view
-            <span class="badge text-bg-success">staff</span>
-          </a>
+    ${
+      authz_data?.overrides?.length > 0 && authnViewTypeMenuChecked === 'instructor'
+        ? html`
+            <a class="dropdown-item" href="${instructorLink}" id="navbar-reset-view">
+              Reset to default staff view
+              <span class="badge text-bg-success">staff</span>
+            </a>
 
-          <div class="dropdown-divider"></div>
-        `
-      : ''}
+            <div class="dropdown-divider"></div>
+          `
+        : ''
+    }
 
     <h6 class="dropdown-header">${headingAuthnViewTypeMenu}</h6>
 
@@ -507,9 +527,11 @@ function ViewTypeMenu({ resLocals }: { resLocals: UntypedResLocals }) {
     >
       <span class="${authnViewTypeMenuChecked !== 'instructor' ? 'invisible' : ''}">&check;</span>
       <span class="ps-3">
-        ${authz_data?.overrides?.length > 0 && authnViewTypeMenuChecked === 'instructor'
-          ? 'Modified staff'
-          : 'Staff'}
+        ${
+          authz_data?.overrides?.length > 0 && authnViewTypeMenuChecked === 'instructor'
+            ? 'Modified staff'
+            : 'Staff'
+        }
         view <span class="badge text-bg-success">staff</span>
       </span>
     </a>
@@ -537,35 +559,43 @@ function ViewTypeMenu({ resLocals }: { resLocals: UntypedResLocals }) {
       </span>
     </a>
 
-    ${authz_data.authn_user.uid !== authz_data.user.uid
-      ? html`
-          <div class="dropdown-divider"></div>
-          <h6 class="dropdown-header">${headingViewTypeMenu}</h6>
+    ${
+      authz_data.authn_user.uid !== authz_data.user.uid
+        ? html`
+            <div class="dropdown-divider"></div>
+            <h6 class="dropdown-header">${headingViewTypeMenu}</h6>
 
-          ${authz_data.user_with_requested_uid_has_instructor_access_to_course_instance
-            ? html`
-                <a class="dropdown-item" href="${instructorLink}" id="navbar-user-view-instructor">
-                  <span class="${viewTypeMenuChecked !== 'instructor' ? 'invisible' : ''}">
-                    &check;
-                  </span>
-                  <span class="ps-3">Staff view</span>
-                </a>
-              `
-            : ''}
+            ${
+            authz_data.user_with_requested_uid_has_instructor_access_to_course_instance
+              ? html`
+                  <a
+                    class="dropdown-item"
+                    href="${instructorLink}"
+                    id="navbar-user-view-instructor"
+                  >
+                    <span class="${viewTypeMenuChecked !== 'instructor' ? 'invisible' : ''}">
+                      &check;
+                    </span>
+                    <span class="ps-3">Staff view</span>
+                  </a>
+                `
+              : ''
+          }
 
-          <a class="dropdown-item" href="${studentLink}" id="navbar-user-view-student">
-            <span class="${viewTypeMenuChecked !== 'student' ? 'invisible' : ''}"> &check; </span>
-            <span class="ps-3">Student view</span>
-          </a>
+            <a class="dropdown-item" href="${studentLink}" id="navbar-user-view-student">
+              <span class="${viewTypeMenuChecked !== 'student' ? 'invisible' : ''}"> &check; </span>
+              <span class="ps-3">Student view</span>
+            </a>
 
-          <a class="dropdown-item" href="${studentLink}" id="navbar-user-view-student-no-rules">
-            <span class="${viewTypeMenuChecked !== 'student-no-rules' ? 'invisible' : ''}">
-              &check;
-            </span>
-            <span class="ps-3">Student view without access restrictions</span>
-          </a>
-        `
-      : ''}
+            <a class="dropdown-item" href="${studentLink}" id="navbar-user-view-student-no-rules">
+              <span class="${viewTypeMenuChecked !== 'student-no-rules' ? 'invisible' : ''}">
+                &check;
+              </span>
+              <span class="ps-3">Student view without access restrictions</span>
+            </a>
+          `
+        : ''
+    }
 
     <div class="dropdown-divider"></div>
   `;
@@ -632,11 +662,12 @@ function AuthnOverrides({
       </button>
     </form>
 
-    ${authz_data?.overrides?.length > 0
-      ? html`
-          <div class="dropdown-item-text">
-            <div class="list-group small text-nowrap">
-              ${authz_data.overrides.map(
+    ${
+      authz_data?.overrides?.length > 0
+        ? html`
+            <div class="dropdown-item-text">
+              <div class="list-group small text-nowrap">
+                ${authz_data.overrides.map(
                 (override: Override) => html`
                   <div class="list-group-item list-group-item-warning small p-2">
                     <div class="d-flex flex-row justify-content-between align-items-center">
@@ -660,10 +691,11 @@ function AuthnOverrides({
                   </div>
                 `,
               )}
+              </div>
             </div>
-          </div>
-        `
-      : ''}
+          `
+        : ''
+    }
 
     <a class="dropdown-item" href="${effectiveUserUrl}">Customize&hellip;</a>
 
@@ -686,13 +718,15 @@ function NavbarButton({
     <li class="nav-item">
       <a class="nav-link ${active ? 'active' : ''}" href="${href}">${text}</a>
     </li>
-    ${showArrow
-      ? html`<li class="nav-item d-none d-lg-block" aria-hidden="true">
-          <span class="nav-link disabled px-0" style="color: var(--bs-nav-link-color);">
-            &rarr;
-          </span>
-        </li>`
-      : ''}
+    ${
+      showArrow
+        ? html`<li class="nav-item d-none d-lg-block" aria-hidden="true">
+            <span class="nav-link disabled px-0" style="color: var(--bs-nav-link-color);">
+              &rarr;
+            </span>
+          </li>`
+        : ''
+    }
   `;
 }
 
@@ -718,13 +752,15 @@ function NavbarButtons({
         href: '/',
         showArrow: false,
       })}
-      ${resLocals.is_administrator
-        ? NavbarButton({
-            text: 'Global Admin',
-            href: '/pl/administrator/admins',
-            showArrow: false,
-          })
-        : ''}
+      ${
+        resLocals.is_administrator
+          ? NavbarButton({
+              text: 'Global Admin',
+              href: '/pl/administrator/admins',
+              showArrow: false,
+            })
+          : ''
+      }
     `;
   }
 
@@ -806,15 +842,17 @@ function NavbarStudent({ resLocals, navPage }: { resLocals: UntypedResLocals; na
       <a class="nav-link" href="${urlPrefix}/gradebook">Gradebook</a>
     </li>
 
-    ${assessment_instance_label != null && assessment_instance != null
-      ? html`
-          <li class="nav-item ${navPage === 'assessment_instance' ? 'active' : ''}">
-            <a class="nav-link" href="${urlPrefix}/assessment_instance/${assessment_instance.id}">
-              ${assessment_instance_label}
-            </a>
-          </li>
-        `
-      : ''}
+    ${
+      assessment_instance_label != null && assessment_instance != null
+        ? html`
+            <li class="nav-item ${navPage === 'assessment_instance' ? 'active' : ''}">
+              <a class="nav-link" href="${urlPrefix}/assessment_instance/${assessment_instance.id}">
+                ${assessment_instance_label}
+              </a>
+            </li>
+          `
+        : ''
+    }
   `;
 }
 

--- a/apps/prairielearn/src/components/PageLayout.tsx
+++ b/apps/prairielearn/src/components/PageLayout.tsx
@@ -358,32 +358,36 @@ export function PageLayout({
             resolvedOptions.showFooter && 'flex-grow-1',
           )}"
         >
-          ${resolvedOptions.enableNavbar
-            ? html`<div class="app-top-nav">
-                ${Navbar({
+          ${
+            resolvedOptions.enableNavbar
+              ? html`<div class="app-top-nav">
+                  ${Navbar({
                   resLocals,
                   navPage: navContext.page,
                   navSubPage: navContext.subPage,
                   navbarType: navContext.type,
                   sideNavEnabled,
                 })}
-              </div>`
-            : ''}
-          ${sideNavEnabled
-            ? html`
-                <nav class="app-side-nav bg-light border-end" aria-label="Course navigation">
-                  <div class="app-side-nav-scroll">
-                    ${SideNav({
+                </div>`
+              : ''
+          }
+          ${
+            sideNavEnabled
+              ? html`
+                  <nav class="app-side-nav bg-light border-end" aria-label="Course navigation">
+                    <div class="app-side-nav-scroll">
+                      ${SideNav({
                       resLocals,
                       page: navContext.page,
                       subPage: navContext.subPage,
                       sideNavExpanded,
                       persistToggleState: resolvedOptions.forcedInitialNavToggleState === undefined,
                     })}
-                  </div>
-                </nav>
-              `
-            : ''}
+                    </div>
+                  </nav>
+                `
+              : ''
+          }
           <div class="${clsx(sideNavEnabled && 'app-main', resolvedOptions.fullHeight && 'h-100')}">
             <div
               class="${clsx(

--- a/apps/prairielearn/src/components/PersonalNotesPanel.tsx
+++ b/apps/prairielearn/src/components/PersonalNotesPanel.tsx
@@ -33,11 +33,12 @@ export function PersonalNotesPanel({
         <i class="fas fa-paperclip"></i>
         <h2>&nbsp;Personal Notes</h2>
       </div>
-      ${fileList.length === 0
-        ? html`<div class="card-body"><i>No attached notes</i></div>`
-        : html`
-            <ul class="list-group list-group-flush">
-              ${fileList.map(
+      ${
+        fileList.length === 0
+          ? html`<div class="card-body"><i>No attached notes</i></div>`
+          : html`
+              <ul class="list-group list-group-flush">
+                ${fileList.map(
                 (file) => html`
                   <li class="list-group-item d-flex align-items-center">
                     <a
@@ -47,45 +48,52 @@ export function PersonalNotesPanel({
                     >
                       ${file.display_filename}
                     </a>
-                    ${assessment_instance.open &&
-                    authz_result.active &&
-                    authz_result.authorized_edit &&
-                    allowNewUploads &&
-                    file.type === 'student_upload'
-                      ? html`
-                          <div class="ms-auto">
-                            ${DeletePersonalNoteButton({ file, variantId, csrfToken })}
-                          </div>
-                        `
-                      : ''}
+                    ${
+                      assessment_instance.open &&
+                      authz_result.active &&
+                      authz_result.authorized_edit &&
+                      allowNewUploads &&
+                      file.type === 'student_upload'
+                        ? html`
+                            <div class="ms-auto">
+                              ${DeletePersonalNoteButton({ file, variantId, csrfToken })}
+                            </div>
+                          `
+                        : ''
+                    }
                   </li>
                 `,
               )}
-            </ul>
-          `}
-      ${allowNewUploads
-        ? html`
-            <div class="card-footer">
-              ${!assessment_instance.open || !authz_result.active
-                ? html`
-                    <p class="small mb-0">
-                      Notes can't be added or deleted because the assessment is closed.
-                    </p>
-                  `
-                : !authz_result.authorized_edit
+              </ul>
+            `
+      }
+      ${
+        allowNewUploads
+          ? html`
+              <div class="card-footer">
+                ${
+                !assessment_instance.open || !authz_result.active
                   ? html`
-                      <div class="alert alert-warning mb-0" role="alert">
-                        You are viewing the ${context} instance of a different user and so are not
-                        authorized to add or delete personal notes.
-                      </div>
+                      <p class="small mb-0">
+                        Notes can't be added or deleted because the assessment is closed.
+                      </p>
                     `
-                  : html`
-                      ${lockdownBrowser ? '' : AttachFileForm({ variantId, csrfToken })}
-                      ${UploadTextForm({ variantId, csrfToken })}
-                    `}
-            </div>
-          `
-        : ''}
+                  : !authz_result.authorized_edit
+                    ? html`
+                        <div class="alert alert-warning mb-0" role="alert">
+                          You are viewing the ${context} instance of a different user and so are not
+                          authorized to add or delete personal notes.
+                        </div>
+                      `
+                    : html`
+                        ${lockdownBrowser ? '' : AttachFileForm({ variantId, csrfToken })}
+                        ${UploadTextForm({ variantId, csrfToken })}
+                      `
+              }
+              </div>
+            `
+          : ''
+      }
     </div>
   `;
 }
@@ -123,9 +131,11 @@ function AttachFileForm({ variantId, csrfToken }: { variantId?: string; csrfToke
           </div>
           <div class="mb-3">
             <input type="hidden" name="__action" value="attach_file" />
-            ${variantId != null
-              ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
-              : ''}
+            ${
+              variantId != null
+                ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
+                : ''
+            }
             <input type="hidden" name="__csrf_token" value="${csrfToken}" />
             <button type="submit" class="btn btn-primary" disabled>Attach file</button>
           </div>
@@ -181,9 +191,11 @@ function UploadTextForm({ variantId, csrfToken }: { variantId?: string; csrfToke
               placeholder="Type or paste text here"
             ></textarea>
           </div>
-          ${variantId != null
-            ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
-            : ''}
+          ${
+            variantId != null
+              ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
+              : ''
+          }
           <input type="hidden" name="__csrf_token" value="${csrfToken}" />
           <button type="submit" class="btn btn-sm btn-primary" name="__action" value="attach_text">
             Add note
@@ -208,9 +220,11 @@ function DeletePersonalNoteButton({
       <p>Are you sure you want to delete <strong>${file.display_filename}</strong>?</p>
       <input type="hidden" name="__action" value="delete_file" />
       <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-      ${variantId != null
-        ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
-        : ''}
+      ${
+        variantId != null
+          ? html`<input type="hidden" name="__variant_id" value="${variantId}" />`
+          : ''
+      }
       <input type="hidden" name="file_id" value="${file.id}" />
       <div class="text-end">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="popover">Cancel</button>

--- a/apps/prairielearn/src/components/QuestionContainer.tsx
+++ b/apps/prairielearn/src/components/QuestionContainer.tsx
@@ -80,16 +80,19 @@ export function QuestionContainer({
       data-variant-token="${variantToken}"
       data-workspace-id="${variant.workspace_id}"
     >
-      ${question.type !== 'Freeform'
-        ? html`<div hidden class="question-data">${questionJsonBase64}</div>`
-        : ''}
+      ${
+        question.type !== 'Freeform'
+          ? html`<div hidden class="question-data">${questionJsonBase64}</div>`
+          : ''
+      }
       ${issues.map((issue: IssueRenderData) =>
         IssuePanel({ issue, course, course_instance, authz_data, is_administrator }),
       )}
-      ${question.type === 'Freeform'
-        ? html`
-            <form class="question-form" name="question-form" method="POST" autocomplete="off">
-              ${QuestionPanel({
+      ${
+        question.type === 'Freeform'
+          ? html`
+              <form class="question-form" name="question-form" method="POST" autocomplete="off">
+                ${QuestionPanel({
                 resLocals,
                 questionContext,
                 questionRenderContext,
@@ -98,9 +101,10 @@ export function QuestionContainer({
                 aiGradingPreviewUrl,
                 questionCopyTargets,
               })}
-            </form>
-          `
-        : QuestionPanel({ resLocals, showFooter, questionContext })}
+              </form>
+            `
+          : QuestionPanel({ resLocals, showFooter, questionContext })
+      }
       ${
         // The correct answer isn't used when performing AI grading, so we hide
         // it here to avoid confusion.
@@ -117,25 +121,30 @@ export function QuestionContainer({
             `
           : ''
       }
-      ${['instructor', 'manual_grading'].includes(questionContext)
-        ? html`
-            <div class="js-ai-grading-explanation-slot">
-              ${aiGradingInfo
-                ? AIGradingExplanation({
-                    explanation: aiGradingInfo.explanation,
-                    hasImage: aiGradingInfo.hasImage,
-                    rotationCorrectionDegrees: aiGradingInfo.rotationCorrectionDegrees,
-                  })
-                : ''}
-            </div>
-            <div class="js-ai-grading-prompt-slot">
-              ${aiGradingInfo?.prompt ? AIGradingPrompt({ prompt: aiGradingInfo.prompt }) : ''}
-            </div>
-          `
-        : ''}
-      ${submissions.length > 0
-        ? html`
-            ${SubmissionList({
+      ${
+        ['instructor', 'manual_grading'].includes(questionContext)
+          ? html`
+              <div class="js-ai-grading-explanation-slot">
+                ${
+                aiGradingInfo
+                  ? AIGradingExplanation({
+                      explanation: aiGradingInfo.explanation,
+                      hasImage: aiGradingInfo.hasImage,
+                      rotationCorrectionDegrees: aiGradingInfo.rotationCorrectionDegrees,
+                    })
+                  : ''
+              }
+              </div>
+              <div class="js-ai-grading-prompt-slot">
+                ${aiGradingInfo?.prompt ? AIGradingPrompt({ prompt: aiGradingInfo.prompt }) : ''}
+              </div>
+            `
+          : ''
+      }
+      ${
+        submissions.length > 0
+          ? html`
+              ${SubmissionList({
               resLocals,
               questionContext,
               questionRenderContext,
@@ -144,24 +153,25 @@ export function QuestionContainer({
               submissionCount: submissions.length,
               renderSubmissionSearchParams,
             })}
-            ${submissions.length > MAX_TOP_RECENTS
-              ? html`
-                  <div class="mb-3 d-flex justify-content-center">
-                    <button
-                      class="btn btn-outline-secondary btn-sm show-hide-btn collapsed"
-                      type="button"
-                      data-bs-toggle="collapse"
-                      data-bs-target="#more-submissions-collapser"
-                      aria-expanded="false"
-                      aria-controls="more-submissions-collapser"
-                    >
-                      Show/hide older submissions
-                      <i class="fa fa-angle-up ms-1 expand-icon"></i>
-                    </button>
-                  </div>
+              ${
+              submissions.length > MAX_TOP_RECENTS
+                ? html`
+                    <div class="mb-3 d-flex justify-content-center">
+                      <button
+                        class="btn btn-outline-secondary btn-sm show-hide-btn collapsed"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#more-submissions-collapser"
+                        aria-expanded="false"
+                        aria-controls="more-submissions-collapser"
+                      >
+                        Show/hide older submissions
+                        <i class="fa fa-angle-up ms-1 expand-icon"></i>
+                      </button>
+                    </div>
 
-                  <div id="more-submissions-collapser" class="collapse">
-                    ${SubmissionList({
+                    <div id="more-submissions-collapser" class="collapse">
+                      ${SubmissionList({
                       resLocals,
                       questionContext,
                       questionRenderContext,
@@ -170,11 +180,13 @@ export function QuestionContainer({
                       submissionCount: submissions.length,
                       renderSubmissionSearchParams,
                     })}
-                  </div>
-                `
-              : ''}
-          `
-        : ''}
+                    </div>
+                  `
+                : ''
+            }
+            `
+          : ''
+      }
       ${CopyQuestionModal({ resLocals, questionCopyTargets })}
     </div>
   `;
@@ -247,22 +259,23 @@ export function AIGradingExplanation({
         id="ai-grading-explanation-body"
       >
         <div class="card-body">
-          ${hasImage && rotationCorrectionApplied
-            ? html`<div class="alert alert-warning mb-3" role="alert">
-                <p>
-                  One or more images were uploaded in a rotated state by the student (this was an
-                  error by the student). The system corrected their rotation prior to AI grading.
-                </p>
-                <div class="card table-responsive mb-0" style="max-width: 800px;">
-                  <table class="table table-sm mb-0">
-                    <thead class="table-light">
-                      <tr>
-                        <th class="text-nowrap">Filename</th>
-                        <th class="text-nowrap">Correction (counterclockwise)</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      ${Object.entries(rotationCorrectionDegrees).map(
+          ${
+            hasImage && rotationCorrectionApplied
+              ? html`<div class="alert alert-warning mb-3" role="alert">
+                  <p>
+                    One or more images were uploaded in a rotated state by the student (this was an
+                    error by the student). The system corrected their rotation prior to AI grading.
+                  </p>
+                  <div class="card table-responsive mb-0" style="max-width: 800px;">
+                    <table class="table table-sm mb-0">
+                      <thead class="table-light">
+                        <tr>
+                          <th class="text-nowrap">Filename</th>
+                          <th class="text-nowrap">Correction (counterclockwise)</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        ${Object.entries(rotationCorrectionDegrees).map(
                         ([filename, degrees]) => html`
                           <tr>
                             <td class="text-nowrap"><code>${filename}</code></td>
@@ -270,18 +283,21 @@ export function AIGradingExplanation({
                           </tr>
                         `,
                       )}
-                    </tbody>
-                  </table>
-                </div>
-              </div>`
-            : ''}
-          ${explanation
-            ? html`
-                <pre class="mb-0 overflow-visible mathjax_process" style="white-space: pre-wrap;">
+                      </tbody>
+                    </table>
+                  </div>
+                </div>`
+              : ''
+          }
+          ${
+            explanation
+              ? html`
+                  <pre class="mb-0 overflow-visible mathjax_process" style="white-space: pre-wrap;">
 ${explanation}
 </pre>
-              `
-            : ''}
+                `
+              : ''
+          }
         </div>
       </div>
     </div>
@@ -336,26 +352,17 @@ function IssuePanel({
           aria-label="Issue information"
         >
           <tbody>
-            ${showUserName
-              ? html`
-                  <tr>
-                    <th>User:</th>
-                    <td>
-                      ${issue.user_name || '-'} (<a href="${mailtoLink}">${issue.user_uid || '-'}</a
-                      >)
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>Student message:</th>
-                    <td style="white-space: pre-wrap;">${issue.student_message}</td>
-                  </tr>
-                  <tr>
-                    <th>Instructor message:</th>
-                    <td>${issue.instructor_message}</td>
-                  </tr>
-                `
-              : authz_data.has_course_permission_preview
+            ${
+              showUserName
                 ? html`
+                    <tr>
+                      <th>User:</th>
+                      <td>
+                        ${issue.user_name || '-'} (<a href="${mailtoLink}"
+                          >${issue.user_uid || '-'}</a
+                        >)
+                      </td>
+                    </tr>
                     <tr>
                       <th>Student message:</th>
                       <td style="white-space: pre-wrap;">${issue.student_message}</td>
@@ -365,12 +372,24 @@ function IssuePanel({
                       <td>${issue.instructor_message}</td>
                     </tr>
                   `
-                : html`
-                    <tr>
-                      <th>Message:</th>
-                      <td style="white-space: pre-wrap;">${issue.student_message}</td>
-                    </tr>
-                  `}
+                : authz_data.has_course_permission_preview
+                  ? html`
+                      <tr>
+                        <th>Student message:</th>
+                        <td style="white-space: pre-wrap;">${issue.student_message}</td>
+                      </tr>
+                      <tr>
+                        <th>Instructor message:</th>
+                        <td>${issue.instructor_message}</td>
+                      </tr>
+                    `
+                  : html`
+                      <tr>
+                        <th>Message:</th>
+                        <td style="white-space: pre-wrap;">${issue.student_message}</td>
+                      </tr>
+                    `
+            }
             <tr>
               <th>ID:</th>
               <td>${issue.id}</td>
@@ -388,60 +407,63 @@ function IssuePanel({
         </table>
       </div>
 
-      ${config.devMode || authz_data.has_course_permission_view
-        ? html`
-            <div class="card-body border border-bottom-0 border-start-0 border-end-0">
-              ${issue.system_data?.courseErrData
-                ? html`
-                    <p><strong>Console log:</strong></p>
-                    <pre class="bg-dark text-white rounded p-3">
-${unsafeHtml(ansiToHtml(issue.system_data.courseErrData.outputBoth))}</pre
-                    >
-                  `
-                : ''}
-              <p>
-                <strong>Associated data:</strong>
-                <button
-                  type="button"
-                  class="btn btn-xs btn-secondary"
-                  data-bs-toggle="collapse"
-                  href="#issue-course-data-${issue.id}"
-                  aria-expanded="false"
-                  aria-controls="#issue-course-data-${issue.id}"
-                >
-                  Show/hide
-                </button>
-              </p>
-              <div class="collapse" id="issue-course-data-${issue.id}">
-                <pre class="bg-dark text-white rounded p-3">
-${JSON.stringify(issue.course_data, null, '    ')}</pre
-                >
-              </div>
-              ${is_administrator
-                ? html`
-                    <p>
-                      <strong>System data:</strong>
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-secondary"
-                        data-bs-toggle="collapse"
-                        href="#issue-system-data-${issue.id}"
-                        aria-expanded="false"
-                        aria-controls="#issue-system-data-${issue.id}"
-                      >
-                        Show/hide
-                      </button>
-                    </p>
-                    <div class="collapse" id="issue-system-data-${issue.id}">
+      ${
+        config.devMode || authz_data.has_course_permission_view
+          ? html`
+              <div class="card-body border border-bottom-0 border-start-0 border-end-0">
+                ${
+                issue.system_data?.courseErrData
+                  ? html`
+                      <p><strong>Console log:</strong></p>
                       <pre class="bg-dark text-white rounded p-3">
-${JSON.stringify(issue.system_data, null, '    ')}</pre
-                      >
-                    </div>
-                  `
-                : ''}
-            </div>
-          `
-        : ''}
+${unsafeHtml(ansiToHtml(issue.system_data.courseErrData.outputBoth))}</pre>
+                    `
+                  : ''
+              }
+                <p>
+                  <strong>Associated data:</strong>
+                  <button
+                    type="button"
+                    class="btn btn-xs btn-secondary"
+                    data-bs-toggle="collapse"
+                    href="#issue-course-data-${issue.id}"
+                    aria-expanded="false"
+                    aria-controls="#issue-course-data-${issue.id}"
+                  >
+                    Show/hide
+                  </button>
+                </p>
+                <div class="collapse" id="issue-course-data-${issue.id}">
+                  <pre class="bg-dark text-white rounded p-3">
+${JSON.stringify(issue.course_data, null, '    ')}</pre>
+                </div>
+                ${
+                is_administrator
+                  ? html`
+                      <p>
+                        <strong>System data:</strong>
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-secondary"
+                          data-bs-toggle="collapse"
+                          href="#issue-system-data-${issue.id}"
+                          aria-expanded="false"
+                          aria-controls="#issue-system-data-${issue.id}"
+                        >
+                          Show/hide
+                        </button>
+                      </p>
+                      <div class="collapse" id="issue-system-data-${issue.id}">
+                        <pre class="bg-dark text-white rounded p-3">
+${JSON.stringify(issue.system_data, null, '    ')}</pre>
+                      </div>
+                    `
+                  : ''
+              }
+              </div>
+            `
+          : ''
+      }
     </div>
   `;
 }
@@ -593,124 +615,141 @@ export function QuestionFooterContent({
       <div class="row">
         <div class="col d-flex justify-content-between flex-wrap gap-2">
           <span class="d-flex align-items-center">
-            ${showSaveButton
-              ? html`
-                  <button
-                    type="submit"
-                    class="btn btn-info question-save disable-on-submit order-2"
-                    ${disableSaveButton ? 'disabled' : ''}
-                    ${question.type === 'Freeform' ? html`name="__action" value="save"` : ''}
-                  >
-                    ${showGradeButton ? 'Save only' : 'Save'}
-                  </button>
-                `
-              : ''}
-            ${showGradeButton
-              ? html`
-                  <button
-                    type="submit"
-                    class="btn btn-primary question-grade disable-on-submit order-1 me-1"
-                    ${disableGradeButton ? 'disabled' : ''}
-                    ${question.type === 'Freeform' ? html`name="__action" value="grade"` : ''}
-                  >
-                    Save &amp; Grade
-                    ${variantAttemptsTotal > 0
-                      ? variantAttemptsLeft > 1
-                        ? html`
-                            <small class="fst-italic ms-2">
-                              ${variantAttemptsLeft} attempts left
-                            </small>
-                          `
-                        : variantAttemptsLeft === 1 && variantAttemptsTotal > 1
-                          ? html`<small class="fst-italic ms-2">Last attempt</small>`
-                          : variantAttemptsLeft === 1
-                            ? html`<small class="fst-italic ms-2">Single attempt</small>`
-                            : ''
-                      : questionContext === 'student_homework'
-                        ? html`<small class="fst-italic ms-2">Unlimited attempts</small>`
-                        : ''}
-                  </button>
-                `
-              : ''}
-            ${group_config?.has_roles && !group_role_permissions?.can_submit && group_info
-              ? html`
-                  <button
-                    type="button"
-                    class="btn btn-xs btn-ghost me-1"
-                    data-bs-toggle="popover"
-                    data-bs-content="Your group role (${getRoleNamesForUser(group_info, user).join(
-                      ', ',
-                    )}) is not allowed to submit this question."
-                    aria-label="Submission blocked"
-                  >
-                    <i class="fa fa-lock" aria-hidden="true"></i>
-                  </button>
-                `
-              : ''}
+            ${
+              showSaveButton
+                ? html`
+                    <button
+                      type="submit"
+                      class="btn btn-info question-save disable-on-submit order-2"
+                      ${disableSaveButton ? 'disabled' : ''}
+                      ${question.type === 'Freeform' ? html`name="__action" value="save"` : ''}
+                    >
+                      ${showGradeButton ? 'Save only' : 'Save'}
+                    </button>
+                  `
+                : ''
+            }
+            ${
+              showGradeButton
+                ? html`
+                    <button
+                      type="submit"
+                      class="btn btn-primary question-grade disable-on-submit order-1 me-1"
+                      ${disableGradeButton ? 'disabled' : ''}
+                      ${question.type === 'Freeform' ? html`name="__action" value="grade"` : ''}
+                    >
+                      Save &amp; Grade
+                      ${
+                      variantAttemptsTotal > 0
+                        ? variantAttemptsLeft > 1
+                          ? html`
+                              <small class="fst-italic ms-2">
+                                ${variantAttemptsLeft} attempts left
+                              </small>
+                            `
+                          : variantAttemptsLeft === 1 && variantAttemptsTotal > 1
+                            ? html`<small class="fst-italic ms-2">Last attempt</small>`
+                            : variantAttemptsLeft === 1
+                              ? html`<small class="fst-italic ms-2">Single attempt</small>`
+                              : ''
+                        : questionContext === 'student_homework'
+                          ? html`<small class="fst-italic ms-2">Unlimited attempts</small>`
+                          : ''
+                    }
+                    </button>
+                  `
+                : ''
+            }
+            ${
+              group_config?.has_roles && !group_role_permissions?.can_submit && group_info
+                ? html`
+                    <button
+                      type="button"
+                      class="btn btn-xs btn-ghost me-1"
+                      data-bs-toggle="popover"
+                      data-bs-content="Your group role (${getRoleNamesForUser(
+                      group_info,
+                      user,
+                    ).join(', ')}) is not allowed to submit this question."
+                      aria-label="Submission blocked"
+                    >
+                      <i class="fa fa-lock" aria-hidden="true"></i>
+                    </button>
+                  `
+                : ''
+            }
           </span>
           <div class="d-flex">
-            ${question.type === 'Freeform'
-              ? html`
-                  <input
-                    type="hidden"
-                    name="__variant_id"
-                    value="${variant.id}"
-                    data-skip-unload-check="true"
-                  />
-                `
-              : html`
-                  <input type="hidden" name="postData" class="postData" />
-                  <input type="hidden" name="__action" class="__action" />
-                `}
-            ${showNewVariantButton
-              ? html`
-                  <a
-                    href="${newVariantUrl}"
-                    class="btn btn-primary disable-on-click ms-1 js-new-variant-button"
-                  >
-                    New variant
-                  </a>
-                `
-              : showTryAgainButton
+            ${
+              question.type === 'Freeform'
                 ? html`
-                    <a href="${tryAgainUrl}" class="btn btn-primary disable-on-click ms-1">
-                      ${instance_question_info.previous_variants?.some(
-                        (variant: SimpleVariantWithScore) => variant.open,
-                      )
-                        ? 'Go to latest variant'
-                        : 'Try a new variant'}
+                    <input
+                      type="hidden"
+                      name="__variant_id"
+                      value="${variant.id}"
+                      data-skip-unload-check="true"
+                    />
+                  `
+                : html`
+                    <input type="hidden" name="postData" class="postData" />
+                    <input type="hidden" name="__action" class="__action" />
+                  `
+            }
+            ${
+              showNewVariantButton
+                ? html`
+                    <a
+                      href="${newVariantUrl}"
+                      class="btn btn-primary disable-on-click ms-1 js-new-variant-button"
+                    >
+                      New variant
                     </a>
                   `
-                : hasAttemptsOtherVariants
+                : showTryAgainButton
                   ? html`
-                      <small class="fst-italic align-self-center">
-                        Additional attempts available with new variants
-                      </small>
-                      <button
-                        type="button"
-                        class="btn btn-xs btn-ghost align-self-center ms-1"
-                        data-bs-toggle="popover"
-                        data-bs-container="body"
-                        data-bs-html="true"
-                        data-bs-title="Explanation of new variants"
-                        data-bs-content="${escapeHtml(
+                      <a href="${tryAgainUrl}" class="btn btn-primary disable-on-click ms-1">
+                        ${
+                        instance_question_info.previous_variants?.some(
+                          (variant: SimpleVariantWithScore) => variant.open,
+                        )
+                          ? 'Go to latest variant'
+                          : 'Try a new variant'
+                      }
+                      </a>
+                    `
+                  : hasAttemptsOtherVariants
+                    ? html`
+                        <small class="fst-italic align-self-center">
+                          Additional attempts available with new variants
+                        </small>
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-ghost align-self-center ms-1"
+                          data-bs-toggle="popover"
+                          data-bs-container="body"
+                          data-bs-html="true"
+                          data-bs-title="Explanation of new variants"
+                          data-bs-content="${escapeHtml(
                           NewVariantInfo({ variantAttemptsLeft, variantAttemptsTotal }),
                         )}"
-                        data-bs-placement="auto"
-                      >
-                        <i class="fa fa-question-circle" aria-hidden="true"></i>
-                      </button>
-                    `
-                  : ''}
+                          data-bs-placement="auto"
+                        >
+                          <i class="fa fa-question-circle" aria-hidden="true"></i>
+                        </button>
+                      `
+                    : ''
+            }
             <div class="d-flex flex-column">
               ${AvailablePointsNotes({ questionContext, instance_question, assessment_question })}
-              ${assessment_question == null || assessment_question.allow_real_time_grading
-                ? ''
-                : html`
-                    <small class="fst-italic text-end">
-                      This question will be graded after the assessment is finished
-                    </small>
-                  `}
+              ${
+                assessment_question == null || assessment_question.allow_real_time_grading
+                  ? ''
+                  : html`
+                      <small class="fst-italic text-end">
+                        This question will be graded after the assessment is finished
+                      </small>
+                    `
+              }
             </div>
           </div>
         </div>
@@ -748,30 +787,34 @@ function SubmitRateFooter({
     </p>
     <p>
       You can still save your answer as frequently as you like.
-      ${questionContext === 'student_exam'
-        ? 'If your assessment ends before your last saved answer is graded, it will be automatically graded for you.'
-        : ''}
+      ${
+        questionContext === 'student_exam'
+          ? 'If your assessment ends before your last saved answer is graded, it will be automatically graded for you.'
+          : ''
+      }
     </p>
   `;
   return html`
     <div class="row">
       <div class="col d-flex justify-content-between">
         <span class="d-flex">
-          ${allowGradeLeftMs > 0
-            ? html`
-                <small class="fst-italic ms-2 mt-1 submission-suspended-msg">
-                  Grading possible in <span id="submission-suspended-display"></span>
-                  <div id="submission-suspended-progress" class="border border-info"></div>
-                </small>
-                ${EncodedData(
+          ${
+            allowGradeLeftMs > 0
+              ? html`
+                  <small class="fst-italic ms-2 mt-1 submission-suspended-msg">
+                    Grading possible in <span id="submission-suspended-display"></span>
+                    <div id="submission-suspended-progress" class="border border-info"></div>
+                  </small>
+                  ${EncodedData(
                   {
                     serverTimeLimitMS: assessment_question.grade_rate_minutes * 60 * 1000,
                     serverRemainingMS: allowGradeLeftMs,
                   },
                   'submission-suspended-data',
                 )}
-              `
-            : ''}
+                `
+              : ''
+          }
         </span>
         <span class="d-flex align-self-center">
           <small class="fst-italic">
@@ -808,11 +851,13 @@ function NewVariantInfo({
       This question allows you to try multiple variants. Each of these variants is equivalent to the
       question you have been presented with, but may include changes in input values, parameters,
       and other settings. Although
-      ${variantAttemptsLeft > 1
-        ? `you have ${variantAttemptsLeft} attempts left`
-        : variantAttemptsTotal > 1
-          ? 'this is your last attempt'
-          : 'you have a single attempt'}
+      ${
+        variantAttemptsLeft > 1
+          ? `you have ${variantAttemptsLeft} attempts left`
+          : variantAttemptsTotal > 1
+            ? 'this is your last attempt'
+            : 'you have a single attempt'
+      }
       with the current variant, you are allowed to try an unlimited number of other variants.
     </p>
   `;
@@ -836,20 +881,26 @@ function AvailablePointsNotes({
 
   return html`
     <small class="fst-italic text-end">
-      ${roundedPoints[0] === 1
-        ? `1 ${additional} point available ${attemptSuffix}`
-        : `${roundedPoints[0]} ${additional} points available ${attemptSuffix}`}
-      ${maxManualPoints > 0
-        ? roundedPoints[0] > maxManualPoints
-          ? html`&mdash; ${Math.round((roundedPoints[0] - maxManualPoints) * 100) / 100}
-            auto-graded, ${maxManualPoints} manually graded`
-          : html`&mdash; manually graded`
-        : ''}
-      ${roundedPoints.length === 2
-        ? html`<br />(following attempt is worth: ${roundedPoints[1]})`
-        : roundedPoints.length > 2
-          ? html`<br />(following attempts are worth: ${roundedPoints.slice(1).join(', ')})`
-          : ''}
+      ${
+        roundedPoints[0] === 1
+          ? `1 ${additional} point available ${attemptSuffix}`
+          : `${roundedPoints[0]} ${additional} points available ${attemptSuffix}`
+      }
+      ${
+        maxManualPoints > 0
+          ? roundedPoints[0] > maxManualPoints
+            ? html`&mdash; ${Math.round((roundedPoints[0] - maxManualPoints) * 100) / 100}
+              auto-graded, ${maxManualPoints} manually graded`
+            : html`&mdash; manually graded`
+          : ''
+      }
+      ${
+        roundedPoints.length === 2
+          ? html`<br />(following attempt is worth: ${roundedPoints[1]})`
+          : roundedPoints.length > 2
+            ? html`<br />(following attempts are worth: ${roundedPoints.slice(1).join(', ')})`
+            : ''
+      }
     </small>
   `;
 }
@@ -898,69 +949,81 @@ function QuestionPanel({
         </h1>
         <div class="ms-auto d-flex flex-row gap-1">
           <div class="btn-group">
-            ${showCopyQuestionButton
-              ? html`
-                  <button
-                    class="btn btn-sm btn-outline-light"
-                    type="button"
-                    aria-label="Copy question"
-                    data-bs-toggle="modal"
-                    data-bs-target="#copyQuestionModal"
-                  >
-                    <i class="fa fa-clone"></i>
-                    <span class="d-none d-sm-inline">Copy question</span>
-                  </button>
-                `
-              : ''}
-            ${manualGradingPreviewUrl || aiGradingPreviewUrl
-              ? html`
-                  <div class="btn-group">
+            ${
+              showCopyQuestionButton
+                ? html`
                     <button
-                      class="btn btn-sm btn-outline-light dropdown-toggle"
+                      class="btn btn-sm btn-outline-light"
                       type="button"
-                      aria-expanded="false"
-                      data-bs-toggle="dropdown"
+                      aria-label="Copy question"
+                      data-bs-toggle="modal"
+                      data-bs-target="#copyQuestionModal"
                     >
-                      View&hellip;
+                      <i class="fa fa-clone"></i>
+                      <span class="d-none d-sm-inline">Copy question</span>
                     </button>
-                    <ul class="dropdown-menu dropdown-menu-end">
-                      ${manualGradingPreviewUrl
-                        ? html`
-                            <li>
-                              <a class="dropdown-item" href="${manualGradingPreviewUrl}">
-                                Manual grading view
-                              </a>
-                            </li>
-                          `
-                        : ''}
-                      ${aiGradingPreviewUrl
-                        ? html`
-                            <li>
-                              <a class="dropdown-item" href="${aiGradingPreviewUrl}">
-                                AI grading view
-                              </a>
-                            </li>
-                          `
-                        : ''}
-                    </ul>
-                  </div>
-                `
-              : ''}
+                  `
+                : ''
+            }
+            ${
+              manualGradingPreviewUrl || aiGradingPreviewUrl
+                ? html`
+                    <div class="btn-group">
+                      <button
+                        class="btn btn-sm btn-outline-light dropdown-toggle"
+                        type="button"
+                        aria-expanded="false"
+                        data-bs-toggle="dropdown"
+                      >
+                        View&hellip;
+                      </button>
+                      <ul class="dropdown-menu dropdown-menu-end">
+                        ${
+                        manualGradingPreviewUrl
+                          ? html`
+                              <li>
+                                <a class="dropdown-item" href="${manualGradingPreviewUrl}">
+                                  Manual grading view
+                                </a>
+                              </li>
+                            `
+                          : ''
+                      }
+                        ${
+                        aiGradingPreviewUrl
+                          ? html`
+                              <li>
+                                <a class="dropdown-item" href="${aiGradingPreviewUrl}">
+                                  AI grading view
+                                </a>
+                              </li>
+                            `
+                          : ''
+                      }
+                      </ul>
+                    </div>
+                  `
+                : ''
+            }
           </div>
         </div>
       </div>
       <div class="card-body overflow-x-auto question-body">
-        ${questionRenderContext === 'ai_grading'
-          ? AiGradingHtmlPreview(questionHtml)
-          : unsafeHtml(questionHtml)}
+        ${
+          questionRenderContext === 'ai_grading'
+            ? AiGradingHtmlPreview(questionHtml)
+            : unsafeHtml(questionHtml)
+        }
       </div>
-      ${showFooter
-        ? QuestionFooter({
-            // TODO: propagate more precise types upwards.
-            resLocals: resLocals as any,
-            questionContext,
-          })
-        : ''}
+      ${
+        showFooter
+          ? QuestionFooter({
+              // TODO: propagate more precise types upwards.
+              resLocals: resLocals as any,
+              questionContext,
+            })
+          : ''
+      }
     </div>
   `;
 }
@@ -1059,13 +1122,15 @@ function CopyQuestionModal({
       <input type="hidden" name="question_id" value="${question.id}" />
       <input type="hidden" name="course_id" value="${course.id}" />
       <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-      ${questionCopyTargets.length > 0
-        ? html`
-            <button type="submit" name="__action" value="copy_question" class="btn btn-primary">
-              Copy question
-            </button>
-          `
-        : ''}
+      ${
+        questionCopyTargets.length > 0
+          ? html`
+              <button type="submit" name="__action" value="copy_question" class="btn btn-primary">
+                Copy question
+              </button>
+            `
+          : ''
+      }
     `,
   });
 }

--- a/apps/prairielearn/src/components/QuestionContainer.types.ts
+++ b/apps/prairielearn/src/components/QuestionContainer.types.ts
@@ -1,8 +1,4 @@
 export type QuestionContext =
-  | 'student_exam'
-  | 'student_homework'
-  | 'instructor'
-  | 'public'
-  | 'manual_grading';
+  'student_exam' | 'student_homework' | 'instructor' | 'public' | 'manual_grading';
 
 export type QuestionRenderContext = 'manual_grading' | 'ai_grading';

--- a/apps/prairielearn/src/components/QuestionNavigation.tsx
+++ b/apps/prairielearn/src/components/QuestionNavigation.tsx
@@ -1,10 +1,7 @@
 import { type HtmlValue, html } from '@prairielearn/html';
 
 type QuestionAccessMode =
-  | 'default'
-  | 'blocked_sequence'
-  | 'blocked_lockpoint'
-  | 'read_only_lockpoint';
+  'default' | 'blocked_sequence' | 'blocked_lockpoint' | 'read_only_lockpoint';
 
 export function QuestionNavSideGroup({
   urlPrefix,

--- a/apps/prairielearn/src/components/QuestionScore.tsx
+++ b/apps/prairielearn/src/components/QuestionScore.tsx
@@ -44,20 +44,24 @@ export function QuestionScorePanel(
         <h2>Question ${instance_question_info.question_number}</h2>
       </div>
       ${QuestionScorePanelContent(props)}
-      ${variant != null && assessment.allow_issue_reporting
-        ? html`
-            <div class="card-footer">
-              ${authz_result?.authorized_edit === false
-                ? html`
-                    <div class="alert alert-warning mb-0" role="alert">
-                      You are viewing the question instance of a different user and so are not
-                      authorized to report an error.
-                    </div>
-                  `
-                : IssueReportingPanel({ variant, csrfToken })}
-            </div>
-          `
-        : ''}
+      ${
+        variant != null && assessment.allow_issue_reporting
+          ? html`
+              <div class="card-footer">
+                ${
+                authz_result?.authorized_edit === false
+                  ? html`
+                      <div class="alert alert-warning mb-0" role="alert">
+                        You are viewing the question instance of a different user and so are not
+                        authorized to report an error.
+                      </div>
+                    `
+                  : IssueReportingPanel({ variant, csrfToken })
+              }
+              </div>
+            `
+          : ''
+      }
     </div>
   `;
 }
@@ -85,23 +89,26 @@ export function QuestionScorePanelContent({
       id="question-score-panel-content"
     >
       <tbody>
-        ${assessment.type === 'Exam'
-          ? html`
-              <tr>
-                <td>Status:</td>
-                <td>
-                  ${ExamQuestionStatus({
+        ${
+          assessment.type === 'Exam'
+            ? html`
+                <tr>
+                  <td>Status:</td>
+                  <td>
+                    ${ExamQuestionStatus({
                     instance_question,
                     assessment_question,
                     allowGradeLeftMs,
                   })}
-                </td>
-              </tr>
-            `
-          : ''}
-        ${assessment.type === 'Homework'
-          ? html`
-              ${
+                  </td>
+                </tr>
+              `
+            : ''
+        }
+        ${
+          assessment.type === 'Homework'
+            ? html`
+                ${
                 // This condition covers two cases:
                 // - A purely manually-graded question
                 // - A question with no points at all
@@ -117,7 +124,7 @@ export function QuestionScorePanelContent({
                     `
                   : ''
               }
-              ${
+                ${
                 // Only show previous variants if the question allows multiple variants,
                 // or there are multiple variants (i.e., they were allowed at some point)
                 !question.single_variant ||
@@ -137,13 +144,13 @@ export function QuestionScorePanelContent({
                     `
                   : ''
               }
-            `
-          : assessment_question.max_auto_points
-            ? html`
-                <tr>
-                  <td>Available points:</td>
-                  <td>
-                    ${ExamQuestionAvailablePoints({
+              `
+            : assessment_question.max_auto_points
+              ? html`
+                  <tr>
+                    <td>Available points:</td>
+                    <td>
+                      ${ExamQuestionAvailablePoints({
                       open: !!assessment_instance.open && instance_question.open,
                       currentWeight:
                         (instance_question.points_list_original?.[
@@ -154,34 +161,37 @@ export function QuestionScorePanelContent({
                       ),
                       highestSubmissionScore: instance_question.highest_submission_score,
                     })}
-                  </td>
-                </tr>
-              `
-            : ''}
-        ${hasAutoAndManualPoints
-          ? html`
-              <tr>
-                <td>Auto-grading:</td>
-                <td>
-                  ${InstanceQuestionPoints({
+                    </td>
+                  </tr>
+                `
+              : ''
+        }
+        ${
+          hasAutoAndManualPoints
+            ? html`
+                <tr>
+                  <td>Auto-grading:</td>
+                  <td>
+                    ${InstanceQuestionPoints({
                     instance_question,
                     assessment_question,
                     component: 'auto',
                   })}
-                </td>
-              </tr>
-              <tr>
-                <td>Manual grading:</td>
-                <td>
-                  ${InstanceQuestionPoints({
+                  </td>
+                </tr>
+                <tr>
+                  <td>Manual grading:</td>
+                  <td>
+                    ${InstanceQuestionPoints({
                     instance_question,
                     assessment_question,
                     component: 'manual',
                   })}
-                </td>
-              </tr>
-            `
-          : ''}
+                  </td>
+                </tr>
+              `
+            : ''
+        }
         <tr>
           <td>Total points:</td>
           <td>
@@ -192,19 +202,23 @@ export function QuestionScorePanelContent({
             })}
           </td>
         </tr>
-        ${!hasAutoAndManualPoints && assessment_question.max_points
-          ? html`
-              <tr>
-                <td colspan="2" class="text-end">
-                  <small>
-                    ${!assessment_question.max_auto_points
-                      ? 'Manually-graded question'
-                      : 'Auto-graded question'}
-                  </small>
-                </td>
-              </tr>
-            `
-          : ''}
+        ${
+          !hasAutoAndManualPoints && assessment_question.max_points
+            ? html`
+                <tr>
+                  <td colspan="2" class="text-end">
+                    <small>
+                      ${
+                      !assessment_question.max_auto_points
+                        ? 'Manually-graded question'
+                        : 'Auto-graded question'
+                    }
+                    </small>
+                  </td>
+                </tr>
+              `
+            : ''
+        }
       </tbody>
     </table>
   `;
@@ -314,19 +328,21 @@ export function InstanceQuestionPoints({
               : html`<span data-testid="awarded-points">${formatPoints(points)}</span>`
       }
       ${maxPoints ? html`<small>/<span class="text-muted">${maxPoints}</span></small>` : ''}
-      ${instance_question.used_for_grade === false && component === 'total' && (points ?? 0) !== 0
-        ? html`
-            <button
-              type="button"
-              class="btn btn-xs"
-              data-bs-toggle="tooltip"
-              aria-label="Not included in grade"
-              title="This zone uses only the best questions for score, and this question is not included."
-            >
-              <i class="far fa-question-circle" aria-hidden="true"></i>
-            </button>
-          `
-        : ''}
+      ${
+        instance_question.used_for_grade === false && component === 'total' && (points ?? 0) !== 0
+          ? html`
+              <button
+                type="button"
+                class="btn btn-xs"
+                data-bs-toggle="tooltip"
+                aria-label="Not included in grade"
+                title="This zone uses only the best questions for score, and this question is not included."
+              >
+                <i class="far fa-question-circle" aria-hidden="true"></i>
+              </button>
+            `
+          : ''
+      }
     </span>
   `;
 }

--- a/apps/prairielearn/src/components/QuestionVariantHistory.tsx
+++ b/apps/prairielearn/src/components/QuestionVariantHistory.tsx
@@ -23,31 +23,35 @@ export function QuestionVariantHistory({
   const collapseButtonId = `variants-points-collapse-button-${instanceQuestionId}`;
 
   return html`
-    ${hasOverflow
-      ? html`
-          <button
-            id="${collapseButtonId}"
-            class="bg-white text-body p-0 m-0 border-0 rounded-0"
-            aria-label="Show older variants"
-            onclick="
+    ${
+      hasOverflow
+        ? html`
+            <button
+              id="${collapseButtonId}"
+              class="bg-white text-body p-0 m-0 border-0 rounded-0"
+              aria-label="Show older variants"
+              onclick="
                 // show all the hidden variant score buttons
                 document.querySelectorAll('.${collapseClass}').forEach(e => e.style.display = '');
                 // hide the ... button that triggered the expansion
                 document.querySelectorAll('#${collapseButtonId}').forEach(e => e.style.display = 'none');
             "
-          >
-            &ctdot;
-          </button>
-        `
-      : ''}
+            >
+              &ctdot;
+            </button>
+          `
+        : ''
+    }
     ${previousVariants.map((variant, index) => {
       const hidden = hasOverflow && index < previousVariants.length - MAX_DISPLAYED_VARIANTS;
 
       return html`
         <a
-          class="badge ${currentVariantId != null && idsEqual(variant.id, currentVariantId)
-            ? 'text-bg-info'
-            : 'text-bg-secondary'} ${collapseClass}"
+          class="badge ${
+            currentVariantId != null && idsEqual(variant.id, currentVariantId)
+              ? 'text-bg-info'
+              : 'text-bg-secondary'
+          } ${collapseClass}"
           ${hidden ? 'style="display: none"' : ''}
           href="${getInstanceQuestionUrl({
             courseInstanceId,
@@ -56,9 +60,11 @@ export function QuestionVariantHistory({
           })}"
         >
           ${variant.open ? 'Open' : `${Math.floor(variant.max_submission_score * 100)}%`}
-          ${currentVariantId != null && idsEqual(variant.id, currentVariantId)
-            ? html`<span class="visually-hidden">(current)</span>`
-            : ''}
+          ${
+            currentVariantId != null && idsEqual(variant.id, currentVariantId)
+              ? html`<span class="visually-hidden">(current)</span>`
+              : ''
+          }
         </a>
       `;
     })}

--- a/apps/prairielearn/src/components/SideNav.tsx
+++ b/apps/prairielearn/src/components/SideNav.tsx
@@ -317,15 +317,18 @@ function CourseInstanceNav({
             aria-expanded="false"
             data-bs-toggle="dropdown"
             data-bs-boundary="window"
-            hx-get="/pl/navbar/course/${resLocals.course.id}/course_instance_switcher/${resLocals
-              .course_instance?.id ?? ''}"
+            hx-get="/pl/navbar/course/${resLocals.course.id}/course_instance_switcher/${
+              resLocals.course_instance?.id ?? ''
+            }"
             hx-trigger="mouseover once, focus once, show.bs.dropdown once delay:200ms"
             hx-target="#sideNavCourseInstancesDropdownContent"
           >
             <span title="${resLocals.course_instance?.short_name ?? ''}">
-              ${resLocals.course_instance
-                ? truncateMiddle(resLocals.course_instance.short_name, 22)
-                : 'Select...'}
+              ${
+                resLocals.course_instance
+                  ? truncateMiddle(resLocals.course_instance.short_name, 22)
+                  : 'Select...'
+              }
             </span>
           </button>
           <div class="dropdown-menu py-0 overflow-hidden">
@@ -342,18 +345,20 @@ function CourseInstanceNav({
             </div>
           </div>
         </div>
-        ${resLocals.course_instance
-          ? courseInstanceSideNavPageTabs.map((tabInfo) =>
-              SideNavLink({
-                resLocals,
-                navPage: page,
-                navSubPage: subPage,
-                tabInfo,
-                urlPrefix,
-                sideNavExpanded,
-              }),
-            )
-          : ''}
+        ${
+          resLocals.course_instance
+            ? courseInstanceSideNavPageTabs.map((tabInfo) =>
+                SideNavLink({
+                  resLocals,
+                  navPage: page,
+                  navSubPage: subPage,
+                  tabInfo,
+                  urlPrefix,
+                  sideNavExpanded,
+                }),
+              )
+            : ''
+        }
       </div>
     </div>
   `;

--- a/apps/prairielearn/src/components/SubmissionPanel.tsx
+++ b/apps/prairielearn/src/components/SubmissionPanel.tsx
@@ -110,41 +110,45 @@ export function SubmissionPanel({
       data-grading-job-id="${submission.grading_job?.id}"
       id="submission-${submission.id}"
     >
-      ${submission.feedback?.manual || submission.rubric_grading
-        ? html`
-            <div class="card mb-4 grading-block border-info">
-              <div
-                class="card-header bg-info d-flex align-items-center collapsible-card-header ${!expanded
-                  ? ' collapsed'
-                  : ''}"
-              >
-                <div class="me-auto">
-                  Feedback from the Course Staff
-                  ${submissionCount > 1
-                    ? `(for submitted answer ${submission.submission_number})`
-                    : ''}
-                </div>
-                <button
-                  type="button"
-                  class="expand-icon-container btn btn-outline-dark btn-sm ${!expanded
-                    ? 'collapsed'
-                    : ''}"
-                  data-bs-toggle="collapse"
-                  data-bs-target="#submission-feedback-${submission.id}-body"
-                  aria-expanded="${expanded ? 'true' : 'false'}"
-                  aria-controls="submission-feedback-${submission.id}-body"
+      ${
+        submission.feedback?.manual || submission.rubric_grading
+          ? html`
+              <div class="card mb-4 grading-block border-info">
+                <div
+                  class="card-header bg-info d-flex align-items-center collapsible-card-header ${
+                  !expanded ? ' collapsed' : ''
+                }"
                 >
-                  <i class="fa fa-angle-up ms-1 expand-icon"></i>
-                </button>
-              </div>
-              <div
-                class="collapse ${expanded ? 'show' : ''}"
-                id="submission-feedback-${submission.id}-body"
-              >
-                <div class="card-body">
-                  ${submission.rubric_grading
-                    ? html`
-                        ${(rubric_data?.rubric_items || [])
+                  <div class="me-auto">
+                    Feedback from the Course Staff
+                    ${
+                    submissionCount > 1
+                      ? `(for submitted answer ${submission.submission_number})`
+                      : ''
+                  }
+                  </div>
+                  <button
+                    type="button"
+                    class="expand-icon-container btn btn-outline-dark btn-sm ${
+                    !expanded ? 'collapsed' : ''
+                  }"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#submission-feedback-${submission.id}-body"
+                    aria-expanded="${expanded ? 'true' : 'false'}"
+                    aria-controls="submission-feedback-${submission.id}-body"
+                  >
+                    <i class="fa fa-angle-up ms-1 expand-icon"></i>
+                  </button>
+                </div>
+                <div
+                  class="collapse ${expanded ? 'show' : ''}"
+                  id="submission-feedback-${submission.id}-body"
+                >
+                  <div class="card-body">
+                    ${
+                    submission.rubric_grading
+                      ? html`
+                          ${(rubric_data?.rubric_items || [])
                           .filter(
                             (item) =>
                               item.rubric_item.always_show_to_students ||
@@ -158,37 +162,47 @@ export function SubmissionPanel({
                                 null,
                             }),
                           )}
-                        ${submission.rubric_grading.adjust_points
-                          ? html`
-                              <div class="mb-2">
-                                <span class="text-muted"> Manual grading adjustment: </span>
-                                <span
-                                  class="text-${submission.rubric_grading.adjust_points >= 0
-                                    ? 'success'
-                                    : 'danger'}"
-                                >
-                                  <strong data-testid="rubric-adjust-points">
-                                    [${(submission.rubric_grading.adjust_points >= 0 ? '+' : '') +
-                                    submission.rubric_grading.adjust_points}]
-                                  </strong>
-                                </span>
-                              </div>
-                            `
-                          : ''}
-                      `
-                    : ''}
-                  ${submission.feedback?.manual
-                    ? html`
-                        <div data-testid="feedback-body">
-                          ${unsafeHtml(submission.feedback_manual_html ?? '')}
-                        </div>
-                      `
-                    : ''}
+                          ${
+                          submission.rubric_grading.adjust_points
+                            ? html`
+                                <div class="mb-2">
+                                  <span class="text-muted"> Manual grading adjustment: </span>
+                                  <span
+                                    class="text-${
+                                    submission.rubric_grading.adjust_points >= 0
+                                      ? 'success'
+                                      : 'danger'
+                                  }"
+                                  >
+                                    <strong data-testid="rubric-adjust-points">
+                                      [${
+                                      (submission.rubric_grading.adjust_points >= 0 ? '+' : '') +
+                                      submission.rubric_grading.adjust_points
+                                    }]
+                                    </strong>
+                                  </span>
+                                </div>
+                              `
+                            : ''
+                        }
+                        `
+                      : ''
+                  }
+                    ${
+                    submission.feedback?.manual
+                      ? html`
+                          <div data-testid="feedback-body">
+                            ${unsafeHtml(submission.feedback_manual_html ?? '')}
+                          </div>
+                        `
+                      : ''
+                  }
+                  </div>
                 </div>
               </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
 
       <div class="card mb-4" data-testid="submission-block">
         <div
@@ -203,9 +217,11 @@ export function SubmissionPanel({
               </span>
             </div>
             <span class="small">
-              ${!submission.user_uid || questionContext === 'manual_grading'
-                ? `Submitted at ${formattedDate} `
-                : `${submission.user_uid} submitted at ${formattedDate}`}
+              ${
+                !submission.user_uid || questionContext === 'manual_grading'
+                  ? `Submitted at ${formattedDate} `
+                  : `${submission.user_uid} submitted at ${formattedDate}`
+              }
             </span>
           </div>
           <div class="me-auto align-self-end" data-testid="submission-status">
@@ -230,9 +246,9 @@ export function SubmissionPanel({
             </button>
             <button
               type="button"
-              class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap ${!expanded
-                ? 'collapsed'
-                : ''}"
+              class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap ${
+                !expanded ? 'collapsed' : ''
+              }"
               data-bs-toggle="collapse"
               data-bs-target="#submission-${submission.id}-body"
               aria-expanded="${expanded ? 'true' : 'false'}"
@@ -244,23 +260,25 @@ export function SubmissionPanel({
         </div>
 
         <div
-          class="collapse js-submission-body js-collapsible-card-body ${expanded
-            ? 'show'
-            : ''} ${submissionHtml == null && question.type === 'Freeform' ? 'render-pending' : ''}"
+          class="collapse js-submission-body js-collapsible-card-body ${
+            expanded ? 'show' : ''
+          } ${submissionHtml == null && question.type === 'Freeform' ? 'render-pending' : ''}"
           data-submission-id="${submission.id}"
           id="submission-${submission.id}-body"
           ${question.type === 'Freeform' ? html`data-dynamic-render-url="${renderUrl}" ` : ''}
         >
           <div class="card-body overflow-x-auto submission-body">
-            ${submissionHtml == null
-              ? html`
-                  <div class="spinner-border" role="status">
-                    <span class="visually-hidden">Loading...</span>
-                  </div>
-                `
-              : questionRenderContext === 'ai_grading'
-                ? AiGradingHtmlPreview(submissionHtml)
-                : unsafeHtml(submissionHtml)}
+            ${
+              submissionHtml == null
+                ? html`
+                    <div class="spinner-border" role="status">
+                      <span class="visually-hidden">Loading...</span>
+                    </div>
+                  `
+                : questionRenderContext === 'ai_grading'
+                  ? AiGradingHtmlPreview(submissionHtml)
+                  : unsafeHtml(submissionHtml)
+            }
           </div>
         </div>
 
@@ -437,74 +455,80 @@ function SubmissionInfoModal({
             <th>Submission time</th>
             <td>${formattedDate}</td>
           </tr>
-          ${submission.user_uid
-            ? html`
-                <tr>
-                  <th>Submitted by</th>
-                  <td>${submission.user_uid}</td>
-                </tr>
-              `
-            : ''}
-          ${gradingJobStats?.grading_method === 'External'
-            ? html`
-                <tr>
-                  <th><span class="text-dark me-2">&bull;</span>Submit duration</th>
-                  <td>${gradingJobStats.submitDuration}</td>
-                </tr>
-                <tr>
-                  <th><span class="text-warning me-2">&bull;</span>Queue duration</th>
-                  <td>${gradingJobStats.queueDuration}</td>
-                </tr>
-                <tr>
-                  <th><span class="text-primary me-2">&bull;</span>Prepare duration</th>
-                  <td>${gradingJobStats.prepareDuration}</td>
-                </tr>
-                <tr>
-                  <th><span class="text-success me-2">&bull;</span>Run duration</th>
-                  <td>${gradingJobStats.runDuration}</td>
-                </tr>
-                <tr>
-                  <th><span class="text-danger me-2">&bull;</span>Report duration</th>
-                  <td>${gradingJobStats.reportDuration}</td>
-                </tr>
-                <tr>
-                  <th>Total duration</th>
-                  <td>${gradingJobStats.totalDuration}</td>
-                </tr>
-              `
-            : ''}
+          ${
+            submission.user_uid
+              ? html`
+                  <tr>
+                    <th>Submitted by</th>
+                    <td>${submission.user_uid}</td>
+                  </tr>
+                `
+              : ''
+          }
+          ${
+            gradingJobStats?.grading_method === 'External'
+              ? html`
+                  <tr>
+                    <th><span class="text-dark me-2">&bull;</span>Submit duration</th>
+                    <td>${gradingJobStats.submitDuration}</td>
+                  </tr>
+                  <tr>
+                    <th><span class="text-warning me-2">&bull;</span>Queue duration</th>
+                    <td>${gradingJobStats.queueDuration}</td>
+                  </tr>
+                  <tr>
+                    <th><span class="text-primary me-2">&bull;</span>Prepare duration</th>
+                    <td>${gradingJobStats.prepareDuration}</td>
+                  </tr>
+                  <tr>
+                    <th><span class="text-success me-2">&bull;</span>Run duration</th>
+                    <td>${gradingJobStats.runDuration}</td>
+                  </tr>
+                  <tr>
+                    <th><span class="text-danger me-2">&bull;</span>Report duration</th>
+                    <td>${gradingJobStats.reportDuration}</td>
+                  </tr>
+                  <tr>
+                    <th>Total duration</th>
+                    <td>${gradingJobStats.totalDuration}</td>
+                  </tr>
+                `
+              : ''
+          }
         </tbody>
       </table>
       ${gradingJobStats ? '' : html`<p class="mt-2">This submission has not been graded.</p>`}
-      ${gradingJobStats?.grading_method === 'External'
-        ? html`
-            <div class="d-flex mt-2 mb-2">
-              <span
-                style="display: inline-block; width: ${gradingJobStats.phases[0]}%; height: 10px;"
-                class="bg-dark m-0"
-              ></span>
-              <span
-                style="display: inline-block; width: ${gradingJobStats.phases[1]}%; height: 10px;"
-                class="bg-warning m-0"
-              ></span>
-              <span
-                style="display: inline-block; width: ${gradingJobStats.phases[2]}%; height: 10px;"
-                class="bg-primary m-0"
-              ></span>
-              <span
-                style="display: inline-block; width: ${gradingJobStats.phases[3]}%; height: 10px;"
-                class="bg-success m-0"
-              ></span>
-              <span
-                style="display: inline-block; width: ${gradingJobStats.phases[4]}%; height: 10px;"
-                class="bg-danger m-0"
-              ></span>
-            </div>
-            <a class="btn btn-primary mt-2" href="${gradingJobUrl}">
-              View grading job ${submission.grading_job?.id}
-            </a>
-          `
-        : ''}
+      ${
+        gradingJobStats?.grading_method === 'External'
+          ? html`
+              <div class="d-flex mt-2 mb-2">
+                <span
+                  style="display: inline-block; width: ${gradingJobStats.phases[0]}%; height: 10px;"
+                  class="bg-dark m-0"
+                ></span>
+                <span
+                  style="display: inline-block; width: ${gradingJobStats.phases[1]}%; height: 10px;"
+                  class="bg-warning m-0"
+                ></span>
+                <span
+                  style="display: inline-block; width: ${gradingJobStats.phases[2]}%; height: 10px;"
+                  class="bg-primary m-0"
+                ></span>
+                <span
+                  style="display: inline-block; width: ${gradingJobStats.phases[3]}%; height: 10px;"
+                  class="bg-success m-0"
+                ></span>
+                <span
+                  style="display: inline-block; width: ${gradingJobStats.phases[4]}%; height: 10px;"
+                  class="bg-danger m-0"
+                ></span>
+              </div>
+              <a class="btn btn-primary mt-2" href="${gradingJobUrl}">
+                View grading job ${submission.grading_job?.id}
+              </a>
+            `
+          : ''
+      }
     `,
     footer: html`
       <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
@@ -531,21 +555,23 @@ function RubricItem({
         <span class="d-inline-block" data-testid="rubric-item-description">
           ${unsafeHtml(item.description_rendered ?? '')}
         </span>
-        ${item.explanation_rendered
-          ? html`
-              <button
-                type="button"
-                class="btn btn-xs btn-ghost"
-                data-bs-toggle="popover"
-                data-bs-content="${item.explanation_rendered}"
-                data-bs-html="true"
-                data-testid="rubric-item-explanation"
-                aria-label="Details"
-              >
-                <i class="fas fa-circle-info"></i>
-              </button>
-            `
-          : ''}
+        ${
+          item.explanation_rendered
+            ? html`
+                <button
+                  type="button"
+                  class="btn btn-xs btn-ghost"
+                  data-bs-toggle="popover"
+                  data-bs-content="${item.explanation_rendered}"
+                  data-bs-html="true"
+                  data-testid="rubric-item-explanation"
+                  aria-label="Details"
+                >
+                  <i class="fas fa-circle-info"></i>
+                </button>
+              `
+            : ''
+        }
       </label>
     </div>
   `;

--- a/apps/prairielearn/src/components/TimeLimitExpiredModal.tsx
+++ b/apps/prairielearn/src/components/TimeLimitExpiredModal.tsx
@@ -12,14 +12,16 @@ export function TimeLimitExpiredModal({ showAutomatically }: { showAutomatically
         <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
       `,
     })}
-    ${showAutomatically
-      ? html`
-          <script type="module">
-            // This script is type="module" so that it is deferred and runs after the DOM is ready.
-            const modalElement = document.getElementById('timeLimitExpiredModal');
-            window.bootstrap.Modal.getOrCreateInstance(modalElement).show();
-          </script>
-        `
-      : ''}
+    ${
+      showAutomatically
+        ? html`
+            <script type="module">
+              // This script is type="module" so that it is deferred and runs after the DOM is ready.
+              const modalElement = document.getElementById('timeLimitExpiredModal');
+              window.bootstrap.Modal.getOrCreateInstance(modalElement).show();
+            </script>
+          `
+        : ''
+    }
   `;
 }

--- a/apps/prairielearn/src/ee/auth/saml/router.html.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.html.ts
@@ -84,104 +84,146 @@ export const SamlTest = ({
       </head>
       <body>
         <main id="content" class="container mb-4">
-          ${usedNameFallback
-            ? html`
-                <div class="alert alert-warning">
-                  <h2 class="h4">Using fallback name attribute</h2>
-                  <p class="mb-0">
-                    Given name and family name mappings are configured, but one or more values were
-                    missing in this SAML response. PrairieLearn used the configured name attribute
-                    (<code>${nameAttribute}</code>) as a fallback.
-                  </p>
-                </div>
-              `
-            : ''}
-          ${hasError
-            ? html`
-                <div class="alert alert-danger">
-                  <h2 class="h4">
-                    One or more errors were encountered while validating the SAML response.
-                  </h2>
-                  <ul class="mb-0">
-                    ${!hasUidAttribute
-                      ? html`<li>No UID attribute mapping is configured for this institution</li>`
-                      : ''}
-                    ${!hasUinAttribute
-                      ? html`<li>No UIN attribute mapping is configured for this institution</li>`
-                      : ''}
-                    ${!hasNameMapping
-                      ? html`<li>No name attribute mapping is configured for this institution</li>`
-                      : ''}
-                    ${!hasEmailAttribute
-                      ? html`<li>No email attribute mapping is configured for this institution</li>`
-                      : ''}
-                    ${hasUidAttribute && !hasUid
+          ${
+            usedNameFallback
+              ? html`
+                  <div class="alert alert-warning">
+                    <h2 class="h4">Using fallback name attribute</h2>
+                    <p class="mb-0">
+                      Given name and family name mappings are configured, but one or more values
+                      were missing in this SAML response. PrairieLearn used the configured name
+                      attribute (<code>${nameAttribute}</code>) as a fallback.
+                    </p>
+                  </div>
+                `
+              : ''
+          }
+          ${
+            hasError
+              ? html`
+                  <div class="alert alert-danger">
+                    <h2 class="h4">
+                      One or more errors were encountered while validating the SAML response.
+                    </h2>
+                    <ul class="mb-0">
+                      ${
+                      !hasUidAttribute
+                        ? html`<li>No UID attribute mapping is configured for this institution</li>`
+                        : ''
+                    }
+                      ${
+                      !hasUinAttribute
+                        ? html`<li>No UIN attribute mapping is configured for this institution</li>`
+                        : ''
+                    }
+                      ${
+                      !hasNameMapping
+                        ? html`<li>
+                            No name attribute mapping is configured for this institution
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      !hasEmailAttribute
+                        ? html`<li>
+                            No email attribute mapping is configured for this institution
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      hasUidAttribute && !hasUid
+                        ? html`<li>
+                            No value found for configured UID attribute
+                            (<code>${uidAttribute}</code>)
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      hasUinAttribute && !hasUin
+                        ? html`<li>
+                            No value found for configured UIN attribute
+                            (<code>${uinAttribute}</code>)
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      hasNameAttribute && !hasName
+                        ? html`<li>
+                            No value found for configured name attribute
+                            (<code>${nameAttribute}</code>)
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      hasGivenNameAttribute && !hasGivenName
+                        ? html`<li>
+                            No value found for configured given name attribute
+                            (<code>${givenNameAttribute}</code>)
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      hasFamilyNameAttribute && !hasFamilyName
+                        ? html`<li>
+                            No value found for configured family name attribute
+                            (<code>${familyNameAttribute}</code>)
+                          </li>`
+                        : ''
+                    }
+                      ${
+                      hasEmailAttribute && !hasEmail
+                        ? html`<li>
+                            No value found for configured email attribute
+                            (<code>${emailAttribute}</code>)
+                          </li>`
+                        : ''
+                    }
+                    </ul>
+                  </div>
+                `
+              : ''
+          }
+          ${
+            hasUid || hasUin || hasName
+              ? html`
+                  <h2 class="h4">Mapped SAML attributes</h2>
+                  <ul>
+                    ${
+                    hasUid
+                      ? html`<li><strong>UID:</strong> ${uid} (<code>${uidAttribute}</code>)</li>`
+                      : ''
+                  }
+                    ${
+                    hasUin
+                      ? html`<li><strong>UIN:</strong> ${uin} (<code>${uinAttribute}</code>)</li>`
+                      : ''
+                  }
+                    ${
+                    hasName
                       ? html`<li>
-                          No value found for configured UID attribute (<code>${uidAttribute}</code>)
+                          <strong>Name:</strong> ${name}
+                          ${
+                          hasSplitNameValues
+                            ? html`(<code>${givenNameAttribute}</code> +
+                                <code>${familyNameAttribute}</code>)`
+                            : usedNameFallback
+                              ? html`(<code>${nameAttribute}</code>, fallback)`
+                              : html`(<code>${nameAttribute}</code>)`
+                        }
                         </li>`
-                      : ''}
-                    ${hasUinAttribute && !hasUin
+                      : ''
+                  }
+                    ${
+                    hasEmail
                       ? html`<li>
-                          No value found for configured UIN attribute (<code>${uinAttribute}</code>)
+                          <strong>Email:</strong> ${email} (<code>${emailAttribute}</code>)
                         </li>`
-                      : ''}
-                    ${hasNameAttribute && !hasName
-                      ? html`<li>
-                          No value found for configured name attribute
-                          (<code>${nameAttribute}</code>)
-                        </li>`
-                      : ''}
-                    ${hasGivenNameAttribute && !hasGivenName
-                      ? html`<li>
-                          No value found for configured given name attribute
-                          (<code>${givenNameAttribute}</code>)
-                        </li>`
-                      : ''}
-                    ${hasFamilyNameAttribute && !hasFamilyName
-                      ? html`<li>
-                          No value found for configured family name attribute
-                          (<code>${familyNameAttribute}</code>)
-                        </li>`
-                      : ''}
-                    ${hasEmailAttribute && !hasEmail
-                      ? html`<li>
-                          No value found for configured email attribute
-                          (<code>${emailAttribute}</code>)
-                        </li>`
-                      : ''}
+                      : ''
+                  }
                   </ul>
-                </div>
-              `
-            : ''}
-          ${hasUid || hasUin || hasName
-            ? html`
-                <h2 class="h4">Mapped SAML attributes</h2>
-                <ul>
-                  ${hasUid
-                    ? html`<li><strong>UID:</strong> ${uid} (<code>${uidAttribute}</code>)</li>`
-                    : ''}
-                  ${hasUin
-                    ? html`<li><strong>UIN:</strong> ${uin} (<code>${uinAttribute}</code>)</li>`
-                    : ''}
-                  ${hasName
-                    ? html`<li>
-                        <strong>Name:</strong> ${name}
-                        ${hasSplitNameValues
-                          ? html`(<code>${givenNameAttribute}</code> +
-                              <code>${familyNameAttribute}</code>)`
-                          : usedNameFallback
-                            ? html`(<code>${nameAttribute}</code>, fallback)`
-                            : html`(<code>${nameAttribute}</code>)`}
-                      </li>`
-                    : ''}
-                  ${hasEmail
-                    ? html`<li>
-                        <strong>Email:</strong> ${email} (<code>${emailAttribute}</code>)
-                      </li>`
-                    : ''}
-                </ul>
-              `
-            : ''}
+                `
+              : ''
+          }
 
           <h2 class="h4">All SAML attributes</h2>
           <pre><code>${JSON.stringify(attributes, null, 2)}</code></pre>

--- a/apps/prairielearn/src/ee/components/courseRequestMessage/CourseRequestMessageSection.tsx
+++ b/apps/prairielearn/src/ee/components/courseRequestMessage/CourseRequestMessageSection.tsx
@@ -42,14 +42,16 @@ export function CourseRequestMessageSection({
         Save
       </button>
     </form>
-    ${courseRequestMessageHtml
-      ? html`
-          <h3 class="h5">Preview</h3>
-          <div class="card mb-3">
-            <div class="card-body">${unsafeHtml(courseRequestMessageHtml)}</div>
-          </div>
-        `
-      : ''}
+    ${
+      courseRequestMessageHtml
+        ? html`
+            <h3 class="h5">Preview</h3>
+            <div class="card mb-3">
+              <div class="card-body">${unsafeHtml(courseRequestMessageHtml)}</div>
+            </div>
+          `
+        : ''
+    }
   `;
 }
 

--- a/apps/prairielearn/src/ee/lib/billing/components/PlanGrantsEditor.tsx
+++ b/apps/prairielearn/src/ee/lib/billing/components/PlanGrantsEditor.tsx
@@ -74,14 +74,16 @@ export function PlanGrantsEditor({
           `;
         })}
       </ul>
-      ${disabled
-        ? ''
-        : html`
-            <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-            <button type="submit" name="__action" value="update_plans" class="btn btn-primary">
-              Save
-            </button>
-          `}
+      ${
+        disabled
+          ? ''
+          : html`
+              <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+              <button type="submit" name="__action" value="update_plans" class="btn btn-primary">
+                Save
+              </button>
+            `
+      }
     </form>
   `;
 }

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -145,16 +145,20 @@ export function AdministratorInstitutionCourse({
                         href="/pl/administrator/institution/${institution.id}/course_instance/${course_instance.id}"
                         >${course_instance.short_name}: ${course_instance.long_name ?? '—'}</a
                       >
-                      ${isDeleted
-                        ? html`<span class="badge text-bg-danger ms-2">Deleted</span>`
-                        : ''}
+                      ${
+                        isDeleted
+                          ? html`<span class="badge text-bg-danger ms-2">Deleted</span>`
+                          : ''
+                      }
                     </div>
                   </td>
                   <td>${enrollment_count}</td>
                   <td>
-                    ${course_instance.enrollment_limit ??
-                    course.course_instance_enrollment_limit ??
-                    institution.course_instance_enrollment_limit}
+                    ${
+                      course_instance.enrollment_limit ??
+                      course.course_instance_enrollment_limit ??
+                      institution.course_instance_enrollment_limit
+                    }
                   </td>
                 </tr>
               `;

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.tsx
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourseInstance/administratorInstitutionCourseInstance.html.tsx
@@ -63,13 +63,15 @@ export function AdministratorInstitutionCourseInstance({
           </li>
         </ol>
       </nav>
-      ${isDeleted
-        ? html`<div class="alert alert-danger" role="alert">
-            <strong>This course instance has been deleted.</strong> You cannot make changes to it.
-          </div>`
-        : html`<p>
-            <a href="/pl/course_instance/${course_instance.id}/instructor">View as instructor</a>
-          </p>`}
+      ${
+        isDeleted
+          ? html`<div class="alert alert-danger" role="alert">
+              <strong>This course instance has been deleted.</strong> You cannot make changes to it.
+            </div>`
+          : html`<p>
+              <a href="/pl/course_instance/${course_instance.id}/instructor">View as instructor</a>
+            </p>`
+      }
 
       <h2 class="h4">Limits</h2>
       <form method="POST" class="mb-3">
@@ -120,19 +122,21 @@ export function AdministratorInstitutionCourseInstance({
             the enrollment limit from either the course or the institution (if any) will be used.
           </small>
         </div>
-        ${isDeleted
-          ? ''
-          : html`
-              <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              <button
-                type="submit"
-                name="__action"
-                value="update_enrollment_limit"
-                class="btn btn-primary"
-              >
-                Save
-              </button>
-            `}
+        ${
+          isDeleted
+            ? ''
+            : html`
+                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                <button
+                  type="submit"
+                  name="__action"
+                  value="update_enrollment_limit"
+                  class="btn btn-primary"
+                >
+                  Save
+                </button>
+              `
+        }
       </form>
 
       <h2 class="h4">Plans</h2>
@@ -144,17 +148,19 @@ export function AdministratorInstitutionCourseInstance({
         csrfToken: resLocals.__csrf_token,
         disabled: isDeleted,
       })}
-      ${aiGradingEnabled && trpcCsrfToken
-        ? hydrateHtml(
-            <AdminCreditPoolSection
-              trpcCsrfToken={trpcCsrfToken}
-              useCustomApiKeys={course_instance.ai_grading_use_custom_api_keys}
-              isDeleted={isDeleted}
-              refundsEnabled={refundsEnabled}
-              creditPoolLimits={creditPoolLimits}
-            />,
-          )
-        : ''}
+      ${
+        aiGradingEnabled && trpcCsrfToken
+          ? hydrateHtml(
+              <AdminCreditPoolSection
+                trpcCsrfToken={trpcCsrfToken}
+                useCustomApiKeys={course_instance.ai_grading_use_custom_api_keys}
+                isDeleted={isDeleted}
+                refundsEnabled={refundsEnabled}
+                creditPoolLimits={creditPoolLimits}
+              />,
+            )
+          : ''
+      }
     `,
   });
 }

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
@@ -162,10 +162,12 @@ function LTI13Instance({
 
       <hr />
       <h5>Name:</h5>
-      ${instance.tool_platform_name
-        ? html` The LMS has referred to itself as:
-            <strong>${instance.tool_platform_name}</strong>`
-        : ''}
+      ${
+        instance.tool_platform_name
+          ? html` The LMS has referred to itself as:
+              <strong>${instance.tool_platform_name}</strong>`
+          : ''
+      }
       <form class="form" method="POST">
         <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
         <input type="hidden" name="__action" value="update_name" />
@@ -232,8 +234,7 @@ function LTI13Instance({
             rows="8"
             spellcheck="false"
           >
-${JSON.stringify(instance.issuer_params, null, 3)}</textarea
-          >
+${JSON.stringify(instance.issuer_params, null, 3)}</textarea>
         </div>
 
         <div class="mb-3 mt-2">
@@ -261,8 +262,7 @@ ${JSON.stringify(instance.issuer_params, null, 3)}</textarea
             rows="4"
             spellcheck="false"
           >
-${JSON.stringify(instance.custom_fields, null, 3)}</textarea
-          >
+${JSON.stringify(instance.custom_fields, null, 3)}</textarea>
           <small id="custom_fieldsHelp" class="form-text text-muted">
             Provide suggestions to the LMS in the config JSON for how to setup LTI 1.3 custom
             fields.
@@ -464,9 +464,11 @@ function RosterInspector({
       link. This exposes every member's <code>sub</code>, email, and UIN. No enrollments or users
       are created or modified.
     </p>
-    ${linkedCourseInstances.length === 0
-      ? html`<p>No course instances are linked to this LTI 1.3 instance yet.</p>`
-      : linkedCourseInstances.map((linked) => RosterInspectorForm({ linked, resLocals }))}
+    ${
+      linkedCourseInstances.length === 0
+        ? html`<p>No course instances are linked to this LTI 1.3 instance yet.</p>`
+        : linkedCourseInstances.map((linked) => RosterInspectorForm({ linked, resLocals }))
+    }
   `;
 }
 
@@ -495,30 +497,33 @@ function RosterInspectorForm({
           </a>
           <span class="text-muted fw-normal">(${lci.context_label ?? 'no context label'})</span>
         </h6>
-        ${lci.context_memberships_url === null
-          ? html`
-              <p class="text-muted mb-0">
-                No <code>context_memberships_url</code> stored yet. Have an instructor launch
-                PrairieLearn from this course in the LMS to populate it.
-              </p>
-            `
-          : html`
-              <form method="POST" class="row g-2 align-items-end">
-                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                <input type="hidden" name="__action" value="inspect_roster" />
-                <input type="hidden" name="lti13_course_instance_id" value="${lci.id}" />
-                <div class="col-md-9">
-                  <label class="form-label" for="rlid-${lci.id}">Resource link</label>
-                  <select class="form-select" id="rlid-${lci.id}" name="rlid">
-                    <option value="">None (plain roster, no custom claims)</option>
-                    ${lci.resource_link_id
-                      ? html`
-                          <option value="${lci.resource_link_id}">
-                            Course navigation (${lci.resource_link_id})
-                          </option>
-                        `
-                      : ''}
-                    ${linked.lineitem_resource_links.map(
+        ${
+          lci.context_memberships_url === null
+            ? html`
+                <p class="text-muted mb-0">
+                  No <code>context_memberships_url</code> stored yet. Have an instructor launch
+                  PrairieLearn from this course in the LMS to populate it.
+                </p>
+              `
+            : html`
+                <form method="POST" class="row g-2 align-items-end">
+                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                  <input type="hidden" name="__action" value="inspect_roster" />
+                  <input type="hidden" name="lti13_course_instance_id" value="${lci.id}" />
+                  <div class="col-md-9">
+                    <label class="form-label" for="rlid-${lci.id}">Resource link</label>
+                    <select class="form-select" id="rlid-${lci.id}" name="rlid">
+                      <option value="">None (plain roster, no custom claims)</option>
+                      ${
+                      lci.resource_link_id
+                        ? html`
+                            <option value="${lci.resource_link_id}">
+                              Course navigation (${lci.resource_link_id})
+                            </option>
+                          `
+                        : ''
+                    }
+                      ${linked.lineitem_resource_links.map(
                       (li) => html`
                         <option value="${li.resource_link_id}">
                           Assessment: ${li.assessment_title ?? li.label ?? li.resource_link_id}
@@ -526,13 +531,14 @@ function RosterInspectorForm({
                         </option>
                       `,
                     )}
-                  </select>
-                </div>
-                <div class="col-md-3">
-                  <button type="submit" class="btn btn-primary w-100">Dump roster</button>
-                </div>
-              </form>
-            `}
+                    </select>
+                  </div>
+                  <div class="col-md-3">
+                    <button type="submit" class="btn btn-primary w-100">Dump roster</button>
+                  </div>
+                </form>
+              `
+        }
       </div>
     </div>
   `;

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -48,77 +48,87 @@ export function AdministratorInstitutionSaml({
     },
     preContent: DeleteSamlConfigurationModal({ csrfToken: resLocals.__csrf_token }),
     content: html`
-      ${hasSamlProvider && !hasEnabledSaml
-        ? html`
-            <div class="alert alert-warning">
-              <h2 class="h5">SAML single sign-on is not enabled</h2>
-              <p class="mb-0">
-                After <a href="${testSamlUrl}">testing your SAML configuration</a>, you must visit
-                the <a href="${resLocals.urlPrefix}/sso">single sign-on configuration</a> page and
-                enable SAML authentication.
-              </p>
-            </div>
-          `
-        : ''}
-      ${hasSamlProvider && missingAttributeMappings
-        ? html`
-            <div class="alert alert-warning">
-              <h2 class="h5">Missing attribute mappings</h2>
-              <p class="mb-0">
-                One or more attribute mappings are missing. These are necessary for authentication
-                to work correctly.
-              </p>
-            </div>
-          `
-        : ''}
-      ${hasSamlProvider && hasPartialSplitNameMapping
-        ? html`
-            <div class="alert alert-warning">
-              <h2 class="h5">Incomplete split name configuration</h2>
-              <p class="mb-0">
-                Only one of the given name and family name attributes is configured. Both must be
-                configured together for split name mapping to take effect.
-              </p>
-            </div>
-          `
-        : ''}
-      ${hasSamlProvider && hasEnabledSaml && !missingAttributeMappings
-        ? html`
-            <div class="alert alert-success">
-              <h2 class="h5">SAML single sign-on is configured and enabled!</h2>
-              <p class="mb-0">
-                Users can sign into your institution using your configured SAML provider.
-              </p>
-            </div>
-          `
-        : ''}
-      ${hasSamlProvider
-        ? html`
-            <div class="card mb-4">
-              <div class="card-header bg-primary text-white d-flex align-items-center">
-                Information required by your Identity Provider
-              </div>
-              <div class="card-body">
-                <p>
-                  If your Identity Provider supports obtaining Service Provider configuration from a
-                  metadata URL, use the following:
+      ${
+        hasSamlProvider && !hasEnabledSaml
+          ? html`
+              <div class="alert alert-warning">
+                <h2 class="h5">SAML single sign-on is not enabled</h2>
+                <p class="mb-0">
+                  After <a href="${testSamlUrl}">testing your SAML configuration</a>, you must visit
+                  the <a href="${resLocals.urlPrefix}/sso">single sign-on configuration</a> page and
+                  enable SAML authentication.
                 </p>
-                <small class="text-muted">Metadata URL</small>
-                <div class="form-control mb-3">${metadataUrl}</div>
-                <p>Otherwise, use the following values to configure your Identity Provider:</p>
-                <small class="text-muted">Issuer / Entity ID</small>
-                <div class="form-control mb-3">${issuer}</div>
-                <small class="text-muted">Assertion Consumer Service URL</small>
-                <div class="form-control mb-3">${assertionConsumerServiceUrl}</div>
-                <small class="text-muted">Public Key</small>
-                <pre
-                  class="form-control mb-0"
-                  style="height: auto;"
-                ><code>${samlProvider.public_key}</code></pre>
               </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
+      ${
+        hasSamlProvider && missingAttributeMappings
+          ? html`
+              <div class="alert alert-warning">
+                <h2 class="h5">Missing attribute mappings</h2>
+                <p class="mb-0">
+                  One or more attribute mappings are missing. These are necessary for authentication
+                  to work correctly.
+                </p>
+              </div>
+            `
+          : ''
+      }
+      ${
+        hasSamlProvider && hasPartialSplitNameMapping
+          ? html`
+              <div class="alert alert-warning">
+                <h2 class="h5">Incomplete split name configuration</h2>
+                <p class="mb-0">
+                  Only one of the given name and family name attributes is configured. Both must be
+                  configured together for split name mapping to take effect.
+                </p>
+              </div>
+            `
+          : ''
+      }
+      ${
+        hasSamlProvider && hasEnabledSaml && !missingAttributeMappings
+          ? html`
+              <div class="alert alert-success">
+                <h2 class="h5">SAML single sign-on is configured and enabled!</h2>
+                <p class="mb-0">
+                  Users can sign into your institution using your configured SAML provider.
+                </p>
+              </div>
+            `
+          : ''
+      }
+      ${
+        hasSamlProvider
+          ? html`
+              <div class="card mb-4">
+                <div class="card-header bg-primary text-white d-flex align-items-center">
+                  Information required by your Identity Provider
+                </div>
+                <div class="card-body">
+                  <p>
+                    If your Identity Provider supports obtaining Service Provider configuration from
+                    a metadata URL, use the following:
+                  </p>
+                  <small class="text-muted">Metadata URL</small>
+                  <div class="form-control mb-3">${metadataUrl}</div>
+                  <p>Otherwise, use the following values to configure your Identity Provider:</p>
+                  <small class="text-muted">Issuer / Entity ID</small>
+                  <div class="form-control mb-3">${issuer}</div>
+                  <small class="text-muted">Assertion Consumer Service URL</small>
+                  <div class="form-control mb-3">${assertionConsumerServiceUrl}</div>
+                  <small class="text-muted">Public Key</small>
+                  <pre
+                    class="form-control mb-0"
+                    style="height: auto;"
+                  ><code>${samlProvider.public_key}</code></pre>
+                </div>
+              </div>
+            `
+          : ''
+      }
 
       <h2 class="h4">Identity Provider configuration</h2>
       <form method="POST" class="mb-3 js-configure-form" ${!hasSamlProvider ? 'hidden' : ''}>
@@ -163,8 +173,7 @@ export function AdministratorInstitutionSaml({
             rows="20"
             aria-describedby="certificateHelp"
           >
-${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}</textarea
-          >
+${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'}</textarea>
           <small id="certificateHelp" class="form-text text-muted">
             The public certificate of the Identity Provider. This is used to verify the signature of
             the SAML response. This <strong>must</strong> be a valid X.509 certificate in PEM
@@ -235,12 +244,14 @@ ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICAT
           <code>urn:oid:...</code>.
         </p>
 
-        ${!hasSamlProvider
-          ? html`<div class="alert alert-info">
-              If you're not sure which attributes are available, you can leave these blank for now
-              and use the "Test SAML login" link after setting up your Identity Provider.
-            </div>`
-          : ''}
+        ${
+          !hasSamlProvider
+            ? html`<div class="alert alert-info">
+                If you're not sure which attributes are available, you can leave these blank for now
+                and use the "Test SAML login" link after setting up your Identity Provider.
+              </div>`
+            : ''
+        }
 
         <div class="mb-3">
           <label class="form-label" for="name_attribute">Name attribute</label>
@@ -358,85 +369,87 @@ ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICAT
           Configure SAML identity provider
         </button>
       </div>
-      ${hasSamlProvider
-        ? html`
-            <p>
-              <a href="${testSamlUrl}" target="_blank">Test SAML login</a>: Shows all attributes
-              from the SAML IdP without establishing a session.
-            </p>
+      ${
+        hasSamlProvider
+          ? html`
+              <p>
+                <a href="${testSamlUrl}" target="_blank">Test SAML login</a>: Shows all attributes
+                from the SAML IdP without establishing a session.
+              </p>
 
-            <p>
-              <a href="${testSamlStrictUrl}" target="_blank">Test SAML login (strict mode)</a>:
-              Forces "validate audience", "require signed assertions", and "require signed response"
-              to be enabled.
-            </p>
+              <p>
+                <a href="${testSamlStrictUrl}" target="_blank">Test SAML login (strict mode)</a>:
+                Forces "validate audience", "require signed assertions", and "require signed
+                response" to be enabled.
+              </p>
 
-            <p>
-              <a href="${metadataUrl}" target="_blank">View SAML metadata</a>: Metadata can be
-              provided to institutions to help them configure their SAML IdP.
-            </p>
+              <p>
+                <a href="${metadataUrl}" target="_blank">View SAML metadata</a>: Metadata can be
+                provided to institutions to help them configure their SAML IdP.
+              </p>
 
-            <p>
-              <button
-                class="btn btn-danger"
-                type="button"
-                data-bs-toggle="modal"
-                data-bs-target="#deleteModal"
-              >
-                Delete SAML configuration
-              </button>
-            </p>
+              <p>
+                <button
+                  class="btn btn-danger"
+                  type="button"
+                  data-bs-toggle="modal"
+                  data-bs-target="#deleteModal"
+                >
+                  Delete SAML configuration
+                </button>
+              </p>
 
-            <h2 class="h4">Decode SAML assertion</h2>
+              <h2 class="h4">Decode SAML assertion</h2>
 
-            <form method="POST">
-              <div class="mb-3">
-                <label class="form-label" for="encodedAssertion">Encoded assertion</label>
-                <textarea
-                  class="form-control"
-                  id="encodedAssertion"
-                  rows="10"
-                  name="encoded_assertion"
-                  aria-describedby="encodedAssertionHelp"
-                ></textarea>
-                <small class="form-text text-muted">
-                  This should be raw base64-encoded data from the
-                  <code>SAMLResponse</code> parameter in the POST request from the IdP.
-                </small>
-              </div>
+              <form method="POST">
+                <div class="mb-3">
+                  <label class="form-label" for="encodedAssertion">Encoded assertion</label>
+                  <textarea
+                    class="form-control"
+                    id="encodedAssertion"
+                    rows="10"
+                    name="encoded_assertion"
+                    aria-describedby="encodedAssertionHelp"
+                  ></textarea>
+                  <small class="form-text text-muted">
+                    This should be raw base64-encoded data from the
+                    <code>SAMLResponse</code> parameter in the POST request from the IdP.
+                  </small>
+                </div>
 
-              <div class="mb-3 form-check">
-                <input
-                  type="checkbox"
-                  class="form-check-input"
-                  id="strictMode"
-                  name="strict_mode"
-                  value="1"
-                  aria-describedby="strictModeHelp"
-                />
-                <label class="form-check-label" for="strictMode">Strict mode</label>
-                <small id="strictModeHelp" class="form-text text-muted mt-0">
-                  Forces "validate audience", "require signed assertions", and "require signed
-                  response" to be enabled.
-                </small>
-              </div>
+                <div class="mb-3 form-check">
+                  <input
+                    type="checkbox"
+                    class="form-check-input"
+                    id="strictMode"
+                    name="strict_mode"
+                    value="1"
+                    aria-describedby="strictModeHelp"
+                  />
+                  <label class="form-check-label" for="strictMode">Strict mode</label>
+                  <small id="strictModeHelp" class="form-text text-muted mt-0">
+                    Forces "validate audience", "require signed assertions", and "require signed
+                    response" to be enabled.
+                  </small>
+                </div>
 
-              <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              <button
-                class="btn btn-primary"
-                type="button"
-                name="__action"
-                value="decode_assertion"
-                hx-post="${resLocals.urlPrefix}/saml"
-                hx-target="#decodedAssertion"
-                hx-swap="innerHTML show:top"
-              >
-                Decode
-              </button>
-              <div id="decodedAssertion"></div>
-            </form>
-          `
-        : ''}
+                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                <button
+                  class="btn btn-primary"
+                  type="button"
+                  name="__action"
+                  value="decode_assertion"
+                  hx-post="${resLocals.urlPrefix}/saml"
+                  hx-target="#decodedAssertion"
+                  hx-swap="innerHTML show:top"
+                >
+                  Decode
+                </button>
+                <div id="decodedAssertion"></div>
+              </form>
+            `
+          : ''
+      }
     `,
     postContent: html`
       <script>

--- a/apps/prairielearn/src/ee/pages/institutionAdminAdmins/institutionAdminAdmins.html.ts
+++ b/apps/prairielearn/src/ee/pages/institutionAdminAdmins/institutionAdminAdmins.html.ts
@@ -64,15 +64,16 @@ function AdminsCard({ rows }: { rows: InstitutionAdminAdminsRow[] }) {
         </button>
       </div>
 
-      ${rows.length === 0
-        ? html`
-            <div class="card-body">
-              <div class="text-center text-muted">No institution administrators</div>
-            </div>
-          `
-        : html`
-            <ul class="list-group list-group-flush">
-              ${rows.map(
+      ${
+        rows.length === 0
+          ? html`
+              <div class="card-body">
+                <div class="text-center text-muted">No institution administrators</div>
+              </div>
+            `
+          : html`
+              <ul class="list-group list-group-flush">
+                ${rows.map(
                 (row) => html`
                   <li class="list-group-item d-flex flex-row align-items-center">
                     <div class="d-flex flex-column">
@@ -93,8 +94,9 @@ function AdminsCard({ rows }: { rows: InstitutionAdminAdminsRow[] }) {
                   </li>
                 `,
               )}
-            </ul>
-          `}
+              </ul>
+            `
+      }
     </div>
   `;
 }

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.html.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDrafts/instructorAiGenerateDrafts.html.tsx
@@ -130,42 +130,48 @@ export function InstructorAIGenerateDrafts({
           />,
         )}
       </div>
-      ${hasDrafts
-        ? html`
-            <div class="d-flex flex-row align-items-center justify-content-between mb-2">
-              <h1 class="h5 mb-0">Continue working on a draft question</h1>
-              <button
-                class="btn btn-sm btn-outline-danger ms-2"
-                data-bs-toggle="modal"
-                data-bs-target="#deleteModal"
-              >
-                <i class="fa fa-trash" aria-hidden="true"></i>
-                <span class="d-none d-sm-inline">Delete all drafts</span>
-              </button>
-            </div>
-            <div class="card">
-              <div class="table-responsive">
-                <table class="table table-sm table-hover" aria-label="AI question generation jobs">
-                  <thead>
-                    <tr>
-                      <th>QID</th>
-                      <th>Created At</th>
-                      <th>Created By</th>
-                      <th>Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${drafts.map(
+      ${
+        hasDrafts
+          ? html`
+              <div class="d-flex flex-row align-items-center justify-content-between mb-2">
+                <h1 class="h5 mb-0">Continue working on a draft question</h1>
+                <button
+                  class="btn btn-sm btn-outline-danger ms-2"
+                  data-bs-toggle="modal"
+                  data-bs-target="#deleteModal"
+                >
+                  <i class="fa fa-trash" aria-hidden="true"></i>
+                  <span class="d-none d-sm-inline">Delete all drafts</span>
+                </button>
+              </div>
+              <div class="card">
+                <div class="table-responsive">
+                  <table
+                    class="table table-sm table-hover"
+                    aria-label="AI question generation jobs"
+                  >
+                    <thead>
+                      <tr>
+                        <th>QID</th>
+                        <th>Created At</th>
+                        <th>Created By</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${drafts.map(
                       (row) => html`
                         <tr>
                           <td>${row.qid}</td>
                           <td>
-                            ${row.draft_question_metadata?.created_at == null
-                              ? html`&mdash;`
-                              : formatDate(
-                                  row.draft_question_metadata.created_at,
-                                  resLocals.course.display_timezone,
-                                )}
+                            ${
+                              row.draft_question_metadata?.created_at == null
+                                ? html`&mdash;`
+                                : formatDate(
+                                    row.draft_question_metadata.created_at,
+                                    resLocals.course.display_timezone,
+                                  )
+                            }
                           </td>
                           <td>${row.uid ?? '(System)'}</td>
                           <td>
@@ -179,12 +185,13 @@ export function InstructorAIGenerateDrafts({
                         </tr>
                       `,
                     )}
-                  </tbody>
-                </table>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
       ${DeleteQuestionsModal({ csrfToken: resLocals.__csrf_token })}
     `,
   });

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -48,38 +48,40 @@ export function InstructorInstanceAdminLti13NoInstances({
           <h1>LMS connections</h1>
         </div>
         <div class="card-body">
-          ${lti13_instances.length === 0
-            ? html`
-                <p>
-                  No learning management systems (LMSes) at your institution are available for
-                  integration with PrairieLearn. Please contact your IT administrators to set up an
-                  integration. You can refer them to the
-                  <a target="_blank" href="https://docs.prairielearn.com/lti13/" rel="noreferrer"
-                    >documentation</a
-                  >.
-                </p>
-              `
-            : html`
-                <p>
-                  The following learning management systems (LMSes) at your institution are
-                  available for integration with PrairieLearn:
-                </p>
+          ${
+            lti13_instances.length === 0
+              ? html`
+                  <p>
+                    No learning management systems (LMSes) at your institution are available for
+                    integration with PrairieLearn. Please contact your IT administrators to set up
+                    an integration. You can refer them to the
+                    <a target="_blank" href="https://docs.prairielearn.com/lti13/" rel="noreferrer"
+                      >documentation</a
+                    >.
+                  </p>
+                `
+              : html`
+                  <p>
+                    The following learning management systems (LMSes) at your institution are
+                    available for integration with PrairieLearn:
+                  </p>
 
-                <ul>
-                  ${lti13_instances.map((i) => {
+                  <ul>
+                    ${lti13_instances.map((i) => {
                     return html`<li>${i.name}</li>`;
                   })}
-                </ul>
-                <p>
-                  <a
-                    target="_blank"
-                    href="https://docs.prairielearn.com/lmsIntegrationInstructor/"
-                    rel="noreferrer"
-                  >
-                    How can I integrate my course with an LMS?
-                  </a>
-                </p>
-              `}
+                  </ul>
+                  <p>
+                    <a
+                      target="_blank"
+                      href="https://docs.prairielearn.com/lmsIntegrationInstructor/"
+                      rel="noreferrer"
+                    >
+                      How can I integrate my course with an LMS?
+                    </a>
+                  </p>
+                `
+          }
           <p class="mb-0">
             Integrating will allow you to push assessment scores from PrairieLearn to the LMS.
           </p>
@@ -140,17 +142,19 @@ export function InstructorInstanceAdminLti13({
                   ${instances.map((i) => {
                     return html`
                       <a
-                        class="dropdown-item ${instance.lti13_course_instance.id ===
-                        i.lti13_course_instance.id
-                          ? 'active'
-                          : ''}"
-                        href="/pl/course_instance/${resLocals.course_instance
-                          .id}/instructor/instance_admin/lti13_instance/${i.lti13_course_instance
-                          .id}"
-                        aria-current="${instance.lti13_course_instance.id ===
-                        i.lti13_course_instance.id
-                          ? 'true'
-                          : ''}"
+                        class="dropdown-item ${
+                          instance.lti13_course_instance.id === i.lti13_course_instance.id
+                            ? 'active'
+                            : ''
+                        }"
+                        href="/pl/course_instance/${
+                          resLocals.course_instance.id
+                        }/instructor/instance_admin/lti13_instance/${i.lti13_course_instance.id}"
+                        aria-current="${
+                          instance.lti13_course_instance.id === i.lti13_course_instance.id
+                            ? 'true'
+                            : ''
+                        }"
                       >
                         ${i.lti13_instance.name}: ${i.lti13_course_instance.context_label}
                       </a>
@@ -171,24 +175,26 @@ export function InstructorInstanceAdminLti13({
             </div>
             <div class="col-10">
               <h3 id="assessments">Linked Assessments</h3>
-              ${instance.lti13_course_instance.context_memberships_url &&
-              instance.lti13_course_instance.lineitems_url
-                ? LinkedAssessments({
-                    resLocals,
-                    lms_name,
-                    assessments,
-                    lineitems,
-                  })
-                : html`
-                    <p>
-                      PrairieLearn does not have enough LTI metadata to link assignments and do
-                      grade passback.
-                    </p>
-                    <p>
-                      To update our metadata, go back to the LMS and initiate a PrairieLearn
-                      connection via LTI as an instructor, then return here.
-                    </p>
-                  `}
+              ${
+                instance.lti13_course_instance.context_memberships_url &&
+                instance.lti13_course_instance.lineitems_url
+                  ? LinkedAssessments({
+                      resLocals,
+                      lms_name,
+                      assessments,
+                      lineitems,
+                    })
+                  : html`
+                      <p>
+                        PrairieLearn does not have enough LTI metadata to link assignments and do
+                        grade passback.
+                      </p>
+                      <p>
+                        To update our metadata, go back to the LMS and initiate a PrairieLearn
+                        connection via LTI as an instructor, then return here.
+                      </p>
+                    `
+              }
 
               <h3 id="connection">Connection to LMS</h3>
               <form method="POST">
@@ -247,11 +253,12 @@ function LinkedAssessments({
               return item.assessment_id === row.id;
             });
             return html`
-              ${row.start_new_assessment_group
-                ? html`
-                    <tr>
-                      <th colspan="5">
-                        ${Modal({
+              ${
+                row.start_new_assessment_group
+                  ? html`
+                      <tr>
+                        <th colspan="5">
+                          ${Modal({
                           id: `bulk-${row.assessment_set_id}-${row.assessment_module_id}`,
                           title: `${row.assessment_group_heading} ${assessments_group_by} Bulk Actions`,
                           body: html`<p>
@@ -305,19 +312,20 @@ function LinkedAssessments({
                             Close
                           </button>`,
                         })}
-                        ${row.assessment_group_heading}
-                        <button
-                          class="btn btn-sm btn-secondary ms-2"
-                          type="button"
-                          data-bs-toggle="modal"
-                          data-bs-target="#bulk-${row.assessment_set_id}-${row.assessment_module_id}"
-                        >
-                          Bulk actions
-                        </button>
-                      </th>
-                    </tr>
-                  `
-                : ''}
+                          ${row.assessment_group_heading}
+                          <button
+                            class="btn btn-sm btn-secondary ms-2"
+                            type="button"
+                            data-bs-toggle="modal"
+                            data-bs-target="#bulk-${row.assessment_set_id}-${row.assessment_module_id}"
+                          >
+                            Bulk actions
+                          </button>
+                        </th>
+                      </tr>
+                    `
+                  : ''
+              }
               <tr id="row-${row.id}">
                 <td class="align-middle" style="width: 1%">
                   <span class="badge color-${row.color}">${row.label}</span>
@@ -325,9 +333,9 @@ function LinkedAssessments({
                 <td class="align-middle">
                   <a href="${urlPrefix}/assessment/${row.id}/"
                     >${row.title}
-                    ${row.team_work
-                      ? html` <i class="fas fa-users" aria-hidden="true"></i> `
-                      : ''}</a
+                    ${
+                      row.team_work ? html` <i class="fas fa-users" aria-hidden="true"></i> ` : ''
+                    }</a
                   >
                 </td>
                 <td>
@@ -382,42 +390,44 @@ function LinkedAssessments({
                   <form method="POST">
                     <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
                     <input type="hidden" name="unsafe_assessment_id" value="${row.id}" />
-                    ${lineitems_linked.length === 0
-                      ? html`
-                          <button
-                            class="btn btn-med-light"
-                            type="button"
-                            data-bs-toggle="modal"
-                            data-bs-target="#assignment-${row.id}"
-                          >
-                            Link assignment
-                          </button>
-                        `
-                      : html`
-                          <div class="btn-group">
-                            <button class="btn btn-info" name="__action" value="send_grades">
-                              Send grades
-                            </button>
+                    ${
+                      lineitems_linked.length === 0
+                        ? html`
                             <button
+                              class="btn btn-med-light"
                               type="button"
-                              class="btn btn-info dropdown-toggle dropdown-toggle-split"
-                              data-bs-toggle="dropdown"
-                              aria-expanded="false"
-                              aria-label="Toggle dropdown"
-                            ></button>
-                            <ul class="dropdown-menu">
-                              <li>
-                                <button
-                                  class="dropdown-item"
-                                  name="__action"
-                                  value="unlink_assessment"
-                                >
-                                  Unlink assignment
-                                </button>
-                              </li>
-                            </ul>
-                          </div>
-                        `}
+                              data-bs-toggle="modal"
+                              data-bs-target="#assignment-${row.id}"
+                            >
+                              Link assignment
+                            </button>
+                          `
+                        : html`
+                            <div class="btn-group">
+                              <button class="btn btn-info" name="__action" value="send_grades">
+                                Send grades
+                              </button>
+                              <button
+                                type="button"
+                                class="btn btn-info dropdown-toggle dropdown-toggle-split"
+                                data-bs-toggle="dropdown"
+                                aria-expanded="false"
+                                aria-label="Toggle dropdown"
+                              ></button>
+                              <ul class="dropdown-menu">
+                                <li>
+                                  <button
+                                    class="dropdown-item"
+                                    name="__action"
+                                    value="unlink_assessment"
+                                  >
+                                    Unlink assignment
+                                  </button>
+                                </li>
+                              </ul>
+                            </div>
+                          `
+                    }
                   </form>
                 </td>
                 <td class="align-middle">

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.html.ts
@@ -29,49 +29,51 @@ export function Lti13CourseNavigationInstructor({
         <strong>${courseName}</strong> with a PrairieLearn course instance.
       </p>
 
-      ${courses.length === 0
-        ? html`<p>
-            <strong>
-              You don't have course owner or editor permissions in any PrairieLearn courses.
-            </strong>
-          </p>`
-        : html`
-            <div class="mb-3">
-              <form method="POST" id="link_form">
-                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+      ${
+        courses.length === 0
+          ? html`<p>
+              <strong>
+                You don't have course owner or editor permissions in any PrairieLearn courses.
+              </strong>
+            </p>`
+          : html`
+              <div class="mb-3">
+                <form method="POST" id="link_form">
+                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
 
-                <label class="form-label" for="connect_course">
-                  Select a PrairieLearn course:
-                </label>
-                <select
-                  id="connect_course"
-                  class="form-select mb-3"
-                  name="unsafe_course_id"
-                  hx-get="/pl/lti13_instance/${lti13_instance_id}/course_navigation/course_instances"
-                  hx-include="#link_form"
-                  hx-target="#course_instances"
-                  required
-                >
-                  <option selected disabled value="">Select a course to continue</option>
-                  ${courses.map((c) => {
+                  <label class="form-label" for="connect_course">
+                    Select a PrairieLearn course:
+                  </label>
+                  <select
+                    id="connect_course"
+                    class="form-select mb-3"
+                    name="unsafe_course_id"
+                    hx-get="/pl/lti13_instance/${lti13_instance_id}/course_navigation/course_instances"
+                    hx-include="#link_form"
+                    hx-target="#course_instances"
+                    required
+                  >
+                    <option selected disabled value="">Select a course to continue</option>
+                    ${courses.map((c) => {
                     return html`<option value="${c.id}">${c.short_name}: ${c.title}</option>`;
                   })}
-                </select>
-                <label class="form-label" for="course_instances">
-                  Select a course instance to connect:
-                </label>
-                <select
-                  id="course_instances"
-                  name="unsafe_course_instance_id"
-                  class="form-select mb-3"
-                  required
-                >
-                  <option selected disabled value="">See above</option>
-                </select>
-                <button type="submit" class="btn btn-primary">Connect course instance</button>
-              </form>
-            </div>
-          `}
+                  </select>
+                  <label class="form-label" for="course_instances">
+                    Select a course instance to connect:
+                  </label>
+                  <select
+                    id="course_instances"
+                    name="unsafe_course_instance_id"
+                    class="form-select mb-3"
+                    required
+                  >
+                    <option selected disabled value="">See above</option>
+                  </select>
+                  <button type="submit" class="btn btn-primary">Connect course instance</button>
+                </form>
+              </div>
+            `
+      }
 
       <p>
         <details>
@@ -128,23 +130,26 @@ export function Lti13CourseNavigationNotReady({
           PrairieLearn home
         </a>
       </p>
-      ${ltiRoles.includes(STUDENT_ROLE)
-        ? ''
-        : html`
-            <div class="card">
-              <div class="card-header bg-info">Debugging information</div>
-              <div class="card-body">
-                <p>
-                  You do not have the permissions to integrate PrairieLearn course instances. An
-                  instructor or designer (and not Teaching Assistant) LMS role is needed to do this.
-                </p>
-                <p>Here are your roles that we received from your LMS:</p>
-                <ul class="mb-0">
-                  ${ltiRoles.map((role) => html`<li><code>${role}</code></li>`)}
-                </ul>
+      ${
+        ltiRoles.includes(STUDENT_ROLE)
+          ? ''
+          : html`
+              <div class="card">
+                <div class="card-header bg-info">Debugging information</div>
+                <div class="card-body">
+                  <p>
+                    You do not have the permissions to integrate PrairieLearn course instances. An
+                    instructor or designer (and not Teaching Assistant) LMS role is needed to do
+                    this.
+                  </p>
+                  <p>Here are your roles that we received from your LMS:</p>
+                  <ul class="mb-0">
+                    ${ltiRoles.map((role) => html`<li><code>${role}</code></li>`)}
+                  </ul>
+                </div>
               </div>
-            </div>
-          `}
+            `
+      }
     `,
   });
 }

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -42,43 +42,45 @@ export function StudentCourseInstanceUpgrade({
         requires an upgrade to support certain features selected by your instructor.
       </p>
 
-      ${planPrices == null
-        ? html`<p>Please contact your instructor for more information.</p>`
-        : html`
-            ${PriceTable({ planNames: missingPlans, planPrices })}
+      ${
+        planPrices == null
+          ? html`<p>Please contact your instructor for more information.</p>`
+          : html`
+              ${PriceTable({ planNames: missingPlans, planPrices })}
 
-            <form method="POST">
-              <div class="form-check mb-3">
-                <input
-                  type="checkbox"
-                  class="form-check-input"
-                  id="js-terms-agreement"
-                  name="terms_agreement"
-                  value="1"
-                />
-                <label class="form-check-label" for="js-terms-agreement">
-                  I agree to the PrairieLearn
-                  <a href="https://www.prairielearn.com/legal/terms">Terms of Service</a> and
-                  <a href="https://www.prairielearn.com/legal/privacy">Privacy Policy</a>.
-                </label>
-              </div>
+              <form method="POST">
+                <div class="form-check mb-3">
+                  <input
+                    type="checkbox"
+                    class="form-check-input"
+                    id="js-terms-agreement"
+                    name="terms_agreement"
+                    value="1"
+                  />
+                  <label class="form-check-label" for="js-terms-agreement">
+                    I agree to the PrairieLearn
+                    <a href="https://www.prairielearn.com/legal/terms">Terms of Service</a> and
+                    <a href="https://www.prairielearn.com/legal/privacy">Privacy Policy</a>.
+                  </label>
+                </div>
 
-              <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              ${missingPlans.map(
+                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                ${missingPlans.map(
                 (plan) => html` <input type="hidden" name="unsafe_plan_names" value="${plan}" /> `,
               )}
-              <button
-                id="js-upgrade"
-                type="submit"
-                name="__action"
-                value="upgrade"
-                class="btn btn-primary d-block w-100"
-                disabled
-              >
-                Upgrade
-              </button>
-            </form>
-          `}
+                <button
+                  id="js-upgrade"
+                  type="submit"
+                  name="__action"
+                  value="upgrade"
+                  class="btn btn-primary d-block w-100"
+                  disabled
+                >
+                  Upgrade
+                </button>
+              </form>
+            `
+      }
     `,
   });
 }
@@ -104,17 +106,21 @@ export function CourseInstanceStudentUpdateSuccess({
     content: html`
       <h1>Thanks!</h1>
 
-      ${paid
-        ? html`
-            <p>Your payment was successfully processed. You may now access the course.</p>
+      ${
+        paid
+          ? html`
+              <p>Your payment was successfully processed. You may now access the course.</p>
 
-            <a href="/pl/course_instance/${courseInstance.id}" class="btn btn-primary">
-              Continue to ${course.short_name}
-            </a>
-          `
-        : html`
-            <p>Once your payment has been fully processed, check back for access to the course.</p>
-          `}
+              <a href="/pl/course_instance/${courseInstance.id}" class="btn btn-primary">
+                Continue to ${course.short_name}
+              </a>
+            `
+          : html`
+              <p>
+                Once your payment has been fully processed, check back for access to the course.
+              </p>
+            `
+      }
     `,
   });
 }

--- a/apps/prairielearn/src/ee/pages/terms/terms.html.ts
+++ b/apps/prairielearn/src/ee/pages/terms/terms.html.ts
@@ -14,28 +14,30 @@ export function Terms({ user, resLocals }: { user: User; resLocals: UntypedResLo
     },
     content: html`
       <h1>Terms and Conditions</h1>
-      ${user.terms_accepted_at
-        ? html`
-            <p>
-              You have already accepted the latest
-              <a href="https://www.prairielearn.com/legal/terms">Terms of Service</a> and
-              <a href="https://www.prairielearn.com/legal/privacy">Privacy Policy</a>.
-            </p>
-            <a href="/" class="btn btn-primary">Continue to PrairieLearn</a>
-          `
-        : html`
-            <p>
-              To continue, please accept the latest
-              <a href="https://www.prairielearn.com/legal/terms">Terms of Service</a> and
-              <a href="https://www.prairielearn.com/legal/privacy">Privacy Policy</a>.
-            </p>
-            <form method="POST">
-              <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              <button type="submit" class="btn btn-primary" name="__action" value="accept_terms">
-                Accept and continue
-              </button>
-            </form>
-          `}
+      ${
+        user.terms_accepted_at
+          ? html`
+              <p>
+                You have already accepted the latest
+                <a href="https://www.prairielearn.com/legal/terms">Terms of Service</a> and
+                <a href="https://www.prairielearn.com/legal/privacy">Privacy Policy</a>.
+              </p>
+              <a href="/" class="btn btn-primary">Continue to PrairieLearn</a>
+            `
+          : html`
+              <p>
+                To continue, please accept the latest
+                <a href="https://www.prairielearn.com/legal/terms">Terms of Service</a> and
+                <a href="https://www.prairielearn.com/legal/privacy">Privacy Policy</a>.
+              </p>
+              <form method="POST">
+                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                <button type="submit" class="btn btn-primary" name="__action" value="accept_terms">
+                  Accept and continue
+                </button>
+              </form>
+            `
+      }
     `,
   });
 }

--- a/apps/prairielearn/src/lib/authz-data-lib.ts
+++ b/apps/prairielearn/src/lib/authz-data-lib.ts
@@ -133,9 +133,7 @@ export type ConstructedCourseOrInstanceContext =
 export type AuthzDataWithoutEffectiveUser = PlainAuthzData | DangerousSystemAuthzData;
 
 export type AuthzDataWithEffectiveUser =
-  | RawPageAuthzData
-  | PageAuthzData
-  | DangerousSystemAuthzData;
+  RawPageAuthzData | PageAuthzData | DangerousSystemAuthzData;
 
 export type AuthzData = AuthzDataWithoutEffectiveUser | AuthzDataWithEffectiveUser;
 
@@ -150,10 +148,7 @@ type InstructorCourseInstanceRole = 'Student Data Viewer' | 'Student Data Editor
 type CourseRole = 'Previewer' | 'Viewer' | 'Editor' | 'Owner';
 
 export type Role =
-  | SystemRole
-  | StudentCourseInstanceRole
-  | InstructorCourseInstanceRole
-  | CourseRole;
+  SystemRole | StudentCourseInstanceRole | InstructorCourseInstanceRole | CourseRole;
 
 export function dangerousFullSystemAuthz(): DangerousSystemAuthzData {
   return {

--- a/apps/prairielearn/src/lib/client/errors.tsx
+++ b/apps/prairielearn/src/lib/client/errors.tsx
@@ -21,8 +21,7 @@ type ResolveAppError<T> = T extends { code: string }
  * already-extracted error rather than a raw mutation error.
  */
 export type AppError<T> =
-  | (ResolveAppError<T> & { message: string })
-  | { code: 'UNKNOWN'; message: string };
+  (ResolveAppError<T> & { message: string }) | { code: 'UNKNOWN'; message: string };
 
 /**
  * Extracts a typed app-level error from a tRPC error, narrowed to the

--- a/apps/prairielearn/src/lib/client/url.ts
+++ b/apps/prairielearn/src/lib/client/url.ts
@@ -310,8 +310,7 @@ type QuestionUrlParts =
   | { courseInstanceId?: undefined; courseId: string };
 
 type CourseAdminUrlParts =
-  | { courseId: string; courseInstanceId?: string }
-  | { courseId?: string; courseInstanceId: string };
+  { courseId: string; courseInstanceId?: string } | { courseId?: string; courseInstanceId: string };
 
 export const QUESTION_TABLE_FILTER_URL_KEYS = {
   topic: 'topic',

--- a/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-container.ts
@@ -33,11 +33,7 @@ const EXITING = Symbol('EXITING');
 const EXITED = Symbol('EXITED');
 
 type CallerState =
-  | typeof CREATED
-  | typeof WAITING
-  | typeof IN_CALL
-  | typeof EXITING
-  | typeof EXITED;
+  typeof CREATED | typeof WAITING | typeof IN_CALL | typeof EXITING | typeof EXITED;
 
 interface CodeCallerContainerOptions {
   questionTimeoutMilliseconds: number;

--- a/apps/prairielearn/src/lib/code-caller/code-caller-shared.ts
+++ b/apps/prairielearn/src/lib/code-caller/code-caller-shared.ts
@@ -11,12 +11,7 @@ export interface CodeCallerResult {
 }
 
 export type CallType =
-  | 'question'
-  | 'v2-question'
-  | 'course-element'
-  | 'core-element'
-  | 'ping'
-  | 'restart';
+  'question' | 'v2-question' | 'course-element' | 'core-element' | 'ping' | 'restart';
 
 export interface PrepareForCourseOptions {
   coursePath: string;

--- a/apps/prairielearn/src/lib/enrollment-eligibility.ts
+++ b/apps/prairielearn/src/lib/enrollment-eligibility.ts
@@ -3,14 +3,10 @@ import { assertNever } from '@prairielearn/utils';
 import type { Course, CourseInstance, Enrollment, User } from './db-types.js';
 
 type EnrollmentIneligibilityReason =
-  | 'blocked'
-  | 'self-enrollment-disabled'
-  | 'self-enrollment-expired'
-  | 'institution-restriction';
+  'blocked' | 'self-enrollment-disabled' | 'self-enrollment-expired' | 'institution-restriction';
 
 type EnrollmentEligibilityResult =
-  | { eligible: true }
-  | { eligible: false; reason: EnrollmentIneligibilityReason };
+  { eligible: true } | { eligible: false; reason: EnrollmentIneligibilityReason };
 
 export function getEligibilityErrorMessage(reason: EnrollmentIneligibilityReason) {
   switch (reason) {

--- a/apps/prairielearn/src/lib/features/manager.ts
+++ b/apps/prairielearn/src/lib/features/manager.ts
@@ -45,11 +45,7 @@ interface CourseInstanceContext extends CourseContext {
 }
 
 type FeatureContext =
-  | EmptyContext
-  | UserContext
-  | InstitutionContext
-  | CourseContext
-  | CourseInstanceContext;
+  EmptyContext | UserContext | InstitutionContext | CourseContext | CourseInstanceContext;
 
 export class FeatureManager<FeatureName extends string> {
   features: Set<FeatureName>;

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
@@ -228,30 +228,34 @@ async function getOverrideUserData({
             <code>${requestedUid}</code>, when no such user exists. All requested changes to the
             effective user have been removed.
           </p>
-          ${config.devMode && isAdministrator
-            ? html`
-                <div class="alert alert-warning" role="alert">
-                  In Development Mode,
-                  <a href="/pl/administrator/query/select_or_insert_user">
-                    go here to add the user
-                  </a>
-                  first and then try the emulation again.
-                </div>
-                ${courseInstanceId
-                  ? html`
-                      <p>
-                        To auto-generate many users for testing, see
-                        <a href="/pl/administrator/query/generate_and_enroll_users"
-                          >Generate random users and enroll them in a course instance</a
-                        >
-                        <br />
-                        (Hint your course_instance_id is
-                        <strong>${courseInstanceId}</strong>)
-                      </p>
-                    `
-                  : ''}
-              `
-            : ''}
+          ${
+            config.devMode && isAdministrator
+              ? html`
+                  <div class="alert alert-warning" role="alert">
+                    In Development Mode,
+                    <a href="/pl/administrator/query/select_or_insert_user">
+                      go here to add the user
+                    </a>
+                    first and then try the emulation again.
+                  </div>
+                  ${
+                  courseInstanceId
+                    ? html`
+                        <p>
+                          To auto-generate many users for testing, see
+                          <a href="/pl/administrator/query/generate_and_enroll_users"
+                            >Generate random users and enroll them in a course instance</a
+                          >
+                          <br />
+                          (Hint your course_instance_id is
+                          <strong>${courseInstanceId}</strong>)
+                        </p>
+                      `
+                    : ''
+                }
+                `
+              : ''
+          }
         `,
       }),
     };

--- a/apps/prairielearn/src/middlewares/studentAssessmentAccess.html.ts
+++ b/apps/prairielearn/src/middlewares/studentAssessmentAccess.html.ts
@@ -32,9 +32,11 @@ export function StudentAssessmentAccess({
     },
     preContent: html`
       ${showTimeLimitExpiredModal ? TimeLimitExpiredModal({ showAutomatically: true }) : ''}
-      ${userCanDeleteAssessmentInstance
-        ? RegenerateInstanceModal({ csrfToken: resLocals.__csrf_token })
-        : ''}
+      ${
+        userCanDeleteAssessmentInstance
+          ? RegenerateInstanceModal({ csrfToken: resLocals.__csrf_token })
+          : ''
+      }
       ${userCanDeleteAssessmentInstance ? RegenerateInstanceAlert() : ''}
     `,
     content: html`
@@ -44,29 +46,31 @@ export function StudentAssessmentAccess({
         </div>
 
         <div class="card-body">
-          ${assessment_instance != null &&
-          (assessment_instance.open === false || authz_result.active === false) &&
-          showClosedScore
-            ? html`
-                <div class="row align-items-center">
-                  <div class="col-md-3 col-sm-6">
-                    Total points:
-                    ${formatPoints(assessment_instance.points)}/${formatPoints(
+          ${
+            assessment_instance != null &&
+            (assessment_instance.open === false || authz_result.active === false) &&
+            showClosedScore
+              ? html`
+                  <div class="row align-items-center">
+                    <div class="col-md-3 col-sm-6">
+                      Total points:
+                      ${formatPoints(assessment_instance.points)}/${formatPoints(
                       assessment_instance.max_points,
                     )}
-                  </div>
-                  <div class="col-md-3 col-sm-6">
-                    ${ScorebarHtml(assessment_instance.score_perc)}
-                  </div>
+                    </div>
+                    <div class="col-md-3 col-sm-6">
+                      ${ScorebarHtml(assessment_instance.score_perc)}
+                    </div>
 
-                  ${AssessmentStatusDescription({
+                    ${AssessmentStatusDescription({
                     assessment_instance,
                     authz_result,
                     extraClasses: 'col-md-6 col-sm-12 text-end',
                   })}
-                </div>
-              `
-            : AssessmentStatusDescription({ assessment_instance, authz_result })}
+                  </div>
+                `
+              : AssessmentStatusDescription({ assessment_instance, authz_result })
+          }
         </div>
       </div>
     `,
@@ -84,11 +88,13 @@ function AssessmentStatusDescription({
 }) {
   return html`
     <div class="${extraClasses}" data-testid="assessment-closed-message">
-      ${assessment_instance?.open === false
-        ? html`Assessment is <strong>closed</strong> and is no longer available.`
-        : authz_result.next_active_time == null
-          ? html`Assessment is no longer available.`
-          : html`Assessment will become available on ${authz_result.next_active_time}.`}
+      ${
+        assessment_instance?.open === false
+          ? html`Assessment is <strong>closed</strong> and is no longer available.`
+          : authz_result.next_active_time == null
+            ? html`Assessment is no longer available.`
+            : html`Assessment will become available on ${authz_result.next_active_time}.`
+      }
     </div>
   `;
 }

--- a/apps/prairielearn/src/models/assessment-instance.ts
+++ b/apps/prairielearn/src/models/assessment-instance.ts
@@ -8,11 +8,7 @@ const sql = loadSqlEquiv(import.meta.url);
 
 /** How the new `date_limit` for an instance is derived in {@link updateAssessmentInstancesTimeLimit}. */
 export type TimeLimitBaseTime =
-  | 'date_limit'
-  | 'null'
-  | 'current_date'
-  | 'start_date'
-  | 'exact_date';
+  'date_limit' | 'null' | 'current_date' | 'start_date' | 'exact_date';
 
 /**
  * Updates the time limit for one or more open assessment instances (re-opening

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -50,8 +50,7 @@ import { generateUsers, selectAndLockUser } from './user.js';
 const sql = loadSqlEquiv(import.meta.url);
 
 type CourseInstanceContext =
-  | CourseInstance
-  | PageContext<'courseInstance', 'student' | 'instructor'>['course_instance'];
+  CourseInstance | PageContext<'courseInstance', 'student' | 'instructor'>['course_instance'];
 
 function assertEnrollmentStatus(
   enrollment: Enrollment,

--- a/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.ts
+++ b/apps/prairielearn/src/pages/administratorBatchedMigrations/administratorBatchedMigrations.html.ts
@@ -30,18 +30,19 @@ export function AdministratorBatchedMigrations({
         <div class="card-header bg-primary text-white d-flex align-items-center">
           <h1>Batched migrations</h1>
         </div>
-        ${hasBatchedMigrations
-          ? html`
-              <div class="table-responsive">
-                <table class="table">
-                  <thead>
-                    <tr>
-                      <th>Filename</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${batchedMigrations.map((migration) => {
+        ${
+          hasBatchedMigrations
+            ? html`
+                <div class="table-responsive">
+                  <table class="table">
+                    <thead>
+                      <tr>
+                        <th>Filename</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${batchedMigrations.map((migration) => {
                       return html`
                         <tr>
                           <td>
@@ -56,11 +57,12 @@ export function AdministratorBatchedMigrations({
                         </tr>
                       `;
                     })}
-                  </tbody>
-                </table>
-              </div>
-            `
-          : html`<div class="card-body text-center text-secondary">No batched migrations</div>`}
+                    </tbody>
+                  </table>
+                </div>
+              `
+            : html`<div class="card-body text-center text-secondary">No batched migrations</div>`
+        }
       </div>
     `,
   });
@@ -189,9 +191,10 @@ function MigrationJobsCard({
       <div class="card-header bg-primary text-white d-flex align-items-center">
         <span class="me-auto">${title}</span>
       </div>
-      ${jobs.length > 0
-        ? html`<div class="list-group list-group-flush">
-            ${jobs.map((job) => {
+      ${
+        jobs.length > 0
+          ? html`<div class="list-group list-group-flush">
+              ${jobs.map((job) => {
               let duration: number | null = null;
               if (job.started_at && job.finished_at) {
                 duration = job.finished_at.getTime() - job.started_at.getTime();
@@ -202,35 +205,40 @@ function MigrationJobsCard({
               const hasData = job.data != null;
               return html`
                 <div class="list-group-item d-flex flex-column">
-                  ${hasData
-                    ? html`
-                        <details>
-                          <summary>${summary}</summary>
+                  ${
+                    hasData
+                      ? html`
+                          <details>
+                            <summary>${summary}</summary>
 
-                          <pre class="mt-3 p-3 rounded bg-dark text-white"><code>${JSON.stringify(
+                            <pre class="mt-3 p-3 rounded bg-dark text-white"><code>${JSON.stringify(
                             job.data,
                             null,
                             2,
                           )}</code></pre>
-                        </details>
-                      `
-                    : html`<div>${summary}</div>`}
-                  ${job.started_at
-                    ? html`
-                        <span
-                          class="text-muted text-small"
-                          style="font-variant-numeric: tabular-nums;"
-                        >
-                          #${job.id} ran at ${job.started_at.toUTCString()} for ${duration}ms
-                          &mdash; ${attempts}
-                        </span>
-                      `
-                    : null}
+                          </details>
+                        `
+                      : html`<div>${summary}</div>`
+                  }
+                  ${
+                    job.started_at
+                      ? html`
+                          <span
+                            class="text-muted text-small"
+                            style="font-variant-numeric: tabular-nums;"
+                          >
+                            #${job.id} ran at ${job.started_at.toUTCString()} for ${duration}ms
+                            &mdash; ${attempts}
+                          </span>
+                        `
+                      : null
+                  }
                 </div>
               `;
             })}
-          </div>`
-        : html`<div class="card-body text-center text-secondary">${emptyText}</div>`}
+            </div>`
+          : html`<div class="card-body text-center text-secondary">${emptyText}</div>`
+      }
     </div>
   `;
 }

--- a/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
+++ b/apps/prairielearn/src/pages/administratorCourses/administratorCourses.html.tsx
@@ -34,12 +34,7 @@ interface DeleteCourseFormData {
 }
 
 type CourseColumnName =
-  | 'short_name'
-  | 'title'
-  | 'display_timezone'
-  | 'path'
-  | 'repository'
-  | 'branch';
+  'short_name' | 'title' | 'display_timezone' | 'path' | 'repository' | 'branch';
 
 export function AdministratorCourses({
   institutions,

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.html.ts
@@ -48,10 +48,11 @@ export function AdministratorFeatures({
         <div class="card-header bg-primary text-white">
           <h1>Features</h1>
         </div>
-        ${features.length > 0
-          ? html`
-              <div class="list-group list-group-flush">
-                ${features.map((feature) => {
+        ${
+          features.length > 0
+            ? html`
+                <div class="list-group list-group-flush">
+                  ${features.map((feature) => {
                   return html`
                     <div class="list-group-item d-flex align-items-center">
                       <a
@@ -63,9 +64,10 @@ export function AdministratorFeatures({
                     </div>
                   `;
                 })}
-              </div>
-            `
-          : html`<div class="card-body text-center text-secondary">No features</div>`}
+                </div>
+              `
+            : html`<div class="card-body text-center text-secondary">No features</div>`
+        }
       </div>
     `,
   });
@@ -116,35 +118,39 @@ export function AdministratorFeature({
             Grant feature
           </button>
         </div>
-        ${featureGrants.length > 0 || featureInConfig != null
-          ? html`
-              <div class="list-group list-group-flush">
-                ${featureInConfig != null
-                  ? html`
-                      <div class="list-group-item">
-                        <i
-                          class="fa-solid me-1 ${featureInConfig
-                            ? 'fa-check text-success'
-                            : 'fa-times text-danger'}"
-                        ></i>
-                        Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
-                      </div>
-                    `
-                  : ''}
-                ${featureGrants.map((featureGrant) =>
+        ${
+          featureGrants.length > 0 || featureInConfig != null
+            ? html`
+                <div class="list-group list-group-flush">
+                  ${
+                  featureInConfig != null
+                    ? html`
+                        <div class="list-group-item">
+                          <i
+                            class="fa-solid me-1 ${
+                            featureInConfig ? 'fa-check text-success' : 'fa-times text-danger'
+                          }"
+                          ></i>
+                          Feature ${featureInConfig ? 'enabled' : 'disabled'} in configuration file
+                        </div>
+                      `
+                    : ''
+                }
+                  ${featureGrants.map((featureGrant) =>
                   FeatureGrant({
                     featureGrant,
                     overridden: featureInConfig != null,
                     csrfToken: resLocals.__csrf_token,
                   }),
                 )}
-              </div>
-            `
-          : html`
-              <div class="card-body text-center text-secondary">
-                There are no grants for this feature
-              </div>
-            `}
+                </div>
+              `
+            : html`
+                <div class="card-body text-center text-secondary">
+                  There are no grants for this feature
+                </div>
+              `
+        }
       </div>
     `,
     postContent: html`
@@ -221,9 +227,9 @@ function FeatureGrant({
 }) {
   return html`
     <div
-      class="list-group-item d-flex flex-column flex-md-row flex-nowrap align-items-md-center ${overridden
-        ? 'text-muted'
-        : ''}"
+      class="list-group-item d-flex flex-column flex-md-row flex-nowrap align-items-md-center ${
+        overridden ? 'text-muted' : ''
+      }"
     >
       <div>${FeatureGrantBreadcrumbs({ featureGrant })}</div>
       <div class="ms-auto d-flex flex-row flex-nowrap flex-shrink-0">

--- a/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
+++ b/apps/prairielearn/src/pages/administratorQueries/administratorQueries.html.ts
@@ -39,25 +39,29 @@ export function AdministratorQueries({
                 (query) => html`
                   <tr>
                     <td>
-                      ${query.error || query.enabled === false
-                        ? html`<code>${query.filePrefix}</code>`
-                        : html`
-                            <a
-                              href="${resLocals.urlPrefix}/administrator/query/${query.filePrefix}"
-                            >
-                              <code>${query.filePrefix}</code>
-                            </a>
-                          `}
+                      ${
+                        query.error || query.enabled === false
+                          ? html`<code>${query.filePrefix}</code>`
+                          : html`
+                              <a
+                                href="${resLocals.urlPrefix}/administrator/query/${query.filePrefix}"
+                              >
+                                <code>${query.filePrefix}</code>
+                              </a>
+                            `
+                      }
                     </td>
                     <td>
-                      ${query.error
-                        ? html`<span class="text-danger">${query.error}</span>`
-                        : query.enabled === false
-                          ? html`
-                              <span class="text-muted">${query.description}</span>
-                              <span class="badge text-bg-info">Disabled</span>
-                            `
-                          : query.description}
+                      ${
+                        query.error
+                          ? html`<span class="text-danger">${query.error}</span>`
+                          : query.enabled === false
+                            ? html`
+                                <span class="text-muted">${query.description}</span>
+                                <span class="badge text-bg-info">Disabled</span>
+                              `
+                            : query.description
+                      }
                     </td>
                   </tr>
                 `,

--- a/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
+++ b/apps/prairielearn/src/pages/administratorQuery/administratorQuery.html.ts
@@ -48,11 +48,11 @@ export function AdministratorQuery({
         rel="stylesheet"
       />
       <script src="${nodeModulesAssetPath(
-          'tablesorter/dist/js/jquery.tablesorter.min.js',
-        )}"></script>
+        'tablesorter/dist/js/jquery.tablesorter.min.js',
+      )}"></script>
       <script src="${nodeModulesAssetPath(
-          'tablesorter/dist/js/jquery.tablesorter.widgets.min.js',
-        )}"></script>
+        'tablesorter/dist/js/jquery.tablesorter.widgets.min.js',
+      )}"></script>
     `,
     content: html`
       <div class="card mb-4">
@@ -64,30 +64,34 @@ export function AdministratorQuery({
 
         <div class="card-body">
           <form method="POST">
-            ${info.params
-              ? info.params.map(
-                  (param) => html`
-                    <div class="mb-3">
-                      <label class="form-label" for="param-${param.name}">${param.name}</label>
-                      <input
-                        class="form-control"
-                        type="text"
-                        id="param-${param.name}"
-                        aria-describedby="param-${param.name}-help"
-                        name="${param.name}"
-                        autocomplete="off"
-                        ${query_run?.params?.[param.name]
-                          ? html`value="${query_run.params[param.name]}"`
-                          : html`value="${param.default ?? ''}"`}
-                      />
+            ${
+              info.params
+                ? info.params.map(
+                    (param) => html`
+                      <div class="mb-3">
+                        <label class="form-label" for="param-${param.name}">${param.name}</label>
+                        <input
+                          class="form-control"
+                          type="text"
+                          id="param-${param.name}"
+                          aria-describedby="param-${param.name}-help"
+                          name="${param.name}"
+                          autocomplete="off"
+                          ${
+                          query_run?.params?.[param.name]
+                            ? html`value="${query_run.params[param.name]}"`
+                            : html`value="${param.default ?? ''}"`
+                        }
+                        />
 
-                      <small id="param-${param.name}-help" class="form-text text-muted">
-                        ${param.description}
-                      </small>
-                    </div>
-                  `,
-                )
-              : null}
+                        <small id="param-${param.name}-help" class="form-text text-muted">
+                          ${param.description}
+                        </small>
+                      </div>
+                    `,
+                  )
+                : null
+            }
             <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
             <button type="submit" class="btn btn-primary">
               <i class="fas fa-play"></i>
@@ -96,56 +100,63 @@ export function AdministratorQuery({
           </form>
         </div>
 
-        ${query_run
-          ? html`
-              <div class="card-body d-flex align-items-center p-2 bg-secondary text-white">
-                Query ran at: ${formatDate(query_run.date, 'UTC')}
-                ${query_run.result != null
-                  ? html`
-                      <div class="ms-auto">
-                        <span class="me-2" data-testid="row-count">
-                          ${query_run.result.rows?.length ?? 0}
-                          ${query_run.result.rows?.length === 1 ? 'row' : 'rows'}
-                        </span>
-                        <a
-                          href="${`?query_run_id=${query_run_id}&format=json`}"
-                          class="btn btn-sm btn-light"
-                        >
-                          <i class="fas fa-download" aria-hidden="true"></i> JSON
-                        </a>
-                        <a
-                          href="${`?query_run_id=${query_run_id}&format=csv`}"
-                          class="btn btn-sm btn-light"
-                        >
-                          <i class="fas fa-download" aria-hidden="true"></i> CSV
-                        </a>
-                      </div>
-                    `
-                  : ''}
-              </div>
-            `
-          : null}
-        ${query_run?.error != null
-          ? html` <p class="text-danger m-2">${query_run.error}</p> `
-          : null}
-        ${query_run?.result != null
-          ? html`
-              <div class="table-responsive">
-                <table
-                  class="table table-sm table-hover table-striped tablesorter"
-                  aria-label="Query results"
-                  data-testid="results-table"
-                >
-                  <thead>
-                    <tr>
-                      ${query_run.result.columns?.map((col: string) =>
+        ${
+          query_run
+            ? html`
+                <div class="card-body d-flex align-items-center p-2 bg-secondary text-white">
+                  Query ran at: ${formatDate(query_run.date, 'UTC')}
+                  ${
+                  query_run.result != null
+                    ? html`
+                        <div class="ms-auto">
+                          <span class="me-2" data-testid="row-count">
+                            ${query_run.result.rows?.length ?? 0}
+                            ${query_run.result.rows?.length === 1 ? 'row' : 'rows'}
+                          </span>
+                          <a
+                            href="${`?query_run_id=${query_run_id}&format=json`}"
+                            class="btn btn-sm btn-light"
+                          >
+                            <i class="fas fa-download" aria-hidden="true"></i> JSON
+                          </a>
+                          <a
+                            href="${`?query_run_id=${query_run_id}&format=csv`}"
+                            class="btn btn-sm btn-light"
+                          >
+                            <i class="fas fa-download" aria-hidden="true"></i> CSV
+                          </a>
+                        </div>
+                      `
+                    : ''
+                }
+                </div>
+              `
+            : null
+        }
+        ${
+          query_run?.error != null
+            ? html` <p class="text-danger m-2">${query_run.error}</p> `
+            : null
+        }
+        ${
+          query_run?.result != null
+            ? html`
+                <div class="table-responsive">
+                  <table
+                    class="table table-sm table-hover table-striped tablesorter"
+                    aria-label="Query results"
+                    data-testid="results-table"
+                  >
+                    <thead>
+                      <tr>
+                        ${query_run.result.columns?.map((col: string) =>
                         renderHeader(query_run.result?.columns, col),
                       )}
-                    </tr>
-                  </thead>
+                      </tr>
+                    </thead>
 
-                  <tbody>
-                    ${query_run.result.rows?.map(
+                    <tbody>
+                      ${query_run.result.rows?.map(
                       (row: any) => html`
                         <tr>
                           ${query_run.result?.columns?.map((col: string) =>
@@ -154,11 +165,12 @@ export function AdministratorQuery({
                         </tr>
                       `,
                     )}
-                  </tbody>
-                </table>
-              </div>
-            `
-          : null}
+                    </tbody>
+                  </table>
+                </div>
+              `
+            : null
+        }
       </div>
 
       <div class="card mb-4">
@@ -166,19 +178,20 @@ export function AdministratorQuery({
           Recent query runs
         </div>
         <div class="table-responsive">
-          ${recent_query_runs.length > 0
-            ? html`
-                <table class="table table-sm" aria-label="Recent query runs">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Params</th>
-                      <th>User name</th>
-                      <th>User UID</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${recent_query_runs.map(
+          ${
+            recent_query_runs.length > 0
+              ? html`
+                  <table class="table table-sm" aria-label="Recent query runs">
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Params</th>
+                        <th>User name</th>
+                        <th>User UID</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${recent_query_runs.map(
                       (run) => html`
                         <tr>
                           <td>
@@ -194,14 +207,15 @@ export function AdministratorQuery({
                         </tr>
                       `,
                     )}
-                  </tbody>
-                </table>
-              `
-            : html`
-                <div class="card-body">
-                  <div class="text-center text-muted">No recent runs found</div>
-                </div>
-              `}
+                    </tbody>
+                  </table>
+                `
+              : html`
+                  <div class="card-body">
+                    <div class="text-center text-muted">No recent runs found</div>
+                  </div>
+                `
+          }
         </div>
       </div>
     `,

--- a/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
+++ b/apps/prairielearn/src/pages/administratorSettings/administratorSettings.html.ts
@@ -95,37 +95,40 @@ export function AdministratorSettings({
               </button>
             </div>
           </form>
-          ${config.newsFeedUrl
-            ? html`
-                <hr />
-                <form method="POST" class="d-inline">
-                  <input type="hidden" name="__action" value="sync_news_feed" />
-                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                  <button type="submit" class="btn btn-primary">Sync news feed</button>
-                </form>
-              `
-            : ''}
+          ${
+            config.newsFeedUrl
+              ? html`
+                  <hr />
+                  <form method="POST" class="d-inline">
+                    <input type="hidden" name="__action" value="sync_news_feed" />
+                    <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                    <button type="submit" class="btn btn-primary">Sync news feed</button>
+                  </form>
+                `
+              : ''
+          }
         </div>
       </div>
 
-      ${newsItems.length > 0
-        ? html`
-            <div class="card mb-4">
-              <div class="card-header bg-primary text-white d-flex align-items-center">
-                <h2>News items</h2>
-              </div>
-              <div class="table-responsive">
-                <table class="table table-sm table-hover table-striped" aria-label="News items">
-                  <thead>
-                    <tr>
-                      <th>Title</th>
-                      <th>Published</th>
-                      <th>Status</th>
-                      <th>Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${newsItems.map(
+      ${
+        newsItems.length > 0
+          ? html`
+              <div class="card mb-4">
+                <div class="card-header bg-primary text-white d-flex align-items-center">
+                  <h2>News items</h2>
+                </div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-hover table-striped" aria-label="News items">
+                    <thead>
+                      <tr>
+                        <th>Title</th>
+                        <th>Published</th>
+                        <th>Status</th>
+                        <th>Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${newsItems.map(
                       (item) => html`
                         <tr>
                           <td class="align-middle">
@@ -135,85 +138,101 @@ export function AdministratorSettings({
                           </td>
                           <td class="align-middle">${formatDate(item.pub_date, 'UTC')}</td>
                           <td class="align-middle">
-                            ${item.managed_by === 'admin' && item.hidden_at != null
-                              ? html`<span class="badge bg-secondary">Hidden by admin</span>`
-                              : item.managed_by === 'sync' && item.hidden_at != null
-                                ? html`<span class="badge bg-secondary">Hidden by sync</span>`
-                                : html`<span class="badge bg-success">Visible</span>`}
+                            ${
+                              item.managed_by === 'admin' && item.hidden_at != null
+                                ? html`<span class="badge bg-secondary">Hidden by admin</span>`
+                                : item.managed_by === 'sync' && item.hidden_at != null
+                                  ? html`<span class="badge bg-secondary">Hidden by sync</span>`
+                                  : html`<span class="badge bg-success">Visible</span>`
+                            }
                           </td>
                           <td class="align-middle">
-                            ${item.hidden_at == null
-                              ? html`
-                                  <form method="POST" class="d-inline">
-                                    <input type="hidden" name="__action" value="hide_news_item" />
-                                    <input
-                                      type="hidden"
-                                      name="__csrf_token"
-                                      value="${resLocals.__csrf_token}"
-                                    />
-                                    <input type="hidden" name="news_item_id" value="${item.id}" />
-                                    <button type="submit" class="btn btn-sm btn-outline-danger">
-                                      Hide
-                                    </button>
-                                  </form>
-                                `
-                              : html`
-                                  <form method="POST" class="d-inline">
-                                    <input type="hidden" name="__action" value="unhide_news_item" />
-                                    <input
-                                      type="hidden"
-                                      name="__csrf_token"
-                                      value="${resLocals.__csrf_token}"
-                                    />
-                                    <input type="hidden" name="news_item_id" value="${item.id}" />
-                                    <button type="submit" class="btn btn-sm btn-outline-secondary">
-                                      Unhide
-                                    </button>
-                                  </form>
-                                `}
+                            ${
+                              item.hidden_at == null
+                                ? html`
+                                    <form method="POST" class="d-inline">
+                                      <input type="hidden" name="__action" value="hide_news_item" />
+                                      <input
+                                        type="hidden"
+                                        name="__csrf_token"
+                                        value="${resLocals.__csrf_token}"
+                                      />
+                                      <input type="hidden" name="news_item_id" value="${item.id}" />
+                                      <button type="submit" class="btn btn-sm btn-outline-danger">
+                                        Hide
+                                      </button>
+                                    </form>
+                                  `
+                                : html`
+                                    <form method="POST" class="d-inline">
+                                      <input
+                                        type="hidden"
+                                        name="__action"
+                                        value="unhide_news_item"
+                                      />
+                                      <input
+                                        type="hidden"
+                                        name="__csrf_token"
+                                        value="${resLocals.__csrf_token}"
+                                      />
+                                      <input type="hidden" name="news_item_id" value="${item.id}" />
+                                      <button
+                                        type="submit"
+                                        class="btn btn-sm btn-outline-secondary"
+                                      >
+                                        Unhide
+                                      </button>
+                                    </form>
+                                  `
+                            }
                           </td>
                         </tr>
                       `,
                     )}
-                  </tbody>
-                </table>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
-          `
-        : ''}
-      ${showAiSettings
-        ? html`
-            <div class="card mb-4">
-              <div class="card-header bg-primary text-white">LLM</div>
-              <div class="card-body">
-                <form method="POST">
-                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                  <button class="btn btn-primary" name="__action" value="sync_context_documents">
-                    Resync context documents
-                  </button>
+            `
+          : ''
+      }
+      ${
+        showAiSettings
+          ? html`
+              <div class="card mb-4">
+                <div class="card-header bg-primary text-white">LLM</div>
+                <div class="card-body">
+                  <form method="POST">
+                    <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                    <button class="btn btn-primary" name="__action" value="sync_context_documents">
+                      Resync context documents
+                    </button>
 
-                  ${config.devMode
-                    ? html`
-                        <hr />
-                        <p>
-                          Benchmarking the AI will generate questions from a set of sample prompts
-                          and ask an LLM to evaluate their quality, including comparing them to gold
-                          standard implementations.
-                        </p>
-                        <button
-                          class="btn btn-primary"
-                          name="__action"
-                          value="benchmark_question_generation"
-                        >
-                          Benchmark question generation
-                        </button>
-                      `
-                    : ''}
-                </form>
+                    ${
+                    config.devMode
+                      ? html`
+                          <hr />
+                          <p>
+                            Benchmarking the AI will generate questions from a set of sample prompts
+                            and ask an LLM to evaluate their quality, including comparing them to
+                            gold standard implementations.
+                          </p>
+                          <button
+                            class="btn btn-primary"
+                            name="__action"
+                            value="benchmark_question_generation"
+                          >
+                            Benchmark question generation
+                          </button>
+                        `
+                      : ''
+                  }
+                  </form>
+                </div>
               </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
 
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">

--- a/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
+++ b/apps/prairielearn/src/pages/administratorWorkspaces/administratorWorkspaces.html.ts
@@ -95,9 +95,9 @@ export function AdministratorWorkspaces({
                       aria-controls="workspaces-${workspaceHost.id}"
                       >${workspaceHost.hostname}</a
                     >
-                    ${instanceId
-                      ? html`<span class="text-muted me-2">(${instanceId})</span>`
-                      : null}
+                    ${
+                      instanceId ? html`<span class="text-muted me-2">(${instanceId})</span>` : null
+                    }
                     ${WorkspaceHostStateBadge({ state: workspaceHost.state })}
                     <span class="badge text-bg-secondary">
                       ${formatInterval(workspaceHostRow.workspace_host_time_in_state)}
@@ -109,15 +109,16 @@ export function AdministratorWorkspaces({
                   })}
                 </div>
                 <div id="workspaces-${workspaceHost.id}" class="collapse">
-                  ${workspaces.length === 0
-                    ? html`
-                        <div class="text-muted my-2">
-                          There are no workspaces running on this host.
-                        </div>
-                      `
-                    : html`
-                        <div class="list-group my-2">
-                          ${workspaces.map((workspace) => {
+                  ${
+                    workspaces.length === 0
+                      ? html`
+                          <div class="text-muted my-2">
+                            There are no workspaces running on this host.
+                          </div>
+                        `
+                      : html`
+                          <div class="list-group my-2">
+                            ${workspaces.map((workspace) => {
                             const maybeCourseInstanceName = workspace.course_instance_name
                               ? html`(<span title="Course instance"
                                     >${workspace.course_instance_name}</span
@@ -146,8 +147,9 @@ export function AdministratorWorkspaces({
                               </div>
                             `;
                           })}
-                        </div>
-                      `}
+                          </div>
+                        `
+                  }
                 </div>
               </div>
             `;

--- a/apps/prairielearn/src/pages/assessmentsSwitcher/assessmentsSwitcher.html.ts
+++ b/apps/prairielearn/src/pages/assessmentsSwitcher/assessmentsSwitcher.html.ts
@@ -30,42 +30,49 @@ export function AssessmentSwitcher({
         const isActive = idsEqual(currentAssessmentId, row.id);
 
         return html`
-          ${row.start_new_assessment_group
-            ? html`
-                <div class="fw-bold ${index === 0 ? 'mt-0' : 'mt-3'}">
-                  ${assessmentsGroupBy === 'Set'
-                    ? AssessmentSetHeadingHtml({ assessment_set: row.assessment_set })
-                    : AssessmentModuleHeadingHtml({
-                        assessment_module: row.assessment_module,
-                      })}
-                </div>
-              `
-            : ''}
+          ${
+            row.start_new_assessment_group
+              ? html`
+                  <div class="fw-bold ${index === 0 ? 'mt-0' : 'mt-3'}">
+                    ${
+                    assessmentsGroupBy === 'Set'
+                      ? AssessmentSetHeadingHtml({ assessment_set: row.assessment_set })
+                      : AssessmentModuleHeadingHtml({
+                          assessment_module: row.assessment_module,
+                        })
+                  }
+                  </div>
+                `
+              : ''
+          }
           <div
-            class="assessment-row column-gap-2 p-2 mt-1 gap-md-1 p-md-1 w-100 rounded ${isActive
-              ? 'bg-primary text-white'
-              : ''}"
+            class="assessment-row column-gap-2 p-2 mt-1 gap-md-1 p-md-1 w-100 rounded ${
+              isActive ? 'bg-primary text-white' : ''
+            }"
           >
             <div class="d-flex align-items-center">
               <span
-                class="badge overflow-hidden text-truncate text-nowrap color-${row.assessment_set
-                  .color}"
+                class="badge overflow-hidden text-truncate text-nowrap color-${
+                  row.assessment_set.color
+                }"
               >
                 ${row.label}
               </span>
             </div>
             <div class="title">
-              ${row.sync_errors
-                ? SyncProblemButtonHtml({
-                    type: 'error',
-                    output: row.sync_errors,
-                  })
-                : row.sync_warnings
+              ${
+                row.sync_errors
                   ? SyncProblemButtonHtml({
-                      type: 'warning',
-                      output: row.sync_warnings,
+                      type: 'error',
+                      output: row.sync_errors,
                     })
-                  : ''}
+                  : row.sync_warnings
+                    ? SyncProblemButtonHtml({
+                        type: 'warning',
+                        output: row.sync_warnings,
+                      })
+                    : ''
+              }
               <a href="${assessmentUrl}" class="${isActive ? 'text-white' : ''}">
                 ${row.title}
                 ${row.team_work ? html` <i class="fas fa-users" aria-hidden="true"></i> ` : ''}

--- a/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.html.ts
@@ -210,33 +210,37 @@ export function AuthLogin({
     service,
     resLocals,
     children: html`
-      ${config.devMode
-        ? html`
-            ${DevModeBypass()}
-            <hr />
-            ${DevModeLogin({ csrfToken: resLocals.__csrf_token })}
-            <hr />
-          `
-        : ''}
+      ${
+        config.devMode
+          ? html`
+              ${DevModeBypass()}
+              <hr />
+              ${DevModeLogin({ csrfToken: resLocals.__csrf_token })}
+              <hr />
+            `
+          : ''
+      }
       <div class="d-flex flex-column gap-2 mt-4">
         ${config.hasShib && !config.hideShibLogin ? ShibLoginButton() : ''}
         ${config.hasOauth ? GoogleLoginButton() : ''}
         ${config.hasAzure && isEnterprise() ? MicrosoftLoginButton() : ''}
       </div>
-      ${institutionAuthnProviders?.length
-        ? html`
-            <div class="institution-header text-muted my-3">Institution sign-on</div>
-            <div class="d-flex flex-column gap-2">
-              ${institutionAuthnProviders.map(
+      ${
+        institutionAuthnProviders?.length
+          ? html`
+              <div class="institution-header text-muted my-3">Institution sign-on</div>
+              <div class="d-flex flex-column gap-2">
+                ${institutionAuthnProviders.map(
                 (provider) => html`
                   <a href="${provider.url}" class="btn btn-outline-dark d-block w-100">
                     <span class="fw-bold">${provider.name}</span>
                   </a>
                 `,
               )}
-            </div>
-          `
-        : ''}
+              </div>
+            `
+          : ''
+      }
     `,
   }).toString();
 }
@@ -352,19 +356,25 @@ export function AuthLoginInstitution({
           `;
         }
       })}
-      ${defaultProviderButton
-        ? html`
-            ${hasNonDefaultProviders
-              ? html`<small class="text-muted text-center d-block mb-2">Preferred method</small>`
-              : ''}
-            ${defaultProviderButton}
-            ${hasNonDefaultProviders
-              ? html`
-                  <small class="text-muted text-center d-block mt-4 mb-2">Other methods</small>
-                `
-              : ''}
-          `
-        : ''}
+      ${
+        defaultProviderButton
+          ? html`
+              ${
+              hasNonDefaultProviders
+                ? html`<small class="text-muted text-center d-block mb-2">Preferred method</small>`
+                : ''
+            }
+              ${defaultProviderButton}
+              ${
+              hasNonDefaultProviders
+                ? html`
+                    <small class="text-muted text-center d-block mt-4 mb-2">Other methods</small>
+                  `
+                : ''
+            }
+            `
+          : ''
+      }
       <div class="d-flex flex-column gap-2">
         ${[
           showSaml ? SamlLoginButton({ institutionId }) : '',

--- a/apps/prairielearn/src/pages/authPassword/authPassword.html.ts
+++ b/apps/prairielearn/src/pages/authPassword/authPassword.html.ts
@@ -23,13 +23,15 @@ export function AuthPassword({
         <div class="card-body">
           <p class="text-center">A password is required to access this assessment.</p>
 
-          ${passwordInvalid
-            ? html`
-                <p class="text-center text-danger">
-                  Previous password invalid or expired. Please try again.
-                </p>
-              `
-            : ''}
+          ${
+            passwordInvalid
+              ? html`
+                  <p class="text-center text-danger">
+                    Previous password invalid or expired. Please try again.
+                  </p>
+                `
+              : ''
+          }
 
           <form method="POST">
             <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
@@ -89,30 +89,32 @@ export function CourseSyncs({
                 <th class="align-middle">Remote repository</th>
                 <td class="align-middle">${course.repository ?? html`&mdash;`}</td>
                 <td>
-                  ${config.devMode
-                    ? html`
-                        <span
-                          class="d-inline-block"
-                          tabindex="0"
-                          data-bs-toggle="tooltip"
-                          data-bs-title="Pulling from a remote repository is not supported in development mode."
-                        >
-                          <button type="button" class="btn btn-sm btn-primary" disabled>
-                            <i class="fa fa-cloud-download-alt" aria-hidden="true"></i>
-                            Pull from remote git repository
-                          </button>
-                        </span>
-                      `
-                    : html`
-                        <form name="confirm-form" method="POST">
-                          <input type="hidden" name="__action" value="pull" />
-                          <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                          <button type="submit" class="btn btn-sm btn-primary">
-                            <i class="fa fa-cloud-download-alt" aria-hidden="true"></i>
-                            Pull from remote git repository
-                          </button>
-                        </form>
-                      `}
+                  ${
+                    config.devMode
+                      ? html`
+                          <span
+                            class="d-inline-block"
+                            tabindex="0"
+                            data-bs-toggle="tooltip"
+                            data-bs-title="Pulling from a remote repository is not supported in development mode."
+                          >
+                            <button type="button" class="btn btn-sm btn-primary" disabled>
+                              <i class="fa fa-cloud-download-alt" aria-hidden="true"></i>
+                              Pull from remote git repository
+                            </button>
+                          </span>
+                        `
+                      : html`
+                          <form name="confirm-form" method="POST">
+                            <input type="hidden" name="__action" value="pull" />
+                            <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                            <button type="submit" class="btn btn-sm btn-primary">
+                              <i class="fa fa-cloud-download-alt" aria-hidden="true"></i>
+                              Pull from remote git repository
+                            </button>
+                          </form>
+                        `
+                  }
                 </td>
               </tr>
               <tr>
@@ -153,9 +155,11 @@ export function CourseSyncs({
                   <tr>
                     <td>${jobSequence.number}</td>
                     <td>
-                      ${jobSequence.start_date == null
-                        ? html`&mdash;`
-                        : formatDate(jobSequence.start_date, course.display_timezone)}
+                      ${
+                        jobSequence.start_date == null
+                          ? html`&mdash;`
+                          : formatDate(jobSequence.start_date, course.display_timezone)
+                      }
                     </td>
                     <td>${jobSequence.description}</td>
                     <td>${jobSequence.user_uid ?? '(System)'}</td>
@@ -174,14 +178,16 @@ export function CourseSyncs({
             </tbody>
           </table>
         </div>
-        ${!showAllJobSequences && jobSequenceCount > jobSequences.length
-          ? html`
-              <div class="card-footer">
-                Showing ${jobSequences.length} of ${jobSequenceCount} sync jobs.
-                <a href="?all" aria-label="View all sync jobs">View all</a>
-              </div>
-            `
-          : ''}
+        ${
+          !showAllJobSequences && jobSequenceCount > jobSequences.length
+            ? html`
+                <div class="card-footer">
+                  Showing ${jobSequences.length} of ${jobSequenceCount} sync jobs.
+                  <a href="?all" aria-label="View all sync jobs">View all</a>
+                </div>
+              `
+            : ''
+        }
       </div>
     `,
   });
@@ -225,49 +231,60 @@ function ImageTable({
                 <td>
                   <div class="d-flex flex-row align-items-center">
                     <span class="me-2">${image.image}</span>
-                    ${image.invalid
-                      ? html`<span class="badge text-bg-danger">Invalid image name</span>`
-                      : ''}
+                    ${
+                      image.invalid
+                        ? html`<span class="badge text-bg-danger">Invalid image name</span>`
+                        : ''
+                    }
                   </div>
                 </td>
                 <td>${image.tag}</td>
                 <td>
-                  ${image.digest
-                    ? html`
-                        <code class="mb-0" title="${image.digest}">
-                          ${image.digest.length <= 24
-                            ? image.digest
-                            : `${image.digest.slice(0, 24)}...`}
-                        </code>
-                      `
-                    : html`&mdash;`}
+                  ${
+                    image.digest
+                      ? html`
+                          <code class="mb-0" title="${image.digest}">
+                            ${
+                            image.digest.length <= 24
+                              ? image.digest
+                              : `${image.digest.slice(0, 24)}...`
+                          }
+                          </code>
+                        `
+                      : html`&mdash;`
+                  }
                 </td>
                 <td>${(image.size ?? 0) > 0 ? filesize(image.size ?? 0) : ''}</td>
                 <td>
-                  ${image.imageSyncNeeded
-                    ? html`<span class="text-warning">Not found in PL registry</span>`
-                    : image.pushed_at
-                      ? formatDate(image.pushed_at, course.display_timezone)
-                      : html`&mdash;`}
+                  ${
+                    image.imageSyncNeeded
+                      ? html`<span class="text-warning">Not found in PL registry</span>`
+                      : image.pushed_at
+                        ? formatDate(image.pushed_at, course.display_timezone)
+                        : html`&mdash;`
+                  }
                 </td>
                 <td>
-                  ${config.cacheImageRegistry
-                    ? html`
-                        <form method="POST">
-                          <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                          <input type="hidden" name="__action" value="syncImage" />
-                          <input type="hidden" name="single_image" value="${image.image}" />
-                          <button type="submit" class="btn btn-xs btn-primary">
-                            <i class="fa fa-sync" aria-hidden="true"></i> Sync
-                          </button>
-                        </form>
-                      `
-                    : ''}
+                  ${
+                    config.cacheImageRegistry
+                      ? html`
+                          <form method="POST">
+                            <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                            <input type="hidden" name="__action" value="syncImage" />
+                            <input type="hidden" name="single_image" value="${image.image}" />
+                            <button type="submit" class="btn btn-xs btn-primary">
+                              <i class="fa fa-sync" aria-hidden="true"></i> Sync
+                            </button>
+                          </form>
+                        `
+                      : ''
+                  }
                 </td>
                 <td>
-                  ${image.questions.length > 0
-                    ? html`
-                        ${QuestionUsageLink({
+                  ${
+                    image.questions.length > 0
+                      ? html`
+                          ${QuestionUsageLink({
                           courseId: course.id,
                           courseInstanceId,
                           image: image.image,
@@ -275,7 +292,7 @@ function ImageTable({
                           filterType: 'external_grading_image',
                           label: 'External grader',
                         })}
-                        ${QuestionUsageLink({
+                          ${QuestionUsageLink({
                           courseId: course.id,
                           courseInstanceId,
                           image: image.image,
@@ -284,21 +301,22 @@ function ImageTable({
                           label: 'Workspace',
                         })}
 
-                        <button
-                          type="button"
-                          class="btn btn-xs btn-secondary"
-                          data-bs-toggle="popover"
-                          data-bs-container="body"
-                          data-bs-html="true"
-                          data-bs-title="Questions using ${image.image}"
-                          data-bs-content="${escapeHtml(
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-secondary"
+                            data-bs-toggle="popover"
+                            data-bs-container="body"
+                            data-bs-html="true"
+                            data-bs-title="Questions using ${image.image}"
+                            data-bs-content="${escapeHtml(
                             ListQuestionsPopover({ image, urlPrefix }),
                           )}"
-                        >
-                          Show
-                        </button>
-                      `
-                    : 'No questions'}
+                          >
+                            Show
+                          </button>
+                        `
+                      : 'No questions'
+                  }
                 </td>
               </tr>
             `,
@@ -306,20 +324,22 @@ function ImageTable({
         </tbody>
       </table>
     </div>
-    ${config.cacheImageRegistry
-      ? html`
-          <div class="card-footer">
-            <form name="confirm-form" method="POST">
-              <input type="hidden" name="__action" value="syncImages" />
-              <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-              <button type="submit" class="btn btn-sm btn-primary">
-                <i class="fa fa-sync" aria-hidden="true"></i>
-                Sync all images from Docker Hub to PrairieLearn
-              </button>
-            </form>
-          </div>
-        `
-      : ''}
+    ${
+      config.cacheImageRegistry
+        ? html`
+            <div class="card-footer">
+              <form name="confirm-form" method="POST">
+                <input type="hidden" name="__action" value="syncImages" />
+                <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                <button type="submit" class="btn btn-sm btn-primary">
+                  <i class="fa fa-sync" aria-hidden="true"></i>
+                  Sync all images from Docker Hub to PrairieLearn
+                </button>
+              </form>
+            </div>
+          `
+        : ''
+    }
   `;
 }
 

--- a/apps/prairielearn/src/pages/editError/editError.html.ts
+++ b/apps/prairielearn/src/pages/editError/editError.html.ts
@@ -42,9 +42,9 @@ export function EditError({
     content: html`
       <div class="card mb-4">
         <div
-          class="card-header ${isWarning
-            ? 'bg-warning'
-            : 'bg-danger text-white'} d-flex align-items-center"
+          class="card-header ${
+            isWarning ? 'bg-warning' : 'bg-danger text-white'
+          } d-flex align-items-center"
         >
           <h1>${isWarning ? 'Edit warning' : 'Edit failure'}</h1>
           <button
@@ -58,41 +58,49 @@ export function EditError({
           </button>
         </div>
         <div class="card-body">
-          ${outcome === 'sync_json_errors'
-            ? html`
-                <p>
-                  Your changes were
-                  saved${config.fileEditorUseGit
-                    ? ' and pushed to the remote GitHub repository'
-                    : ''},
-                  but some course content contains errors that prevented it from syncing correctly.
-                  This may be caused by your edit or by pre-existing issues in other files.
-                </p>
-              `
-            : html`
-                <p>The file edit did not complete successfully.</p>
-                ${outcome === 'sync_failed'
-                  ? html`
-                      <p>
-                        In particular, it looks like your changes were written to
-                        disk${config.fileEditorUseGit
-                          ? ' and were pushed to the remote GitHub repository'
-                          : ''},
-                        but that there was a failure to sync these changes to the database. The most
-                        likely cause is broken course content. Please fix this content, then click
-                        <strong>Pull from remote GitHub repository</strong> to try again.
-                      </p>
-                      <form method="POST">
-                        <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                        <div class="mx-4">
-                          <button name="__action" value="pull" class="btn btn-primary">
-                            Pull from remote GitHub repository
-                          </button>
-                        </div>
-                      </form>
-                    `
-                  : html`<p>Please go back and try again.</p>`}
-              `}
+          ${
+            outcome === 'sync_json_errors'
+              ? html`
+                  <p>
+                    Your changes were
+                    saved${
+                    config.fileEditorUseGit ? ' and pushed to the remote GitHub repository' : ''
+                  },
+                    but some course content contains errors that prevented it from syncing
+                    correctly. This may be caused by your edit or by pre-existing issues in other
+                    files.
+                  </p>
+                `
+              : html`
+                  <p>The file edit did not complete successfully.</p>
+                  ${
+                  outcome === 'sync_failed'
+                    ? html`
+                        <p>
+                          In particular, it looks like your changes were written to
+                          disk${
+                          config.fileEditorUseGit
+                            ? ' and were pushed to the remote GitHub repository'
+                            : ''
+                        },
+                          but that there was a failure to sync these changes to the database. The
+                          most likely cause is broken course content. Please fix this content, then
+                          click
+                          <strong>Pull from remote GitHub repository</strong> to try again.
+                        </p>
+                        <form method="POST">
+                          <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                          <div class="mx-4">
+                            <button name="__action" value="pull" class="btn btn-primary">
+                              Pull from remote GitHub repository
+                            </button>
+                          </div>
+                        </form>
+                      `
+                    : html`<p>Please go back and try again.</p>`
+                }
+                `
+          }
         </div>
       </div>
 

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -74,48 +74,62 @@ export function ErrorPage({
             </a>
           </div>
 
-          ${outputStderr
-            ? html`
-                <p><strong>Standard error:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${outputStderr}</pre>
-              `
-            : ''}
-          ${outputStdout
-            ? html`
-                <p><strong>Standard output:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${outputStdout}</pre>
-              `
-            : ''}
-          ${error.stack
-            ? html`
-                <p><strong>Stack trace:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${formatErrorStack(error)}</pre>
-              `
-            : ''}
-          ${formattedSqlQuery
-            ? html`
-                <p><strong>SQL query:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${formattedSqlQuery}</pre>
-              `
-            : ''}
-          ${!isEmpty(sqlParams)
-            ? html`
-                <p><strong>SQL params:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${formatJson(sqlParams)}</pre>
-              `
-            : ''}
-          ${!isEmpty(sqlError)
-            ? html`
-                <p><strong>SQL error data:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${formatJson(sqlError)}</pre>
-              `
-            : ''}
-          ${!isEmpty(restData)
-            ? html`
-                <p><strong>Additional data:</strong></p>
-                <pre class="bg-dark text-white rounded p-2">${formatJson(restData)}</pre>
-              `
-            : ''}
+          ${
+            outputStderr
+              ? html`
+                  <p><strong>Standard error:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${outputStderr}</pre>
+                `
+              : ''
+          }
+          ${
+            outputStdout
+              ? html`
+                  <p><strong>Standard output:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${outputStdout}</pre>
+                `
+              : ''
+          }
+          ${
+            error.stack
+              ? html`
+                  <p><strong>Stack trace:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${formatErrorStack(error)}</pre>
+                `
+              : ''
+          }
+          ${
+            formattedSqlQuery
+              ? html`
+                  <p><strong>SQL query:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${formattedSqlQuery}</pre>
+                `
+              : ''
+          }
+          ${
+            !isEmpty(sqlParams)
+              ? html`
+                  <p><strong>SQL params:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${formatJson(sqlParams)}</pre>
+                `
+              : ''
+          }
+          ${
+            !isEmpty(sqlError)
+              ? html`
+                  <p><strong>SQL error data:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${formatJson(sqlError)}</pre>
+                `
+              : ''
+          }
+          ${
+            !isEmpty(restData)
+              ? html`
+                  <p><strong>Additional data:</strong></p>
+                  <pre class="bg-dark text-white rounded p-2">${formatJson(restData)}</pre>
+                `
+              : ''
+          }
         </div>
       </div>
     `,

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/PrairieTestControlForm.tsx
@@ -17,9 +17,7 @@ import { useAccessControlRuleEditable } from './AccessControlEditabilityContext.
 import type { AccessControlFormData } from './types.js';
 
 type AfterCompleteVisibilityMode =
-  | 'show_questions_and_score'
-  | 'show_score_only'
-  | 'hide_questions_and_score';
+  'show_questions_and_score' | 'show_score_only' | 'hide_questions_and_score';
 
 const AFTER_COMPLETE_VISIBILITY_ITEMS: RichSelectItem<AfterCompleteVisibilityMode>[] = [
   {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -14,9 +14,7 @@ const DATE_CONTROL_FIELD_NAMES = [
 ] as const;
 
 export type OverridableFieldName =
-  | (typeof DATE_CONTROL_FIELD_NAMES)[number]
-  | 'questionVisibility'
-  | 'scoreVisibility';
+  (typeof DATE_CONTROL_FIELD_NAMES)[number] | 'questionVisibility' | 'scoreVisibility';
 
 export interface DeadlineEntry {
   date: string;
@@ -40,8 +38,7 @@ export interface DueValue {
 }
 
 export type AfterLastDeadlineValue =
-  | { allowSubmissions: false }
-  | { allowSubmissions: true; credit: number };
+  { allowSubmissions: false } | { allowSubmissions: true; credit: number };
 
 export interface QuestionVisibilityValue {
   hidden: boolean;

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -66,8 +66,7 @@ type RuleValidationFieldPath =
   | 'scoreVisibility.visibleFromDate';
 
 type DateControlValidationPath =
-  | `defaultRule.${RuleValidationFieldPath}`
-  | `overrides.${number}.${RuleValidationFieldPath}`;
+  `defaultRule.${RuleValidationFieldPath}` | `overrides.${number}.${RuleValidationFieldPath}`;
 
 type RuleFormFields = Pick<AccessControlFormData['defaultRule'], OverridableFieldName>;
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/instructorAssessmentAccess.html.tsx
@@ -76,37 +76,45 @@ export function InstructorAssessmentAccess({
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex align-items-center">
           <h1>${resLocals.assessment_set.name} ${resLocals.assessment.number}: Access</h1>
-          ${migrationPreview && canEdit
-            ? html`
-                <button
-                  type="button"
-                  class="btn btn-light btn-sm ms-auto"
-                  data-bs-toggle="modal"
-                  data-bs-target="#migrationConfirmModal"
-                >
-                  ${migrationPreview.isIncompatible
-                    ? 'Migrate and clear'
-                    : 'Migrate to modern format'}
-                </button>
-              `
-            : ''}
+          ${
+            migrationPreview && canEdit
+              ? html`
+                  <button
+                    type="button"
+                    class="btn btn-light btn-sm ms-auto"
+                    data-bs-toggle="modal"
+                    data-bs-target="#migrationConfirmModal"
+                  >
+                    ${
+                    migrationPreview.isIncompatible
+                      ? 'Migrate and clear'
+                      : 'Migrate to modern format'
+                  }
+                  </button>
+                `
+              : ''
+          }
         </div>
 
         <div class="alert alert-warning mb-0 rounded-0 border-start-0 border-end-0 border-top-0">
-          ${migrationAnalysis && migrationAnalysis.errors.length > 0
-            ? html`This assessment uses the legacy access control system. Automatic migration is not
-              available for this assessment's access rules.`
-            : html`This assessment uses the legacy access control system. Consider migrating to the
-              modern format for a better editing experience.`}
+          ${
+            migrationAnalysis && migrationAnalysis.errors.length > 0
+              ? html`This assessment uses the legacy access control system. Automatic migration is
+                not available for this assessment's access rules.`
+              : html`This assessment uses the legacy access control system. Consider migrating to
+                the modern format for a better editing experience.`
+          }
         </div>
 
         <div class="table-responsive">
           <table class="table table-sm table-hover" aria-label="Access rules">
             <thead>
               <tr>
-                ${showComments
-                  ? html`<th style="width: 1%"><span class="visually-hidden">Comments</span></th>`
-                  : ''}
+                ${
+                  showComments
+                    ? html`<th style="width: 1%"><span class="visually-hidden">Comments</span></th>`
+                    : ''
+                }
                 <th>Mode</th>
                 <th>UIDs</th>
                 <th>Start date</th>
@@ -129,72 +137,84 @@ export function InstructorAssessmentAccess({
                 // student data. See https://github.com/PrairieLearn/PrairieLearn/issues/3342
                 return html`
                   <tr>
-                    ${showComments
-                      ? html`<td>${CommentPopoverHtml(access_rule.rule.json_comment)}</td>`
-                      : ''}
+                    ${
+                      showComments
+                        ? html`<td>${CommentPopoverHtml(access_rule.rule.json_comment)}</td>`
+                        : ''
+                    }
                     <td>${access_rule.rule.mode ?? '—'}</td>
                     <td>
-                      ${access_rule.rule.uids == null ||
-                      resLocals.authz_data.has_course_instance_permission_view
-                        ? (access_rule.rule.uids?.join(', ') ?? '—')
-                        : html`
-                            <button
-                              type="button"
-                              class="btn btn-xs btn-warning"
-                              data-bs-toggle="popover"
-                              data-bs-container="body"
-                              data-bs-placement="auto"
-                              data-bs-title="Hidden UIDs"
-                              data-bs-content="This access rule is specific to individual students. You need student data viewer permissions to see which ones."
-                            >
-                              Hidden
-                            </button>
-                          `}
+                      ${
+                        access_rule.rule.uids == null ||
+                        resLocals.authz_data.has_course_instance_permission_view
+                          ? (access_rule.rule.uids?.join(', ') ?? '—')
+                          : html`
+                              <button
+                                type="button"
+                                class="btn btn-xs btn-warning"
+                                data-bs-toggle="popover"
+                                data-bs-container="body"
+                                data-bs-placement="auto"
+                                data-bs-title="Hidden UIDs"
+                                data-bs-content="This access rule is specific to individual students. You need student data viewer permissions to see which ones."
+                              >
+                                Hidden
+                              </button>
+                            `
+                      }
                     </td>
                     <td>
-                      ${access_rule.rule.start_date == null
-                        ? '—'
-                        : formatDate(
-                            access_rule.rule.start_date,
-                            resLocals.course_instance.display_timezone,
-                          )}
+                      ${
+                        access_rule.rule.start_date == null
+                          ? '—'
+                          : formatDate(
+                              access_rule.rule.start_date,
+                              resLocals.course_instance.display_timezone,
+                            )
+                      }
                     </td>
                     <td>
-                      ${access_rule.rule.end_date == null
-                        ? '—'
-                        : formatDate(
-                            access_rule.rule.end_date,
-                            resLocals.course_instance.display_timezone,
-                          )}
+                      ${
+                        access_rule.rule.end_date == null
+                          ? '—'
+                          : formatDate(
+                              access_rule.rule.end_date,
+                              resLocals.course_instance.display_timezone,
+                            )
+                      }
                     </td>
                     <td>${access_rule.rule.active ? 'True' : 'False'}</td>
                     <td>
                       ${access_rule.rule.credit == null ? '—' : `${access_rule.rule.credit}%`}
                     </td>
                     <td>
-                      ${access_rule.rule.time_limit_min == null
-                        ? '—'
-                        : `${access_rule.rule.time_limit_min} min`}
+                      ${
+                        access_rule.rule.time_limit_min == null
+                          ? '—'
+                          : `${access_rule.rule.time_limit_min} min`
+                      }
                     </td>
                     <td>${access_rule.rule.password ?? '—'}</td>
                     <td>
-                      ${access_rule.pt_exam_name
-                        ? html`
-                            <a
-                              href="${config.ptHost}/pt/course/${access_rule.pt_course_id}/staff/exam/${access_rule.pt_exam_id}"
-                            >
-                              ${access_rule.pt_course_name}: ${access_rule.pt_exam_name}
-                            </a>
-                          `
-                        : access_rule.rule.exam_uuid
-                          ? config.devMode
-                            ? access_rule.rule.exam_uuid
-                            : html`
-                                <span class="text-danger">
-                                  Exam not found: ${access_rule.rule.exam_uuid}
-                                </span>
-                              `
-                          : html`&mdash;`}
+                      ${
+                        access_rule.pt_exam_name
+                          ? html`
+                              <a
+                                href="${config.ptHost}/pt/course/${access_rule.pt_course_id}/staff/exam/${access_rule.pt_exam_id}"
+                              >
+                                ${access_rule.pt_course_name}: ${access_rule.pt_exam_name}
+                              </a>
+                            `
+                          : access_rule.rule.exam_uuid
+                            ? config.devMode
+                              ? access_rule.rule.exam_uuid
+                              : html`
+                                  <span class="text-danger">
+                                    Exam not found: ${access_rule.rule.exam_uuid}
+                                  </span>
+                                `
+                            : html`&mdash;`
+                      }
                     </td>
                   </tr>
                 `;
@@ -219,9 +239,11 @@ export function InstructorAssessmentAccess({
         </div>
       </div>
 
-      ${migrationPreview && canEdit
-        ? MigrationConfirmModal({ migrationPreview, resLocals, origHash })
-        : ''}
+      ${
+        migrationPreview && canEdit
+          ? MigrationConfirmModal({ migrationPreview, resLocals, origHash })
+          : ''
+      }
     `,
   });
 }
@@ -241,47 +263,55 @@ function MigrationConfirmModal({
     size: 'modal-xl',
     content: html`
       <div class="modal-body">
-        ${migrationPreview.isIncompatible
-          ? html`
-              <div class="alert alert-danger">
-                <i class="bi bi-exclamation-triangle-fill"></i>
-                This assessment's access rules cannot be automatically migrated. Proceeding will
-                <strong>remove all existing access rules</strong> and switch to the modern format
-                with no access control configured. You will need to set up access control from
-                scratch.
-              </div>
-            `
-          : ''}
-        ${migrationPreview.hasUidRules
-          ? html`
-              <div class="alert alert-warning">
-                <i class="bi bi-exclamation-triangle-fill"></i>
-                This assessment has UID-based access rules that will be dropped during migration.
-                UID-based rules are not supported in the modern format.
-              </div>
-            `
-          : ''}
-        ${migrationPreview.errors.length > 0
-          ? html`
-              <div class="alert alert-danger">
-                <i class="bi bi-exclamation-triangle-fill"></i>
-                <ul class="mb-0 mt-1">
-                  ${migrationPreview.errors.map((e) => html`<li>${e}</li>`)}
-                </ul>
-              </div>
-            `
-          : ''}
-        ${migrationPreview.notes.length > 0
-          ? html`
-              <div class="alert alert-info">
-                <i class="bi bi-info-circle-fill"></i>
-                <strong>Migration notes:</strong>
-                <ul class="mb-0 mt-1">
-                  ${migrationPreview.notes.map((w) => html`<li>${w}</li>`)}
-                </ul>
-              </div>
-            `
-          : ''}
+        ${
+          migrationPreview.isIncompatible
+            ? html`
+                <div class="alert alert-danger">
+                  <i class="bi bi-exclamation-triangle-fill"></i>
+                  This assessment's access rules cannot be automatically migrated. Proceeding will
+                  <strong>remove all existing access rules</strong> and switch to the modern format
+                  with no access control configured. You will need to set up access control from
+                  scratch.
+                </div>
+              `
+            : ''
+        }
+        ${
+          migrationPreview.hasUidRules
+            ? html`
+                <div class="alert alert-warning">
+                  <i class="bi bi-exclamation-triangle-fill"></i>
+                  This assessment has UID-based access rules that will be dropped during migration.
+                  UID-based rules are not supported in the modern format.
+                </div>
+              `
+            : ''
+        }
+        ${
+          migrationPreview.errors.length > 0
+            ? html`
+                <div class="alert alert-danger">
+                  <i class="bi bi-exclamation-triangle-fill"></i>
+                  <ul class="mb-0 mt-1">
+                    ${migrationPreview.errors.map((e) => html`<li>${e}</li>`)}
+                  </ul>
+                </div>
+              `
+            : ''
+        }
+        ${
+          migrationPreview.notes.length > 0
+            ? html`
+                <div class="alert alert-info">
+                  <i class="bi bi-info-circle-fill"></i>
+                  <strong>Migration notes:</strong>
+                  <ul class="mb-0 mt-1">
+                    ${migrationPreview.notes.map((w) => html`<li>${w}</li>`)}
+                  </ul>
+                </div>
+              `
+            : ''
+        }
         <p>
           See the
           <a
@@ -352,9 +382,11 @@ function MigrationConfirmModal({
         name="fallback_release_date"
         value="${migrationPreview.fallbackReleaseDate}"
       />
-      ${migrationPreview.isIncompatible
-        ? html`<input type="hidden" name="migrate_strategy" value="clear" />`
-        : ''}
+      ${
+        migrationPreview.isIncompatible
+          ? html`<input type="hidden" name="migrate_strategy" value="clear" />`
+          : ''
+      }
       <small class="text-muted me-auto">
         This can be reverted through the file editor or git history.
       </small>

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
@@ -107,18 +107,20 @@ export function InstructorAssessmentInstance({
       />
       ${compiledScriptTag('instructorAssessmentInstanceClient.ts')}
       <script src="${nodeModulesAssetPath(
-          'tablesorter/dist/js/jquery.tablesorter.min.js',
-        )}"></script>
+        'tablesorter/dist/js/jquery.tablesorter.min.js',
+      )}"></script>
       <script src="${nodeModulesAssetPath(
-          'tablesorter/dist/js/jquery.tablesorter.widgets.min.js',
-        )}"></script>
+        'tablesorter/dist/js/jquery.tablesorter.widgets.min.js',
+      )}"></script>
     `,
     content: html`
       <h1 class="visually-hidden">
         ${resLocals.assessment_instance_label} instance for
-        ${resLocals.instance_group
-          ? html`${resLocals.instance_group.name}`
-          : html`${resLocals.instance_user.name}`}
+        ${
+          resLocals.instance_group
+            ? html`${resLocals.instance_group.name}`
+            : html`${resLocals.instance_user.name}`
+        }
       </h1>
       ${ResetQuestionVariantsModal({
         assessment: resLocals.assessment,
@@ -135,63 +137,68 @@ export function InstructorAssessmentInstance({
             aria-label="Assessment instance summary"
           >
             <tbody>
-              ${resLocals.instance_group
-                ? html`
-                    <tr>
-                      <th>Name</th>
-                      <td colspan="2">${resLocals.instance_group.name}</td>
-                    </tr>
-                    <tr>
-                      <th>Group Members</th>
-                      <td colspan="2">${resLocals.instance_group_uid_list.join(', ')}</td>
-                    </tr>
-                  `
-                : html`
-                    <tr>
-                      <th>UID</th>
-                      <td colspan="2">${resLocals.instance_user.uid}</td>
-                    </tr>
-                    <tr>
-                      <th>Name</th>
-                      <td colspan="2">${resLocals.instance_user.name}</td>
-                    </tr>
-                    <tr>
-                      <th>Role</th>
-                      <td colspan="2">${resLocals.instance_role}</td>
-                    </tr>
-                  `}
+              ${
+                resLocals.instance_group
+                  ? html`
+                      <tr>
+                        <th>Name</th>
+                        <td colspan="2">${resLocals.instance_group.name}</td>
+                      </tr>
+                      <tr>
+                        <th>Group Members</th>
+                        <td colspan="2">${resLocals.instance_group_uid_list.join(', ')}</td>
+                      </tr>
+                    `
+                  : html`
+                      <tr>
+                        <th>UID</th>
+                        <td colspan="2">${resLocals.instance_user.uid}</td>
+                      </tr>
+                      <tr>
+                        <th>Name</th>
+                        <td colspan="2">${resLocals.instance_user.name}</td>
+                      </tr>
+                      <tr>
+                        <th>Role</th>
+                        <td colspan="2">${resLocals.instance_role}</td>
+                      </tr>
+                    `
+              }
               <tr>
                 <th>Instance</th>
                 <td colspan="2">
                   ${resLocals.assessment_instance.number} (<a
-                    href="/pl/course_instance/${resLocals.course_instance
-                      .id}/assessment_instance/${resLocals.assessment_instance.id}"
+                    href="/pl/course_instance/${
+                      resLocals.course_instance.id
+                    }/assessment_instance/${resLocals.assessment_instance.id}"
                     >student view</a
                   >)
                 </td>
               </tr>
-              ${resLocals.instance_user
-                ? html`
-                    <tr>
-                      <th>Fingerprint Changes</th>
-                      <td colspan="2">
-                        ${resLocals.assessment_instance.client_fingerprint_id_change_count}
-                        <button
-                          type="button"
-                          class="btn btn-xs btn-ghost"
-                          id="fingerprintDescriptionPopover"
-                          data-bs-toggle="popover"
-                          data-bs-container="body"
-                          data-bs-html="false"
-                          data-bs-title="Client fingerprint changes"
-                          data-bs-content="Client fingerprints are a record of a user's IP address, user agent and session. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
-                        >
-                          <i class="fa fa-question-circle"></i>
-                        </button>
-                      </td>
-                    </tr>
-                  `
-                : ''}
+              ${
+                resLocals.instance_user
+                  ? html`
+                      <tr>
+                        <th>Fingerprint Changes</th>
+                        <td colspan="2">
+                          ${resLocals.assessment_instance.client_fingerprint_id_change_count}
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-ghost"
+                            id="fingerprintDescriptionPopover"
+                            data-bs-toggle="popover"
+                            data-bs-container="body"
+                            data-bs-html="false"
+                            data-bs-title="Client fingerprint changes"
+                            data-bs-content="Client fingerprints are a record of a user's IP address, user agent and session. These attributes are tracked while a user is accessing an assessment. This value indicates the amount of times that those attributes changed as the student accessed the assessment, while the assessment was active. Some changes may naturally occur during an assessment, such as if a student changes network connections or browsers. However, a high number of changes in an exam-like environment could be an indication of multiple people accessing the same assessment simultaneously, which may suggest an academic integrity issue. Accesses taking place after the assessment has been closed are not counted, as they typically indicate scenarios where a student is reviewing their results, which may happen outside of a controlled environment."
+                          >
+                            <i class="fa fa-question-circle"></i>
+                          </button>
+                        </td>
+                      </tr>
+                    `
+                  : ''
+              }
 
               <tr>
                 <th>Points</th>
@@ -204,27 +211,29 @@ export function InstructorAssessmentInstance({
                       >${formatPoints(resLocals.assessment_instance.max_points)}
                     </span>
                   </small>
-                  ${resLocals.authz_data.has_course_instance_permission_edit
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn btn-xs btn-secondary"
-                          id="editTotalPointsButton"
-                          data-bs-toggle="popover"
-                          data-bs-container="body"
-                          data-bs-html="true"
-                          data-bs-placement="auto"
-                          data-bs-title="Change total points"
-                          data-bs-content="${escapeHtml(
+                  ${
+                    resLocals.authz_data.has_course_instance_permission_edit
+                      ? html`
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-secondary"
+                            id="editTotalPointsButton"
+                            data-bs-toggle="popover"
+                            data-bs-container="body"
+                            data-bs-html="true"
+                            data-bs-placement="auto"
+                            data-bs-title="Change total points"
+                            data-bs-content="${escapeHtml(
                             EditTotalPointsForm({
                               resLocals,
                             }),
                           )}"
-                        >
-                          <i class="fa fa-edit" aria-hidden="true"></i>
-                        </button>
-                      `
-                    : ''}
+                          >
+                            <i class="fa fa-edit" aria-hidden="true"></i>
+                          </button>
+                        `
+                      : ''
+                  }
                 </td>
               </tr>
               <tr>
@@ -233,61 +242,65 @@ export function InstructorAssessmentInstance({
                   ${ScorebarHtml(resLocals.assessment_instance.score_perc)}
                 </td>
                 <td class="align-middle" style="width: 100%;">
-                  ${resLocals.authz_data.has_course_instance_permission_edit
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn btn-xs btn-secondary"
-                          id="editTotalScorePercButton"
-                          data-bs-toggle="popover"
-                          data-bs-container="body"
-                          data-bs-html="true"
-                          data-bs-placement="auto"
-                          data-bs-title="Change total percentage score"
-                          data-bs-content="${escapeHtml(
+                  ${
+                    resLocals.authz_data.has_course_instance_permission_edit
+                      ? html`
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-secondary"
+                            id="editTotalScorePercButton"
+                            data-bs-toggle="popover"
+                            data-bs-container="body"
+                            data-bs-html="true"
+                            data-bs-placement="auto"
+                            data-bs-title="Change total percentage score"
+                            data-bs-content="${escapeHtml(
                             EditTotalScorePercForm({
                               resLocals,
                             }),
                           )}"
-                        >
-                          <i class="fa fa-edit" aria-hidden="true"></i>
-                        </button>
-                      `
-                    : ''}
+                          >
+                            <i class="fa fa-edit" aria-hidden="true"></i>
+                          </button>
+                        `
+                      : ''
+                  }
                 </td>
               </tr>
               <tr>
                 <th>Statistics</th>
                 <td colspan="2">
-                  ${resLocals.assessment_instance.include_in_statistics
-                    ? html`
-                        Included
-                        <button
-                          type="button"
-                          class="btn btn-xs btn-ghost"
-                          data-bs-toggle="popover"
-                          data-bs-container="body"
-                          data-bs-html="true"
-                          data-bs-title="Included in statistics"
-                          data-bs-content="This assessment is included in the calculation of assessment and question statistics"
-                        >
-                          <i class="fa fa-question-circle"></i>
-                        </button>
-                      `
-                    : html`
-                        Not included
-                        <button
-                          type="button"
-                          class="btn btn-xs btn-ghost"
-                          data-bs-toggle="popover"
-                          data-bs-container="body"
-                          data-bs-html="true"
-                          data-bs-title="Not included in statistics"
-                          data-bs-content="This assessment is not included in the calculation of assessment and question statistics because it was created by a course staff member"
-                        >
-                          <i class="fa fa-question-circle"></i>
-                        </button>
-                      `}
+                  ${
+                    resLocals.assessment_instance.include_in_statistics
+                      ? html`
+                          Included
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-ghost"
+                            data-bs-toggle="popover"
+                            data-bs-container="body"
+                            data-bs-html="true"
+                            data-bs-title="Included in statistics"
+                            data-bs-content="This assessment is included in the calculation of assessment and question statistics"
+                          >
+                            <i class="fa fa-question-circle"></i>
+                          </button>
+                        `
+                      : html`
+                          Not included
+                          <button
+                            type="button"
+                            class="btn btn-xs btn-ghost"
+                            data-bs-toggle="popover"
+                            data-bs-container="body"
+                            data-bs-html="true"
+                            data-bs-title="Not included in statistics"
+                            data-bs-content="This assessment is not included in the calculation of assessment and question statistics because it was created by a course staff member"
+                          >
+                            <i class="fa fa-question-circle"></i>
+                          </button>
+                        `
+                  }
                 </td>
               </tr>
               <tr>
@@ -351,59 +364,71 @@ export function InstructorAssessmentInstance({
                   }
 
                   return html`
-                    ${instance_question.start_new_zone && instance_question.lockpoint
-                      ? html`
-                          <tr>
-                            <th colspan="9" class="bg-light fw-normal">
-                              ${instance_question.lockpoint_crossed
-                                ? html`
-                                    Lockpoint crossed by
-                                    ${instance_question.lockpoint_crossed_authn_user_uid ??
-                                    'unknown user'}
-                                    ${instance_question.lockpoint_crossed_at
-                                      ? html`at
-                                        ${formatDate(
+                    ${
+                      instance_question.start_new_zone && instance_question.lockpoint
+                        ? html`
+                            <tr>
+                              <th colspan="9" class="bg-light fw-normal">
+                                ${
+                                instance_question.lockpoint_crossed
+                                  ? html`
+                                      Lockpoint crossed by
+                                      ${
+                                      instance_question.lockpoint_crossed_authn_user_uid ??
+                                      'unknown user'
+                                    }
+                                      ${
+                                      instance_question.lockpoint_crossed_at
+                                        ? html`at
+                                          ${formatDate(
                                           instance_question.lockpoint_crossed_at,
                                           resLocals.course_instance.display_timezone,
                                         )}`
-                                      : ''}
-                                  `
-                                : html`Lockpoint not yet crossed`}
-                            </th>
-                          </tr>
-                        `
-                      : ''}
-                    ${showZoneInfo
-                      ? html`
-                          <tr>
-                            <th colspan="9">
-                              ${zoneHasInfo
-                                ? (() => {
-                                    const constraints = [
-                                      instance_question.zone_has_max_points
-                                        ? `maximum ${instance_question.zone_max_points} points`
-                                        : null,
-                                      instance_question.zone_has_best_questions
-                                        ? `best ${instance_question.zone_best_questions} questions`
-                                        : null,
-                                    ].filter(Boolean);
-
-                                    if (instance_question.zone_title) {
-                                      // Title with optional constraints in parentheses
-                                      return constraints.length > 0
-                                        ? `${instance_question.zone_title} (${constraints.join(', ')})`
-                                        : instance_question.zone_title;
-                                    } else {
-                                      // No title - capitalize the first constraint
-                                      const text = constraints.join(', ');
-                                      return text.charAt(0).toUpperCase() + text.slice(1);
+                                        : ''
                                     }
-                                  })()
-                                : html`&nbsp;`}
-                            </th>
-                          </tr>
-                        `
-                      : ''}
+                                    `
+                                  : html`Lockpoint not yet crossed`
+                              }
+                              </th>
+                            </tr>
+                          `
+                        : ''
+                    }
+                    ${
+                      showZoneInfo
+                        ? html`
+                            <tr>
+                              <th colspan="9">
+                                ${
+                                zoneHasInfo
+                                  ? (() => {
+                                      const constraints = [
+                                        instance_question.zone_has_max_points
+                                          ? `maximum ${instance_question.zone_max_points} points`
+                                          : null,
+                                        instance_question.zone_has_best_questions
+                                          ? `best ${instance_question.zone_best_questions} questions`
+                                          : null,
+                                      ].filter(Boolean);
+
+                                      if (instance_question.zone_title) {
+                                        // Title with optional constraints in parentheses
+                                        return constraints.length > 0
+                                          ? `${instance_question.zone_title} (${constraints.join(', ')})`
+                                          : instance_question.zone_title;
+                                      } else {
+                                        // No title - capitalize the first constraint
+                                        const text = constraints.join(', ');
+                                        return text.charAt(0).toUpperCase() + text.slice(1);
+                                      }
+                                    })()
+                                  : html`&nbsp;`
+                              }
+                              </th>
+                            </tr>
+                          `
+                        : ''
+                    }
                     <tr>
                       <td>
                         S-${instance_question.question_number}. (<a
@@ -417,18 +442,20 @@ export function InstructorAssessmentInstance({
                       </td>
                       <td>
                         I-${instance_question.instructor_question_number}. ${instance_question.qid}
-                        ${resLocals.authz_data.has_course_permission_preview
-                          ? html`
-                              (<a
-                                href="${getQuestionUrl({
+                        ${
+                          resLocals.authz_data.has_course_permission_preview
+                            ? html`
+                                (<a
+                                  href="${getQuestionUrl({
                                   courseInstanceId: resLocals.course_instance.id,
                                   questionId: instance_question.question_id,
                                   variantSeed: instance_question.last_variant_seed,
                                 })}"
-                                >instructor view</a
-                              >)
-                            `
-                          : ''}
+                                  >instructor view</a
+                                >)
+                              `
+                            : ''
+                        }
                       </td>
                       <td class="text-center">
                         ${InstanceQuestionPoints({
@@ -436,15 +463,17 @@ export function InstructorAssessmentInstance({
                           assessment_question: instance_question.assessment_question,
                           component: 'auto',
                         })}
-                        ${resLocals.authz_data.has_course_instance_permission_edit
-                          ? EditQuestionPointsScoreButtonHtml({
-                              field: 'auto_points',
-                              instance_question,
-                              assessment_question: instance_question.assessment_question,
-                              urlPrefix: resLocals.urlPrefix,
-                              csrfToken: resLocals.__csrf_token,
-                            })
-                          : ''}
+                        ${
+                          resLocals.authz_data.has_course_instance_permission_edit
+                            ? EditQuestionPointsScoreButtonHtml({
+                                field: 'auto_points',
+                                instance_question,
+                                assessment_question: instance_question.assessment_question,
+                                urlPrefix: resLocals.urlPrefix,
+                                csrfToken: resLocals.__csrf_token,
+                              })
+                            : ''
+                        }
                       </td>
                       <td class="text-center">
                         ${InstanceQuestionPoints({
@@ -452,15 +481,17 @@ export function InstructorAssessmentInstance({
                           assessment_question: instance_question.assessment_question,
                           component: 'manual',
                         })}
-                        ${resLocals.authz_data.has_course_instance_permission_edit
-                          ? EditQuestionPointsScoreButtonHtml({
-                              field: 'manual_points',
-                              instance_question,
-                              assessment_question: instance_question.assessment_question,
-                              urlPrefix: resLocals.urlPrefix,
-                              csrfToken: resLocals.__csrf_token,
-                            })
-                          : ''}
+                        ${
+                          resLocals.authz_data.has_course_instance_permission_edit
+                            ? EditQuestionPointsScoreButtonHtml({
+                                field: 'manual_points',
+                                instance_question,
+                                assessment_question: instance_question.assessment_question,
+                                urlPrefix: resLocals.urlPrefix,
+                                csrfToken: resLocals.__csrf_token,
+                              })
+                            : ''
+                        }
                       </td>
                       <td class="text-center">
                         ${InstanceQuestionPoints({
@@ -468,42 +499,49 @@ export function InstructorAssessmentInstance({
                           assessment_question: instance_question.assessment_question,
                           component: 'total',
                         })}
-                        ${resLocals.authz_data.has_course_instance_permission_edit
-                          ? EditQuestionPointsScoreButtonHtml({
-                              field: 'points',
-                              instance_question,
-                              assessment_question: instance_question.assessment_question,
-                              urlPrefix: resLocals.urlPrefix,
-                              csrfToken: resLocals.__csrf_token,
-                            })
-                          : ''}
+                        ${
+                          resLocals.authz_data.has_course_instance_permission_edit
+                            ? EditQuestionPointsScoreButtonHtml({
+                                field: 'points',
+                                instance_question,
+                                assessment_question: instance_question.assessment_question,
+                                urlPrefix: resLocals.urlPrefix,
+                                csrfToken: resLocals.__csrf_token,
+                              })
+                            : ''
+                        }
                       </td>
                       <td class="text-center text-nowrap" style="padding-top: 0.65rem;">
                         ${ScorebarHtml(instance_question.score_perc)}
                       </td>
                       <td style="width: 1em;">
-                        ${resLocals.authz_data.has_course_instance_permission_edit
-                          ? EditQuestionPointsScoreButtonHtml({
-                              field: 'score_perc',
-                              instance_question,
-                              assessment_question: instance_question.assessment_question,
-                              urlPrefix: resLocals.urlPrefix,
-                              csrfToken: resLocals.__csrf_token,
-                            })
-                          : ''}
+                        ${
+                          resLocals.authz_data.has_course_instance_permission_edit
+                            ? EditQuestionPointsScoreButtonHtml({
+                                field: 'score_perc',
+                                instance_question,
+                                assessment_question: instance_question.assessment_question,
+                                urlPrefix: resLocals.urlPrefix,
+                                csrfToken: resLocals.__csrf_token,
+                              })
+                            : ''
+                        }
                       </td>
                       <td class="text-nowrap" style="width: 1em;">
-                        ${resLocals.authz_data.has_course_instance_permission_edit &&
-                        instance_question.status !== 'unanswered'
-                          ? html`
-                              <a
-                                class="btn btn-xs btn-secondary"
-                                href="${resLocals.urlPrefix}/assessment/${resLocals.assessment
-                                  .id}/manual_grading/instance_question/${instance_question.id}"
-                                >Manual grading</a
-                              >
-                            `
-                          : ''}
+                        ${
+                          resLocals.authz_data.has_course_instance_permission_edit &&
+                          instance_question.status !== 'unanswered'
+                            ? html`
+                                <a
+                                  class="btn btn-xs btn-secondary"
+                                  href="${resLocals.urlPrefix}/assessment/${
+                                  resLocals.assessment.id
+                                }/manual_grading/instance_question/${instance_question.id}"
+                                  >Manual grading</a
+                                >
+                              `
+                            : ''
+                        }
                       </td>
                       <td class="text-end">
                         <div class="dropdown js-question-actions">
@@ -517,24 +555,28 @@ export function InstructorAssessmentInstance({
                             Action <span class="caret"></span>
                           </button>
                           <div class="dropdown-menu dropdown-menu-end">
-                            ${resLocals.authz_data.has_course_instance_permission_edit
-                              ? html`
-                                  <button
-                                    class="dropdown-item"
-                                    data-bs-toggle="modal"
-                                    data-bs-target="${resLocals.assessment.type === 'Exam'
-                                      ? '#examResetNotSupportedModal'
-                                      : '#resetQuestionVariantsModal'}"
-                                    data-instance-question-id="${instance_question.id}"
-                                  >
-                                    Reset question variants
-                                  </button>
-                                `
-                              : html`
-                                  <button class="dropdown-item disabled" disabled>
-                                    Must have editor permission
-                                  </button>
-                                `}
+                            ${
+                              resLocals.authz_data.has_course_instance_permission_edit
+                                ? html`
+                                    <button
+                                      class="dropdown-item"
+                                      data-bs-toggle="modal"
+                                      data-bs-target="${
+                                      resLocals.assessment.type === 'Exam'
+                                        ? '#examResetNotSupportedModal'
+                                        : '#resetQuestionVariantsModal'
+                                    }"
+                                      data-instance-question-id="${instance_question.id}"
+                                    >
+                                      Reset question variants
+                                    </button>
+                                  `
+                                : html`
+                                    <button class="dropdown-item disabled" disabled>
+                                      Must have editor permission
+                                    </button>
+                                  `
+                            }
                           </div>
                         </div>
                       </td>
@@ -578,18 +620,20 @@ export function InstructorAssessmentInstance({
                   <tr>
                     <td>
                       I-${row.number}.
-                      ${resLocals.authz_data.has_course_permission_preview
-                        ? html`
-                            <a
-                              href="${getQuestionUrl({
+                      ${
+                        resLocals.authz_data.has_course_permission_preview
+                          ? html`
+                              <a
+                                href="${getQuestionUrl({
                                 courseInstanceId: resLocals.course_instance.id,
                                 questionId: row.question_id,
                                 variantSeed: instance_question?.last_variant_seed,
                               })}"
-                              >${row.qid}</a
-                            >
-                          `
-                        : row.qid}
+                                >${row.qid}</a
+                              >
+                            `
+                          : row.qid
+                      }
                     </td>
                     <td>${row.some_submission}</td>
                     <td>${row.some_perfect_submission}</td>
@@ -624,8 +668,9 @@ export function InstructorAssessmentInstance({
           <small>
             Click on a column header to sort. Shift-click on a second header to sub-sort. Download
             <a
-              href="${resLocals.urlPrefix}/assessment_instance/${resLocals.assessment_instance
-                .id}/${logCsvFilename}"
+              href="${resLocals.urlPrefix}/assessment_instance/${
+                resLocals.assessment_instance.id
+              }/${logCsvFilename}"
               >${logCsvFilename}</a
             >. Uploaded student files are not shown above or in the CSV file. Student files can be
             downloaded on the
@@ -661,32 +706,34 @@ export function InstructorAssessmentInstance({
                       ${formatDate(row.event_date, resLocals.course_instance.display_timezone)}
                     </td>
                     <td>${row.auth_user_uid ?? html`&mdash;`}</td>
-                    ${resLocals.instance_user
-                      ? row.client_fingerprint && row.client_fingerprint_number !== null
-                        ? html`
-                            <td>
-                              <button
-                                type="button"
-                                class="btn btn-badge color-${FINGERPRINT_COLORS[
-                                  row.client_fingerprint_number % 6
-                                ]}"
-                                id="fingerprintPopover${row.client_fingerprint.id}-${index}"
-                                data-bs-toggle="popover"
-                                data-bs-container="body"
-                                data-bs-html="true"
-                                data-bs-placement="auto"
-                                data-bs-title="Fingerprint ${row.client_fingerprint_number}"
-                                data-bs-custom-class="popover-wide"
-                                data-bs-content="${escapeHtml(
+                    ${
+                      resLocals.instance_user
+                        ? row.client_fingerprint && row.client_fingerprint_number !== null
+                          ? html`
+                              <td>
+                                <button
+                                  type="button"
+                                  class="btn btn-badge color-${
+                                  FINGERPRINT_COLORS[row.client_fingerprint_number % 6]
+                                }"
+                                  id="fingerprintPopover${row.client_fingerprint.id}-${index}"
+                                  data-bs-toggle="popover"
+                                  data-bs-container="body"
+                                  data-bs-html="true"
+                                  data-bs-placement="auto"
+                                  data-bs-title="Fingerprint ${row.client_fingerprint_number}"
+                                  data-bs-custom-class="popover-wide"
+                                  data-bs-content="${escapeHtml(
                                   FingerprintContent({ fingerprint: row.client_fingerprint }),
                                 )}"
-                              >
-                                ${row.client_fingerprint_number}
-                              </button>
-                            </td>
-                          `
-                        : html`<td>&mdash;</td>`
-                      : ''}
+                                >
+                                  ${row.client_fingerprint_number}
+                                </button>
+                              </td>
+                            `
+                          : html`<td>&mdash;</td>`
+                        : ''
+                    }
                     <td><span class="badge color-${row.event_color}">${row.event_name}</span></td>
                     <td>
                       ${run(() => {
@@ -713,36 +760,40 @@ export function InstructorAssessmentInstance({
                       })}
                     </td>
                     <td>
-                      ${row.student_question_number
-                        ? row.instance_question_id && row.variant_id
-                          ? html`
-                              <a
-                                href="${getInstanceQuestionUrl({
+                      ${
+                        row.student_question_number
+                          ? row.instance_question_id && row.variant_id
+                            ? html`
+                                <a
+                                  href="${getInstanceQuestionUrl({
                                   courseInstanceId: resLocals.course_instance.id,
                                   instanceQuestionId: row.instance_question_id,
                                   variantId: row.variant_id,
                                 })}"
-                              >
-                                S-${row.student_question_number}#${row.variant_number}
-                              </a>
-                            `
-                          : html`S-${row.student_question_number}`
-                        : ''}
+                                >
+                                  S-${row.student_question_number}#${row.variant_number}
+                                </a>
+                              `
+                            : html`S-${row.student_question_number}`
+                          : ''
+                      }
                     </td>
-                    ${row.event_name !== 'External grading results'
-                      ? html`<td style="word-break: break-all;">
-                          ${row.data != null ? JSON.stringify(row.data) : ''}
-                        </td>`
-                      : html`
-                          <td>
-                            <a
-                              class="btn btn-primary"
-                              href="${resLocals.urlPrefix}/grading_job/${row.data?.id}"
-                            >
-                              View grading job ${row.data?.id}
-                            </a>
-                          </td>
-                        `}
+                    ${
+                      row.event_name !== 'External grading results'
+                        ? html`<td style="word-break: break-all;">
+                            ${row.data != null ? JSON.stringify(row.data) : ''}
+                          </td>`
+                        : html`
+                            <td>
+                              <a
+                                class="btn btn-primary"
+                                href="${resLocals.urlPrefix}/grading_job/${row.data?.id}"
+                              >
+                                View grading job ${row.data?.id}
+                              </a>
+                            </td>
+                          `
+                    }
                   </tr>
                 `;
               })}
@@ -763,8 +814,9 @@ export function InstructorAssessmentInstance({
           <small>
             Download
             <a
-              href="${resLocals.urlPrefix}/assessment_instance/${resLocals.assessment_instance
-                .id}/${logCsvFilename}"
+              href="${resLocals.urlPrefix}/assessment_instance/${
+                resLocals.assessment_instance.id
+              }/${logCsvFilename}"
               >${logCsvFilename}</a
             >. Uploaded student files are not shown above or in the CSV file. Student files can be
             downloaded on the

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/TimeLimitEditForm.tsx
@@ -12,13 +12,7 @@ import { useTRPC } from '../../../trpc/assessment/context.js';
 import { useInvalidateAssessmentInstancesList } from './useInvalidateAssessmentInstancesList.js';
 
 type TimeLimitAction =
-  | 'set_total'
-  | 'set_rem'
-  | 'set_exact'
-  | 'add'
-  | 'subtract'
-  | 'remove'
-  | 'expire';
+  'set_total' | 'set_rem' | 'set_exact' | 'add' | 'subtract' | 'remove' | 'expire';
 
 function TimeLimitExplanation({ action }: { action: TimeLimitAction }) {
   let explanation = '';

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
@@ -59,9 +59,11 @@ export function ManualGradingAssessment({
       ${compiledScriptTag('instructorAssessmentManualGradingAssessmentClient.ts')}
     `,
     preContent: html`
-      ${resLocals.authz_data.has_course_instance_permission_edit
-        ? GraderAssignmentModal({ courseStaff, csrfToken: resLocals.__csrf_token })
-        : ''}
+      ${
+        resLocals.authz_data.has_course_instance_permission_edit
+          ? GraderAssignmentModal({ courseStaff, csrfToken: resLocals.__csrf_token })
+          : ''
+      }
     `,
     content: (
       <>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/GroupInfoModal.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/GroupInfoModal.tsx
@@ -8,10 +8,7 @@ import type { useManualGradingActions } from '../utils/useManualGradingActions.j
 const defaultClosedSubmissionsOnly = true;
 
 export type GroupInfoModalState =
-  | { type: 'selected'; ids: string[] }
-  | { type: 'all' }
-  | { type: 'ungrouped' }
-  | null;
+  { type: 'selected'; ids: string[] } | { type: 'all' } | { type: 'ungrouped' } | null;
 
 export function GroupInfoModal({
   modalState,

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -146,69 +146,74 @@ export function GradingPanel({
       />
       <input type="hidden" name="submission_id" value="${resLocals.submission.id}" />
       <ul class="list-group list-group-flush">
-        ${resLocals.assessment_question.max_points
-          ? // Percentage-based grading is only suitable if the question has points
-            html`
-              <li class="list-group-item d-flex justify-content-center">
-                <span>Points</span>
-                <div class="form-check form-switch mx-2">
-                  <input
-                    class="form-check-input js-manual-grading-pts-perc-select"
-                    name="use_score_perc"
-                    id="use-score-perc"
-                    type="checkbox"
-                  />
-                  <label class="form-check-label" for="use-score-perc">Percentage</label>
-                </div>
-              </li>
-            `
-          : ''}
-        ${showInstanceQuestionGroup && context === 'main'
-          ? html`
-              <li class="list-group-item align-items-center">
-                <label
-                  for="instance-question-group-toggle"
-                  class="form-label d-flex align-items-center gap-2"
-                >
-                  Submission Group:
-                  ${instanceQuestionGroups && instanceQuestionGroups.length > 0
-                    ? html`
-                        <div
-                          id="instance-question-group-description-tooltip"
-                          data-bs-toggle="tooltip"
-                          data-bs-html="true"
-                          data-bs-title="${displayedSelectedGroup.instance_question_group_description}"
-                        >
-                          <i class="fas fa-circle-info text-secondary"></i>
-                        </div>
-                      `
-                    : ''}
-                </label>
-                <div class="dropdown w-100 mb-2" role="combobox">
-                  <button
-                    id="instance-question-group-toggle"
-                    type="button"
-                    class="btn dropdown-toggle border border-gray bg-white d-flex justify-content-between align-items-center w-100"
-                    aria-label="Change selected submission group"
-                    aria-haspopup="listbox"
-                    aria-expanded="false"
-                    data-bs-toggle="dropdown"
-                    data-bs-boundary="window"
+        ${
+          resLocals.assessment_question.max_points
+            ? // Percentage-based grading is only suitable if the question has points
+              html`
+                <li class="list-group-item d-flex justify-content-center">
+                  <span>Points</span>
+                  <div class="form-check form-switch mx-2">
+                    <input
+                      class="form-check-input js-manual-grading-pts-perc-select"
+                      name="use_score_perc"
+                      id="use-score-perc"
+                      type="checkbox"
+                    />
+                    <label class="form-check-label" for="use-score-perc">Percentage</label>
+                  </div>
+                </li>
+              `
+            : ''
+        }
+        ${
+          showInstanceQuestionGroup && context === 'main'
+            ? html`
+                <li class="list-group-item align-items-center">
+                  <label
+                    for="instance-question-group-toggle"
+                    class="form-label d-flex align-items-center gap-2"
                   >
-                    <span id="instance-question-group-selection-dropdown-span">
-                      ${displayedSelectedGroup.instance_question_group_name}
-                    </span>
-                  </button>
-
-                  <div class="dropdown-menu py-0 overflow-hidden">
-                    <div
-                      id="instance-question-group-selection-dropdown"
-                      style="max-height: 50vh"
-                      class="overflow-auto py-2"
-                      role="listbox"
-                      aria-labelledby="instance-question-group-toggle"
+                    Submission Group:
+                    ${
+                    instanceQuestionGroups && instanceQuestionGroups.length > 0
+                      ? html`
+                          <div
+                            id="instance-question-group-description-tooltip"
+                            data-bs-toggle="tooltip"
+                            data-bs-html="true"
+                            data-bs-title="${displayedSelectedGroup.instance_question_group_description}"
+                          >
+                            <i class="fas fa-circle-info text-secondary"></i>
+                          </div>
+                        `
+                      : ''
+                  }
+                  </label>
+                  <div class="dropdown w-100 mb-2" role="combobox">
+                    <button
+                      id="instance-question-group-toggle"
+                      type="button"
+                      class="btn dropdown-toggle border border-gray bg-white d-flex justify-content-between align-items-center w-100"
+                      aria-label="Change selected submission group"
+                      aria-haspopup="listbox"
+                      aria-expanded="false"
+                      data-bs-toggle="dropdown"
+                      data-bs-boundary="window"
                     >
-                      ${instanceQuestionGroupsWithEmpty.map((group) => {
+                      <span id="instance-question-group-selection-dropdown-span">
+                        ${displayedSelectedGroup.instance_question_group_name}
+                      </span>
+                    </button>
+
+                    <div class="dropdown-menu py-0 overflow-hidden">
+                      <div
+                        id="instance-question-group-selection-dropdown"
+                        style="max-height: 50vh"
+                        class="overflow-auto py-2"
+                        role="listbox"
+                        aria-labelledby="instance-question-group-toggle"
+                      >
+                        ${instanceQuestionGroupsWithEmpty.map((group) => {
                         const isSelected = run(() => {
                           if (!group.id) {
                             return displayedSelectedGroup.id === null;
@@ -233,26 +238,30 @@ export function GradingPanel({
                           </a>
                         `;
                       })}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </li>
-            `
-          : ''}
-        ${graderGuidelinesRendered
-          ? html`
-              <li class="list-group-item">
-                <div class="mb-1">Guidelines:</div>
-                <p class="my-3" style="white-space: pre-line;">${graderGuidelinesRendered}</p>
-              </li>
-            `
-          : ''}
-        ${gradedByAi || gradedByHuman
-          ? html`
-              <li class="list-group-item">
-                <div class="d-flex align-items-center flex-wrap gap-1">
-                  <span>Graded by:</span>
-                  ${run(() => {
+                </li>
+              `
+            : ''
+        }
+        ${
+          graderGuidelinesRendered
+            ? html`
+                <li class="list-group-item">
+                  <div class="mb-1">Guidelines:</div>
+                  <p class="my-3" style="white-space: pre-line;">${graderGuidelinesRendered}</p>
+                </li>
+              `
+            : ''
+        }
+        ${
+          gradedByAi || gradedByHuman
+            ? html`
+                <li class="list-group-item">
+                  <div class="d-flex align-items-center flex-wrap gap-1">
+                    <span>Graded by:</span>
+                    ${run(() => {
                     const aiBadge = html`<span class="badge text-bg-light border fw-medium"
                       >AI</span
                     >`;
@@ -272,41 +281,54 @@ export function GradingPanel({
                     }
                     return html`<span>${gradedByHumanName}</span>`;
                   })}
-                </div>
-                ${gradedByAi && gradedByHuman
-                  ? html`<div class="text-muted small mt-1">
-                      Human grading always takes priority
-                    </div>`
-                  : ''}
-              </li>
-            `
-          : ''}
+                  </div>
+                  ${
+                  gradedByAi && gradedByHuman
+                    ? html`<div class="text-muted small mt-1">
+                        Human grading always takes priority
+                      </div>`
+                    : ''
+                }
+                </li>
+              `
+            : ''
+        }
         <li class="list-group-item">
           ${ManualPointsSection({ context, disable, manual_points, resLocals })}
-          ${!resLocals.rubric_data?.rubric.replace_auto_points ||
-          (!resLocals.assessment_question.max_auto_points && !auto_points)
-            ? RubricInputSection({ resLocals, disable, aiGradingInfo, context })
-            : ''}
+          ${
+            !resLocals.rubric_data?.rubric.replace_auto_points ||
+            (!resLocals.assessment_question.max_auto_points && !auto_points)
+              ? RubricInputSection({ resLocals, disable, aiGradingInfo, context })
+              : ''
+          }
         </li>
-        ${resLocals.assessment_question.max_auto_points || auto_points
-          ? html`
-              <li class="list-group-item">
-                ${AutoPointsSection({ context, disable, auto_points, resLocals })}
-              </li>
-              <li class="list-group-item">
-                ${TotalPointsSection({ points, resLocals })}
-                ${resLocals.rubric_data?.rubric.replace_auto_points
-                  ? RubricInputSection({ resLocals, disable, aiGradingInfo, context })
-                  : ''}
-              </li>
-            `
-          : ''}
+        ${
+          resLocals.assessment_question.max_auto_points || auto_points
+            ? html`
+                <li class="list-group-item">
+                  ${AutoPointsSection({ context, disable, auto_points, resLocals })}
+                </li>
+                <li class="list-group-item">
+                  ${TotalPointsSection({ points, resLocals })}
+                  ${
+                  resLocals.rubric_data?.rubric.replace_auto_points
+                    ? RubricInputSection({ resLocals, disable, aiGradingInfo, context })
+                    : ''
+                }
+                </li>
+              `
+            : ''
+        }
         <li class="list-group-item">
           <label>
             Feedback:
-            ${enableEditKeyboardShortcuts
-              ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent mb-1 ms-2">F</kbd>`
-              : ''}
+            ${
+              enableEditKeyboardShortcuts
+                ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent mb-1 ms-2"
+                    >F</kbd
+                  >`
+                : ''
+            }
             <textarea
               name="submission_note"
               class="form-control js-submission-feedback"
@@ -315,18 +337,18 @@ export function GradingPanel({
               aria-describedby="submission-feedback-help-${context}"
               ${enableEditKeyboardShortcuts ? html`data-key-binding="f"` : ''}
             >
-${submission.feedback?.manual}</textarea
-            >
+${submission.feedback?.manual}</textarea>
             <small id="submission-feedback-help-${context}" class="form-text text-muted">
               Markdown formatting, such as *<em>emphasis</em>* or &#96;<code>code</code>&#96;, is
               permitted and will be used to format the feedback when presented to the student.
             </small>
           </label>
         </li>
-        ${open_issues.length > 0 && context !== 'existing'
-          ? html`
-              <li class="list-group-item">
-                ${open_issues.map(
+        ${
+          open_issues.length > 0 && context !== 'existing'
+            ? html`
+                <li class="list-group-item">
+                  ${open_issues.map(
                   (issue) => html`
                     <div class="form-check">
                       <input
@@ -342,181 +364,197 @@ ${submission.feedback?.manual}</textarea
                     </div>
                   `,
                 )}
-              </li>
-            `
-          : ''}
+                </li>
+              `
+            : ''
+        }
         <li class="list-group-item d-flex align-items-center justify-content-end flex-wrap gap-2">
           <div>
             <div class="form-check">
-              ${showSkipGradedSubmissionsButton
-                ? html`
-                    <input
-                      id="skip_graded_submissions"
-                      type="checkbox"
-                      class="form-check-input"
-                      name="skip_graded_submissions"
-                      value="true"
-                      ${skip_graded_submissions ? 'checked' : ''}
-                    />
-                    <label class="form-check-label" for="skip_graded_submissions">
-                      Skip graded submissions
-                    </label>
-                  `
-                : html`
-                    <input
-                      id="skip_graded_submissions"
-                      type="hidden"
-                      name="skip_graded_submissions"
-                      value="${skip_graded_submissions ? 'true' : 'false'}"
-                    />
-                  `}
+              ${
+                showSkipGradedSubmissionsButton
+                  ? html`
+                      <input
+                        id="skip_graded_submissions"
+                        type="checkbox"
+                        class="form-check-input"
+                        name="skip_graded_submissions"
+                        value="true"
+                        ${skip_graded_submissions ? 'checked' : ''}
+                      />
+                      <label class="form-check-label" for="skip_graded_submissions">
+                        Skip graded submissions
+                      </label>
+                    `
+                  : html`
+                      <input
+                        id="skip_graded_submissions"
+                        type="hidden"
+                        name="skip_graded_submissions"
+                        value="${skip_graded_submissions ? 'true' : 'false'}"
+                      />
+                    `
+              }
             </div>
 
             <div class="form-check">
-              ${showAssignedToMeButton
-                ? html`
-                    <input
-                      id="show_submissions_assigned_to_me_only"
-                      type="checkbox"
-                      class="form-check-input"
-                      name="show_submissions_assigned_to_me_only"
-                      value="true"
-                      ${show_submissions_assigned_to_me_only ? 'checked' : ''}
-                    />
-                    <label class="form-check-label" for="show_submissions_assigned_to_me_only">
-                      Skip submissions not assigned to me
-                    </label>
-                  `
-                : html`
-                    <input
-                      id="show_submissions_assigned_to_me_only"
-                      type="hidden"
-                      name="show_submissions_assigned_to_me_only"
-                      value="${show_submissions_assigned_to_me_only ? 'true' : 'false'}"
-                    />
-                  `}
+              ${
+                showAssignedToMeButton
+                  ? html`
+                      <input
+                        id="show_submissions_assigned_to_me_only"
+                        type="checkbox"
+                        class="form-check-input"
+                        name="show_submissions_assigned_to_me_only"
+                        value="true"
+                        ${show_submissions_assigned_to_me_only ? 'checked' : ''}
+                      />
+                      <label class="form-check-label" for="show_submissions_assigned_to_me_only">
+                        Skip submissions not assigned to me
+                      </label>
+                    `
+                  : html`
+                      <input
+                        id="show_submissions_assigned_to_me_only"
+                        type="hidden"
+                        name="show_submissions_assigned_to_me_only"
+                        value="${show_submissions_assigned_to_me_only ? 'true' : 'false'}"
+                      />
+                    `
+              }
             </div>
           </div>
 
           <span class="ms-auto">
-            ${!disable
-              ? html`
-                  ${context === 'main'
-                    ? html`
-                        <div
-                          id="grade-button-with-options"
-                          class="btn-group ${selectedInstanceQuestionGroup ? '' : 'd-none'}"
-                        >
-                          <button
-                            type="submit"
-                            class="btn btn-primary"
-                            name="__action"
-                            value="add_manual_grade"
+            ${
+              !disable
+                ? html`
+                    ${
+                    context === 'main'
+                      ? html`
+                          <div
+                            id="grade-button-with-options"
+                            class="btn-group ${selectedInstanceQuestionGroup ? '' : 'd-none'}"
                           >
-                            Grade
-                          </button>
-                          <button
-                            id="grade-options-dropdown"
-                            type="button"
-                            class="btn btn-primary dropdown-toggle dropdown-toggle-split"
-                            data-bs-toggle="dropdown"
-                            aria-haspopup="true"
-                            aria-expanded="false"
-                          ></button>
-                          <div class="dropdown-menu dropdown-menu-end">
                             <button
                               type="submit"
-                              class="dropdown-item"
+                              class="btn btn-primary"
                               name="__action"
                               value="add_manual_grade"
                             >
-                              This instance question
-                            </button>
-
-                            <div class="dropdown-divider"></div>
-
-                            <button
-                              type="submit"
-                              class="dropdown-item"
-                              name="__action"
-                              value="add_manual_grade_for_instance_question_group_ungraded"
-                            >
-                              All ungraded instance questions in submission group
+                              Grade
                             </button>
                             <button
-                              type="submit"
-                              class="dropdown-item"
-                              name="__action"
-                              value="add_manual_grade_for_instance_question_group"
-                            >
-                              All instance questions in submission group
-                            </button>
+                              id="grade-options-dropdown"
+                              type="button"
+                              class="btn btn-primary dropdown-toggle dropdown-toggle-split"
+                              data-bs-toggle="dropdown"
+                              aria-haspopup="true"
+                              aria-expanded="false"
+                            ></button>
+                            <div class="dropdown-menu dropdown-menu-end">
+                              <button
+                                type="submit"
+                                class="dropdown-item"
+                                name="__action"
+                                value="add_manual_grade"
+                              >
+                                This instance question
+                              </button>
 
-                            <div class="dropdown-item-text text-muted small">
-                              AI can make mistakes. Review submission groups before grading.
+                              <div class="dropdown-divider"></div>
+
+                              <button
+                                type="submit"
+                                class="dropdown-item"
+                                name="__action"
+                                value="add_manual_grade_for_instance_question_group_ungraded"
+                              >
+                                All ungraded instance questions in submission group
+                              </button>
+                              <button
+                                type="submit"
+                                class="dropdown-item"
+                                name="__action"
+                                value="add_manual_grade_for_instance_question_group"
+                              >
+                                All instance questions in submission group
+                              </button>
+
+                              <div class="dropdown-item-text text-muted small">
+                                AI can make mistakes. Review submission groups before grading.
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      `
-                    : ''}
-                  <button
-                    id="grade-button"
-                    type="submit"
-                    class="btn btn-primary ${selectedInstanceQuestionGroup
-                      ? 'd-none'
-                      : 'd-inline-flex'} align-items-center"
-                    name="__action"
-                    value="add_manual_grade"
-                    ${enableEditKeyboardShortcuts ? html`data-key-binding="g"` : ''}
-                  >
-                    Grade
-                    ${enableEditKeyboardShortcuts
-                      ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent ms-2"
-                          >G</kbd
-                        >`
-                      : ''}
-                  </button>
-                  ${context === 'main' && aiGradingMode
-                    ? html`
-                        <button
-                          id="ai-grade-button"
-                          type="button"
-                          class="btn btn-primary ms-1"
-                          onclick="document.dispatchEvent(new CustomEvent('${AI_GRADING_MODAL_OPEN_EVENT}'))"
-                        >
-                          <i class="bi bi-stars me-1" aria-hidden="true"></i>AI grade
-                        </button>
-                      `
-                    : ''}
-                `
-              : ''}
+                        `
+                      : ''
+                  }
+                    <button
+                      id="grade-button"
+                      type="submit"
+                      class="btn btn-primary ${
+                      selectedInstanceQuestionGroup ? 'd-none' : 'd-inline-flex'
+                    } align-items-center"
+                      name="__action"
+                      value="add_manual_grade"
+                      ${enableEditKeyboardShortcuts ? html`data-key-binding="g"` : ''}
+                    >
+                      Grade
+                      ${
+                      enableEditKeyboardShortcuts
+                        ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent ms-2"
+                            >G</kbd
+                          >`
+                        : ''
+                    }
+                    </button>
+                    ${
+                    context === 'main' && aiGradingMode
+                      ? html`
+                          <button
+                            id="ai-grade-button"
+                            type="button"
+                            class="btn btn-primary ms-1"
+                            onclick="document.dispatchEvent(new CustomEvent('${AI_GRADING_MODAL_OPEN_EVENT}'))"
+                          >
+                            <i class="bi bi-stars me-1" aria-hidden="true"></i>AI grade
+                          </button>
+                        `
+                      : ''
+                  }
+                  `
+                : ''
+            }
             <div class="btn-group">
               <button
                 type="submit"
-                class="btn btn-secondary ${showNextShortcut
-                  ? 'd-inline-flex align-items-center'
-                  : ''}"
+                class="btn btn-secondary ${
+                  showNextShortcut ? 'd-inline-flex align-items-center' : ''
+                }"
                 name="__action"
                 value="next_instance_question"
                 ${showNextShortcut ? html`data-key-binding="n"` : ''}
               >
                 ${skip_text}
-                ${showNextShortcut
-                  ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent ms-2">N</kbd>`
-                  : ''}
+                ${
+                  showNextShortcut
+                    ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent ms-2">N</kbd>`
+                    : ''
+                }
               </button>
-              ${!disable
-                ? html`
-                    <button
-                      type="button"
-                      class="btn btn-secondary dropdown-toggle dropdown-toggle-split"
-                      data-bs-toggle="dropdown"
-                      aria-haspopup="true"
-                      aria-expanded="false"
-                      aria-label="Change assigned grader"
-                    ></button>
-                    <div class="dropdown-menu dropdown-menu-end">
-                      ${(graders || []).map(
+              ${
+                !disable
+                  ? html`
+                      <button
+                        type="button"
+                        class="btn btn-secondary dropdown-toggle dropdown-toggle-split"
+                        data-bs-toggle="dropdown"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        aria-label="Change assigned grader"
+                      ></button>
+                      <div class="dropdown-menu dropdown-menu-end">
+                        ${(graders || []).map(
                         (grader) => html`
                           <button
                             type="submit"
@@ -528,25 +566,26 @@ ${submission.feedback?.manual}</textarea
                           </button>
                         `,
                       )}
-                      <button
-                        type="submit"
-                        class="dropdown-item"
-                        name="__action"
-                        value="reassign_nobody"
-                      >
-                        Tag for grading without assigned grader
-                      </button>
-                      <button
-                        type="submit"
-                        class="dropdown-item"
-                        name="__action"
-                        value="reassign_graded"
-                      >
-                        Tag as graded (keep current grade)
-                      </button>
-                    </div>
-                  `
-                : ''}
+                        <button
+                          type="submit"
+                          class="dropdown-item"
+                          name="__action"
+                          value="reassign_nobody"
+                        >
+                          Tag for grading without assigned grader
+                        </button>
+                        <button
+                          type="submit"
+                          class="dropdown-item"
+                          name="__action"
+                          value="reassign_graded"
+                        >
+                          Tag as graded (keep current grade)
+                        </button>
+                      </div>
+                    `
+                  : ''
+              }
             </div>
           </span>
         </li>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPointsSection.html.ts
@@ -65,14 +65,16 @@ export function TotalPointsSection({
         / ${resLocals.assessment_question.max_points}
       </span>
     </div>
-    ${resLocals.assessment_question.max_points
-      ? html`
-          <div class="mb-3 js-manual-grading-percentage w-100">
-            Total Score:
-            <span class="float-end"> <span class="js-value-total-percentage"></span>% </span>
-          </div>
-        `
-      : ''}
+    ${
+      resLocals.assessment_question.max_points
+        ? html`
+            <div class="mb-3 js-manual-grading-percentage w-100">
+              Total Score:
+              <span class="float-end"> <span class="js-value-total-percentage"></span>% </span>
+            </div>
+          `
+        : ''
+    }
   `;
 }
 
@@ -106,47 +108,55 @@ function GradingPointsSection({
         >
           ${type_label} Points:
         </label>
-        ${show_percentage
-          ? html`
-              <label
-                for="js-${type}-score-value-input-percentage-${context}"
-                class="js-manual-grading-percentage"
-              >
-                ${type_label} Score:
-              </label>
-            `
-          : ''}
-        <span class="float-end">
-          ${!show_input
+        ${
+          show_percentage
             ? html`
-                <span class="js-manual-grading-points">
-                  <span class="js-${type}-score-value-info">
-                    <span class="js-value-${type}-points">${Math.round(points * 100) / 100}</span>
-                    / ${max_points}
-                  </span>
-                </span>
-                ${show_percentage
-                  ? html`
-                      <span class="js-manual-grading-percentage">
-                        <span class="js-${type}-score-value-info">
-                          <span class="js-value-${type}-percentage"></span>%
-                        </span>
-                      </span>
-                    `
-                  : ''}
+                <label
+                  for="js-${type}-score-value-input-percentage-${context}"
+                  class="js-manual-grading-percentage"
+                >
+                  ${type_label} Score:
+                </label>
               `
-            : ''}
-          <div class="btn-group btn-group-sm" role="group">
-            ${show_input_edit
+            : ''
+        }
+        <span class="float-end">
+          ${
+            !show_input
               ? html`
-                  <button
-                    type="button"
-                    class="btn btn-outline-secondary js-enable-${type}-score-edit js-${type}-score-value-info"
-                  >
-                    <i class="fas fa-pencil"></i>
-                  </button>
+                  <span class="js-manual-grading-points">
+                    <span class="js-${type}-score-value-info">
+                      <span class="js-value-${type}-points">${Math.round(points * 100) / 100}</span>
+                      / ${max_points}
+                    </span>
+                  </span>
+                  ${
+                  show_percentage
+                    ? html`
+                        <span class="js-manual-grading-percentage">
+                          <span class="js-${type}-score-value-info">
+                            <span class="js-value-${type}-percentage"></span>%
+                          </span>
+                        </span>
+                      `
+                    : ''
+                }
                 `
-              : ''}
+              : ''
+          }
+          <div class="btn-group btn-group-sm" role="group">
+            ${
+              show_input_edit
+                ? html`
+                    <button
+                      type="button"
+                      class="btn btn-outline-secondary js-enable-${type}-score-edit js-${type}-score-value-info"
+                    >
+                      <i class="fas fa-pencil"></i>
+                    </button>
+                  `
+                : ''
+            }
           </div>
         </span>
       </span>
@@ -166,24 +176,28 @@ function GradingPointsSection({
           <span class="input-group-text">/ ${max_points}</span>
         </div>
       </div>
-      ${show_percentage
-        ? html`
-            <div class="js-manual-grading-percentage">
-              <div class="input-group js-${type}-score-value-input ${!show_input ? 'd-none' : ''}">
-                <input
-                  type="number"
-                  step="any"
-                  required
-                  id="js-${type}-score-value-input-percentage-${context}"
-                  class="form-control js-grading-score-input js-${type}-score-value-input-percentage"
-                  name="score_${type}_percent"
-                  ${disable ? 'disabled' : ''}
-                />
-                <span class="input-group-text">%</span>
+      ${
+        show_percentage
+          ? html`
+              <div class="js-manual-grading-percentage">
+                <div
+                  class="input-group js-${type}-score-value-input ${!show_input ? 'd-none' : ''}"
+                >
+                  <input
+                    type="number"
+                    step="any"
+                    required
+                    id="js-${type}-score-value-input-percentage-${context}"
+                    class="form-control js-grading-score-input js-${type}-score-value-input-percentage"
+                    name="score_${type}_percent"
+                    ${disable ? 'disabled' : ''}
+                  />
+                  <span class="input-group-text">%</span>
+                </div>
               </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
     </div>
   `;
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.html.tsx
@@ -118,14 +118,16 @@ export function InstanceQuestion({
           border: 1px solid currentColor;
         }
       </style>
-      ${resLocals.question.type !== 'Freeform'
-        ? html`
-            <script src="${assetPath('javascripts/lodash.min.js')}"></script>
-            <script src="${assetPath('javascripts/require.js')}"></script>
-            <script src="${assetPath('localscripts/question.js')}"></script>
-            <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
-          `
-        : ''}
+      ${
+        resLocals.question.type !== 'Freeform'
+          ? html`
+              <script src="${assetPath('javascripts/lodash.min.js')}"></script>
+              <script src="${assetPath('javascripts/require.js')}"></script>
+              <script src="${assetPath('localscripts/question.js')}"></script>
+              <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
+            `
+          : ''
+      }
       ${unsafeHtml(resLocals.extraHeadersHtml)}
       ${compiledScriptTag('instructorAssessmentManualGradingInstanceQuestion.js')}
       ${EncodedData(
@@ -141,23 +143,27 @@ export function InstanceQuestion({
     `,
     content: html`
       <h1 class="visually-hidden">Instance Question Manual Grading</h1>
-      ${resLocals.assessment_instance.open
-        ? html`
-            <div class="alert alert-danger" role="alert">
-              This assessment instance is still open. Student may still be able to submit new
-              answers.
-            </div>
-          `
-        : ''}
-      ${submissionCredits.some((credit) => credit !== 100)
-        ? html`
-            <div class="alert alert-warning" role="alert">
-              There are submissions in this assessment instance with credit different than 100%.
-              Submitting a manual grade will override any credit limits set for this assessment
-              instance.
-            </div>
-          `
-        : ''}
+      ${
+        resLocals.assessment_instance.open
+          ? html`
+              <div class="alert alert-danger" role="alert">
+                This assessment instance is still open. Student may still be able to submit new
+                answers.
+              </div>
+            `
+          : ''
+      }
+      ${
+        submissionCredits.some((credit) => credit !== 100)
+          ? html`
+              <div class="alert alert-warning" role="alert">
+                There are submissions in this assessment instance with credit different than 100%.
+                Submitting a manual grade will override any credit limits set for this assessment
+                instance.
+              </div>
+            `
+          : ''
+      }
       <div class="d-flex flex-row justify-content-between align-items-center mb-3 gap-2">
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb mb-0">
@@ -168,8 +174,9 @@ export function InstanceQuestion({
             </li>
             <li class="breadcrumb-item">
               <a
-                href="${resLocals.urlPrefix}/assessment/${resLocals.assessment
-                  .id}/manual_grading/assessment_question/${resLocals.assessment_question.id}"
+                href="${resLocals.urlPrefix}/assessment/${
+                  resLocals.assessment.id
+                }/manual_grading/assessment_question/${resLocals.assessment_question.id}"
               >
                 Question ${resLocals.instance_question_info.instructor_question_number}.
                 ${resLocals.question.title}
@@ -179,28 +186,30 @@ export function InstanceQuestion({
           </ol>
         </nav>
 
-        ${aiGradingEnabled
-          ? html`
-              <form method="POST" class="card px-3 py-2 mb-0">
-                <input type="hidden" name="__action" value="toggle_ai_grading_mode" />
-                <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                <div class="form-check form-switch mb-0">
-                  <input
-                    class="form-check-input"
-                    type="checkbox"
-                    role="switch"
-                    id="switchCheckDefault"
-                    ${aiGradingMode ? 'checked' : ''}
-                    onchange="setTimeout(() => this.form.submit(), 150)"
-                  />
-                  <label class="form-check-label" for="switchCheckDefault">
-                    <i class="bi bi-stars"></i>
-                    AI grading mode
-                  </label>
-                </div>
-              </form>
-            `
-          : ''}
+        ${
+          aiGradingEnabled
+            ? html`
+                <form method="POST" class="card px-3 py-2 mb-0">
+                  <input type="hidden" name="__action" value="toggle_ai_grading_mode" />
+                  <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+                  <div class="form-check form-switch mb-0">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      role="switch"
+                      id="switchCheckDefault"
+                      ${aiGradingMode ? 'checked' : ''}
+                      onchange="setTimeout(() => this.form.submit(), 150)"
+                    />
+                    <label class="form-check-label" for="switchCheckDefault">
+                      <i class="bi bi-stars"></i>
+                      AI grading mode
+                    </label>
+                  </div>
+                </form>
+              `
+            : ''
+        }
       </div>
 
       <div class="mb-3">
@@ -226,40 +235,46 @@ export function InstanceQuestion({
         )}
       </div>
 
-      ${instanceQuestionAiGradeProps
-        ? hydrateHtml(
-            <InstanceQuestionAiGrade
-              courseInstanceId={instanceQuestionAiGradeProps.courseInstanceId}
-              assessmentId={instanceQuestionAiGradeProps.assessmentId}
-              assessmentQuestionId={instanceQuestionAiGradeProps.assessmentQuestionId}
-              instanceQuestionId={instanceQuestionAiGradeProps.instanceQuestionId}
-              trpcCsrfToken={instanceQuestionAiGradeProps.trpcCsrfToken}
-              isDevMode={instanceQuestionAiGradeProps.isDevMode}
-              hasRubric={instanceQuestionAiGradeProps.hasRubric}
-              useCustomApiKeys={instanceQuestionAiGradeProps.useCustomApiKeys}
-              aiGradingSettingsUrl={instanceQuestionAiGradeProps.aiGradingSettingsUrl}
-              availableAiGradingProviders={instanceQuestionAiGradeProps.availableAiGradingProviders}
-              aiGradingRelativeCosts={instanceQuestionAiGradeProps.aiGradingRelativeCosts}
-              aiGradingLastSelectedModel={instanceQuestionAiGradeProps.aiGradingLastSelectedModel}
-              initialOngoingJobSequenceTokens={
-                instanceQuestionAiGradeProps.initialOngoingJobSequenceTokens
-              }
-              hasCourseInstancePermissionEdit={
-                instanceQuestionAiGradeProps.hasCourseInstancePermissionEdit
-              }
-            />,
-          )
-        : ''}
-      ${conflict_grading_job
-        ? ConflictGradingJobModal({
-            resLocals,
-            conflict_grading_job,
-            graders,
-            lastGrader,
-            skipGradedSubmissions,
-            showSubmissionsAssignedToMeOnly,
-          })
-        : ''}
+      ${
+        instanceQuestionAiGradeProps
+          ? hydrateHtml(
+              <InstanceQuestionAiGrade
+                courseInstanceId={instanceQuestionAiGradeProps.courseInstanceId}
+                assessmentId={instanceQuestionAiGradeProps.assessmentId}
+                assessmentQuestionId={instanceQuestionAiGradeProps.assessmentQuestionId}
+                instanceQuestionId={instanceQuestionAiGradeProps.instanceQuestionId}
+                trpcCsrfToken={instanceQuestionAiGradeProps.trpcCsrfToken}
+                isDevMode={instanceQuestionAiGradeProps.isDevMode}
+                hasRubric={instanceQuestionAiGradeProps.hasRubric}
+                useCustomApiKeys={instanceQuestionAiGradeProps.useCustomApiKeys}
+                aiGradingSettingsUrl={instanceQuestionAiGradeProps.aiGradingSettingsUrl}
+                availableAiGradingProviders={
+                  instanceQuestionAiGradeProps.availableAiGradingProviders
+                }
+                aiGradingRelativeCosts={instanceQuestionAiGradeProps.aiGradingRelativeCosts}
+                aiGradingLastSelectedModel={instanceQuestionAiGradeProps.aiGradingLastSelectedModel}
+                initialOngoingJobSequenceTokens={
+                  instanceQuestionAiGradeProps.initialOngoingJobSequenceTokens
+                }
+                hasCourseInstancePermissionEdit={
+                  instanceQuestionAiGradeProps.hasCourseInstancePermissionEdit
+                }
+              />,
+            )
+          : ''
+      }
+      ${
+        conflict_grading_job
+          ? ConflictGradingJobModal({
+              resLocals,
+              conflict_grading_job,
+              graders,
+              lastGrader,
+              skipGradedSubmissions,
+              showSubmissionsAssignedToMeOnly,
+            })
+          : ''
+      }
       <div class="row">
         <div class="col-lg-8 col-12">
           ${QuestionContainer({
@@ -290,18 +305,20 @@ export function InstanceQuestion({
             </div>
           </div>
 
-          ${resLocals.file_list.length > 0
-            ? PersonalNotesPanel({
-                fileList: resLocals.file_list,
-                context: 'question',
-                courseInstanceId: resLocals.course_instance.id,
-                assessment_instance: resLocals.assessment_instance,
-                authz_result: resLocals.authz_result,
-                variantId: resLocals.variant.id,
-                csrfToken: resLocals.__csrf_token,
-                allowNewUploads: false,
-              })
-            : ''}
+          ${
+            resLocals.file_list.length > 0
+              ? PersonalNotesPanel({
+                  fileList: resLocals.file_list,
+                  context: 'question',
+                  courseInstanceId: resLocals.course_instance.id,
+                  assessment_instance: resLocals.assessment_instance,
+                  authz_result: resLocals.authz_result,
+                  variantId: resLocals.variant.id,
+                  csrfToken: resLocals.__csrf_token,
+                  allowNewUploads: false,
+                })
+              : ''
+          }
           ${InstructorInfoPanel({
             course: resLocals.course,
             course_instance: resLocals.course_instance,
@@ -386,12 +403,14 @@ function ConflictGradingJobModal({
               <div class="col-lg-6 col-12">
                 <div><strong>Conflicting score and feedback</strong></div>
                 <div class="mb-2">
-                  ${conflict_grading_job.date
-                    ? `${formatDateYMDHM(
-                        conflict_grading_job.date,
-                        resLocals.course_instance.display_timezone,
-                      )},`
-                    : ''}
+                  ${
+                    conflict_grading_job.date
+                      ? `${formatDateYMDHM(
+                          conflict_grading_job.date,
+                          resLocals.course_instance.display_timezone,
+                        )},`
+                      : ''
+                  }
                   by ${conflict_grading_job.grader_name}
                 </div>
                 <div class="card">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
@@ -52,21 +52,22 @@ export function RubricInputSection({
     <div class="js-adjust-points d-flex justify-content-end">
       <button
         type="button"
-        class="js-adjust-points-enable btn btn-sm btn-link ${rubric_grading?.adjust_points ||
-        disable
-          ? 'd-none'
-          : ''}"
+        class="js-adjust-points-enable btn btn-sm btn-link ${
+          rubric_grading?.adjust_points || disable ? 'd-none' : ''
+        }"
         ${enableKeyboardShortcuts ? html`data-key-binding="a"` : ''}
       >
         Apply adjustment
-        ${enableKeyboardShortcuts
-          ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent ms-2">A</kbd>`
-          : ''}
+        ${
+          enableKeyboardShortcuts
+            ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent ms-2">A</kbd>`
+            : ''
+        }
       </button>
       <div
-        class="js-adjust-points-input-container w-25 ${rubric_grading?.adjust_points
-          ? ''
-          : 'd-none'}"
+        class="js-adjust-points-input-container w-25 ${
+          rubric_grading?.adjust_points ? '' : 'd-none'
+        }"
       >
         <label>
           <span class="small">Adjustment:</span>
@@ -77,36 +78,44 @@ export function RubricInputSection({
                 step="any"
                 class="form-control js-adjust-points-points"
                 name="score_manual_adjust_points"
-                data-max-points="${resLocals.assessment_question.max_manual_points ||
-                resLocals.assessment_question.max_points}"
+                data-max-points="${
+                  resLocals.assessment_question.max_manual_points ||
+                  resLocals.assessment_question.max_points
+                }"
                 value="${Math.round((rubric_grading?.adjust_points ?? 0) * 100) / 100 || ''}"
                 ${disable ? 'disabled' : ''}
               />
             </div>
           </div>
-          ${resLocals.assessment_question.max_points
-            ? html`
-                <div class="js-manual-grading-percentage">
-                  <div class="input-group input-group-sm">
-                    <input
-                      type="number"
-                      step="any"
-                      class="form-control js-adjust-points-percentage"
-                      name="score_manual_adjust_percent"
-                      data-max-points="${resLocals.assessment_question.max_manual_points ||
-                      resLocals.assessment_question.max_points}"
-                      value="${Math.round(
-                        ((rubric_grading?.adjust_points || 0) * 10000) /
-                          (resLocals.assessment_question.max_manual_points ||
-                            resLocals.assessment_question.max_points),
-                      ) / 100 || ''}"
-                      ${disable ? 'disabled' : ''}
-                    />
-                    <span class="input-group-text">%</span>
+          ${
+            resLocals.assessment_question.max_points
+              ? html`
+                  <div class="js-manual-grading-percentage">
+                    <div class="input-group input-group-sm">
+                      <input
+                        type="number"
+                        step="any"
+                        class="form-control js-adjust-points-percentage"
+                        name="score_manual_adjust_percent"
+                        data-max-points="${
+                        resLocals.assessment_question.max_manual_points ||
+                        resLocals.assessment_question.max_points
+                      }"
+                        value="${
+                        Math.round(
+                          ((rubric_grading?.adjust_points || 0) * 10000) /
+                            (resLocals.assessment_question.max_manual_points ||
+                              resLocals.assessment_question.max_points),
+                        ) / 100 || ''
+                      }"
+                        ${disable ? 'disabled' : ''}
+                      />
+                      <span class="input-group-text">%</span>
+                    </div>
                   </div>
-                </div>
-              `
-            : ''}
+                `
+              : ''
+          }
         </label>
       </div>
     </div>
@@ -137,42 +146,48 @@ function RubricItems({
   return html`
     <div class="d-flex align-items-center justify-content-between mb-1">
       <div class="d-flex align-items-center gap-2 text-secondary" style="padding-left: 3px;">
-        ${aiGradingInfo?.submissionManuallyGraded
-          ? html`
-              <div data-bs-toggle="tooltip" data-bs-title="AI grading">
-                <i class="bi bi-stars"></i>
-              </div>
-              <div data-bs-toggle="tooltip" data-bs-title="Human grading">
-                <i class="bi bi-person-fill"></i>
-              </div>
-            `
-          : ''}
+        ${
+          aiGradingInfo?.submissionManuallyGraded
+            ? html`
+                <div data-bs-toggle="tooltip" data-bs-title="AI grading">
+                  <i class="bi bi-stars"></i>
+                </div>
+                <div data-bs-toggle="tooltip" data-bs-title="Human grading">
+                  <i class="bi bi-person-fill"></i>
+                </div>
+              `
+            : ''
+        }
       </div>
-      ${!disable && showEditRubricButton
-        ? html`
-            <button
-              type="button"
-              class="btn btn-sm btn-link p-0 text-decoration-none js-show-rubric-settings-button"
-            >
-              <i class="bi bi-pencil me-1" aria-hidden="true"></i>Edit rubric
-            </button>
-          `
-        : ''}
+      ${
+        !disable && showEditRubricButton
+          ? html`
+              <button
+                type="button"
+                class="btn btn-sm btn-link p-0 text-decoration-none js-show-rubric-settings-button"
+              >
+                <i class="bi bi-pencil me-1" aria-hidden="true"></i>Edit rubric
+              </button>
+            `
+          : ''
+      }
     </div>
-    ${rubric_items
-      ? rubric_items.map((item) =>
-          RubricItem({
-            item,
-            item_grading: rubric_grading_items?.[item.rubric_item.id],
-            assessment_question,
-            disable,
-            enableKeyboardShortcuts,
-            ai_checked: ai_selected_rubric_item_ids_set
-              ? ai_selected_rubric_item_ids_set.has(item.rubric_item.id)
-              : undefined,
-          }),
-        )
-      : ''}
+    ${
+      rubric_items
+        ? rubric_items.map((item) =>
+            RubricItem({
+              item,
+              item_grading: rubric_grading_items?.[item.rubric_item.id],
+              assessment_question,
+              disable,
+              enableKeyboardShortcuts,
+              ai_checked: ai_selected_rubric_item_ids_set
+                ? ai_selected_rubric_item_ids_set.has(item.rubric_item.id)
+                : undefined,
+            }),
+          )
+        : ''
+    }
   `;
 }
 
@@ -194,21 +209,23 @@ function RubricItem({
   return html`
     <div>
       <label class="js-selectable-rubric-item-label w-100">
-        ${ai_checked !== undefined
-          ? html`
-              <input
-                type="checkbox"
-                style="margin-left: 3px; margin-right: 8px;"
-                name="rubric_item_selected_ai"
-                value="${item.rubric_item.id}"
-                ${ai_checked ? 'checked' : ''}
-                disabled
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-                title="${ai_checked ? 'Selected by AI' : 'Not selected by AI'}"
-              />
-            `
-          : ''}
+        ${
+          ai_checked !== undefined
+            ? html`
+                <input
+                  type="checkbox"
+                  style="margin-left: 3px; margin-right: 8px;"
+                  name="rubric_item_selected_ai"
+                  value="${item.rubric_item.id}"
+                  ${ai_checked ? 'checked' : ''}
+                  disabled
+                  data-bs-toggle="tooltip"
+                  data-bs-placement="top"
+                  title="${ai_checked ? 'Selected by AI' : 'Not selected by AI'}"
+                />
+              `
+            : ''
+        }
         <input
           type="checkbox"
           name="rubric_item_selected_manual"
@@ -217,33 +234,43 @@ function RubricItem({
           ${item_grading?.score ? 'checked' : ''}
           ${disable ? 'disabled' : ''}
           data-rubric-item-points="${item.rubric_item.points}"
-          ${enableKeyboardShortcuts && item.rubric_item.key_binding
-            ? html`data-key-binding="${item.rubric_item.key_binding}"`
-            : ''}
+          ${
+            enableKeyboardShortcuts && item.rubric_item.key_binding
+              ? html`data-key-binding="${item.rubric_item.key_binding}"`
+              : ''
+          }
         />
-        ${enableKeyboardShortcuts && item.rubric_item.key_binding
-          ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent"
-              >${item.rubric_item.key_binding}</kbd
-            >`
-          : ''}
+        ${
+          enableKeyboardShortcuts && item.rubric_item.key_binding
+            ? html`<kbd aria-hidden="true" class="pl-kbd kbd-semi-transparent"
+                >${item.rubric_item.key_binding}</kbd
+              >`
+            : ''
+        }
         <span class="float-end text-${item.rubric_item.points >= 0 ? 'success' : 'danger'}">
           <strong>
             <span class="js-manual-grading-points" data-testid="rubric-item-points">
-              [${(item.rubric_item.points >= 0 ? '+' : '') +
-              Math.round(item.rubric_item.points * 100) / 100}]
+              [${
+                (item.rubric_item.points >= 0 ? '+' : '') +
+                Math.round(item.rubric_item.points * 100) / 100
+              }]
             </span>
-            ${assessment_question.max_points
-              ? html`
-                  <span class="js-manual-grading-percentage">
-                    [${(item.rubric_item.points >= 0 ? '+' : '') +
-                    Math.round(
-                      (item.rubric_item.points * 10000) /
-                        (assessment_question.max_manual_points || assessment_question.max_points),
-                    ) /
-                      100}%]
-                  </span>
-                `
-              : ''}
+            ${
+              assessment_question.max_points
+                ? html`
+                    <span class="js-manual-grading-percentage">
+                      [${
+                      (item.rubric_item.points >= 0 ? '+' : '') +
+                      Math.round(
+                        (item.rubric_item.points * 10000) /
+                          (assessment_question.max_manual_points || assessment_question.max_points),
+                      ) /
+                        100
+                    }%]
+                    </span>
+                  `
+                : ''
+            }
           </strong>
         </span>
         <span>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/questions.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/utils/questions.ts
@@ -511,17 +511,15 @@ export function buildQuestionMetadata(opts: {
     if (!courseQuestion?.assessments?.length) return null;
     const filtered = courseQuestion.assessments
       .filter((a) => a.assessment_id !== assessment.id)
-      .map(
-        (a): OtherAssessment => ({
-          assessment_id: a.assessment_id,
-          assessment_set_abbreviation: a.assessment_set_abbreviation ?? '',
-          assessment_set_name: a.assessment_set_name ?? '',
-          assessment_number: a.assessment_number ?? '',
-          assessment_set_color: a.assessment_set_color ?? '',
-          assessment_course_instance_id: courseInstance.id,
-          assessment_share_source_publicly: false,
-        }),
-      );
+      .map((a): OtherAssessment => ({
+        assessment_id: a.assessment_id,
+        assessment_set_abbreviation: a.assessment_set_abbreviation ?? '',
+        assessment_set_name: a.assessment_set_name ?? '',
+        assessment_number: a.assessment_number ?? '',
+        assessment_set_color: a.assessment_set_color ?? '',
+        assessment_course_instance_id: courseInstance.id,
+        assessment_share_source_publicly: false,
+      }));
     return filtered.length > 0 ? filtered : null;
   })();
 

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.tsx
@@ -62,68 +62,77 @@ export function InstructorAssessments({
       <div class="card mb-4">
         <div class="card-header bg-primary text-white d-flex align-items-center">
           <h1>Assessments</h1>
-          ${authz_data.has_course_permission_edit && !course.example_course
-            ? html`
-                <div class="d-flex gap-2 ms-auto">
-                  <a
-                    href="${urlPrefix}/instance_admin/qti_import"
-                    class="btn btn-sm btn-light"
-                    aria-label="Import content"
-                  >
-                    <i class="bi bi-cloud-arrow-up" aria-hidden="true"></i>
-                    <span class="d-none d-sm-inline">Import content</span>
-                  </a>
-                  ${rows.length > 0
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn btn-sm btn-light"
-                          data-bs-toggle="modal"
-                          data-bs-target="#createAssessmentModal"
-                          aria-label="Add assessment"
-                        >
-                          <i class="fa fa-plus" aria-hidden="true"></i>
-                          <span class="d-none d-sm-inline">Add assessment</span>
-                        </button>
-                      `
-                    : ''}
-                </div>
-              `
-            : ''}
+          ${
+            authz_data.has_course_permission_edit && !course.example_course
+              ? html`
+                  <div class="d-flex gap-2 ms-auto">
+                    <a
+                      href="${urlPrefix}/instance_admin/qti_import"
+                      class="btn btn-sm btn-light"
+                      aria-label="Import content"
+                    >
+                      <i class="bi bi-cloud-arrow-up" aria-hidden="true"></i>
+                      <span class="d-none d-sm-inline">Import content</span>
+                    </a>
+                    ${
+                    rows.length > 0
+                      ? html`
+                          <button
+                            type="button"
+                            class="btn btn-sm btn-light"
+                            data-bs-toggle="modal"
+                            data-bs-target="#createAssessmentModal"
+                            aria-label="Add assessment"
+                          >
+                            <i class="fa fa-plus" aria-hidden="true"></i>
+                            <span class="d-none d-sm-inline">Add assessment</span>
+                          </button>
+                        `
+                      : ''
+                  }
+                  </div>
+                `
+              : ''
+          }
         </div>
-        ${rows.length > 0
-          ? html`
-              <div class="table-responsive">
-                <table class="table table-sm table-hover" aria-label="Assessments">
-                  <thead>
-                    <tr>
-                      <th style="width: 1%"><span class="visually-hidden">Label</span></th>
-                      <th><span class="visually-hidden">Title</span></th>
-                      <th>Short name</th>
-                      <th class="text-center">Students</th>
-                      <th class="text-center">Scores</th>
-                      <th class="text-center">Mean Score</th>
-                      <th class="text-center">Mean Duration</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${rows.map(
+        ${
+          rows.length > 0
+            ? html`
+                <div class="table-responsive">
+                  <table class="table table-sm table-hover" aria-label="Assessments">
+                    <thead>
+                      <tr>
+                        <th style="width: 1%"><span class="visually-hidden">Label</span></th>
+                        <th><span class="visually-hidden">Title</span></th>
+                        <th>Short name</th>
+                        <th class="text-center">Students</th>
+                        <th class="text-center">Scores</th>
+                        <th class="text-center">Mean Score</th>
+                        <th class="text-center">Mean Duration</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${rows.map(
                       (row) => html`
-                        ${row.start_new_assessment_group
-                          ? html`
-                              <tr>
-                                <th colspan="7" scope="row">
-                                  ${assessmentsGroupBy === 'Set'
-                                    ? AssessmentSetHeadingHtml({
-                                        assessment_set: row.assessment_set,
-                                      })
-                                    : AssessmentModuleHeadingHtml({
-                                        assessment_module: row.assessment_module,
-                                      })}
-                                </th>
-                              </tr>
-                            `
-                          : ''}
+                        ${
+                          row.start_new_assessment_group
+                            ? html`
+                                <tr>
+                                  <th colspan="7" scope="row">
+                                    ${
+                                    assessmentsGroupBy === 'Set'
+                                      ? AssessmentSetHeadingHtml({
+                                          assessment_set: row.assessment_set,
+                                        })
+                                      : AssessmentModuleHeadingHtml({
+                                          assessment_module: row.assessment_module,
+                                        })
+                                  }
+                                  </th>
+                                </tr>
+                              `
+                            : ''
+                        }
                         <tr id="row-${row.id}">
                           <td class="align-middle" style="width: 1%">
                             <span class="badge color-${row.assessment_set.color}">
@@ -131,36 +140,42 @@ export function InstructorAssessments({
                             </span>
                           </td>
                           <td class="align-middle">
-                            ${row.sync_errors
-                              ? SyncProblemButtonHtml({
-                                  type: 'error',
-                                  output: row.sync_errors,
-                                })
-                              : row.sync_warnings
+                            ${
+                              row.sync_errors
                                 ? SyncProblemButtonHtml({
-                                    type: 'warning',
-                                    output: row.sync_warnings,
+                                    type: 'error',
+                                    output: row.sync_errors,
                                   })
-                                : ''}
+                                : row.sync_warnings
+                                  ? SyncProblemButtonHtml({
+                                      type: 'warning',
+                                      output: row.sync_warnings,
+                                    })
+                                  : ''
+                            }
                             <a href="${urlPrefix}/assessment/${row.id}/">
                               ${row.title}
-                              ${row.team_work
-                                ? html` <i class="fas fa-users" aria-hidden="true"></i> `
-                                : ''}
+                              ${
+                                row.team_work
+                                  ? html` <i class="fas fa-users" aria-hidden="true"></i> `
+                                  : ''
+                              }
                             </a>
                             ${IssueBadgeHtml({
                               count: row.open_issue_count,
                               courseInstanceId: course_instance.id,
                               issueAid: row.tid,
                             })}
-                            ${resLocals.authz_data.has_course_instance_permission_view
-                              ? ManualGradingBadgeHtml({
-                                  ungradedSubmissionCount:
-                                    row.ungraded_manual_grading_submission_count,
-                                  courseInstanceId: course_instance.id,
-                                  assessmentId: row.id,
-                                })
-                              : ''}
+                            ${
+                              resLocals.authz_data.has_course_instance_permission_view
+                                ? ManualGradingBadgeHtml({
+                                    ungradedSubmissionCount:
+                                      row.ungraded_manual_grading_submission_count,
+                                    courseInstanceId: course_instance.id,
+                                    assessmentId: row.id,
+                                  })
+                                : ''
+                            }
                           </td>
 
                           <td class="align-middle">${row.tid}</td>
@@ -169,34 +184,34 @@ export function InstructorAssessments({
                         </tr>
                       `,
                     )}
-                  </tbody>
-                </table>
-              </div>
-              <div class="card-footer">
-                Download
-                <a href="${urlPrefix}/instance_admin/assessments/file/${csvFilename}">
-                  ${csvFilename}
-                </a>
-                (includes more statistics columns than displayed above)
-              </div>
-            `
-          : html`
-              <div class="my-4 card-body text-center" style="text-wrap: balance;">
-                <p class="fw-bold">No assessments found.</p>
-                <p class="mb-0">
-                  An assessment is a collection of questions to build or assess a student's
-                  knowledge.
-                </p>
-                <p>
-                  Learn more in the
-                  <a
-                    href="https://docs.prairielearn.com/assessment/overview/"
-                    target="_blank"
-                    rel="noreferrer"
-                    >assessments documentation</a
-                  >.
-                </p>
-                ${run(() => {
+                    </tbody>
+                  </table>
+                </div>
+                <div class="card-footer">
+                  Download
+                  <a href="${urlPrefix}/instance_admin/assessments/file/${csvFilename}">
+                    ${csvFilename}
+                  </a>
+                  (includes more statistics columns than displayed above)
+                </div>
+              `
+            : html`
+                <div class="my-4 card-body text-center" style="text-wrap: balance;">
+                  <p class="fw-bold">No assessments found.</p>
+                  <p class="mb-0">
+                    An assessment is a collection of questions to build or assess a student's
+                    knowledge.
+                  </p>
+                  <p>
+                    Learn more in the
+                    <a
+                      href="https://docs.prairielearn.com/assessment/overview/"
+                      target="_blank"
+                      rel="noreferrer"
+                      >assessments documentation</a
+                    >.
+                  </p>
+                  ${run(() => {
                   if (course.example_course) {
                     return html`<p>You can't add assessments to the example course.</p>`;
                   }
@@ -215,8 +230,9 @@ export function InstructorAssessments({
                     </button>
                   `;
                 })}
-              </div>
-            `}
+                </div>
+              `
+        }
       </div>
     `,
     postContent: html`
@@ -243,37 +259,43 @@ export function AssessmentStats({ row }: { row: AssessmentStatsRow }) {
     </td>
 
     <td class="text-center align-middle score-stat-score-hist" style="white-space: nowrap;">
-      ${row.needs_statistics_update
-        ? spinner
-        : row.score_stat_number > 0
-          ? html`
-              <div
-                class="js-histmini d-inline-block"
-                data-data="${JSON.stringify(row.score_stat_hist)}"
-                data-options="${JSON.stringify({ width: 60, height: 20 })}"
-              ></div>
-            `
-          : html`&mdash;`}
+      ${
+        row.needs_statistics_update
+          ? spinner
+          : row.score_stat_number > 0
+            ? html`
+                <div
+                  class="js-histmini d-inline-block"
+                  data-data="${JSON.stringify(row.score_stat_hist)}"
+                  data-options="${JSON.stringify({ width: 60, height: 20 })}"
+                ></div>
+              `
+            : html`&mdash;`
+      }
     </td>
 
     <td class="text-center align-middle score-stat-mean" style="white-space: nowrap;">
-      ${row.needs_statistics_update
-        ? spinner
-        : row.score_stat_number > 0
-          ? html`
-              <div class="d-inline-block align-middle" style="min-width: 8em; max-width: 20em;">
-                ${ScorebarHtml(Math.round(row.score_stat_mean))}
-              </div>
-            `
-          : html`&mdash;`}
+      ${
+        row.needs_statistics_update
+          ? spinner
+          : row.score_stat_number > 0
+            ? html`
+                <div class="d-inline-block align-middle" style="min-width: 8em; max-width: 20em;">
+                  ${ScorebarHtml(Math.round(row.score_stat_mean))}
+                </div>
+              `
+            : html`&mdash;`
+      }
     </td>
 
     <td class="text-center align-middle duration-stat-mean" style="white-space: nowrap;">
-      ${row.needs_statistics_update
-        ? spinner
-        : row.score_stat_number > 0
-          ? formatInterval(row.duration_stat_mean)
-          : html`&mdash;`}
+      ${
+        row.needs_statistics_update
+          ? spinner
+          : row.score_stat_number > 0
+            ? formatInterval(row.duration_stat_mean)
+            : html`&mdash;`
+      }
     </td>
   `;
 }
@@ -351,28 +373,30 @@ function CreateAssessmentModal({
           to.
         </small>
       </div>
-      ${assessmentsGroupBy === 'Module'
-        ? html`
-            <div class="mb-3">
-              <label class="form-label" for="module">Module</label>
-              <select
-                class="form-select"
-                id="module"
-                name="module"
-                aria-describedby="module_help"
-                required
-              >
-                ${assessmentModules.map(
+      ${
+        assessmentsGroupBy === 'Module'
+          ? html`
+              <div class="mb-3">
+                <label class="form-label" for="module">Module</label>
+                <select
+                  class="form-select"
+                  id="module"
+                  name="module"
+                  aria-describedby="module_help"
+                  required
+                >
+                  ${assessmentModules.map(
                   (module) => html`<option value="${module.name}">${module.name}</option>`,
                 )}
-              </select>
-              <small id="module_help" class="form-text text-muted">
-                The <a href="${urlPrefix}/course_admin/modules">module</a> this assessment belongs
-                to.
-              </small>
-            </div>
-          `
-        : ''}
+                </select>
+                <small id="module_help" class="form-text text-muted">
+                  The <a href="${urlPrefix}/course_admin/modules">module</a> this assessment belongs
+                  to.
+                </small>
+              </div>
+            `
+          : ''
+      }
     `,
     footer: html`
       <input type="hidden" name="__action" value="add_assessment" />

--- a/apps/prairielearn/src/pages/instructorCourseAdminGettingStarted/instructorCourseAdminGettingStarted.html.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminGettingStarted/instructorCourseAdminGettingStarted.html.tsx
@@ -54,16 +54,20 @@ function GettingStartedTask(task: GettingStartedTaskInfo) {
     <div class="list-group-item">
       <div class="d-flex align-items-center gap-3">
         <i
-          class="${task.isComplete
-            ? 'fa-solid fa-check-circle text-success'
-            : 'fa-regular fa-circle text-muted'} "
+          class="${
+            task.isComplete
+              ? 'fa-solid fa-check-circle text-success'
+              : 'fa-regular fa-circle text-muted'
+          } "
         ></i>
         <div>
-          ${!task.isComplete && task.link
-            ? html` <a href="${task.link}">
-                <p class="my-0">${task.header}</p>
-              </a>`
-            : html`<p class="my-0">${task.header}</p>`}
+          ${
+            !task.isComplete && task.link
+              ? html` <a href="${task.link}">
+                  <p class="my-0">${task.header}</p>
+                </a>`
+              : html`<p class="my-0">${task.header}</p>`
+          }
           <p class="text-muted my-0">${task.description}</p>
         </div>
       </div>

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.html.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.html.ts
@@ -69,14 +69,16 @@ export function InstructorEffectiveUser({
           <p><strong>Authenticated UID:</strong> ${authz_data.authn_user.uid}</p>
           <p><strong>Authenticated name:</strong> ${authz_data.authn_user.name}</p>
           <p><strong>Authenticated course role:</strong> ${authz_data.authn_course_role}</p>
-          ${'authn_course_instance_role' in authz_data
-            ? html`
-                <p>
-                  <strong>Authenticated course instance role:</strong>
-                  ${authz_data.authn_course_instance_role}
-                </p>
-              `
-            : ''}
+          ${
+            'authn_course_instance_role' in authz_data
+              ? html`
+                  <p>
+                    <strong>Authenticated course instance role:</strong>
+                    ${authz_data.authn_course_instance_role}
+                  </p>
+                `
+              : ''
+          }
           <p><strong>Authenticated mode:</strong> ${authz_data.authn_mode}</p>
           <p><strong>Authenticated date:</strong> ${formattedTrueReqDate}</p>
 
@@ -202,31 +204,32 @@ export function InstructorEffectiveUser({
         </div>
       </div>
 
-      ${'course_instance_role' in authz_data
-        ? html`
-            <div class="card mb-4">
-              <div class="card-header bg-primary text-white">
-                <h2>Effective course instance role</h2>
-              </div>
+      ${
+        'course_instance_role' in authz_data
+          ? html`
+              <div class="card mb-4">
+                <div class="card-header bg-primary text-white">
+                  <h2>Effective course instance role</h2>
+                </div>
 
-              <div class="card-body">
-                <p>
-                  <strong>Effective course instance role:</strong>
-                  ${authz_data.course_instance_role}
-                </p>
+                <div class="card-body">
+                  <p>
+                    <strong>Effective course instance role:</strong>
+                    ${authz_data.course_instance_role}
+                  </p>
 
-                <div class="alert alert-secondary mb-0">
-                  <form id="changeCourseInstanceRoleForm" method="POST">
-                    <div class="mb-3">
-                      <label class="form-label" for="changeEffectiveCourseInstanceRole">
-                        Change effective course instance role to:
-                      </label>
-                      <select
-                        class="form-select me-2"
-                        id="changeEffectiveCourseInstanceRole"
-                        name="pl_requested_course_instance_role"
-                      >
-                        ${[...courseRoles.available_course_instance_roles]
+                  <div class="alert alert-secondary mb-0">
+                    <form id="changeCourseInstanceRoleForm" method="POST">
+                      <div class="mb-3">
+                        <label class="form-label" for="changeEffectiveCourseInstanceRole">
+                          Change effective course instance role to:
+                        </label>
+                        <select
+                          class="form-select me-2"
+                          id="changeEffectiveCourseInstanceRole"
+                          name="pl_requested_course_instance_role"
+                        >
+                          ${[...courseRoles.available_course_instance_roles]
                           .reverse()
                           .map((available_course_instance_role) =>
                             available_course_instance_role === authz_data.course_instance_role
@@ -241,28 +244,29 @@ export function InstructorEffectiveUser({
                                   </option>
                                 `,
                           )}
-                      </select>
-                    </div>
-                    <input type="hidden" name="__action" value="changeCourseInstanceRole" />
-                    <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                    <button type="submit" class="btn btn-primary">
-                      Change course instance role
-                    </button>
-                  </form>
+                        </select>
+                      </div>
+                      <input type="hidden" name="__action" value="changeCourseInstanceRole" />
+                      <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                      <button type="submit" class="btn btn-primary">
+                        Change course instance role
+                      </button>
+                    </form>
+                  </div>
+                </div>
+
+                <div class="card-footer">
+                  <small>
+                    Your <em>course instance role</em> determines the permissions that you have to
+                    view and edit student data in PrairieLearn. It is specific to this course
+                    instance, so you can be a Student Data Editor in one course instance but a
+                    Student Data Viewer in a different course instance.
+                  </small>
                 </div>
               </div>
-
-              <div class="card-footer">
-                <small>
-                  Your <em>course instance role</em> determines the permissions that you have to
-                  view and edit student data in PrairieLearn. It is specific to this course
-                  instance, so you can be a Student Data Editor in one course instance but a Student
-                  Data Viewer in a different course instance.
-                </small>
-              </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
 
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">

--- a/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.tsx
+++ b/apps/prairielearn/src/pages/instructorFileEditor/instructorFileEditor.tsx
@@ -200,59 +200,65 @@ router.get(
               name="ace-base-path"
               content="${nodeModulesAssetPath('ace-builds/src-min-noconflict/')}"
             />
-            ${editorData.lintHtmlMustache
-              ? html`
-                  <meta
-                    name="htmlmustache-runtime-wasm"
-                    content="${nodeModulesAssetPath('web-tree-sitter/web-tree-sitter.wasm')}"
-                  />
-                  <meta
-                    name="htmlmustache-grammar-wasm"
-                    content="${nodeModulesAssetPath(
+            ${
+              editorData.lintHtmlMustache
+                ? html`
+                    <meta
+                      name="htmlmustache-runtime-wasm"
+                      content="${nodeModulesAssetPath('web-tree-sitter/web-tree-sitter.wasm')}"
+                    />
+                    <meta
+                      name="htmlmustache-grammar-wasm"
+                      content="${nodeModulesAssetPath(
                       '@prairielearn/tree-sitter-htmlmustache/tree-sitter-htmlmustache.wasm',
                     )}"
-                  />
-                  ${compiledScriptTag('instructorFileEditorHtmlMustacheLinterClient.ts')}
-                `
-              : ''}
+                    />
+                    ${compiledScriptTag('instructorFileEditorHtmlMustacheLinterClient.ts')}
+                  `
+                : ''
+            }
           `,
           content: html`
-            ${editorData.fileMetadata?.syncErrors
-              ? html`
-                  <div class="alert alert-danger" role="alert">
-                    <h2 class="h5 alert-heading">Sync error</h2>
-                    <p>
-                      There were one or more errors in this file the last time you tried to sync.
-                      This file will not be able to be synced until the errors are corrected. The
-                      errors are listed below.
-                    </p>
-                    <pre
-                      class="text-white rounded p-3 mb-0"
-                      style="background-color: black;"
-                    ><code>${unsafeHtml(
+            ${
+              editorData.fileMetadata?.syncErrors
+                ? html`
+                    <div class="alert alert-danger" role="alert">
+                      <h2 class="h5 alert-heading">Sync error</h2>
+                      <p>
+                        There were one or more errors in this file the last time you tried to sync.
+                        This file will not be able to be synced until the errors are corrected. The
+                        errors are listed below.
+                      </p>
+                      <pre
+                        class="text-white rounded p-3 mb-0"
+                        style="background-color: black;"
+                      ><code>${unsafeHtml(
                       ansiToHtml(editorData.fileMetadata.syncErrors),
                     )}</code></pre>
-                  </div>
-                `
-              : ''}
-            ${editorData.fileMetadata?.syncWarnings
-              ? html`
-                  <div class="alert alert-warning" role="alert">
-                    <h2 class="h5 alert-heading">Sync warning</h2>
-                    <p>
-                      There were one or more warnings in this file the last time you tried to sync.
-                      These warnings do not prevent this file from being synced, but they should
-                      still be fixed. The warnings are listed below.
-                    </p>
-                    <pre
-                      class="text-white rounded p-3 mb-0"
-                      style="background-color: black;"
-                    ><code>${unsafeHtml(
+                    </div>
+                  `
+                : ''
+            }
+            ${
+              editorData.fileMetadata?.syncWarnings
+                ? html`
+                    <div class="alert alert-warning" role="alert">
+                      <h2 class="h5 alert-heading">Sync warning</h2>
+                      <p>
+                        There were one or more warnings in this file the last time you tried to
+                        sync. These warnings do not prevent this file from being synced, but they
+                        should still be fixed. The warnings are listed below.
+                      </p>
+                      <pre
+                        class="text-white rounded p-3 mb-0"
+                        style="background-color: black;"
+                      ><code>${unsafeHtml(
                       ansiToHtml(editorData.fileMetadata.syncWarnings),
                     )}</code></pre>
-                  </div>
-                `
-              : ''}
+                    </div>
+                  `
+                : ''
+            }
             <h1 class="visually-hidden">File editor</h1>
 
             ${hydrateHtml(

--- a/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
+++ b/apps/prairielearn/src/pages/instructorGradingJob/instructorGradingJob.html.ts
@@ -96,108 +96,117 @@ export function InstructorGradingJob({
         </div>
       </div>
 
-      ${gradingJobRow.grading_job.s3_bucket && gradingJobRow.grading_job.s3_root_key
-        ? html`
-            <div class="card mb-4">
-              <div class="card-header bg-primary text-white">Downloads</div>
-              <div class="table-responsive">
-                <table class="table table-sm table-hover" aria-label="Grading job downloads">
-                  <thead>
-                    <tr>
-                      <th>File</th>
-                      <th>Description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${resLocals.authz_data.has_course_permission_view
-                      ? html` <tr>
-                            <td>
-                              <a
-                                href="${resLocals.urlPrefix}/grading_job/${gradingJobRow.grading_job
-                                  .id}/file/job.tar.gz"
-                              >
-                                job.tar.gz
-                              </a>
-                            </td>
-                            <td>
-                              Contains all files necessary for grading; this is what is mounted to
-                              <code>/grade</code> when your job is run.
-                            </td>
-                          </tr>
-                          <tr>
-                            <td>
-                              <a
-                                href="${resLocals.urlPrefix}/grading_job/${gradingJobRow.grading_job
-                                  .id}/file/archive.tar.gz"
-                                >archive.tar.gz</a
-                              >
-                            </td>
-                            <td>
-                              A snapshot of <code>/grade</code> after your job has been executed.
-                            </td>
-                          </tr>`
-                      : ''}
-                    <tr>
-                      <td>
-                        <a
-                          href="${resLocals.urlPrefix}/grading_job/${gradingJobRow.grading_job
-                            .id}/file/results.json"
-                          >results.json</a
-                        >
-                      </td>
-                      <td>
-                        Contains the PrairieLearn-generated results, which includes the contents of
-                        your
-                        <code>results.json</code> as well as some PrairieLearn metadata.
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <a
-                          href="${resLocals.urlPrefix}/grading_job/${gradingJobRow.grading_job
-                            .id}/file/output.log"
-                          >output.log</a
-                        >
-                      </td>
-                      <td>
-                        Contains the raw output from stdout/stderr for your job. Lines beginning
-                        with <code>container&gt;</code> are from your container; the rest are
-                        diagnostic logs from PrairieLearn.
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+      ${
+        gradingJobRow.grading_job.s3_bucket && gradingJobRow.grading_job.s3_root_key
+          ? html`
+              <div class="card mb-4">
+                <div class="card-header bg-primary text-white">Downloads</div>
+                <div class="table-responsive">
+                  <table class="table table-sm table-hover" aria-label="Grading job downloads">
+                    <thead>
+                      <tr>
+                        <th>File</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${
+                      resLocals.authz_data.has_course_permission_view
+                        ? html` <tr>
+                              <td>
+                                <a
+                                  href="${resLocals.urlPrefix}/grading_job/${
+                                  gradingJobRow.grading_job.id
+                                }/file/job.tar.gz"
+                                >
+                                  job.tar.gz
+                                </a>
+                              </td>
+                              <td>
+                                Contains all files necessary for grading; this is what is mounted to
+                                <code>/grade</code> when your job is run.
+                              </td>
+                            </tr>
+                            <tr>
+                              <td>
+                                <a
+                                  href="${resLocals.urlPrefix}/grading_job/${
+                                  gradingJobRow.grading_job.id
+                                }/file/archive.tar.gz"
+                                  >archive.tar.gz</a
+                                >
+                              </td>
+                              <td>
+                                A snapshot of <code>/grade</code> after your job has been executed.
+                              </td>
+                            </tr>`
+                        : ''
+                    }
+                      <tr>
+                        <td>
+                          <a
+                            href="${resLocals.urlPrefix}/grading_job/${
+                            gradingJobRow.grading_job.id
+                          }/file/results.json"
+                            >results.json</a
+                          >
+                        </td>
+                        <td>
+                          Contains the PrairieLearn-generated results, which includes the contents
+                          of your
+                          <code>results.json</code> as well as some PrairieLearn metadata.
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <a
+                            href="${resLocals.urlPrefix}/grading_job/${
+                            gradingJobRow.grading_job.id
+                          }/file/output.log"
+                            >output.log</a
+                          >
+                        </td>
+                        <td>
+                          Contains the raw output from stdout/stderr for your job. Lines beginning
+                          with <code>container&gt;</code> are from your container; the rest are
+                          diagnostic logs from PrairieLearn.
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
               </div>
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
 
       <div class="card mb-4">
         <div class="card-header bg-primary text-white">Job Output</div>
         <div class="card-body">
-          ${gradingJobRow.grading_job.s3_bucket && gradingJobRow.grading_job.s3_root_key
-            ? html`
-                <pre
-                  class="bg-dark text-white rounded p-3 mb-0 d-none"
-                  id="job-output"
-                  data-output-url="${resLocals.urlPrefix}/grading_job/${gradingJobRow.grading_job
-                    .id}/file/output.log"
-                ></pre>
-                <div id="job-output-loading" class="w-100 text-center">
-                  <i class="fa fa-spinner fa-spin fa-2x"></i>
-                </div>
-              `
-            : gradingJobRow.grading_job.output
+          ${
+            gradingJobRow.grading_job.s3_bucket && gradingJobRow.grading_job.s3_root_key
               ? html`
-                  <pre class="bg-dark text-white rounded p-3 mb-0" id="job-output">
-${gradingJobRow.grading_job.output}</pre
-                  >
+                  <pre
+                    class="bg-dark text-white rounded p-3 mb-0 d-none"
+                    id="job-output"
+                    data-output-url="${resLocals.urlPrefix}/grading_job/${
+                    gradingJobRow.grading_job.id
+                  }/file/output.log"
+                  ></pre>
+                  <div id="job-output-loading" class="w-100 text-center">
+                    <i class="fa fa-spinner fa-spin fa-2x"></i>
+                  </div>
                 `
-              : html`
-                  <pre class="bg-dark text-white rounded p-3 mb-0">
-No output was captured for this grading job.</pre
-                  >
-                `}
+              : gradingJobRow.grading_job.output
+                ? html`
+                    <pre class="bg-dark text-white rounded p-3 mb-0" id="job-output">
+${gradingJobRow.grading_job.output}</pre>
+                  `
+                : html`
+                    <pre class="bg-dark text-white rounded p-3 mb-0">
+No output was captured for this grading job.</pre>
+                  `
+          }
         </div>
       </div>
     `,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminLti/instructorInstanceAdminLti.html.tsx
@@ -95,33 +95,39 @@ export function InstructorInstanceAdminLti({
           <p>
             <strong>
               This version of LTI is deprecated.
-              ${isEnterprise()
-                ? html`See the "LMS connections" tab for more information about newer integration
-                  methods.`
-                : html`Check with your PrairieLearn admins about newer integration methods.`}
+              ${
+                isEnterprise()
+                  ? html`See the "LMS connections" tab for more information about newer integration
+                    methods.`
+                  : html`Check with your PrairieLearn admins about newer integration methods.`
+              }
             </strong>
           </p>
-          ${!resLocals.lti11_enabled
-            ? html`<p><em>LTI 1.1 is not enabled for this course instance.</em></p>`
-            : ''}
+          ${
+            !resLocals.lti11_enabled
+              ? html`<p><em>LTI 1.1 is not enabled for this course instance.</em></p>`
+              : ''
+          }
         </div>
       </div>
 
-      ${resLocals.lti11_enabled
-        ? html`
-            ${LtiCredentialCard({
+      ${
+        resLocals.lti11_enabled
+          ? html`
+              ${LtiCredentialCard({
               lti_credentials,
               csrfToken: resLocals.__csrf_token,
               timezone: resLocals.course_instance.display_timezone,
             })}
-            ${LtiLinkTargetsCard({
+              ${LtiLinkTargetsCard({
               lti_links,
               assessments,
               csrfToken: resLocals.__csrf_token,
               timezone: resLocals.course_instance.display_timezone,
             })}
-          `
-        : ''}
+            `
+          : ''
+      }
     `,
   });
 }
@@ -157,57 +163,59 @@ function LtiCredentialCard({
             </tr>
           </thead>
           <tbody>
-            ${lti_credentials
-              ? lti_credentials.map(
-                  (tc) => html`
-                    <tr>
-                      <td>
-                        <code>${config.ltiRedirectUrl}</code>
-                        <button
-                          type="button"
-                          class="btn btn-sm btn-ghost js-copy-button"
-                          data-clipboard-text="${config.ltiRedirectUrl}"
-                          aria-label="Copy redirect URL to clipboard"
-                        >
-                          <i class="bi bi-clipboard"></i>
-                        </button>
-                      </td>
-                      <td>
-                        <code>${tc.consumer_key}</code>
-                        <button
-                          type="button"
-                          class="btn btn-sm btn-ghost js-copy-button"
-                          data-clipboard-text="${tc.consumer_key}"
-                          aria-label="Copy consumer key to clipboard"
-                        >
-                          <i class="bi bi-clipboard"></i>
-                        </button>
-                      </td>
-                      <td>
-                        <code>${tc.secret}</code>
-                        <button
-                          type="button"
-                          class="btn btn-sm btn-ghost js-copy-button"
-                          data-clipboard-text="${tc.secret}"
-                          aria-label="Copy shared secret to clipboard"
-                        >
-                          <i class="bi bi-clipboard"></i>
-                        </button>
-                      </td>
-                      <td>${formatDate(tc.created_at!, timezone)}</td>
-                      <td>
-                        ${tc.deleted_at != null
-                          ? formatDate(tc.deleted_at, timezone)
-                          : html`
-                              <button
-                                type="button"
-                                class="btn btn-sm btn-danger"
-                                data-bs-toggle="popover"
-                                data-bs-container="body"
-                                data-bs-html="true"
-                                data-bs-placement="auto"
-                                data-bs-title="Confirm delete"
-                                data-bs-content="${escapeHtml(html`
+            ${
+              lti_credentials
+                ? lti_credentials.map(
+                    (tc) => html`
+                      <tr>
+                        <td>
+                          <code>${config.ltiRedirectUrl}</code>
+                          <button
+                            type="button"
+                            class="btn btn-sm btn-ghost js-copy-button"
+                            data-clipboard-text="${config.ltiRedirectUrl}"
+                            aria-label="Copy redirect URL to clipboard"
+                          >
+                            <i class="bi bi-clipboard"></i>
+                          </button>
+                        </td>
+                        <td>
+                          <code>${tc.consumer_key}</code>
+                          <button
+                            type="button"
+                            class="btn btn-sm btn-ghost js-copy-button"
+                            data-clipboard-text="${tc.consumer_key}"
+                            aria-label="Copy consumer key to clipboard"
+                          >
+                            <i class="bi bi-clipboard"></i>
+                          </button>
+                        </td>
+                        <td>
+                          <code>${tc.secret}</code>
+                          <button
+                            type="button"
+                            class="btn btn-sm btn-ghost js-copy-button"
+                            data-clipboard-text="${tc.secret}"
+                            aria-label="Copy shared secret to clipboard"
+                          >
+                            <i class="bi bi-clipboard"></i>
+                          </button>
+                        </td>
+                        <td>${formatDate(tc.created_at!, timezone)}</td>
+                        <td>
+                          ${
+                          tc.deleted_at != null
+                            ? formatDate(tc.deleted_at, timezone)
+                            : html`
+                                <button
+                                  type="button"
+                                  class="btn btn-sm btn-danger"
+                                  data-bs-toggle="popover"
+                                  data-bs-container="body"
+                                  data-bs-html="true"
+                                  data-bs-placement="auto"
+                                  data-bs-title="Confirm delete"
+                                  data-bs-content="${escapeHtml(html`
                                   <form method="post">
                                     <input type="hidden" name="__action" value="lti_del_cred" />
                                     <input type="hidden" name="__csrf_token" value="${csrfToken}" />
@@ -215,21 +223,23 @@ function LtiCredentialCard({
                                     <input type="submit" class="btn btn-danger" value="Delete" />
                                   </form>
                                 `)}"
-                              >
-                                Delete
-                              </button>
-                            `}
+                                >
+                                  Delete
+                                </button>
+                              `
+                        }
+                        </td>
+                      </tr>
+                    `,
+                  )
+                : html`
+                    <tr>
+                      <td colspan="5">
+                        <em>No LTI credentials have been created.</em>
                       </td>
                     </tr>
-                  `,
-                )
-              : html`
-                  <tr>
-                    <td colspan="5">
-                      <em>No LTI credentials have been created.</em>
-                    </td>
-                  </tr>
-                `}
+                  `
+            }
           </tbody>
         </table>
       </div>
@@ -279,51 +289,57 @@ function LtiLinkTargetsCard({
             </tr>
           </thead>
           <tbody>
-            ${lti_links
-              ? lti_links.map(
-                  (link) => html`
-                    <tr>
-                      <td title="${link.resource_link_description}">${link.resource_link_title}</td>
-                      <td>
-                        <form method="post">
-                          <input type="hidden" name="__action" value="lti_link_target" />
-                          <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-                          <input type="hidden" name="lti_link_id" value="${link.id}" />
-                          <select
-                            class="form-select"
-                            onchange="this.form.submit();"
-                            name="newAssessment"
-                          >
-                            <option value="" ${!link.assessment_id ? 'selected' : ''}>
-                              -- None
-                            </option>
-                            ${assessments?.map(
+            ${
+              lti_links
+                ? lti_links.map(
+                    (link) => html`
+                      <tr>
+                        <td title="${link.resource_link_description}">
+                          ${link.resource_link_title}
+                        </td>
+                        <td>
+                          <form method="post">
+                            <input type="hidden" name="__action" value="lti_link_target" />
+                            <input type="hidden" name="__csrf_token" value="${csrfToken}" />
+                            <input type="hidden" name="lti_link_id" value="${link.id}" />
+                            <select
+                              class="form-select"
+                              onchange="this.form.submit();"
+                              name="newAssessment"
+                            >
+                              <option value="" ${!link.assessment_id ? 'selected' : ''}>
+                                -- None
+                              </option>
+                              ${assessments?.map(
                               (a) => html`
                                 <option
                                   value="${a.assessment_id}"
-                                  ${link.assessment_id &&
-                                  idsEqual(link.assessment_id, a.assessment_id)
-                                    ? 'selected'
-                                    : ''}
+                                  ${
+                                    link.assessment_id &&
+                                    idsEqual(link.assessment_id, a.assessment_id)
+                                      ? 'selected'
+                                      : ''
+                                  }
                                 >
                                   ${a.label}: ${a.title} (${a.tid})
                                 </option>
                               `,
                             )}
-                          </select>
-                        </form>
+                            </select>
+                          </form>
+                        </td>
+                        <td>${formatDate(link.created_at, timezone)}</td>
+                      </tr>
+                    `,
+                  )
+                : html`
+                    <tr>
+                      <td colspan="3">
+                        <em>No LTI links have been created.</em>
                       </td>
-                      <td>${formatDate(link.created_at, timezone)}</td>
                     </tr>
-                  `,
-                )
-              : html`
-                  <tr>
-                    <td colspan="3">
-                      <em>No LTI links have been created.</em>
-                    </td>
-                  </tr>
-                `}
+                  `
+            }
           </tbody>
         </table>
       </div>

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
@@ -333,8 +333,7 @@ router.post(
 );
 
 type ConvertEntryResult =
-  | { ok: true; value: SerializedEntryResult }
-  | { ok: false; warning: ParseWarning };
+  { ok: true; value: SerializedEntryResult } | { ok: false; warning: ParseWarning };
 
 interface SerializedEntryResult {
   result: StoredSerializedConversionResult;

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
@@ -57,8 +57,7 @@ interface SerializedQuestionBankConversionResult extends SerializedConversionRes
 
 /** Conversion result sent to the browser for review. */
 export type SerializedConversionResult =
-  | SerializedAssessmentConversionResult
-  | SerializedQuestionBankConversionResult;
+  SerializedAssessmentConversionResult | SerializedQuestionBankConversionResult;
 
 type StoredSerializedConversionResultCommon = Omit<
   SerializedConversionResultCommon,

--- a/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionPreview/instructorQuestionPreview.html.tsx
@@ -57,14 +57,16 @@ export function InstructorQuestionPreview({
       <script>
         document.urlPrefix = '${resLocals.urlPrefix}';
       </script>
-      ${resLocals.question.type !== 'Freeform'
-        ? html`
-            <script src="${nodeModulesAssetPath('lodash/lodash.min.js')}"></script>
-            <script src="${assetPath('javascripts/require.js')}"></script>
-            <script src="${assetPath('localscripts/question.js')}"></script>
-            <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
-          `
-        : ''}
+      ${
+        resLocals.question.type !== 'Freeform'
+          ? html`
+              <script src="${nodeModulesAssetPath('lodash/lodash.min.js')}"></script>
+              <script src="${assetPath('javascripts/require.js')}"></script>
+              <script src="${assetPath('localscripts/question.js')}"></script>
+              <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
+            `
+          : ''
+      }
       ${unsafeHtml(resLocals.extraHeadersHtml)}
       <style>
         .markdown-body :last-child {
@@ -90,60 +92,66 @@ export function InstructorQuestionPreview({
       storageKey: `calculator-preview-${resLocals.question.id}`,
     }),
     content: html`
-      ${questionRenderContext === 'manual_grading'
-        ? html`
-            <div class="alert alert-primary">
-              You are viewing this question as it will appear in the manual grading interface.
-              <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a> when
-              you are done.
-            </div>
-          `
-        : ''}
-      ${questionRenderContext === 'ai_grading'
-        ? html`
-            <div class="alert alert-primary">
-              You are viewing this question as it will appear to the AI grader.
-              <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a> when
-              you are done.
-            </div>
-          `
-        : ''}
+      ${
+        questionRenderContext === 'manual_grading'
+          ? html`
+              <div class="alert alert-primary">
+                You are viewing this question as it will appear in the manual grading interface.
+                <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a> when
+                you are done.
+              </div>
+            `
+          : ''
+      }
+      ${
+        questionRenderContext === 'ai_grading'
+          ? html`
+              <div class="alert alert-primary">
+                You are viewing this question as it will appear to the AI grader.
+                <a href="${normalPreviewUrl}" class="alert-link">Return to the normal view</a> when
+                you are done.
+              </div>
+            `
+          : ''
+      }
       <div class="row">
         <div class="col-lg-9 col-sm-12">
-          ${readmeHtml
-            ? html`
-                <div class="card mb-3 js-readme-card overflow-hidden">
-                  <div class="card-header d-flex align-items-center collapsible-card-header">
-                    <h2 class="me-auto">
-                      README <span class="small text-muted">(not visible to students)</span>
-                    </h2>
-                    <button
-                      type="button"
-                      class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap"
-                      data-bs-toggle="collapse"
-                      data-bs-target="#readme-card-body"
-                      aria-expanded="true"
-                      aria-controls="#readme-card-body"
-                    >
-                      <i class="fa fa-angle-up ms-1 expand-icon"></i>
-                    </button>
-                  </div>
-                  <div class="show js-collapsible-card-body" id="readme-card-body">
-                    <div
-                      class="card-body position-relative markdown-body overflow-hidden max-height"
-                    >
-                      ${unsafeHtml(readmeHtml)}
+          ${
+            readmeHtml
+              ? html`
+                  <div class="card mb-3 js-readme-card overflow-hidden">
+                    <div class="card-header d-flex align-items-center collapsible-card-header">
+                      <h2 class="me-auto">
+                        README <span class="small text-muted">(not visible to students)</span>
+                      </h2>
+                      <button
+                        type="button"
+                        class="expand-icon-container btn btn-outline-dark btn-sm text-nowrap"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#readme-card-body"
+                        aria-expanded="true"
+                        aria-controls="#readme-card-body"
+                      >
+                        <i class="fa fa-angle-up ms-1 expand-icon"></i>
+                      </button>
                     </div>
-                    <div class="reveal-fade d-none"></div>
-                    <div
-                      class="py-1 z-1 position-relative d-none justify-content-center bg-light js-expand-button-container"
-                    >
-                      <button type="button" class="btn btn-sm btn-link">Expand</button>
+                    <div class="show js-collapsible-card-body" id="readme-card-body">
+                      <div
+                        class="card-body position-relative markdown-body overflow-hidden max-height"
+                      >
+                        ${unsafeHtml(readmeHtml)}
+                      </div>
+                      <div class="reveal-fade d-none"></div>
+                      <div
+                        class="py-1 z-1 position-relative d-none justify-content-center bg-light js-expand-button-container"
+                      >
+                        <button type="button" class="btn btn-sm btn-link">Expand</button>
+                      </div>
                     </div>
                   </div>
-                </div>
-              `
-            : ''}
+                `
+              : ''
+          }
           ${QuestionContainer({
             resLocals,
             showFooter: questionRenderContext != null ? false : undefined,

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
@@ -669,8 +669,7 @@ router.get(
 
     let sharingSets: QuestionSharingSetRow[] | undefined;
     let sharingConstraints:
-      | Awaited<ReturnType<typeof selectQuestionSharingConstraints>>
-      | undefined;
+      Awaited<ReturnType<typeof selectQuestionSharingConstraints>> | undefined;
     if (sharingEnabled) {
       sharingSets = await selectSharingSetsForQuestion({
         question_id: question.id,

--- a/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionStatistics/instructorQuestionStatistics.html.tsx
@@ -111,18 +111,20 @@ export function InstructorQuestionStatistics({
                       ${formatFloat(row.first_submission_score_variance, 2)}
                     </td>
                     <td class="text-center">
-                      ${row.first_submission_score_hist !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify({
+                      ${
+                        row.first_submission_score_hist !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify({
                                 ...histminiOptions,
                                 normalize: true,
                               })}"
-                              data-data="${JSON.stringify(row.first_submission_score_hist)}"
-                            ></div>
-                          `
-                        : ''}
+                                data-data="${JSON.stringify(row.first_submission_score_hist)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">
                       ${formatFloat(row.average_last_submission_score, 2)}
@@ -131,36 +133,40 @@ export function InstructorQuestionStatistics({
                       ${formatFloat(row.last_submission_score_variance, 2)}
                     </td>
                     <td class="text-center">
-                      ${row.last_submission_score_hist !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify({
+                      ${
+                        row.last_submission_score_hist !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify({
                                 ...histminiOptions,
                                 normalize: true,
                               })}"
-                              data-data="${JSON.stringify(row.last_submission_score_hist)}"
-                            ></div>
-                          `
-                        : ''}
+                                data-data="${JSON.stringify(row.last_submission_score_hist)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">${formatFloat(row.average_max_submission_score, 2)}</td>
                     <td class="text-center">
                       ${formatFloat(row.max_submission_score_variance, 2)}
                     </td>
                     <td class="text-center">
-                      ${row.max_submission_score_hist !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify({
+                      ${
+                        row.max_submission_score_hist !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify({
                                 ...histminiOptions,
                                 normalize: true,
                               })}"
-                              data-data="${JSON.stringify(row.max_submission_score_hist)}"
-                            ></div>
-                          `
-                        : ''}
+                                data-data="${JSON.stringify(row.max_submission_score_hist)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">
                       ${formatFloat(row.average_average_submission_score, 2)}
@@ -169,92 +175,106 @@ export function InstructorQuestionStatistics({
                       ${formatFloat(row.average_submission_score_variance, 2)}
                     </td>
                     <td class="text-center">
-                      ${row.average_submission_score_hist !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify({
+                      ${
+                        row.average_submission_score_hist !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify({
                                 ...histminiOptions,
                                 normalize: true,
                               })}"
-                              data-data="${JSON.stringify(row.average_submission_score_hist)}"
-                            ></div>
-                          `
-                        : ''}
+                                data-data="${JSON.stringify(row.average_submission_score_hist)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">
-                      ${row.submission_score_array_averages !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify(histminiOptions)}"
-                              data-data="${JSON.stringify(row.submission_score_array_averages)}"
-                            ></div>
-                          `
-                        : ''}
+                      ${
+                        row.submission_score_array_averages !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify(histminiOptions)}"
+                                data-data="${JSON.stringify(row.submission_score_array_averages)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">
-                      ${row.incremental_submission_score_array_averages !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify(histminiOptions)}"
-                              data-data="${JSON.stringify(
+                      ${
+                        row.incremental_submission_score_array_averages !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify(histminiOptions)}"
+                                data-data="${JSON.stringify(
                                 row.incremental_submission_score_array_averages,
                               )}"
-                            ></div>
-                          `
-                        : ''}
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">
-                      ${row.assessment_type !== 'Homework'
-                        ? html`
-                            ${row.incremental_submission_points_array_averages != null
-                              ? html`
-                                  <div
-                                    class="js-histmini"
-                                    data-options="${JSON.stringify({
+                      ${
+                        row.assessment_type !== 'Homework'
+                          ? html`
+                              ${
+                              row.incremental_submission_points_array_averages != null
+                                ? html`
+                                    <div
+                                      class="js-histmini"
+                                      data-options="${JSON.stringify({
                                       ...histminiOptions,
                                       ymax: row.max_points,
                                     })}"
-                                    data-data="${JSON.stringify(
+                                      data-data="${JSON.stringify(
                                       row.incremental_submission_points_array_averages,
                                     )}"
-                                  ></div>
-                                `
-                              : ''}
-                          `
-                        : 'N/A'}
+                                    ></div>
+                                  `
+                                : ''
+                            }
+                            `
+                          : 'N/A'
+                      }
                     </td>
                     <td class="text-center">${formatFloat(row.average_number_submissions, 2)}</td>
                     <td class="text-center">${formatFloat(row.number_submissions_variance, 2)}</td>
                     <td class="text-center">
-                      ${row.number_submissions_hist !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify({
+                      ${
+                        row.number_submissions_hist !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify({
                                 ...histminiOptions,
                                 normalize: true,
                               })}"
-                              data-data="${JSON.stringify(row.number_submissions_hist)}"
-                            ></div>
-                          `
-                        : ''}
+                                data-data="${JSON.stringify(row.number_submissions_hist)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                     <td class="text-center">
-                      ${row.quintile_question_scores !== null
-                        ? html`
-                            <div
-                              class="js-histmini"
-                              data-options="${JSON.stringify({
+                      ${
+                        row.quintile_question_scores !== null
+                          ? html`
+                              <div
+                                class="js-histmini"
+                                data-options="${JSON.stringify({
                                 ...histminiOptions,
                                 ymax: 100,
                               })}"
-                              data-data="${JSON.stringify(row.quintile_question_scores)}"
-                            ></div>
-                          `
-                        : ''}
+                                data-data="${JSON.stringify(row.quintile_question_scores)}"
+                              ></div>
+                            `
+                          : ''
+                      }
                     </td>
                   </tr>
                 `;
@@ -267,8 +287,9 @@ export function InstructorQuestionStatistics({
           <p>
             Download
             <a
-              href="${resLocals.urlPrefix}/question/${resLocals.question
-                .id}/statistics/${questionStatsCsvFilename}"
+              href="${resLocals.urlPrefix}/question/${
+                resLocals.question.id
+              }/statistics/${questionStatsCsvFilename}"
             >
               ${questionStatsCsvFilename}
             </a>

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -192,87 +192,89 @@ function CourseNewRequestForm({
           />
         </div>
       </div>
-      ${isDefaultInstitution
-        ? html`
-            <div class="row">
-              <div class="mb-3 col-md-6">
-                <label class="form-label" for="cr-institution">Institution</label>
-                <input
-                  type="text"
-                  class="form-control"
-                  name="cr-institution"
-                  id="cr-institution"
-                  minlength="1"
-                  required
-                />
-                <small class="form-text text-muted">
-                  This is your academic institution (e.g., "University of Illinois").
-                </small>
-              </div>
-              <div class="mb-3 col-md-6">
-                <label class="form-label" for="cr-email">Email</label>
-                <input
-                  type="email"
-                  class="form-control"
-                  name="cr-email"
-                  id="cr-email"
-                  aria-invalid="false"
-                  aria-errormessage="cr-email-warning"
-                  placeholder="login@yourinstitution.edu"
-                  minlength="1"
-                  required
-                />
-                <small class="form-text text-muted">
-                  You are not signed in with an institutional account, please sign into PrairieLearn
-                  with your institutional account when requesting a course. Alternatively, you can
-                  enter your institutional email address here (your request may be processed more
-                  slowly).
-                </small>
-                <div
-                  class="d-none alert alert-warning mt-2 mb-0"
-                  id="cr-email-warning"
-                  role="alert"
-                >
-                  This doesn't look like an institutional email address. Course requests from
-                  non-institutional email addresses may be rejected. Please use your official
-                  institution email if you have one.
+      ${
+        isDefaultInstitution
+          ? html`
+              <div class="row">
+                <div class="mb-3 col-md-6">
+                  <label class="form-label" for="cr-institution">Institution</label>
+                  <input
+                    type="text"
+                    class="form-control"
+                    name="cr-institution"
+                    id="cr-institution"
+                    minlength="1"
+                    required
+                  />
+                  <small class="form-text text-muted">
+                    This is your academic institution (e.g., "University of Illinois").
+                  </small>
+                </div>
+                <div class="mb-3 col-md-6">
+                  <label class="form-label" for="cr-email">Email</label>
+                  <input
+                    type="email"
+                    class="form-control"
+                    name="cr-email"
+                    id="cr-email"
+                    aria-invalid="false"
+                    aria-errormessage="cr-email-warning"
+                    placeholder="login@yourinstitution.edu"
+                    minlength="1"
+                    required
+                  />
+                  <small class="form-text text-muted">
+                    You are not signed in with an institutional account, please sign into
+                    PrairieLearn with your institutional account when requesting a course.
+                    Alternatively, you can enter your institutional email address here (your request
+                    may be processed more slowly).
+                  </small>
+                  <div
+                    class="d-none alert alert-warning mt-2 mb-0"
+                    id="cr-email-warning"
+                    role="alert"
+                  >
+                    This doesn't look like an institutional email address. Course requests from
+                    non-institutional email addresses may be rejected. Please use your official
+                    institution email if you have one.
+                  </div>
                 </div>
               </div>
-            </div>
-          `
-        : html`
-            <div class="row">
-              <div class="mb-3 col-md-6">
-                <label class="form-label" for="cr-institution">Institution</label>
-                <input
-                  type="text"
-                  class="form-control"
-                  name="cr-institution"
-                  id="cr-institution"
-                  disabled
-                  value="${institutionName}"
-                />
-                <small class="form-text text-muted">
-                  This is determined by your sign-in account. If you want to request a course for a
-                  different institution, please sign in with the appropriate account.
-                </small>
+            `
+          : html`
+              <div class="row">
+                <div class="mb-3 col-md-6">
+                  <label class="form-label" for="cr-institution">Institution</label>
+                  <input
+                    type="text"
+                    class="form-control"
+                    name="cr-institution"
+                    id="cr-institution"
+                    disabled
+                    value="${institutionName}"
+                  />
+                  <small class="form-text text-muted">
+                    This is determined by your sign-in account. If you want to request a course for
+                    a different institution, please sign in with the appropriate account.
+                  </small>
+                </div>
+                <div class="mb-3 col-md-6">
+                  <label class="form-label" for="cr-email">Email</label>
+                  <input
+                    type="text"
+                    class="form-control"
+                    name="cr-email"
+                    id="cr-email"
+                    disabled
+                    value="${userEmail}"
+                  />
+                  <small class="form-text text-muted">
+                    This is determined by your sign-in account.
+                  </small>
+                </div>
               </div>
-              <div class="mb-3 col-md-6">
-                <label class="form-label" for="cr-email">Email</label>
-                <input
-                  type="text"
-                  class="form-control"
-                  name="cr-email"
-                  id="cr-email"
-                  disabled
-                  value="${userEmail}"
-                />
-                <small class="form-text text-muted">
-                  This is determined by your sign-in account.
-                </small>
-              </div>
-            </div>
-          `}
+            `
+      }
       <hr class="my-3" />
       <h2 class="h5 mb-3">About your course</h2>
       <div class="mb-3">

--- a/apps/prairielearn/src/pages/publicAssessmentQuestions/publicAssessmentQuestions.html.tsx
+++ b/apps/prairielearn/src/pages/publicAssessmentQuestions/publicAssessmentQuestions.html.tsx
@@ -102,19 +102,21 @@ function AssessmentQuestionsTable({
                 <td>${TopicBadgeHtml(question.topic)}</td>
                 <td>${renderHtml(<TagBadgeList tags={question.tags} />)}</td>
                 <td>
-                  ${question.other_assessments
-                    ? question.other_assessments.map((assessment) => {
-                        return AssessmentBadgeHtml({
-                          assessment: {
-                            assessment_id: assessment.assessment_id,
-                            color: assessment.assessment_set_color,
-                            label: `${assessment.assessment_set_abbreviation}${assessment.assessment_number}`,
-                          },
-                          courseInstanceId: course_instance_id,
-                          publicURL: true,
-                        });
-                      })
-                    : ''}
+                  ${
+                    question.other_assessments
+                      ? question.other_assessments.map((assessment) => {
+                          return AssessmentBadgeHtml({
+                            assessment: {
+                              assessment_id: assessment.assessment_id,
+                              color: assessment.assessment_set_color,
+                              label: `${assessment.assessment_set_abbreviation}${assessment.assessment_number}`,
+                            },
+                            courseInstanceId: course_instance_id,
+                            publicURL: true,
+                          });
+                        })
+                      : ''
+                  }
                 </td>
               </tr>
             `;

--- a/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.html.ts
+++ b/apps/prairielearn/src/pages/publicQuestionPreview/publicQuestionPreview.html.ts
@@ -36,14 +36,16 @@ export function PublicQuestionPreview({
       <script>
         document.urlPrefix = '${resLocals.urlPrefix}';
       </script>
-      ${resLocals.question.type !== 'Freeform'
-        ? html`
-            <script src="${nodeModulesAssetPath('lodash/lodash.min.js')}"></script>
-            <script src="${assetPath('javascripts/require.js')}"></script>
-            <script src="${assetPath('localscripts/question.js')}"></script>
-            <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
-          `
-        : ''}
+      ${
+        resLocals.question.type !== 'Freeform'
+          ? html`
+              <script src="${nodeModulesAssetPath('lodash/lodash.min.js')}"></script>
+              <script src="${assetPath('javascripts/require.js')}"></script>
+              <script src="${assetPath('localscripts/question.js')}"></script>
+              <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
+            `
+          : ''
+      }
       ${unsafeHtml(resLocals.extraHeadersHtml)}
     `,
     content: html`

--- a/apps/prairielearn/src/pages/studentAssessment/studentAssessment.html.ts
+++ b/apps/prairielearn/src/pages/studentAssessment/studentAssessment.html.ts
@@ -45,11 +45,13 @@ export function StudentAssessment({
         </div>
 
         <div class="card-body">
-          ${authz_result.mode === 'Exam' || authz_result.password != null
-            ? html`
-                <p class="lead text-center">Please wait until instructed to start by a proctor</p>
-              `
-            : ''}
+          ${
+            authz_result.mode === 'Exam' || authz_result.password != null
+              ? html`
+                  <p class="lead text-center">Please wait until instructed to start by a proctor</p>
+                `
+              : ''
+          }
 
           <p class="lead text-center">
             This is
@@ -57,26 +59,30 @@ export function StudentAssessment({
             for <strong>${course.short_name}</strong>
           </p>
 
-          ${authz_result.time_limit_min != null
-            ? html`
-                <p class="lead text-center">
-                  The time limit for this assessment is
-                  <strong>
-                    ${authz_result.time_limit_min}
-                    ${authz_result.time_limit_min === 1 ? 'minute' : 'minutes'}
-                  </strong>
-                </p>
-              `
-            : ''}
-          ${assessment.team_work
-            ? StudentGroupControls({ groupConfig, groupInfo, userCanAssignRoles, resLocals })
-            : StartAssessmentForm({
-                assessment,
-                user,
-                __csrf_token,
-                startAllowed: true,
-                customHonorCode,
-              })}
+          ${
+            authz_result.time_limit_min != null
+              ? html`
+                  <p class="lead text-center">
+                    The time limit for this assessment is
+                    <strong>
+                      ${authz_result.time_limit_min}
+                      ${authz_result.time_limit_min === 1 ? 'minute' : 'minutes'}
+                    </strong>
+                  </p>
+                `
+              : ''
+          }
+          ${
+            assessment.team_work
+              ? StudentGroupControls({ groupConfig, groupInfo, userCanAssignRoles, resLocals })
+              : StartAssessmentForm({
+                  assessment,
+                  user,
+                  __csrf_token,
+                  startAllowed: true,
+                  customHonorCode,
+                })
+          }
         </div>
       </div>
     `,
@@ -97,13 +103,15 @@ function StartAssessmentForm({
   customHonorCode?: string;
 }) {
   return html`
-    ${startAllowed && assessment.type === 'Exam' && assessment.require_honor_code
-      ? HonorPledge({
-          user,
-          groupWork: !!assessment.team_work,
-          customHonorCode,
-        })
-      : ''}
+    ${
+      startAllowed && assessment.type === 'Exam' && assessment.require_honor_code
+        ? HonorPledge({
+            user,
+            groupWork: !!assessment.team_work,
+            customHonorCode,
+          })
+        : ''
+    }
     <form
       id="confirm-form"
       name="confirm-form"
@@ -116,9 +124,11 @@ function StartAssessmentForm({
         id="start-assessment"
         type="submit"
         class="btn btn-primary"
-        ${(assessment.type === 'Exam' && assessment.require_honor_code) || !startAllowed
-          ? 'disabled'
-          : ''}
+        ${
+          (assessment.type === 'Exam' && assessment.require_honor_code) || !startAllowed
+            ? 'disabled'
+            : ''
+        }
       >
         Start assessment
       </button>
@@ -137,19 +147,21 @@ function HonorPledge({
 }) {
   return html`
     <div class="card card-secondary mb-4" data-testid="honor-code">
-      ${customHonorCode
-        ? html`<div class="px-3 py-2 honor-code">${unsafeHtml(customHonorCode)}</div>`
-        : html`<ul class="list-group list-group-flush">
-            <li class="list-group-item py-2">
-              I certify that I am ${user.name} and ${groupWork ? 'our group is' : 'I am'} allowed to
-              take this assessment.
-            </li>
-            <li class="list-group-item py-2">
-              ${groupWork ? 'We' : 'I'} pledge on ${groupWork ? 'our' : 'my'} honor that
-              ${groupWork ? 'we' : 'I'} will not give or receive any unauthorized assistance on this
-              assessment and that all work will be ${groupWork ? 'our' : 'my'} own.
-            </li>
-          </ul>`}
+      ${
+        customHonorCode
+          ? html`<div class="px-3 py-2 honor-code">${unsafeHtml(customHonorCode)}</div>`
+          : html`<ul class="list-group list-group-flush">
+              <li class="list-group-item py-2">
+                I certify that I am ${user.name} and ${groupWork ? 'our group is' : 'I am'} allowed
+                to take this assessment.
+              </li>
+              <li class="list-group-item py-2">
+                ${groupWork ? 'We' : 'I'} pledge on ${groupWork ? 'our' : 'my'} honor that
+                ${groupWork ? 'we' : 'I'} will not give or receive any unauthorized assistance on
+                this assessment and that all work will be ${groupWork ? 'our' : 'my'} own.
+              </li>
+            </ul>`
+      }
       <div class="card-footer d-flex justify-content-center">
         <span class="form-check">
           <input type="checkbox" class="form-check-input" id="certify-pledge" />
@@ -188,14 +200,16 @@ function StudentGroupControls({
       csrfToken: __csrf_token,
     })}
     ${StartAssessmentForm({ assessment, user, __csrf_token, startAllowed: groupInfo.start })}
-    ${groupConfig.minimum != null && groupConfig.minimum - groupInfo.groupSize > 0
-      ? html`
-          <p class="text-center">
-            * Minimum group size is ${groupConfig.minimum}. You need at least
-            ${groupConfig.minimum - groupInfo.groupSize} more group member(s) to start.
-          </p>
-        `
-      : ''}
+    ${
+      groupConfig.minimum != null && groupConfig.minimum - groupInfo.groupSize > 0
+        ? html`
+            <p class="text-center">
+              * Minimum group size is ${groupConfig.minimum}. You need at least
+              ${groupConfig.minimum - groupInfo.groupSize} more group member(s) to start.
+            </p>
+          `
+        : ''
+    }
   `;
 }
 
@@ -216,87 +230,99 @@ function GroupCreationJoinForm({
 
   return html`
     <p class="text-center">
-      ${(groupConfig.minimum ?? 0) > 1
-        ? html`
-            This is a group assessment. A group must have
-            ${groupConfig.maximum != null
-              ? `between ${groupConfig.minimum} and ${groupConfig.maximum}`
-              : `at least ${groupConfig.minimum}`}
-            students.
-          `
-        : html`
-            This assessment can be done individually or in groups.
-            ${groupConfig.maximum
-              ? `A group must have no more than ${groupConfig.maximum} students.`
-              : ''}
-            <br />To work individually, you must also create a group, but you don't need to share
-            your join code.
-          `}
+      ${
+        (groupConfig.minimum ?? 0) > 1
+          ? html`
+              This is a group assessment. A group must have
+              ${
+              groupConfig.maximum != null
+                ? `between ${groupConfig.minimum} and ${groupConfig.maximum}`
+                : `at least ${groupConfig.minimum}`
+            }
+              students.
+            `
+          : html`
+              This assessment can be done individually or in groups.
+              ${
+              groupConfig.maximum
+                ? `A group must have no more than ${groupConfig.maximum} students.`
+                : ''
+            }
+              <br />To work individually, you must also create a group, but you don't need to share
+              your join code.
+            `
+      }
     </p>
     <div class="container-fluid">
       <div class="row">
-        ${groupConfig.student_authz_create
-          ? html`
-              <div class="col-sm bg-light py-4 px-4 border">
-                <form id="create-form" name="create-form" method="POST">
-                  ${groupConfig.student_authz_choose_name
-                    ? html`
-                        <label for="group-name-input">Group name</label>
-                        <input
-                          type="text"
-                          class="form-control"
-                          id="group-name-input"
-                          name="group_name"
-                          maxlength="30"
-                          pattern="[a-zA-Z0-9]+"
-                          placeholder="e.g. teamOne"
-                          aria-label="Group name"
-                          aria-describedby="group-name-help"
-                        />
-                        <small id="group-name-help" class="form-text text-muted">
-                          Group names can only contain letters and numbers, with maximum length of
-                          30 characters. If you leave this blank, a group name will be generated for
-                          you.
-                        </small>
-                      `
-                    : ''}
-                  <div class="mt-4 d-flex justify-content-center">
-                    <div class="mb-3">
-                      <input type="hidden" name="__action" value="create_group" />
-                      <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                      <button type="submit" class="btn btn-primary">Create new group</button>
+        ${
+          groupConfig.student_authz_create
+            ? html`
+                <div class="col-sm bg-light py-4 px-4 border">
+                  <form id="create-form" name="create-form" method="POST">
+                    ${
+                    groupConfig.student_authz_choose_name
+                      ? html`
+                          <label for="group-name-input">Group name</label>
+                          <input
+                            type="text"
+                            class="form-control"
+                            id="group-name-input"
+                            name="group_name"
+                            maxlength="30"
+                            pattern="[a-zA-Z0-9]+"
+                            placeholder="e.g. teamOne"
+                            aria-label="Group name"
+                            aria-describedby="group-name-help"
+                          />
+                          <small id="group-name-help" class="form-text text-muted">
+                            Group names can only contain letters and numbers, with maximum length of
+                            30 characters. If you leave this blank, a group name will be generated
+                            for you.
+                          </small>
+                        `
+                      : ''
+                  }
+                    <div class="mt-4 d-flex justify-content-center">
+                      <div class="mb-3">
+                        <input type="hidden" name="__action" value="create_group" />
+                        <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                        <button type="submit" class="btn btn-primary">Create new group</button>
+                      </div>
                     </div>
-                  </div>
-                </form>
-              </div>
-            `
-          : ''}
-        ${groupConfig.student_authz_join
-          ? html`
-              <div class="col-sm bg-light py-4 px-4 border">
-                <form id="joingroup-form" name="joingroup-form" method="POST">
-                  <label for="join-code-input">Join code</label>
-                  <input
-                    type="text"
-                    class="form-control"
-                    id="join-code-input"
-                    name="join_code"
-                    placeholder="abcd-1234"
-                    pattern="[a-zA-Z0-9]+-[0-9]{4}"
-                    maxlength="35"
-                    required
-                  />
-                  <div class="mt-4 d-flex justify-content-center">
-                    <div class="mb-3">
-                      <input type="hidden" name="__action" value="join_group" />
-                      <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
-                      <button type="submit" class="btn btn-primary">Join group</button>
+                  </form>
+                </div>
+              `
+            : ''
+        }
+        ${
+          groupConfig.student_authz_join
+            ? html`
+                <div class="col-sm bg-light py-4 px-4 border">
+                  <form id="joingroup-form" name="joingroup-form" method="POST">
+                    <label for="join-code-input">Join code</label>
+                    <input
+                      type="text"
+                      class="form-control"
+                      id="join-code-input"
+                      name="join_code"
+                      placeholder="abcd-1234"
+                      pattern="[a-zA-Z0-9]+-[0-9]{4}"
+                      maxlength="35"
+                      required
+                    />
+                    <div class="mt-4 d-flex justify-content-center">
+                      <div class="mb-3">
+                        <input type="hidden" name="__action" value="join_group" />
+                        <input type="hidden" name="__csrf_token" value="${__csrf_token}" />
+                        <button type="submit" class="btn btn-primary">Join group</button>
+                      </div>
                     </div>
-                  </div>
-                </form>
-              </div>
-            `
-          : ''}
+                  </form>
+                </div>
+              `
+            : ''
+        }
       </div>
     </div>
   `;

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/ExamFooterContent.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/ExamFooterContent.tsx
@@ -24,36 +24,42 @@ export function ExamFooterContent({
       <form name="grade-form" method="POST">
         <input type="hidden" name="__action" value="grade" />
         <input type="hidden" name="__csrf_token" value="${csrfToken}" />
-        ${savedAnswers > 0
-          ? html`
-              <button type="submit" class="btn btn-info" ${!authorizedEdit ? 'disabled' : ''}>
-                Grade ${savedAnswers} saved ${savedAnswers !== 1 ? 'answers' : 'answer'}
-              </button>
-            `
-          : html`
-              <button type="submit" class="btn btn-info" disabled>No saved answers to grade</button>
-            `}
+        ${
+          savedAnswers > 0
+            ? html`
+                <button type="submit" class="btn btn-info" ${!authorizedEdit ? 'disabled' : ''}>
+                  Grade ${savedAnswers} saved ${savedAnswers !== 1 ? 'answers' : 'answer'}
+                </button>
+              `
+            : html`
+                <button type="submit" class="btn btn-info" disabled>
+                  No saved answers to grade
+                </button>
+              `
+        }
       </form>
       <ul class="mb-0">
-        ${suspendedSavedAnswers > 1
-          ? html`
-              <li>
-                There are ${suspendedSavedAnswers} saved answers that cannot be graded yet because
-                their grade rate has not been reached. They are marked with the
-                <i class="fa fa-hourglass-half"></i> icon above. Reload this page to update this
-                information.
-              </li>
-            `
-          : suspendedSavedAnswers === 1
+        ${
+          suspendedSavedAnswers > 1
             ? html`
                 <li>
-                  There is one saved answer that cannot be graded yet because its grade rate has not
-                  been reached. It is marked with the
+                  There are ${suspendedSavedAnswers} saved answers that cannot be graded yet because
+                  their grade rate has not been reached. They are marked with the
                   <i class="fa fa-hourglass-half"></i> icon above. Reload this page to update this
                   information.
                 </li>
               `
-            : ''}
+            : suspendedSavedAnswers === 1
+              ? html`
+                  <li>
+                    There is one saved answer that cannot be graded yet because its grade rate has
+                    not been reached. It is marked with the
+                    <i class="fa fa-hourglass-half"></i> icon above. Reload this page to update this
+                    information.
+                  </li>
+                `
+              : ''
+        }
         <li>
           Submit your answer to each question with the
           <strong>Save & Grade</strong> or <strong>Save only</strong> buttons on the question page.
@@ -64,32 +70,34 @@ export function ExamFooterContent({
           with <strong>Available points</strong> can be attempted again for more points. Attempting
           questions again will never reduce the points you already have.
         </li>
-        ${hasPassword ||
-        !showClosedAssessment ||
-        // If this is true, this assessment has a mix of real-time-graded and
-        // non-real-time-graded questions. We need to show the "Finish assessment"
-        // button.
-        someQuestionsForbidRealTimeGrading
-          ? html`
-              <li>
-                After you have answered all the questions completely, click here:
-                <button
-                  class="btn btn-danger"
-                  data-bs-toggle="modal"
-                  data-bs-target="#confirmFinishModal"
-                  ${!authorizedEdit ? 'disabled' : ''}
-                >
-                  Finish assessment
-                </button>
-              </li>
-            `
-          : html`
-              <li>
-                When you are done, please logout and close your browser. If you have any saved
-                answers when you leave, they will be automatically graded before your final score is
-                computed.
-              </li>
-            `}
+        ${
+          hasPassword ||
+          !showClosedAssessment ||
+          // If this is true, this assessment has a mix of real-time-graded and
+          // non-real-time-graded questions. We need to show the "Finish assessment"
+          // button.
+          someQuestionsForbidRealTimeGrading
+            ? html`
+                <li>
+                  After you have answered all the questions completely, click here:
+                  <button
+                    class="btn btn-danger"
+                    data-bs-toggle="modal"
+                    data-bs-target="#confirmFinishModal"
+                    ${!authorizedEdit ? 'disabled' : ''}
+                  >
+                    Finish assessment
+                  </button>
+                </li>
+              `
+            : html`
+                <li>
+                  When you are done, please logout and close your browser. If you have any saved
+                  answers when you leave, they will be automatically graded before your final score
+                  is computed.
+                </li>
+              `
+        }
       </ul>
     `;
   }

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/LockpointRow.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/LockpointRow.tsx
@@ -80,9 +80,11 @@ export function LockpointRow({
           <div>
             <span class="fw-bold text-muted">Lockpoint</span>
             <small class="text-muted d-block">
-              ${blockedByAdvanceScorePerc
-                ? 'A previous question requires a higher score before you can proceed past this lockpoint.'
-                : 'Complete previous questions to unlock.'}
+              ${
+                blockedByAdvanceScorePerc
+                  ? 'A previous question requires a higher score before you can proceed past this lockpoint.'
+                  : 'Complete previous questions to unlock.'
+              }
             </small>
           </div>
         </div>

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/QuestionTableBody.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/QuestionTableBody.tsx
@@ -62,53 +62,65 @@ export function QuestionTableBody({
     }
 
     return html`
-      ${row.start_new_zone && row.zone.lockpoint
-        ? LockpointRow({
-            row,
-            colspan: zoneTitleColspan,
-            crossable: !!isLockpointCrossable(row),
-            blockedByAdvanceScorePerc: hasUnmetAdvanceScorePercBeforeLockpoint(row.zone.number),
-            isGroupAssessment,
-            displayTimezone,
-          })
-        : ''}
-      ${showZoneInfo
-        ? html`
-            <tr>
-              <th colspan="${zoneTitleColspan}">
-                ${zoneHasInfo
-                  ? html`
-                      <div class="d-flex align-items-center gap-2">
-                        ${row.zone.title ? html`<span>${row.zone.title}</span>` : ''}
-                        ${row.zone.max_points != null
-                          ? ZoneInfoPopover({
-                              label: row.zone.title
-                                ? `maximum ${row.zone.max_points} points`
-                                : `Maximum ${row.zone.max_points} points`,
-                              content: `Of the points that you are awarded for answering these ${row.zone_question_count} questions, at most ${row.zone.max_points} will count toward your total points.`,
-                            })
-                          : ''}
-                        ${showBestQuestions
-                          ? ZoneInfoPopover({
-                              label:
-                                row.zone.title || row.zone.max_points != null
-                                  ? `best ${row.zone.best_questions} of ${row.zone_question_count} questions`
-                                  : `Best ${row.zone.best_questions} of ${row.zone_question_count} questions`,
-                              content: `Of these ${row.zone_question_count} questions, only the ${row.zone.best_questions} with the highest number of awarded points will count toward your total points.`,
-                            })
-                          : ''}
-                      </div>
-                    `
-                  : html`&nbsp;`}
-              </th>
-            </tr>
-          `
-        : ''}
+      ${
+        row.start_new_zone && row.zone.lockpoint
+          ? LockpointRow({
+              row,
+              colspan: zoneTitleColspan,
+              crossable: !!isLockpointCrossable(row),
+              blockedByAdvanceScorePerc: hasUnmetAdvanceScorePercBeforeLockpoint(row.zone.number),
+              isGroupAssessment,
+              displayTimezone,
+            })
+          : ''
+      }
+      ${
+        showZoneInfo
+          ? html`
+              <tr>
+                <th colspan="${zoneTitleColspan}">
+                  ${
+                  zoneHasInfo
+                    ? html`
+                        <div class="d-flex align-items-center gap-2">
+                          ${row.zone.title ? html`<span>${row.zone.title}</span>` : ''}
+                          ${
+                          row.zone.max_points != null
+                            ? ZoneInfoPopover({
+                                label: row.zone.title
+                                  ? `maximum ${row.zone.max_points} points`
+                                  : `Maximum ${row.zone.max_points} points`,
+                                content: `Of the points that you are awarded for answering these ${row.zone_question_count} questions, at most ${row.zone.max_points} will count toward your total points.`,
+                              })
+                            : ''
+                        }
+                          ${
+                          showBestQuestions
+                            ? ZoneInfoPopover({
+                                label:
+                                  row.zone.title || row.zone.max_points != null
+                                    ? `best ${row.zone.best_questions} of ${row.zone_question_count} questions`
+                                    : `Best ${row.zone.best_questions} of ${row.zone_question_count} questions`,
+                                content: `Of these ${row.zone_question_count} questions, only the ${row.zone.best_questions} with the highest number of awarded points will count toward your total points.`,
+                              })
+                            : ''
+                        }
+                        </div>
+                      `
+                    : html`&nbsp;`
+                }
+                </th>
+              </tr>
+            `
+          : ''
+      }
       <tr
-        class="${row.question_access_mode === 'blocked_sequence' ||
-        row.question_access_mode === 'blocked_lockpoint'
-          ? 'bg-light pl-sequence-locked'
-          : ''}"
+        class="${
+          row.question_access_mode === 'blocked_sequence' ||
+          row.question_access_mode === 'blocked_lockpoint'
+            ? 'bg-light pl-sequence-locked'
+            : ''
+        }"
       >
         <td>
           <div class="d-flex align-items-center">
@@ -126,21 +138,23 @@ export function QuestionTableBody({
             })}
           </div>
         </td>
-        ${assessmentType === 'Exam'
-          ? ExamQuestionCells({
-              row,
-              someQuestionsAllowRealTimeGrading,
-              someQuestionsForbidRealTimeGrading,
-              hasAutoGradingQuestion,
-              hasManualGradingQuestion,
-              assessmentInstanceOpen,
-            })
-          : HomeworkQuestionCells({
-              row,
-              courseInstanceId,
-              hasAutoGradingQuestion,
-              hasManualGradingQuestion,
-            })}
+        ${
+          assessmentType === 'Exam'
+            ? ExamQuestionCells({
+                row,
+                someQuestionsAllowRealTimeGrading,
+                someQuestionsForbidRealTimeGrading,
+                hasAutoGradingQuestion,
+                hasManualGradingQuestion,
+                assessmentInstanceOpen,
+              })
+            : HomeworkQuestionCells({
+                row,
+                courseInstanceId,
+                hasAutoGradingQuestion,
+                hasManualGradingQuestion,
+              })
+        }
       </tr>
     `;
   });
@@ -177,66 +191,76 @@ function ExamQuestionCells({
             })
       }
     </td>
-    ${hasAutoGradingQuestion && someQuestionsAllowRealTimeGrading
-      ? html`
-          <td class="text-center">
-            ${row.assessment_question.max_auto_points
-              ? ExamQuestionAvailablePoints({
-                  open: assessmentInstanceOpen && row.instance_question.open,
-                  currentWeight:
-                    (row.instance_question.points_list_original?.[
-                      row.instance_question.number_attempts
-                    ] ?? 0) - (row.assessment_question.max_manual_points ?? 0),
-                  pointsList: row.instance_question.points_list?.map(
-                    (p) => p - (row.assessment_question.max_manual_points ?? 0),
-                  ),
-                  highestSubmissionScore: row.instance_question.highest_submission_score,
-                })
-              : html`&mdash;`}
-          </td>
-        `
-      : ''}
-    ${someQuestionsAllowRealTimeGrading || !assessmentInstanceOpen
-      ? html`
-          ${hasAutoGradingQuestion && hasManualGradingQuestion
-            ? html`
-                <td class="text-center">
-                  ${InstanceQuestionPoints({
+    ${
+      hasAutoGradingQuestion && someQuestionsAllowRealTimeGrading
+        ? html`
+            <td class="text-center">
+              ${
+              row.assessment_question.max_auto_points
+                ? ExamQuestionAvailablePoints({
+                    open: assessmentInstanceOpen && row.instance_question.open,
+                    currentWeight:
+                      (row.instance_question.points_list_original?.[
+                        row.instance_question.number_attempts
+                      ] ?? 0) - (row.assessment_question.max_manual_points ?? 0),
+                    pointsList: row.instance_question.points_list?.map(
+                      (p) => p - (row.assessment_question.max_manual_points ?? 0),
+                    ),
+                    highestSubmissionScore: row.instance_question.highest_submission_score,
+                  })
+                : html`&mdash;`
+            }
+            </td>
+          `
+        : ''
+    }
+    ${
+      someQuestionsAllowRealTimeGrading || !assessmentInstanceOpen
+        ? html`
+            ${
+            hasAutoGradingQuestion && hasManualGradingQuestion
+              ? html`
+                  <td class="text-center">
+                    ${InstanceQuestionPoints({
                     instance_question: row.instance_question,
                     assessment_question: row.assessment_question,
                     component: 'auto',
                   })}
-                </td>
-                <td class="text-center">
-                  ${InstanceQuestionPoints({
+                  </td>
+                  <td class="text-center">
+                    ${InstanceQuestionPoints({
                     instance_question: row.instance_question,
                     assessment_question: row.assessment_question,
                     component: 'manual',
                   })}
-                </td>
-              `
-            : ''}
-          <td class="text-center">
-            ${InstanceQuestionPoints({
+                  </td>
+                `
+              : ''
+          }
+            <td class="text-center">
+              ${InstanceQuestionPoints({
               instance_question: row.instance_question,
               assessment_question: row.assessment_question,
               component: 'total',
             })}
-          </td>
-        `
-      : html`
-          ${hasAutoGradingQuestion && hasManualGradingQuestion
-            ? html`
-                <td class="text-center">
-                  ${formatPoints(row.assessment_question.max_auto_points)}
-                </td>
-                <td class="text-center">
-                  ${formatPoints(row.assessment_question.max_manual_points)}
-                </td>
-              `
-            : ''}
-          <td class="text-center">${formatPoints(row.assessment_question.max_points)}</td>
-        `}
+            </td>
+          `
+        : html`
+            ${
+            hasAutoGradingQuestion && hasManualGradingQuestion
+              ? html`
+                  <td class="text-center">
+                    ${formatPoints(row.assessment_question.max_auto_points)}
+                  </td>
+                  <td class="text-center">
+                    ${formatPoints(row.assessment_question.max_manual_points)}
+                  </td>
+                `
+              : ''
+          }
+            <td class="text-center">${formatPoints(row.assessment_question.max_points)}</td>
+          `
+    }
   `;
 }
 
@@ -252,10 +276,11 @@ function HomeworkQuestionCells({
   hasManualGradingQuestion: boolean;
 }) {
   return html`
-    ${hasAutoGradingQuestion
-      ? html`
-          <td class="text-center">
-            ${run(() => {
+    ${
+      hasAutoGradingQuestion
+        ? html`
+            <td class="text-center">
+              ${run(() => {
               if (!row.assessment_question.max_auto_points) {
                 return html`&mdash;`;
               }
@@ -270,34 +295,37 @@ function HomeworkQuestionCells({
 
               return formatPoints(currentAutoValue);
             })}
-          </td>
-          <td class="text-center">
-            ${QuestionVariantHistory({
+            </td>
+            <td class="text-center">
+              ${QuestionVariantHistory({
               instanceQuestionId: row.instance_question.id,
               courseInstanceId,
               previousVariants: row.previous_variants,
             })}
-          </td>
-        `
-      : ''}
-    ${hasAutoGradingQuestion && hasManualGradingQuestion
-      ? html`
-          <td class="text-center">
-            ${InstanceQuestionPoints({
+            </td>
+          `
+        : ''
+    }
+    ${
+      hasAutoGradingQuestion && hasManualGradingQuestion
+        ? html`
+            <td class="text-center">
+              ${InstanceQuestionPoints({
               instance_question: row.instance_question,
               assessment_question: row.assessment_question,
               component: 'auto',
             })}
-          </td>
-          <td class="text-center">
-            ${InstanceQuestionPoints({
+            </td>
+            <td class="text-center">
+              ${InstanceQuestionPoints({
               instance_question: row.instance_question,
               assessment_question: row.assessment_question,
               component: 'manual',
             })}
-          </td>
-        `
-      : ''}
+            </td>
+          `
+        : ''
+    }
     <td class="text-center">
       ${InstanceQuestionPoints({
         instance_question: row.instance_question,

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/components/RowLabel.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/components/RowLabel.tsx
@@ -36,17 +36,19 @@ export function RowLabel({
   }
 
   return html`
-    ${showLink
-      ? html`
-          <a
-            href="${getInstanceQuestionUrl({
+    ${
+      showLink
+        ? html`
+            <a
+              href="${getInstanceQuestionUrl({
               courseInstanceId,
               instanceQuestionId: row.instance_question.id,
             })}"
-            >${rowLabelText}</a
-          >
-        `
-      : html`<span class="text-muted">${rowLabelText}</span>`}
+              >${rowLabelText}</a
+            >
+          `
+        : html`<span class="text-muted">${rowLabelText}</span>`
+    }
     ${
       // On exams, blocked_lockpoint questions show "Locked" in the Status column,
       // so we skip the inline badge to avoid duplication. On homeworks (no Status
@@ -74,20 +76,22 @@ export function RowLabel({
             `
           : ''
     }
-    ${row.file_count > 0
-      ? html`
-          <button
-            type="button"
-            class="btn btn-xs border text-secondary ms-1"
-            data-bs-toggle="popover"
-            data-bs-container="body"
-            data-bs-html="true"
-            data-bs-content="Personal notes: ${row.file_count}"
-            aria-label="Has personal note attachments"
-          >
-            <i class="fas fa-paperclip"></i>
-          </button>
-        `
-      : ''}
+    ${
+      row.file_count > 0
+        ? html`
+            <button
+              type="button"
+              class="btn btn-xs border text-secondary ms-1"
+              data-bs-toggle="popover"
+              data-bs-container="body"
+              data-bs-html="true"
+              data-bs-content="Personal notes: ${row.file_count}"
+              aria-label="Has personal note attachments"
+            >
+              <i class="fas fa-paperclip"></i>
+            </button>
+          `
+        : ''
+    }
   `;
 }

--- a/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessmentInstance/studentAssessmentInstance.html.tsx
@@ -171,9 +171,10 @@ export function StudentAssessmentInstance({
       page: 'assessment_instance',
     },
     headContent: html`
-      ${resLocals.assessment.type === 'Exam'
-        ? html`${compiledScriptTag('examTimeLimitCountdown.ts')}
-          ${EncodedData(
+      ${
+        resLocals.assessment.type === 'Exam'
+          ? html`${compiledScriptTag('examTimeLimitCountdown.ts')}
+            ${EncodedData(
             {
               serverRemainingMS: resLocals.assessment_instance_remaining_ms,
               serverTimeLimitMS: resLocals.assessment_instance_time_limit_ms,
@@ -185,15 +186,18 @@ export function StudentAssessmentInstance({
             },
             'time-limit-data',
           )}`
-        : ''}
+          : ''
+      }
     `,
     preContent: html`
-      ${resLocals.assessment.type === 'Exam' && resLocals.authz_result.authorized_edit
-        ? ConfirmFinishModal({
-            instance_question_rows,
-            csrfToken: resLocals.__csrf_token,
-          })
-        : ''}
+      ${
+        resLocals.assessment.type === 'Exam' && resLocals.authz_result.authorized_edit
+          ? ConfirmFinishModal({
+              instance_question_rows,
+              csrfToken: resLocals.__csrf_token,
+            })
+          : ''
+      }
       ${crossableLockpointRows.map((row) =>
         Modal({
           id: `crossLockpointModal-${row.zone.id}`,
@@ -203,21 +207,24 @@ export function StudentAssessmentInstance({
               After proceeding, you will not be able to submit answers to previous questions. You
               can still review your previous submissions.
             </p>
-            ${groupConfig != null
-              ? html`
-                  <p class="fw-bold">
-                    This will affect all group members. No one in your group will be able to submit
-                    answers to previous questions.
-                  </p>
-                `
-              : ''}
+            ${
+              groupConfig != null
+                ? html`
+                    <p class="fw-bold">
+                      This will affect all group members. No one in your group will be able to
+                      submit answers to previous questions.
+                    </p>
+                  `
+                : ''
+            }
             <div class="form-check">
               <input
                 class="form-check-input"
                 type="checkbox"
                 id="lockpoint-confirm-${row.zone.id}"
-                onchange="document.getElementById('lockpoint-submit-${row.zone
-                  .id}').disabled = !this.checked"
+                onchange="document.getElementById('lockpoint-submit-${
+                  row.zone.id
+                }').disabled = !this.checked"
               />
               <label class="form-check-label" for="lockpoint-confirm-${row.zone.id}">
                 I understand that I will not be able to submit answers to previous questions
@@ -242,9 +249,11 @@ export function StudentAssessmentInstance({
         }),
       )}
       ${showTimeLimitExpiredModal ? TimeLimitExpiredModal({ showAutomatically: true }) : ''}
-      ${userCanDeleteAssessmentInstance
-        ? RegenerateInstanceModal({ csrfToken: resLocals.__csrf_token })
-        : ''}
+      ${
+        userCanDeleteAssessmentInstance
+          ? RegenerateInstanceModal({ csrfToken: resLocals.__csrf_token })
+          : ''
+      }
     `,
     content: html`
       ${userCanDeleteAssessmentInstance ? RegenerateInstanceAlert() : ''}
@@ -263,95 +272,107 @@ export function StudentAssessmentInstance({
             assessment_instance: resLocals.assessment_instance,
           })}
           <div class="row align-items-center">
-            ${run(() => {
-              const allQuestionsDisabled = instance_question_rows.every(
-                (row) => !row.assessment_question.allow_real_time_grading,
-              );
-              return allQuestionsDisabled && resLocals.assessment_instance.open;
-            })
-              ? html`
-                  <div class="col-md-3 col-sm-12">
-                    Total points: ${formatPoints(resLocals.assessment_instance.max_points)}
-                    ${resLocals.assessment_instance.max_bonus_points
-                      ? html`
-                          <br />
-                          (${resLocals.assessment_instance.max_bonus_points} bonus
-                          ${resLocals.assessment_instance.max_bonus_points > 1 ? 'points' : 'point'}
-                          possible)
-                        `
-                      : ''}
-                  </div>
-                  <div class="col-md-9 col-sm-12">
-                    ${AssessmentStatus({
+            ${
+              run(() => {
+                const allQuestionsDisabled = instance_question_rows.every(
+                  (row) => !row.assessment_question.allow_real_time_grading,
+                );
+                return allQuestionsDisabled && resLocals.assessment_instance.open;
+              })
+                ? html`
+                    <div class="col-md-3 col-sm-12">
+                      Total points: ${formatPoints(resLocals.assessment_instance.max_points)}
+                      ${
+                      resLocals.assessment_instance.max_bonus_points
+                        ? html`
+                            <br />
+                            (${resLocals.assessment_instance.max_bonus_points} bonus
+                            ${resLocals.assessment_instance.max_bonus_points > 1 ? 'points' : 'point'}
+                            possible)
+                          `
+                        : ''
+                    }
+                    </div>
+                    <div class="col-md-9 col-sm-12">
+                      ${AssessmentStatus({
                       assessment: resLocals.assessment,
                       assessment_instance: resLocals.assessment_instance,
                       displayTimezone: resLocals.course_instance.display_timezone,
                       authz_result: resLocals.authz_result,
                     })}
-                  </div>
-                `
-              : html`
-                  <div class="col-md-3 col-sm-6">
-                    Total points:
-                    ${formatPoints(resLocals.assessment_instance.points)}/${formatPoints(
+                    </div>
+                  `
+                : html`
+                    <div class="col-md-3 col-sm-6">
+                      Total points:
+                      ${formatPoints(resLocals.assessment_instance.points)}/${formatPoints(
                       resLocals.assessment_instance.max_points,
                     )}
-                    ${resLocals.assessment_instance.max_bonus_points
-                      ? html`
-                          <br />
-                          (${resLocals.assessment_instance.max_bonus_points} bonus
-                          ${resLocals.assessment_instance.max_bonus_points > 1 ? 'points' : 'point'}
-                          possible)
-                        `
-                      : ''}
-                  </div>
-                  <div class="col-md-3 col-sm-6">
-                    ${ScorebarHtml(resLocals.assessment_instance.score_perc)}
-                  </div>
-                  <div class="col-md-6 col-sm-12">
-                    ${AssessmentStatus({
+                      ${
+                      resLocals.assessment_instance.max_bonus_points
+                        ? html`
+                            <br />
+                            (${resLocals.assessment_instance.max_bonus_points} bonus
+                            ${resLocals.assessment_instance.max_bonus_points > 1 ? 'points' : 'point'}
+                            possible)
+                          `
+                        : ''
+                    }
+                    </div>
+                    <div class="col-md-3 col-sm-6">
+                      ${ScorebarHtml(resLocals.assessment_instance.score_perc)}
+                    </div>
+                    <div class="col-md-6 col-sm-12">
+                      ${AssessmentStatus({
                       assessment: resLocals.assessment,
                       assessment_instance: resLocals.assessment_instance,
                       displayTimezone: resLocals.course_instance.display_timezone,
                       authz_result: resLocals.authz_result,
                     })}
-                  </div>
-                `}
-            ${groupConfig != null
-              ? html`
-                  <div class="col-lg-12">
-                    ${GroupWorkInfoContainer({
+                    </div>
+                  `
+            }
+            ${
+              groupConfig != null
+                ? html`
+                    <div class="col-lg-12">
+                      ${GroupWorkInfoContainer({
                       groupConfig,
                       groupInfo,
                       userCanAssignRoles,
                       csrfToken: resLocals.__csrf_token,
                     })}
-                  </div>
-                `
-              : ''}
+                    </div>
+                  `
+                : ''
+            }
           </div>
 
-          ${resLocals.assessment_instance.open && resLocals.assessment_instance_remaining_ms
-            ? html`
-                <div class="alert alert-secondary mt-4" role="alert">
-                  <div class="row">
-                    <div class="col-md-2 col-sm-12 col-xs-12">
-                      <div id="countdownProgress"></div>
-                    </div>
-                    <div class="col-md-10 col-sm-12 col-xs-12">
-                      Time remaining: <span id="countdownDisplay"></span>
+          ${
+            resLocals.assessment_instance.open && resLocals.assessment_instance_remaining_ms
+              ? html`
+                  <div class="alert alert-secondary mt-4" role="alert">
+                    <div class="row">
+                      <div class="col-md-2 col-sm-12 col-xs-12">
+                        <div id="countdownProgress"></div>
+                      </div>
+                      <div class="col-md-10 col-sm-12 col-xs-12">
+                        Time remaining: <span id="countdownDisplay"></span>
+                      </div>
                     </div>
                   </div>
-                </div>
-              `
-            : ''}
-          ${resLocals.assessment_text_templated
-            ? html`
-                <div class="card bg-light mb-0 mt-4">
-                  <div class="card-body">${unsafeHtml(resLocals.assessment_text_templated)}</div>
-                </div>
-              `
-            : ''}
+                `
+              : ''
+          }
+          ${
+            resLocals.assessment_text_templated
+              ? html`
+                  <div class="card bg-light mb-0 mt-4">
+                    <div class="card-body">${unsafeHtml(resLocals.assessment_text_templated)}</div>
+                  </div>
+                `
+              : ''
+          }
         </div>
 
         <div class="table-responsive">
@@ -388,45 +409,54 @@ export function StudentAssessmentInstance({
           </table>
         </div>
 
-        ${showCardFooter
-          ? html`
-              <div class="card-footer d-flex flex-column gap-3">
-                ${showExamFooterContent
-                  ? ExamFooterContent({
-                      someQuestionsAllowRealTimeGrading,
-                      someQuestionsForbidRealTimeGrading,
-                      savedAnswers,
-                      suspendedSavedAnswers,
-                      authorizedEdit: resLocals.authz_result.authorized_edit,
-                      hasPassword: resLocals.authz_result.password != null,
-                      showClosedAssessment: resLocals.authz_result.show_closed_assessment,
-                      csrfToken: resLocals.__csrf_token,
-                    })
-                  : ''}
-                ${showUnauthorizedEditWarning
-                  ? html`
-                      <div class="alert alert-warning mb-0" role="alert">
-                        You are viewing the assessment of a different user and so are not authorized
-                        to submit questions for grading or to mark the assessment as complete.
-                      </div>
-                    `
-                  : ''}
-              </div>
-            `
-          : ''}
+        ${
+          showCardFooter
+            ? html`
+                <div class="card-footer d-flex flex-column gap-3">
+                  ${
+                  showExamFooterContent
+                    ? ExamFooterContent({
+                        someQuestionsAllowRealTimeGrading,
+                        someQuestionsForbidRealTimeGrading,
+                        savedAnswers,
+                        suspendedSavedAnswers,
+                        authorizedEdit: resLocals.authz_result.authorized_edit,
+                        hasPassword: resLocals.authz_result.password != null,
+                        showClosedAssessment: resLocals.authz_result.show_closed_assessment,
+                        csrfToken: resLocals.__csrf_token,
+                      })
+                    : ''
+                }
+                  ${
+                  showUnauthorizedEditWarning
+                    ? html`
+                        <div class="alert alert-warning mb-0" role="alert">
+                          You are viewing the assessment of a different user and so are not
+                          authorized to submit questions for grading or to mark the assessment as
+                          complete.
+                        </div>
+                      `
+                    : ''
+                }
+                </div>
+              `
+            : ''
+        }
       </div>
 
-      ${resLocals.assessment.allow_personal_notes
-        ? PersonalNotesPanel({
-            fileList: resLocals.file_list,
-            context: 'assessment',
-            courseInstanceId: resLocals.course_instance.id,
-            assessment_instance: resLocals.assessment_instance,
-            csrfToken: resLocals.__csrf_token,
-            authz_result: resLocals.authz_result,
-            lockdownBrowser: resLocals.lockdown_browser,
-          })
-        : ''}
+      ${
+        resLocals.assessment.allow_personal_notes
+          ? PersonalNotesPanel({
+              fileList: resLocals.file_list,
+              context: 'assessment',
+              courseInstanceId: resLocals.course_instance.id,
+              assessment_instance: resLocals.assessment_instance,
+              csrfToken: resLocals.__csrf_token,
+              authz_result: resLocals.authz_result,
+              lockdownBrowser: resLocals.lockdown_browser,
+            })
+          : ''
+      }
       ${InstructorInfoPanel({
         course: resLocals.course,
         course_instance: resLocals.course_instance,
@@ -459,14 +489,16 @@ function AssessmentStatus({
       Assessment is <strong>open</strong> and you can answer questions.
       <br />
       Available credit: ${authz_result.credit_date_string}
-      ${assessment.modern_access_control
-        ? StudentAccessTimelinePopover({
-            accessTimeline: authz_result.access_timeline,
-            displayTimezone,
-          })
-        : StudentAccessRulesPopover({
-            accessRules: authz_result.access_rules,
-          })}
+      ${
+        assessment.modern_access_control
+          ? StudentAccessTimelinePopover({
+              accessTimeline: authz_result.access_timeline,
+              displayTimezone,
+            })
+          : StudentAccessRulesPopover({
+              accessRules: authz_result.access_rules,
+            })
+      }
     `;
   }
 
@@ -523,75 +555,85 @@ function InstanceQuestionTableHeader({
   const trailingColumns =
     resLocals.assessment.type === 'Exam'
       ? html`
-          ${resLocals.has_auto_grading_question && someQuestionsAllowRealTimeGrading
-            ? html`
-                <th class="text-center">Available points ${ExamQuestionHelpAvailablePoints()}</th>
-                <th class="text-center">Awarded points ${ExamQuestionHelpAwardedPoints()}</th>
-              `
-            : resLocals.has_auto_grading_question && resLocals.has_manual_grading_question
+          ${
+            resLocals.has_auto_grading_question && someQuestionsAllowRealTimeGrading
               ? html`
-                  <th class="text-center">Auto-grading points</th>
-                  <th class="text-center">Manual grading points</th>
-                  <th class="text-center">Total points</th>
+                  <th class="text-center">Available points ${ExamQuestionHelpAvailablePoints()}</th>
+                  <th class="text-center">Awarded points ${ExamQuestionHelpAwardedPoints()}</th>
                 `
-              : html`<th class="text-center">Points</th>`}
+              : resLocals.has_auto_grading_question && resLocals.has_manual_grading_question
+                ? html`
+                    <th class="text-center">Auto-grading points</th>
+                    <th class="text-center">Manual grading points</th>
+                    <th class="text-center">Total points</th>
+                  `
+                : html`<th class="text-center">Points</th>`
+          }
         `
       : html`
-          ${resLocals.has_auto_grading_question
-            ? html`
-                <th class="text-center">Value</th>
-                <th class="text-center">Variant history</th>
-              `
-            : ''}
+          ${
+            resLocals.has_auto_grading_question
+              ? html`
+                  <th class="text-center">Value</th>
+                  <th class="text-center">Variant history</th>
+                `
+              : ''
+          }
           <th class="text-center">Awarded points</th>
         `;
 
   return html`
-    ${resLocals.assessment.type === 'Exam'
-      ? html`
-          ${resLocals.has_auto_grading_question &&
-          resLocals.has_manual_grading_question &&
-          someQuestionsAllowRealTimeGrading
-            ? html`
-                <tr>
-                  <th rowspan="2">Question</th>
-                  <th rowspan="2">Status</th>
-                  <th class="text-center" colspan="2">Auto-grading</th>
-                  <th class="text-center" rowspan="2">Manual grading points</th>
-                  <th class="text-center" rowspan="2">Total points</th>
-                </tr>
-                <tr>
-                  ${trailingColumns}
-                </tr>
-              `
-            : html`
-                <tr>
-                  <th>Question</th>
-                  <th>Status</th>
-                  ${trailingColumns}
-                </tr>
-              `}
-        `
-      : html`
-          ${resLocals.has_auto_grading_question && resLocals.has_manual_grading_question
-            ? html`
-                <tr>
-                  <th rowspan="2">Question</th>
-                  <th class="text-center" colspan="3">Auto-grading</th>
-                  <th class="text-center" rowspan="2">Manual grading points</th>
-                  <th class="text-center" rowspan="2">Total points</th>
-                </tr>
-                <tr>
-                  ${trailingColumns}
-                </tr>
-              `
-            : html`
-                <tr>
-                  <th>Question</th>
-                  ${trailingColumns}
-                </tr>
-              `}
-        `}
+    ${
+      resLocals.assessment.type === 'Exam'
+        ? html`
+            ${
+            resLocals.has_auto_grading_question &&
+            resLocals.has_manual_grading_question &&
+            someQuestionsAllowRealTimeGrading
+              ? html`
+                  <tr>
+                    <th rowspan="2">Question</th>
+                    <th rowspan="2">Status</th>
+                    <th class="text-center" colspan="2">Auto-grading</th>
+                    <th class="text-center" rowspan="2">Manual grading points</th>
+                    <th class="text-center" rowspan="2">Total points</th>
+                  </tr>
+                  <tr>
+                    ${trailingColumns}
+                  </tr>
+                `
+              : html`
+                  <tr>
+                    <th>Question</th>
+                    <th>Status</th>
+                    ${trailingColumns}
+                  </tr>
+                `
+          }
+          `
+        : html`
+            ${
+            resLocals.has_auto_grading_question && resLocals.has_manual_grading_question
+              ? html`
+                  <tr>
+                    <th rowspan="2">Question</th>
+                    <th class="text-center" colspan="3">Auto-grading</th>
+                    <th class="text-center" rowspan="2">Manual grading points</th>
+                    <th class="text-center" rowspan="2">Total points</th>
+                  </tr>
+                  <tr>
+                    ${trailingColumns}
+                  </tr>
+                `
+              : html`
+                  <tr>
+                    <th>Question</th>
+                    ${trailingColumns}
+                  </tr>
+                `
+          }
+          `
+    }
   `;
 }
 
@@ -644,9 +686,11 @@ function ConfirmFinishModal({
     id: 'confirmFinishModal',
     title: 'All done?',
     body: html`
-      ${!all_questions_answered
-        ? html`<div class="alert alert-warning">There are still unanswered questions.</div>`
-        : ''}
+      ${
+        !all_questions_answered
+          ? html`<div class="alert alert-warning">There are still unanswered questions.</div>`
+          : ''
+      }
       <p class="text-danger">
         <strong>Warning</strong>: You will not be able to answer any more questions after finishing
         the assessment.

--- a/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.tsx
+++ b/apps/prairielearn/src/pages/studentAssessments/studentAssessments.html.tsx
@@ -82,16 +82,18 @@ export function StudentAssessments({
             <tbody>
               ${rows.map(
                 (row, index) => html`
-                  ${index === 0 ||
-                  !idsEqual(row.assessment_group_id, rows[index - 1].assessment_group_id)
-                    ? html`
-                        <tr>
-                          <th colspan="4" scope="row" data-testid="assessment-group-heading">
-                            ${row.assessment_group_heading}
-                          </th>
-                        </tr>
-                      `
-                    : ''}
+                  ${
+                    index === 0 ||
+                    !idsEqual(row.assessment_group_id, rows[index - 1].assessment_group_id)
+                      ? html`
+                          <tr>
+                            <th colspan="4" scope="row" data-testid="assessment-group-heading">
+                              ${row.assessment_group_heading}
+                            </th>
+                          </tr>
+                        `
+                      : ''
+                  }
                   <tr>
                     <td class="align-middle" style="width: 1%">
                       <span
@@ -102,19 +104,23 @@ export function StudentAssessments({
                       </span>
                     </td>
                     <td class="align-middle">
-                      ${row.show_before_release
-                        ? html`<span class="text-muted">${row.title}</span>`
-                        : row.multiple_instance_header ||
-                            (!row.active && row.assessment_instance_id == null)
-                          ? row.title
-                          : html`
-                              <a href="${urlPrefix}${row.link}">
-                                ${row.title}
-                                ${row.team_work
-                                  ? html`<i class="fas fa-users" aria-hidden="true"></i>`
-                                  : ''}
-                              </a>
-                            `}
+                      ${
+                        row.show_before_release
+                          ? html`<span class="text-muted">${row.title}</span>`
+                          : row.multiple_instance_header ||
+                              (!row.active && row.assessment_instance_id == null)
+                            ? row.title
+                            : html`
+                                <a href="${urlPrefix}${row.link}">
+                                  ${row.title}
+                                  ${
+                                  row.team_work
+                                    ? html`<i class="fas fa-users" aria-hidden="true"></i>`
+                                    : ''
+                                }
+                                </a>
+                              `
+                      }
                     </td>
                     <td class="text-center align-middle">
                       ${AvailableCredit({
@@ -123,9 +129,11 @@ export function StudentAssessments({
                       })}
                     </td>
                     <td class="text-center align-middle">
-                      ${row.multiple_instance_header
-                        ? NewInstanceButton({ urlPrefix, row })
-                        : AssessmentScore(row)}
+                      ${
+                        row.multiple_instance_header
+                          ? NewInstanceButton({ urlPrefix, row })
+                          : AssessmentScore(row)
+                      }
                     </td>
                   </tr>
                 `,
@@ -134,15 +142,17 @@ export function StudentAssessments({
           </table>
         </div>
       </div>
-      ${authz_data.mode === 'Exam'
-        ? html`
-            <p>
-              Don't see your exam? Exams for this course are only made available to students with
-              checked-in exam reservations who have clicked the "Start exam" button in PrairieTest.
-              See a proctor for assistance.
-            </p>
-          `
-        : ''}
+      ${
+        authz_data.mode === 'Exam'
+          ? html`
+              <p>
+                Don't see your exam? Exams for this course are only made available to students with
+                checked-in exam reservations who have clicked the "Start exam" button in
+                PrairieTest. See a proctor for assistance.
+              </p>
+            `
+          : ''
+      }
     `,
   });
 }
@@ -180,12 +190,14 @@ function AvailableCredit({
   if (row.assessment_instance_open !== false) {
     return html`
       ${row.credit_date_string}
-      ${row.modern_access_control
-        ? StudentAccessTimelinePopover({
-            accessTimeline: row.access_timeline,
-            displayTimezone,
-          })
-        : StudentAccessRulesPopover({ accessRules: row.access_rules })}
+      ${
+        row.modern_access_control
+          ? StudentAccessTimelinePopover({
+              accessTimeline: row.access_timeline,
+              displayTimezone,
+            })
+          : StudentAccessRulesPopover({ accessRules: row.access_rules })
+      }
     `;
   }
   return html`Assessment closed.`;

--- a/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.html.ts
+++ b/apps/prairielearn/src/pages/studentInstanceQuestion/studentInstanceQuestion.html.ts
@@ -60,10 +60,11 @@ export function StudentInstanceQuestion({
         content="${nodeModulesAssetPath('@mathjax/mathjax-newcm-font')}"
       />
       ${compiledScriptTag('question.ts')} ${hasCalculator ? CalculatorDrawerHeadScripts() : ''}
-      ${resLocals.assessment.type === 'Exam'
-        ? html`
-            ${compiledScriptTag('examTimeLimitCountdown.ts')}
-            ${EncodedData(
+      ${
+        resLocals.assessment.type === 'Exam'
+          ? html`
+              ${compiledScriptTag('examTimeLimitCountdown.ts')}
+              ${EncodedData(
               {
                 serverRemainingMS: resLocals.assessment_instance_remaining_ms,
                 serverTimeLimitMS: resLocals.assessment_instance_time_limit_ms,
@@ -75,30 +76,37 @@ export function StudentInstanceQuestion({
               },
               'time-limit-data',
             )}
-          `
-        : ''}
+            `
+          : ''
+      }
       <script defer src="${nodeModulesAssetPath('mathjax/tex-svg.js')}"></script>
       <script>
         document.urlPrefix = '${resLocals.urlPrefix}';
       </script>
-      ${renderState?.variant == null
-        ? ''
-        : html`
-            ${resLocals.question.type !== 'Freeform'
-              ? html`
-                  <script src="${nodeModulesAssetPath('lodash/lodash.min.js')}"></script>
-                  <script src="${assetPath('javascripts/require.js')}"></script>
-                  <script src="${assetPath('localscripts/question.js')}"></script>
-                  <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
-                `
-              : ''}
-            ${unsafeHtml(renderState.extraHeadersHtml)}
-          `}
+      ${
+        renderState?.variant == null
+          ? ''
+          : html`
+              ${
+              resLocals.question.type !== 'Freeform'
+                ? html`
+                    <script src="${nodeModulesAssetPath('lodash/lodash.min.js')}"></script>
+                    <script src="${assetPath('javascripts/require.js')}"></script>
+                    <script src="${assetPath('localscripts/question.js')}"></script>
+                    <script src="${assetPath('localscripts/questionCalculation.js')}"></script>
+                  `
+                : ''
+            }
+              ${unsafeHtml(renderState.extraHeadersHtml)}
+            `
+      }
     `,
     preContent: html`
-      ${userCanDeleteAssessmentInstance
-        ? RegenerateInstanceModal({ csrfToken: resLocals.__csrf_token })
-        : ''}
+      ${
+        userCanDeleteAssessmentInstance
+          ? RegenerateInstanceModal({ csrfToken: resLocals.__csrf_token })
+          : ''
+      }
     `,
     postContent: hasCalculator
       ? CalculatorDrawer({
@@ -109,86 +117,98 @@ export function StudentInstanceQuestion({
       ${userCanDeleteAssessmentInstance ? RegenerateInstanceAlert() : ''}
       <div class="row">
         <div class="col-lg-9 col-sm-12">
-          ${resLocals.instance_question_info.question_access_mode === 'read_only_lockpoint'
-            ? html`
-                <div class="alert alert-warning">
-                  This question is read-only because you advanced past a lockpoint. You can review
-                  your previous submissions but cannot make new ones.
-                </div>
-              `
-            : ''}
-          ${renderState?.variant == null
-            ? html`
-                <div class="card mb-4">
-                  <div class="card-header bg-primary text-white">
-                    <h1>
-                      ${QuestionTitle({
+          ${
+            resLocals.instance_question_info.question_access_mode === 'read_only_lockpoint'
+              ? html`
+                  <div class="alert alert-warning">
+                    This question is read-only because you advanced past a lockpoint. You can review
+                    your previous submissions but cannot make new ones.
+                  </div>
+                `
+              : ''
+          }
+          ${
+            renderState?.variant == null
+              ? html`
+                  <div class="card mb-4">
+                    <div class="card-header bg-primary text-white">
+                      <h1>
+                        ${QuestionTitle({
                         questionContext,
                         question: resLocals.question,
                         questionNumber: resLocals.instance_question_info.question_number,
                         showQuestionTitles: !!resLocals.assessment.show_question_titles,
                       })}
-                    </h1>
+                      </h1>
+                    </div>
+                    <div class="card-body">
+                      This question was not viewed while the assessment was open, so no variant was
+                      created.
+                    </div>
                   </div>
-                  <div class="card-body">
-                    This question was not viewed while the assessment was open, so no variant was
-                    created.
-                  </div>
-                </div>
-              `
-            : QuestionContainer({
-                resLocals,
-                questionContext,
-                questionCopyTargets,
-                showFooter: resLocals.assessment_instance.open ?? false,
-              })}
+                `
+              : QuestionContainer({
+                  resLocals,
+                  questionContext,
+                  questionCopyTargets,
+                  showFooter: resLocals.assessment_instance.open ?? false,
+                })
+          }
         </div>
 
         <div class="col-lg-3 col-sm-12">
-          ${resLocals.assessment.type === 'Exam'
-            ? html`
-                <div class="card mb-4">
-                  <div class="card-header bg-secondary">
-                    <h2>
-                      <a
-                        class="text-white"
-                        href="${resLocals.urlPrefix}/assessment_instance/${resLocals
-                          .assessment_instance.id}/"
-                      >
-                        ${resLocals.assessment_set.name} ${resLocals.assessment.number}
-                      </a>
-                    </h2>
-                  </div>
-
-                  <div class="card-body">
-                    <div class="d-flex justify-content-center">
-                      <a
-                        class="btn btn-info"
-                        href="${resLocals.urlPrefix}/assessment_instance/${resLocals
-                          .assessment_instance.id}/"
-                      >
-                        Assessment overview
-                      </a>
+          ${
+            resLocals.assessment.type === 'Exam'
+              ? html`
+                  <div class="card mb-4">
+                    <div class="card-header bg-secondary">
+                      <h2>
+                        <a
+                          class="text-white"
+                          href="${resLocals.urlPrefix}/assessment_instance/${
+                          resLocals.assessment_instance.id
+                        }/"
+                        >
+                          ${resLocals.assessment_set.name} ${resLocals.assessment.number}
+                        </a>
+                      </h2>
                     </div>
 
-                    ${resLocals.assessment_instance.open &&
-                    resLocals.assessment_instance_remaining_ms != null
-                      ? html`
-                          <div class="mt-3">
-                            <div id="countdownProgress"></div>
-                            <p class="mb-0">Time remaining: <span id="countdownDisplay"></span></p>
-                          </div>
-                        `
-                      : ''}
+                    <div class="card-body">
+                      <div class="d-flex justify-content-center">
+                        <a
+                          class="btn btn-info"
+                          href="${resLocals.urlPrefix}/assessment_instance/${
+                          resLocals.assessment_instance.id
+                        }/"
+                        >
+                          Assessment overview
+                        </a>
+                      </div>
+
+                      ${
+                      resLocals.assessment_instance.open &&
+                      resLocals.assessment_instance_remaining_ms != null
+                        ? html`
+                            <div class="mt-3">
+                              <div id="countdownProgress"></div>
+                              <p class="mb-0">
+                                Time remaining: <span id="countdownDisplay"></span>
+                              </p>
+                            </div>
+                          `
+                        : ''
+                    }
+                    </div>
                   </div>
-                </div>
-              `
-            : AssessmentScorePanel({
-                urlPrefix: resLocals.urlPrefix,
-                assessment: resLocals.assessment,
-                assessment_set: resLocals.assessment_set,
-                assessment_instance: resLocals.assessment_instance,
-              })}
+                `
+              : AssessmentScorePanel({
+                  urlPrefix: resLocals.urlPrefix,
+                  assessment: resLocals.assessment,
+                  assessment_set: resLocals.assessment_set,
+                  assessment_instance: resLocals.assessment_instance,
+                })
+          }
           ${QuestionScorePanel({
             instance_question: resLocals.instance_question,
             assessment: resLocals.assessment,
@@ -214,18 +234,20 @@ export function StudentInstanceQuestion({
               ? getRoleNamesForUser(resLocals.group_info, resLocals.user).join(', ')
               : null,
           })}
-          ${resLocals.assessment.allow_personal_notes
-            ? PersonalNotesPanel({
-                fileList: resLocals.file_list,
-                context: 'question',
-                courseInstanceId: resLocals.course_instance.id,
-                assessment_instance: resLocals.assessment_instance,
-                authz_result: resLocals.authz_result,
-                variantId: renderState?.variant.id,
-                csrfToken: resLocals.__csrf_token,
-                lockdownBrowser: resLocals.lockdown_browser,
-              })
-            : ''}
+          ${
+            resLocals.assessment.allow_personal_notes
+              ? PersonalNotesPanel({
+                  fileList: resLocals.file_list,
+                  context: 'question',
+                  courseInstanceId: resLocals.course_instance.id,
+                  assessment_instance: resLocals.assessment_instance,
+                  authz_result: resLocals.authz_result,
+                  variantId: renderState?.variant.id,
+                  csrfToken: resLocals.__csrf_token,
+                  lockdownBrowser: resLocals.lockdown_browser,
+                })
+              : ''
+          }
           ${hasCalculator ? CalculatorDrawerToggle() : ''}
           ${InstructorInfoPanel({
             course: resLocals.course,

--- a/apps/prairielearn/src/pages/workspace/workspace.html.ts
+++ b/apps/prairielearn/src/pages/workspace/workspace.html.ts
@@ -52,9 +52,10 @@ export function Workspace({
     headContent: html`
       <link href="${assetPath('stylesheets/workspace.css')}" rel="stylesheet" />
       ${compiledScriptTag('workspaceClient.ts')}
-      ${resLocals.assessment?.type === 'Exam' && resLocals.assessment_instance_remaining_ms
-        ? html`${compiledScriptTag('examTimeLimitCountdown.ts')}
-          ${EncodedData(
+      ${
+        resLocals.assessment?.type === 'Exam' && resLocals.assessment_instance_remaining_ms
+          ? html`${compiledScriptTag('examTimeLimitCountdown.ts')}
+            ${EncodedData(
             {
               serverRemainingMS: resLocals.assessment_instance_remaining_ms,
               serverTimeLimitMS: resLocals.assessment_instance_time_limit_ms,
@@ -66,7 +67,8 @@ export function Workspace({
             },
             'time-limit-data',
           )}`
-        : ''}
+          : ''
+      }
     `,
     preContent: html`
       ${RebootModal({ __csrf_token })} ${ResetModal({ __csrf_token })}
@@ -101,14 +103,16 @@ export function Workspace({
           </button>
           <div class="collapse navbar-collapse" id="workspace-nav">
             <ul class="navbar-nav ms-auto">
-              ${resLocals.assessment?.type === 'Exam' && resLocals.assessment_instance_remaining_ms
-                ? html` <li class="nav-item ms-2 my-1">
-                    <div id="countdownProgress"></div>
-                    <div class="text-white small">
-                      Time remaining: <span id="countdownDisplay"></span>
-                    </div>
-                  </li>`
-                : ''}
+              ${
+                resLocals.assessment?.type === 'Exam' && resLocals.assessment_instance_remaining_ms
+                  ? html` <li class="nav-item ms-2 my-1">
+                      <div id="countdownProgress"></div>
+                      <div class="text-white small">
+                        Time remaining: <span id="countdownDisplay"></span>
+                      </div>
+                    </li>`
+                  : ''
+              }
               <li class="nav-item ms-2 my-1">
                 <button
                   id="reboot"
@@ -131,20 +135,22 @@ export function Workspace({
                   Reset
                 </button>
               </li>
-              ${showLogs
-                ? html`
-                    <li class="nav-item ms-2 my-1">
-                      <a
-                        class="nav-item btn btn-light"
-                        href="${urlPrefix}/workspace/${workspace_id}/logs"
-                        target="_blank"
-                      >
-                        <i class="fas fa-bars-staggered" aria-hidden="true"></i>
-                        Logs
-                      </a>
-                    </li>
-                  `
-                : null}
+              ${
+                showLogs
+                  ? html`
+                      <li class="nav-item ms-2 my-1">
+                        <a
+                          class="nav-item btn btn-light"
+                          href="${urlPrefix}/workspace/${workspace_id}/logs"
+                          target="_blank"
+                        >
+                          <i class="fas fa-bars-staggered" aria-hidden="true"></i>
+                          Logs
+                        </a>
+                      </li>
+                    `
+                  : null
+              }
               <li class="nav-item ms-2 ms-md-3 my-1">
                 <button
                   type="button"

--- a/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.html.ts
+++ b/apps/prairielearn/src/pages/workspaceLogs/workspaceLogs.html.ts
@@ -91,27 +91,31 @@ export function WorkspaceVersionLogs({
       <h1 class="mb-4">Workspace version logs</h1>
 
       <h2>Container logs</h2>
-      ${containerLogs !== null && containerLogsEnabled && !containerLogsExpired
-        ? html`
-            <pre class="bg-dark rounded text-white p-3 mb-3"><code>${containerLogs}</code></pre>
-          `
-        : html`
-            <div class="bg-dark py-5 px-2 mb-3 rounded text-white text-center font-monospace">
-              <div class="mb-2">
-                <i
-                  class="fa ${containerLogsEnabled && containerLogsExpired
-                    ? 'fa-calendar'
-                    : 'fa-ban'} fa-2xl"
-                  aria-hidden="true"
-                ></i>
+      ${
+        containerLogs !== null && containerLogsEnabled && !containerLogsExpired
+          ? html`
+              <pre class="bg-dark rounded text-white p-3 mb-3"><code>${containerLogs}</code></pre>
+            `
+          : html`
+              <div class="bg-dark py-5 px-2 mb-3 rounded text-white text-center font-monospace">
+                <div class="mb-2">
+                  <i
+                    class="fa ${
+                    containerLogsEnabled && containerLogsExpired ? 'fa-calendar' : 'fa-ban'
+                  } fa-2xl"
+                    aria-hidden="true"
+                  ></i>
+                </div>
+                <div>
+                  ${
+                  containerLogsEnabled
+                    ? 'The container logs for this workspace have expired and are no longer available.'
+                    : 'Container logs are not available for this workspace.'
+                }
+                </div>
               </div>
-              <div>
-                ${containerLogsEnabled
-                  ? 'The container logs for this workspace have expired and are no longer available.'
-                  : 'Container logs are not available for this workspace.'}
-              </div>
-            </div>
-          `}
+            `
+      }
 
       <h2>History</h2>
       ${WorkspaceLogsTable({

--- a/apps/prairielearn/src/tests/testLockpoints.test.ts
+++ b/apps/prairielearn/src/tests/testLockpoints.test.ts
@@ -18,10 +18,7 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 interface QuestionState {
   id: number;
   question_access_mode:
-    | 'default'
-    | 'blocked_sequence'
-    | 'blocked_lockpoint'
-    | 'read_only_lockpoint';
+    'default' | 'blocked_sequence' | 'blocked_lockpoint' | 'read_only_lockpoint';
   url: string;
 }
 

--- a/apps/prairielearn/src/trpc/course/questions.ts
+++ b/apps/prairielearn/src/trpc/course/questions.ts
@@ -78,14 +78,11 @@ export interface QuestionsError {
   AddToAssessment: { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   RemoveFromAssessment: { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   ChangeTopic:
-    | { code: 'INVALID_TOPIC'; topic: string }
-    | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
+    { code: 'INVALID_TOPIC'; topic: string } | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   AddTags:
-    | { code: 'INVALID_TAGS'; tags: string[] }
-    | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
+    { code: 'INVALID_TAGS'; tags: string[] } | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   RemoveTags:
-    | { code: 'INVALID_TAGS'; tags: string[] }
-    | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
+    { code: 'INVALID_TAGS'; tags: string[] } | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   DeleteQuestions:
     | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string }
     | { code: 'QUESTIONS_USED_IN_OTHER_COURSES'; qids: string[] };

--- a/apps/prairielearn/src/trpc/course/sharing.ts
+++ b/apps/prairielearn/src/trpc/course/sharing.ts
@@ -29,11 +29,9 @@ export interface SharingError {
   RegenerateSharingToken: never;
   AddCourseToSharingSet: never;
   CreateSharingSet:
-    | { code: 'DUPLICATE_NAME'; name: string }
-    | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
+    { code: 'DUPLICATE_NAME'; name: string } | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   UpdateSharingSetDescription:
-    | { code: 'NOT_FOUND'; name: string }
-    | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
+    { code: 'NOT_FOUND'; name: string } | { code: 'SYNC_JOB_FAILED'; jobSequenceId: string };
   DeleteSharingSet:
     | { code: 'IN_USE'; name: string }
     | { code: 'NOT_FOUND'; name: string }

--- a/docs/assessment/accessControlLegacy.md
+++ b/docs/assessment/accessControlLegacy.md
@@ -20,17 +20,7 @@ The general format of `allowAccess` is:
 
 ```json
 {
-  "allowAccess": [
-    {
-      /* <accessRule1> */
-    },
-    {
-      /* <accessRule2> */
-    },
-    {
-      /* <accessRule3> */
-    }
-  ]
+  "allowAccess": [{/* <accessRule1> */}, {/* <accessRule2> */}, {/* <accessRule3> */}]
 }
 ```
 

--- a/docs/assessment/configuration.md
+++ b/docs/assessment/configuration.md
@@ -237,9 +237,7 @@ By default, when using `maxAutoPoints`, PrairieLearn provides an incentive for s
   "constantQuestionValue": true,
   "zones": [
     {
-      "questions": [
-        /* ... */
-      ]
+      "questions": [/* ... */]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "knip": "^6.14.2",
     "linkinator": "^7.6.1",
     "markdownlint-cli2": "^0.22.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.4",
     "prettier-plugin-pkg": "^0.22.1",
     "prettier-plugin-sh": "^0.18.1",
     "prettier-plugin-sql": "^0.20.0",

--- a/packages/html/src/index.ts
+++ b/packages/html/src/index.ts
@@ -62,14 +62,7 @@ export class HtmlSafeString {
 }
 
 export type HtmlValue =
-  | string
-  | number
-  | boolean
-  | bigint
-  | HtmlSafeString
-  | undefined
-  | null
-  | HtmlValue[];
+  string | number | boolean | bigint | HtmlSafeString | undefined | null | HtmlValue[];
 
 export function html(strings: TemplateStringsArray, ...values: HtmlValue[]): HtmlSafeString {
   return new HtmlSafeString(strings, values);

--- a/packages/question-conversion/src/parsers/qti12/qti12-item-container-parser.ts
+++ b/packages/question-conversion/src/parsers/qti12/qti12-item-container-parser.ts
@@ -708,8 +708,7 @@ export class QTI12ItemContainerParser implements InputParser {
 
     const resprocessing = itemEl['resprocessing'] as Record<string, unknown> | undefined;
     const calcBlock = getNestedValue(itemEl, 'itemproc_extension', 'calculated') as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
 
     return {
       ident,

--- a/packages/question-conversion/src/trimmer/trimmer.ts
+++ b/packages/question-conversion/src/trimmer/trimmer.ts
@@ -65,8 +65,7 @@ interface ManifestObject {
   };
   organizations?: {
     organization?:
-      | { item?: ManifestItem | ManifestItem[] }[]
-      | { item?: ManifestItem | ManifestItem[] };
+      { item?: ManifestItem | ManifestItem[] }[] | { item?: ManifestItem | ManifestItem[] };
   };
 }
 
@@ -101,10 +100,7 @@ interface LocalAssets {
 }
 
 type QtiContainerKind =
-  | 'assessment'
-  | 'objectbank-title-attr'
-  | 'objectbank-bank-title'
-  | 'unknown';
+  'assessment' | 'objectbank-title-attr' | 'objectbank-bank-title' | 'unknown';
 
 interface QtiContainer extends QtiArchiveEntry {
   kind: QtiContainerKind;

--- a/packages/utils/src/zip/index.ts
+++ b/packages/utils/src/zip/index.ts
@@ -5,9 +5,7 @@ import extractZip from 'extract-zip';
 import * as yauzl from 'yauzl';
 
 export type ZipArchiveValidationErrorCode =
-  | 'max_entries_exceeded'
-  | 'max_extracted_bytes_exceeded'
-  | 'symlink_entry';
+  'max_entries_exceeded' | 'max_extracted_bytes_exceeded' | 'symlink_entry';
 
 export class ZipArchiveValidationError extends Error {
   code: ZipArchiveValidationErrorCode;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: link:packages/signed-token
       '@prairielearn/tree-sitter-htmlmustache':
         specifier: ^1.4.3
-        version: 1.4.3(prettier@3.8.3)
+        version: 1.4.3(prettier@3.9.4)
       '@prairielearn/tsconfig':
         specifier: workspace:^
         version: link:packages/tsconfig
@@ -92,20 +92,20 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.9.4
+        version: 3.9.4
       prettier-plugin-pkg:
         specifier: ^0.22.1
-        version: 0.22.1(prettier@3.8.3)
+        version: 0.22.1(prettier@3.9.4)
       prettier-plugin-sh:
         specifier: ^0.18.1
-        version: 0.18.1(prettier@3.8.3)
+        version: 0.18.1(prettier@3.9.4)
       prettier-plugin-sql:
         specifier: ^0.20.0
-        version: 0.20.0(prettier@3.8.3)
+        version: 0.20.0(prettier@3.9.4)
       prettier-plugin-toml:
         specifier: ^2.0.6
-        version: 2.0.6(prettier@3.8.3)
+        version: 2.0.6(prettier@3.9.4)
       pyright:
         specifier: ^1.1.410
         version: 1.1.410
@@ -406,7 +406,7 @@ importers:
         version: 0.1.4(stylelint@16.26.1(typescript@6.0.3))
       '@prairielearn/tree-sitter-htmlmustache':
         specifier: ^1.4.3
-        version: 1.4.3(prettier@3.8.3)
+        version: 1.4.3(prettier@3.9.4)
       '@prairielearn/tsconfig':
         specifier: workspace:^
         version: link:../../packages/tsconfig
@@ -813,8 +813,8 @@ importers:
         specifier: ^1.16.1
         version: 1.16.1
       prettier:
-        specifier: ^3.8.3
-        version: 3.8.3
+        specifier: ^3.9.4
+        version: 3.9.4
       prosemirror-model:
         specifier: ^1.25.7
         version: 1.25.7
@@ -2976,11 +2976,11 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@cacheable/memory@2.0.9':
-    resolution: {integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==}
+  '@cacheable/memory@2.2.0':
+    resolution: {integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==}
 
-  '@cacheable/utils@2.4.1':
-    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+  '@cacheable/utils@2.5.0':
+    resolution: {integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==}
 
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
@@ -3078,8 +3078,8 @@ packages:
   '@cropper/utils@2.1.1':
     resolution: {integrity: sha512-0eQs08WyQUNFMfU3ieE091dEQkrW0YdgZ3n6Thnk1EUQv45ypfiL+MevHwr7UzNnUlqUYR2FNSCgE6qBxK0sFw==}
 
-  '@csstools/color-helpers@6.0.2':
-    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
     engines: {node: '>=20.19.0'}
 
   '@csstools/css-calc@3.2.1':
@@ -3089,8 +3089,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.1':
-    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -3108,8 +3108,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5':
-    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -3757,6 +3757,12 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -5070,6 +5076,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/archiver@8.0.0':
     resolution: {integrity: sha512-YpXPbEuv9+eUIPPQWUPahj3cvs9isWRuF+J4z+KbdYVDO3rWorWQFxUVHnwPu2AgKwvgpki5F2VMX0Xx+mX45A==}
 
@@ -6170,8 +6179,8 @@ packages:
   cache-manager@3.6.3:
     resolution: {integrity: sha512-dS4DnV6c6cQcVH5OxzIU1XZaACXwvVIiUPkFytnRmLOACuBGv3GQgRQ1RJGRRw4/9DF14ZK2RFlZu1TUgDniMg==}
 
-  cacheable@2.3.5:
-    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
+  cacheable@2.5.0:
+    resolution: {integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -7286,8 +7295,8 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
-  file-entry-cache@11.1.3:
-    resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
+  file-entry-cache@11.1.5:
+    resolution: {integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -7328,8 +7337,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flat-cache@6.1.22:
-    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
+  flat-cache@6.1.23:
+    resolution: {integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==}
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
@@ -7695,8 +7704,8 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immutable@5.1.6:
-    resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -7704,6 +7713,10 @@ packages:
 
   import-in-the-middle@3.0.2:
     resolution: {integrity: sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==}
+    engines: {node: '>=18'}
+
+  import-in-the-middle@3.2.0:
+    resolution: {integrity: sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==}
     engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
@@ -7923,6 +7936,10 @@ packages:
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsbi@4.3.2:
@@ -8584,8 +8601,8 @@ packages:
   nan@2.27.0:
     resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9033,8 +9050,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -9097,8 +9114,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  prettier@3.8.3:
-    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -9915,11 +9932,11 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.4.2:
-    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+  tldts-core@7.4.5:
+    resolution: {integrity: sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==}
 
-  tldts@7.4.2:
-    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+  tldts@7.4.5:
+    resolution: {integrity: sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==}
     hasBin: true
 
   tmp-promise@3.0.3:
@@ -10624,7 +10641,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -11175,14 +11192,14 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@cacheable/memory@2.0.9':
+  '@cacheable/memory@2.2.0':
     dependencies:
-      '@cacheable/utils': 2.4.1
+      '@cacheable/utils': 2.5.0
       '@keyv/bigmap': 1.3.1(keyv@5.6.0)
       hookified: 1.15.1
       keyv: 5.6.0
 
-  '@cacheable/utils@2.4.1':
+  '@cacheable/utils@2.5.0':
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
@@ -11404,16 +11421,16 @@ snapshots:
 
   '@cropper/utils@2.1.1': {}
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 6.0.2
+      '@csstools/color-helpers': 6.1.0
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
@@ -11426,7 +11443,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -12011,6 +12028,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodable/entities@2.1.1': {}
 
   '@node-saml/node-saml@5.1.0':
@@ -12324,7 +12348,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.219.0
-      import-in-the-middle: 3.0.2
+      import-in-the-middle: 3.2.0
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
@@ -12707,7 +12731,7 @@ snapshots:
       - stylelint
       - webpack
 
-  '@prairielearn/tree-sitter-htmlmustache@1.4.3(prettier@3.8.3)':
+  '@prairielearn/tree-sitter-htmlmustache@1.4.3(prettier@3.9.4)':
     dependencies:
       ajv: 8.20.0
       ajv-errors: 3.0.0(ajv@8.20.0)
@@ -12718,7 +12742,7 @@ snapshots:
       web-tree-sitter: 0.26.9
       zod: 4.4.3
     optionalDependencies:
-      prettier: 3.8.3
+      prettier: 3.9.4
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -12816,7 +12840,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
@@ -13231,6 +13255,11 @@ snapshots:
     optional: true
 
   '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -14357,10 +14386,10 @@ snapshots:
       lodash.clonedeep: 4.5.0
       lru-cache: 6.0.0
 
-  cacheable@2.3.5:
+  cacheable@2.5.0:
     dependencies:
-      '@cacheable/memory': 2.0.9
-      '@cacheable/utils': 2.4.1
+      '@cacheable/memory': 2.2.0
+      '@cacheable/utils': 2.5.0
       hookified: 1.15.1
       keyv: 5.6.0
       qified: 0.10.1
@@ -14616,7 +14645,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -15639,9 +15668,9 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
-  file-entry-cache@11.1.3:
+  file-entry-cache@11.1.5:
     dependencies:
-      flat-cache: 6.1.22
+      flat-cache: 6.1.23
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -15693,9 +15722,9 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
-  flat-cache@6.1.22:
+  flat-cache@6.1.23:
     dependencies:
-      cacheable: 2.3.5
+      cacheable: 2.5.0
       flatted: 3.4.2
       hookified: 1.15.1
 
@@ -16099,7 +16128,7 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immutable@5.1.6: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -16107,6 +16136,13 @@ snapshots:
       resolve-from: 4.0.0
 
   import-in-the-middle@3.0.2:
+    dependencies:
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@3.2.0:
     dependencies:
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -16300,6 +16336,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsbi@4.3.2: {}
 
   jsdoc-type-pratt-parser@7.2.0: {}
@@ -16309,7 +16349,7 @@ snapshots:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
-      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
       '@exodus/bytes': 1.15.1
       css-tree: 3.2.1
       data-urls: 7.0.0
@@ -17188,7 +17228,7 @@ snapshots:
 
   nan@2.27.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.15: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -17634,9 +17674,9 @@ snapshots:
 
   postcss-resolve-nested-selector@0.1.6: {}
 
-  postcss-safe-parser@7.0.1(postcss@8.5.15):
+  postcss-safe-parser@7.0.1(postcss@8.5.16):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.16
 
   postcss-selector-parser@7.1.4:
     dependencies:
@@ -17645,9 +17685,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.16:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -17669,32 +17709,32 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-pkg@0.22.1(prettier@3.8.3):
+  prettier-plugin-pkg@0.22.1(prettier@3.9.4):
     dependencies:
-      prettier: 3.8.3
+      prettier: 3.9.4
 
-  prettier-plugin-sh@0.18.1(prettier@3.8.3):
+  prettier-plugin-sh@0.18.1(prettier@3.9.4):
     dependencies:
       '@reteps/dockerfmt': 0.5.2
-      prettier: 3.8.3
+      prettier: 3.9.4
       sh-syntax: 0.5.8
 
-  prettier-plugin-sql@0.20.0(prettier@3.8.3):
+  prettier-plugin-sql@0.20.0(prettier@3.9.4):
     dependencies:
       jsox: 1.2.125
       node-sql-parser: 5.4.0
-      prettier: 3.8.3
+      prettier: 3.9.4
       sql-formatter: 15.8.0
       tslib: 2.8.1
 
-  prettier-plugin-toml@2.0.6(prettier@3.8.3):
+  prettier-plugin-toml@2.0.6(prettier@3.9.4):
     dependencies:
       '@taplo/lib': 0.5.0
-      prettier: 3.8.3
+      prettier: 3.9.4
 
   prettier@2.8.8: {}
 
-  prettier@3.8.3: {}
+  prettier@3.9.4: {}
 
   pretty-bytes@7.1.0: {}
 
@@ -18193,7 +18233,7 @@ snapshots:
   sass@1.100.0:
     dependencies:
       chokidar: 5.0.0
-      immutable: 5.1.6
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
@@ -18562,7 +18602,7 @@ snapshots:
   stylelint@16.26.1(typescript@6.0.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
       '@csstools/css-tokenizer': 3.0.4
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.4)
@@ -18575,7 +18615,7 @@ snapshots:
       debug: 4.4.3
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
-      file-entry-cache: 11.1.3
+      file-entry-cache: 11.1.5
       global-modules: 2.0.0
       globby: 11.1.0
       globjoin: 0.1.4
@@ -18589,9 +18629,9 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
+      postcss: 8.5.16
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 7.0.1(postcss@8.5.15)
+      postcss-safe-parser: 7.0.1(postcss@8.5.16)
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -18717,11 +18757,11 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.4.2: {}
+  tldts-core@7.4.5: {}
 
-  tldts@7.4.2:
+  tldts@7.4.5:
     dependencies:
-      tldts-core: 7.4.2
+      tldts-core: 7.4.5
 
   tmp-promise@3.0.3:
     dependencies:
@@ -18753,7 +18793,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.4.2
+      tldts: 7.4.5
 
   tr46@6.0.0:
     dependencies:
@@ -19013,7 +19053,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Extracted from #15382 for easier review. Upgrades prettier to 3.9.4 and reformats existing code. Most prominent changes:
* ternaries in templates are moved to new line if they don't fit the existing line, instead of just keeping the conditional in the first line.
* a few other template expressions are moved to new lines if they fit a single line.
* keep union types in single line when possible.
* fixed handling of pre/textarea close tags.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

CI only.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
