### PR TITLE
Add `pl-order-blocks` to AI generation element list

### DIFF
--- a/docs/question/ai-generation.md
+++ b/docs/question/ai-generation.md
@@ -47,6 +47,7 @@ Input elements:
 - [`pl-integer-input`](../elements/pl-integer-input.md)
 - [`pl-multiple-choice`](../elements/pl-multiple-choice.md)
 - [`pl-number-input`](../elements/pl-number-input.md)
+- [`pl-order-blocks`](../elements/pl-order-blocks.md)
 - [`pl-string-input`](../elements/pl-string-input.md)
 - [`pl-symbolic-input`](../elements/pl-symbolic-input.md)
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

`pl-order-blocks` was missing for the ai input list

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
no ai used for this pr.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
