### PR TITLE
Add pl-graph text alternatives and document element accessibility

### DIFF
--- a/apps/prairielearn/elements/pl-graph/pl-graph.py
+++ b/apps/prairielearn/elements/pl-graph/pl-graph.py
@@ -174,7 +174,7 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     aria_description = pl.get_string_attrib(
         element, "aria-description", ARIA_DESCRIPTION_DEFAULT
     )
-    if aria_description is not None and aria_label is None:
+    if aria_description and not aria_label:
         raise ValueError(
             'The "aria-description" attribute requires an "aria-label" attribute, which provides the graph\'s accessible name.'
         )
@@ -271,9 +271,9 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     # internal structure. `role="img"` requires an accessible name, so the image
     # treatment is gated on `aria-label`; `aria-description` only supplements it.
     wrapper_attribs = 'class="pl-graph"'
-    if aria_label is not None:
+    if aria_label:
         wrapper_attribs += f' role="img" aria-label="{html.escape(aria_label)}"'
-        if aria_description is not None:
+        if aria_description:
             wrapper_attribs += f' aria-description="{html.escape(aria_description)}"'
 
     return f"<div {wrapper_attribs}>{svg}</div>"

--- a/apps/prairielearn/elements/pl-graph/pl-graph.py
+++ b/apps/prairielearn/elements/pl-graph/pl-graph.py
@@ -1,3 +1,4 @@
+import html
 import os
 import re
 import warnings
@@ -22,6 +23,8 @@ DIRECTED_DEFAULT = True
 LOG_WARNINGS_DEFAULT = True
 SOURCE_FILE_NAME_DEFAULT = None
 DIRECTORY_DEFAULT = "."
+ARIA_LABEL_DEFAULT = None
+ARIA_DESCRIPTION_DEFAULT = None
 XML_DECLARATION = r"<\?xml[^>\?]*\?>"
 DOCTYPE_DECLARATION = r"<!DOCTYPE svg [^>]*>"
 
@@ -142,6 +145,8 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
         "log-warnings",
         "source-file-name",
         "directory",
+        "aria-label",
+        "aria-description",
     ]
 
     # Load attributes from extensions if they have any
@@ -163,6 +168,15 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
     ):
         raise ValueError(
             'Existing graph content cannot be added inside html element when "source-file-name" attribute is used.'
+        )
+
+    aria_label = pl.get_string_attrib(element, "aria-label", ARIA_LABEL_DEFAULT)
+    aria_description = pl.get_string_attrib(
+        element, "aria-description", ARIA_DESCRIPTION_DEFAULT
+    )
+    if aria_description is not None and aria_label is None:
+        raise ValueError(
+            'The "aria-description" attribute requires an "aria-label" attribute, which provides the graph\'s accessible name.'
         )
 
 
@@ -194,6 +208,11 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         element, "source-file-name", SOURCE_FILE_NAME_DEFAULT
     )
     directory = pl.get_string_attrib(element, "directory", DIRECTORY_DEFAULT)
