### PR TITLE
Fix changeset PR release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           # This invokes the `release` script in `package.json`, which will build
           # all the packages and then invoke `changeset publish`.
           publish: pnpm run release
-          # Avoid creating GitHub releaseses, as we don't need them.
+          # Avoid creating GitHub releases, as we don't need them.
           # This complements `--no-git-tag` in the `release` script in `package.json`.
           createGithubReleases: false
         env:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "^11.5.0"
+      "version": "^11.5.0",
+      "onFail": "warn"
     },
     "runtime": {
       "name": "node",


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

The changeset release CI is failing because it relies on a hardcoded "npm info", while our code expects "pnpm info" (see https://github.com/changesets/changesets/issues/965). Because of our explicit use of "devEngines" since #15389, npm will complain about the mismatched package manager. This PR adds a setting to cause "npm info" to still warn but not fail in this case.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: change suggested by Gemini.

# Testing

Can only be tested after merging.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
