### PR TITLE
Add allow-blank to pl-checkbox element schema

### DIFF
--- a/apps/prairielearn/elements/pl-checkbox/schemas/pl-checkbox.json
+++ b/apps/prairielearn/elements/pl-checkbox/schemas/pl-checkbox.json
@@ -2,6 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "allow-blank": {
+      "type": "string",
+      "format": "boolean"
+    },
     "answers-name": {
       "type": "string"
     },

--- a/apps/prairielearn/src/lib/element-schemas/elements/pl-checkbox.ts
+++ b/apps/prairielearn/src/lib/element-schemas/elements/pl-checkbox.ts
@@ -21,6 +21,7 @@ const plCheckboxAnswerAttributesSchema = z
 
 const plCheckboxAttributesSchema = z
   .object({
+    'allow-blank': booleanFormat().optional(),
     'answers-name': z.string(),
     'detailed-help-text': booleanFormat().optional(),
     display: z.enum(['block', 'inline']).optional(),


### PR DESCRIPTION
# Description

`pl-checkbox` accepts `allow-blank` at runtime (it's in `optional_attribs` and read via `get_boolean_attrib`), and the docs list it, but the schema module omitted it. Because the schema is `.strict()`, the HTML linter rejected `allow-blank="true"` as an unknown attribute.

This adds `'allow-blank': booleanFormat().optional()` to `pl-checkbox.ts` — matching the other input elements — and regenerates the on-disk schemas.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). — majority of implementation

# Testing

Ran the HTML linter on `<pl-checkbox answers-name="c" allow-blank="true">`: no errors now, while an unknown attribute still errors (strictness preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)