+
+    aria_label = pl.get_string_attrib(element, "aria-label", ARIA_LABEL_DEFAULT)
+    aria_description = pl.get_string_attrib(
+        element, "aria-description", ARIA_DESCRIPTION_DEFAULT
+    )
 
     if (
         len(str(element.text)) == 0
@@ -245,4 +264,16 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         svg = re.sub(XML_DECLARATION, "", svg)
         svg = re.sub(DOCTYPE_DECLARATION, "", svg)
 
-    return f'<div class="pl-graph">{svg}</div>'
+    # When an author provides a text alternative, expose the whole graph as a
+    # single labeled image. The `role="img"` makes the SVG's descendants
+    # (including Graphviz's per-node/edge <title> elements) presentational, so
+    # screen readers announce the provided text instead of crawling the graph's
+    # internal structure. `role="img"` requires an accessible name, so the image
+    # treatment is gated on `aria-label`; `aria-description` only supplements it.
+    wrapper_attribs = 'class="pl-graph"'
+    if aria_label is not None:
+        wrapper_attribs += f' role="img" aria-label="{html.escape(aria_label)}"'
+        if aria_description is not None:
+            wrapper_attribs += f' aria-description="{html.escape(aria_description)}"'
+
+    return f"<div {wrapper_attribs}>{svg}</div>"

--- a/apps/prairielearn/elements/pl-graph/pl_graph_test.py
+++ b/apps/prairielearn/elements/pl-graph/pl_graph_test.py
@@ -55,6 +55,33 @@ def test_prepare_with_source_file_name_and_content_error() -> None:
         graph.prepare(element_html, data)
 
 
+def test_render_aria_attributes_expose_labeled_image() -> None:
+    """When a text alternative is given, the graph is exposed as an image with
+    HTML-escaped ARIA attributes."""
+    data = {"options": {}, "extensions": []}
+
+    element_html = (
+        "<pl-graph aria-label='Graph &lt;a&gt; \"b\"' aria-description='A to B'>"
+        "digraph G { A -> B }</pl-graph>"
+    )
+
+    result = graph.render(element_html, data)
+
+    assert 'role="img"' in result
+    assert 'aria-label="Graph &lt;a&gt; &quot;b&quot;"' in result
+    assert 'aria-description="A to B"' in result
+
+
+def test_prepare_aria_description_without_label_error() -> None:
+    """aria-description requires aria-label to supply the accessible name."""
+    data = {"options": {}, "extensions": []}
+
+    element_html = '<pl-graph aria-description="A to B">digraph G { A -> B }</pl-graph>'
+
+    with pytest.raises(ValueError, match='"aria-description" attribute requires'):
+        graph.prepare(element_html, data)
+
+
 def test_render_missing_file_error() -> None:
     """Test that render raises an error when source file doesn't exist"""
     data = {

--- a/docs/elements/pl-excalidraw.md
+++ b/docs/elements/pl-excalidraw.md
@@ -32,5 +32,9 @@ Note that only manual grading is supported. For auto-gradable drawings, consider
 
 The `width` and `height` attributes are used as CSS property values. Unitless numbers such as `height="900"` are invalid; use `height="900px"` for pixels.
 
+## Accessibility
+
+`pl-excalidraw` is a canvas-based drawing tool and is not fully accessible. While the toolbar can be reached with the keyboard, shapes cannot be drawn using the keyboard alone, and the drawing surface is not exposed to screen readers. If you use this element, consider providing an alternative version of the question for students who cannot use it, for example a freeform text input where they can describe the diagram in words.
+
 [css-height-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/height
 [css-width-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/width

--- a/docs/elements/pl-graph.md
+++ b/docs/elements/pl-graph.md
@@ -55,6 +55,8 @@ def generate(data):
 
 | Attribute                   | Type    | Default              | Description                                                                                                                                                                                                                                                                           |
 | --------------------------- | ------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aria-label`                | string  | —                    | A short text alternative describing the graph, read by screen readers. See the [accessibility section](#accessibility).                                                                                                                                                               |
+| `aria-description`          | string  | —                    | A longer, more detailed text description of the graph, read by screen readers. Requires `aria-label`. See the [accessibility section](#accessibility).                                                                                                                                |
 | `directed`                  | boolean | true                 | Whether to treat edges in an adjacency matrix as directed or undirected. If set to false, then edges will be rendered as undirected. _The input adjacency matrix must be symmetric if this is set to false._                                                                          |
 | `directory`                 | string  | `"."`                | Directory where the source file is located. Can be `"."` (question directory), `"clientFilesCourse"`, or `"serverFilesCourse"`.                                                                                                                                                       |
 | `engine`                    | string  | dot                  | The rendering engine to use; supports `"circo"`, `"dot"`, `"fdp"`, `"neato"`, `"osage"`, and `"twopi"`.                                                                                                                                                                               |
@@ -81,6 +83,79 @@ The following deprecated attribute is still supported for backward compatibility
 Note that using networkx for rendering, attributes from the input networkx graph are retained when creating a Graphviz DOT visualization. As a result, it is possible to set node and edge properties such as color, line weight, as part of the input graph and have these reflected in the rendering. These include global properties of the graph, such as the `rankdir` used in rendering. See the [Graphviz documentation on attributes](https://graphviz.org/doc/info/attrs.html) for more information on what attributes are supported. The currently used Graphviz version is 2.44.0.
 
 The `source-file-name` attribute is particularly useful when working with static graphs that contain special characters like angle brackets (`<>`), which are used in [record-based nodes](https://graphviz.org/doc/info/shapes.html#record) but can interfere with HTML parsing. By placing the graph content in an external file, you can avoid the need to escape these characters.
+
+## Accessibility
+
+A `pl-graph` renders as an SVG. Graphviz adds a `<title>` to every node and edge, but those are hover tooltips, not a description of the graph as a whole, so a screen reader user gets no meaningful information by default. How you provide an accessible equivalent depends on how the graph is used.
+
+### Informational graphs
+
+If the graph conveys information (rather than being the thing a student must interpret to answer), give it a text alternative with `aria-label`. When `aria-label` is set, the graph is exposed to assistive technologies as a single labeled image, which also hides Graphviz's per-node titles. Use `aria-description` for additional detail if needed, though the `aria-description` attribute has inconsistent screen reader support and requires `aria-label` to also be set.
+
+For a **static** graph, describe it directly:
+
+```html title="question.html"
+<pl-graph aria-label="Directed graph with an edge from A to B and from B to C">
+  digraph G { A -> B -> C }
+</pl-graph>
+```
+
+For a **randomly generated** graph, a fixed string like "a random graph" tells a screen reader user nothing about what was actually drawn. Generate the description from the same data so it always matches the graph:
+
+```python title="server.py"
+import prairielearn as pl
+import networkx as nx
+
+def generate(data):
+    graph = nx.gnm_random_graph(5, 6)
+    data["params"]["graph"] = pl.to_json(graph)
+
+    edges = ", ".join(f"{u} to {v}" for u, v in graph.edges())
+    data["params"]["graph_alt"] = (
+        f"Undirected graph with {graph.number_of_nodes()} nodes "
+        f"and {graph.number_of_edges()} edges: {edges}."
+    )
+```
+
+```html title="question.html"
+<pl-graph params-type="networkx" params-name="graph" aria-label="{{ params.graph_alt }}"></pl-graph>
+```
+
+### Presenting the same information in an accessible format
+
+Packing a large graph into a single `aria-label` string produces a long, unstructured announcement that is hard to navigate. Often the better option is to also present the data in a natively accessible format that every student benefits from — for example an adjacency matrix rendered with [`pl-matrix-latex`](pl-matrix-latex.md), or an edge table:
+
+```html title="question.html"
+<pl-graph
+  params-type="networkx"
+  params-name="graph"
+  aria-label="Undirected graph; its edges are listed in the table below"
+></pl-graph>
+
+<table>
+  <caption>
+    Edges of the graph above
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">From</th>
+      <th scope="col">To</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#params.edge_rows}}
+    <tr>
+      <td>{{from}}</td>
+      <td>{{to}}</td>
+    </tr>
+    {{/params.edge_rows}}
+  </tbody>
+</table>
+```
+
+### Graphs that are the question
+
+If a student must read the graph to answer (for example, "give the adjacency matrix of the graph below"), a descriptive `aria-label` is **not** appropriate. It appears in the page source, so it would reveal the answer, and no text alternative can convey the graph in a form the student is expected to reason about. Such a question is not accessible to screen reader users as-is; provide an [alternative version of the question](../question/accessibility.md) instead.
 
 ## Example implementations
 

--- a/docs/question/accessibility.md
+++ b/docs/question/accessibility.md
@@ -65,7 +65,7 @@ Most PrairieLearn elements are designed to meet these requirements by default. H
 
 !!! note "Alternative question formats"
 
-    Some elements that are inherently used for visual input, e.g. `<pl-drawing>` and `<pl-excalidraw>`, are currently not usable via keyboard navigation and screen readers. If you use these elements, consider providing an alternative question format for students who cannot use them, e.g. a freeform text input where they can describe the drawing or diagram.
+    Some elements that are inherently used for visual input, e.g. `<pl-drawing>`, `<pl-sketch>`, and `<pl-excalidraw>`, are currently not usable via keyboard navigation and screen readers. If you use these elements, consider providing an alternative question format for students who cannot use them, e.g. a freeform text input where they can describe the drawing or diagram.
 
 ## Understandable content
 

--- a/exampleCourse/questions/element/graph/question.html
+++ b/exampleCourse/questions/element/graph/question.html
@@ -175,3 +175,10 @@ data['params']['random-graph'] = pl.to_json(random_graph)
     </pl-question-panel>
     <pl-graph source-file-name="record-graph.dot"></pl-graph>
 </pl-card>
+
+<pl-card>
+    <pl-question-panel>
+        <p>Here's the same networkx graph made accessible to screen readers with <code>aria-label</code>. Because a static label can't describe a randomly-generated graph, its description is generated in <code>server.py</code> from the same data.</p>
+    </pl-question-panel>
+    <pl-graph params-type="networkx" params-name="random-graph" aria-label="{{ params.random_graph_alt }}"></pl-graph>
+</pl-card>

--- a/exampleCourse/questions/element/graph/question.html
+++ b/exampleCourse/questions/element/graph/question.html
@@ -124,6 +124,7 @@ data['params']['matrix'] = pl.to_json(mat)
         <p>Here's a graph created from a randomly-generated networkx graph.
             To specify the use of a networkx graph, set <code>params-type="networkx"</code>.
             The graph can be specified with <code>params-name</code>.
+            To make it accessible to screen readers, set <code>aria-label</code> to a description of the graph; since a static label can't describe a randomly-generated graph, that description is generated in <code>server.py</code> from the graph data.
         </p>
 
 <pl-code language="python">
@@ -133,12 +134,21 @@ for in_node, out_node, edge_data in random_graph.edges(data=True):
     edge_data['label'] = random.choice(string.ascii_lowercase)
 
 data['params']['random-graph'] = pl.to_json(random_graph)
+
+edges = ", ".join(
+    f"{in_node} to {out_node} (labeled {edge_data['label']})"
+    for in_node, out_node, edge_data in random_graph.edges(data=True)
+)
+data['params']['random_graph_alt'] = (
+    f"Undirected graph with {random_graph.number_of_nodes()} nodes "
+    f"and {random_graph.number_of_edges()} edges: {edges}."
+)
 </pl-code>
 <pl-code language="html">
-&lt;pl-graph params-type="networkx" params-name="random-graph"&gt;&lt;/pl-graph&gt;
+&lt;pl-graph params-type="networkx" params-name="random-graph" aria-label="&#123;{ params.random_graph_alt }}"&gt;&lt;/pl-graph&gt;
 </pl-code>
     </pl-question-panel>
-    <pl-graph params-type="networkx" params-name="random-graph"></pl-graph>
+    <pl-graph params-type="networkx" params-name="random-graph" aria-label="{{ params.random_graph_alt }}"></pl-graph>
 </pl-card>
 
 <pl-card>
@@ -174,11 +184,4 @@ data['params']['random-graph'] = pl.to_json(random_graph)
 
     </pl-question-panel>
     <pl-graph source-file-name="record-graph.dot"></pl-graph>
-</pl-card>
-
-<pl-card>
-    <pl-question-panel>
-        <p>Here's the same networkx graph made accessible to screen readers with <code>aria-label</code>. Because a static label can't describe a randomly-generated graph, its description is generated in <code>server.py</code> from the same data.</p>
-    </pl-question-panel>
-    <pl-graph params-type="networkx" params-name="random-graph" aria-label="{{ params.random_graph_alt }}"></pl-graph>
 </pl-card>

--- a/exampleCourse/questions/element/graph/server.py
+++ b/exampleCourse/questions/element/graph/server.py
@@ -35,6 +35,18 @@ def generate(data):
 
     data["params"]["random-graph"] = pl.to_json(random_graph)
 
+    # Text alternative for the graph, generated from the same data so it always
+    # matches what is drawn; a static label like "a random graph" would tell a
+    # screen reader user nothing about the actual edges.
+    edges = ", ".join(
+        f"{in_node} to {out_node} (labeled {edge_data['label']})"
+        for in_node, out_node, edge_data in random_graph.edges(data=True)
+    )
+    data["params"]["random_graph_alt"] = (
+        f"Undirected graph with {random_graph.number_of_nodes()} nodes "
+        f"and {random_graph.number_of_edges()} edges: {edges}."
+    )
+
     multigraph = nx.MultiDiGraph(
         [(1, 2), (2, 1), (1, 2), (1, 3), (3, 2), (2, 3)], rankdir="LR"
     )


### PR DESCRIPTION
# Description

`pl-graph` rendered raw inline SVG with no way to attach a text alternative, so screen reader users got only Graphviz's per-node titles rather than a description of the graph. This adds optional `aria-label`/`aria-description` attributes that expose the graph as a single labeled image (`role="img"`, which also hides the noisy per-node titles), gated on `aria-label` since `role="img"` requires an accessible name. It also documents `pl-graph` accessibility as a decision guide — static labels, descriptions generated in `server.py` for random graphs, presenting data in an accessible format, and the case where the graph _is_ the question (a descriptive label would leak the answer) — and adds accessibility notes for `pl-excalidraw` and `pl-sketch`. The `element/graph` example demonstrates generating a text alternative from the graph data.

- [x] I have disclosed the level of AI assistance used: majority of implementation, authored with Claude Code under direction and review.

# Testing

Added unit tests for the labeled-image rendering (including HTML-escaping of author input) and the `aria-description`-requires-`aria-label` validation. I also tested the updated example with VoiceOver in the browser. VoiceOver is unfortunately pretty bad at reading punctuation, but it's correctly identified as an image in the rotor, and the label is read.