### PR TITLE
Show missing assessment is hidden header until assessment is released

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -1040,7 +1040,11 @@ function buildDefaultRuleCurrentIndicator(
         text: 'Listed but not accessible',
       };
     }
-    return null;
+    return {
+      variant: 'primary',
+      icon: 'bi-eye-slash',
+      text: 'Hidden',
+    };
   }
 
   const friendlyDate = (date: Date) => (

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -1063,7 +1063,7 @@ function buildDefaultRuleCurrentIndicator(
     return {
       variant: 'primary',
       icon: 'bi-eye-slash',
-      text: opensAt ? <>Hidden · opens {friendlyDate(opensAt)}</> : 'Hidden',
+      text: <>Hidden · opens {friendlyDate(opensAt!)}</>,
     };
   }
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Until the assessment is visible to students, the "hidden" indicator should be explicitly shown.

Also removed "hidden" text when scheduled release date is set.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
none used for this PR

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

**before**

<img width="2020" height="859" alt="image" src="https://github.com/user-attachments/assets/79de66e3-9e42-413d-901d-0e7be24226a9" />


**after**

<img width="2096" height="703" alt="image" src="https://github.com/user-attachments/assets/33548375-2639-48a5-98af-4b6f5ab83343" />
