### PR TITLE
Fix bulk tag checkbox IDs

### DIFF
--- a/apps/prairielearn/src/pages/instructorQuestions/components/UpdateTagsModal.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestions/components/UpdateTagsModal.tsx
@@ -161,8 +161,8 @@ export function UpdateTagsModal({
             <div className="text-muted">None of the selected questions have tags to remove.</div>
           ) : (
             <div className="d-flex flex-column gap-1">
-              {availableTags.map((tag) => {
-                const checkboxId = `${config.idPrefix}-${tag.name}`;
+              {availableTags.map((tag, index) => {
+                const checkboxId = `${config.idPrefix}-tag-${index}`;
                 return (
                   <div key={tag.name} className="form-check">
                     <input


### PR DESCRIPTION
# Description

Bulk tag modal checkboxes now use generated modal-local IDs instead of interpolating free-text tag names into `id` and `htmlFor`, which keeps label association and accessibility checks stable for names with spaces or punctuation.

This fixes a follow-up from #15342, which added the bulk question topic/tag actions and introduced checkbox IDs derived from tag names.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

N/A; trivial change.
