### PR TITLE
Fix redis error in log when generating ai question

### DIFF
--- a/apps/prairielearn/src/lib/redis-rate-limiter.ts
+++ b/apps/prairielearn/src/lib/redis-rate-limiter.ts
@@ -52,14 +52,23 @@ export class RedisRateLimiter {
     const prefixedKey = this.getKey(key);
 
     // We accept the possibility of a small amount of clock skew here.
-    // We use `NX` to avoid overwriting an existing TTL if one is already set.
     const ttl = this.options.intervalSeconds - ((Date.now() / 1000) % this.options.intervalSeconds);
 
-    await redis
-      .multi()
-      .incrbyfloat(prefixedKey, amount)
-      .expire(prefixedKey, Math.ceil(ttl), 'NX')
-      .exec();
+    // We only set the TTL when the key doesn't already have one, so we don't
+    // overwrite an existing expiry. This is done in a Lua script so the
+    // increment and conditional expiry are atomic. Note that we can't use
+    // `EXPIRE ... NX` here because that option requires Redis 7.0+, and the
+    // bundled Redis in our Docker image is Redis 6.
+    await redis.eval(
+      `redis.call('INCRBYFLOAT', KEYS[1], ARGV[1])
+       if redis.call('TTL', KEYS[1]) < 0 then
+         redis.call('EXPIRE', KEYS[1], ARGV[2])
+       end`,
+      1,
+      prefixedKey,
+      amount.toString(),
+      Math.ceil(ttl).toString(),
+    );
   }
 
   async close() {

--- a/apps/prairielearn/src/lib/redis-rate-limiter.ts
+++ b/apps/prairielearn/src/lib/redis-rate-limiter.ts
@@ -54,11 +54,7 @@ export class RedisRateLimiter {
     // We accept the possibility of a small amount of clock skew here.
     const ttl = this.options.intervalSeconds - ((Date.now() / 1000) % this.options.intervalSeconds);
 
-    // We only set the TTL when the key doesn't already have one, so we don't
-    // overwrite an existing expiry. This is done in a Lua script so the
-    // increment and conditional expiry are atomic. Note that we can't use
-    // `EXPIRE ... NX` here because that option requires Redis 7.0+, and the
-    // bundled Redis in our Docker image is Redis 6.
+    // Set TTL only if the key does not have an existing expiry
     await redis.eval(
       `redis.call('INCRBYFLOAT', KEYS[1], ARGV[1])
        if redis.call('TTL', KEYS[1]) < 0 then

--- a/apps/prairielearn/src/lib/redis-rate-limiter.ts
+++ b/apps/prairielearn/src/lib/redis-rate-limiter.ts
@@ -54,17 +54,7 @@ export class RedisRateLimiter {
     // We accept the possibility of a small amount of clock skew here.
     const ttl = this.options.intervalSeconds - ((Date.now() / 1000) % this.options.intervalSeconds);
 
-    // Set TTL only if the key does not have an existing expiry
-    await redis.eval(
-      `redis.call('INCRBYFLOAT', KEYS[1], ARGV[1])
-       if redis.call('TTL', KEYS[1]) < 0 then
-         redis.call('EXPIRE', KEYS[1], ARGV[2])
-       end`,
-      1,
-      prefixedKey,
-      amount.toString(),
-      Math.ceil(ttl).toString(),
-    );
+    await redis.multi().incrbyfloat(prefixedKey, amount).expire(prefixedKey, Math.ceil(ttl)).exec();
   }
 
   async close() {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Redis 6 which comes bundled with the docker image does not have support for `NX`
Overwriting the TTL (i.e. without NX) is harmless.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
Used for the first commit and which is later refactored by me.


# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

**before**

<img width="1049" height="118" alt="image" src="https://github.com/user-attachments/assets/44ec7bea-06ec-4ba8-8fef-4af65934b840" />

<img width="1020" height="150" alt="image" src="https://github.com/user-attachments/assets/6499edbd-34ee-4b02-99e3-fd3937d3e5fb" />

**after**

<img width="928" height="202" alt="image" src="https://github.com/user-attachments/assets/05594842-ab70-43fb-93e0-0614e33277b1" />

