### PR TITLE
Replace rubric-points alert with table footer warning

### DIFF
--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -877,7 +877,7 @@ export function RubricSettings({
                         {maxPoints} points
                         {maxPointsShortfall > 0 && rubricItems.length > 0 && (
                           <span className="text-muted ms-2">
-                            <i className="fas fa-triangle-exclamation" aria-hidden="true" />{' '}
+                            <i className="bi bi-exclamation-triangle-fill" aria-hidden="true" />{' '}
                             {maxPointsShortfall} below maximum
                           </span>
                         )}
@@ -887,7 +887,7 @@ export function RubricSettings({
                         {minRubricScore} points
                         {minPointsShortfall > 0 && rubricItems.length > 0 && (
                           <span className="text-muted ms-2">
-                            <i className="fas fa-triangle-exclamation" aria-hidden="true" />{' '}
+                            <i className="bi bi-exclamation-triangle-fill" aria-hidden="true" />{' '}
                             {minPointsShortfall} above minimum
                           </span>
                         )}

--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -152,7 +152,7 @@ export function RubricSettings({
   const defaultMaxExtraPointsRef = useRef<number>(rubricData?.rubric.max_extra_points ?? 0);
   const defaultGraderGuidelinesRef = useRef<string>(rubricData?.rubric.grader_guidelines ?? '');
 
-  // Derived totals/warnings
+  // Derived totals
   const { totalPositive, totalNegative } = useMemo(() => {
     const [pos, neg] = rubricItems
       .map((item) => item.rubric_item.points ?? 0)
@@ -170,22 +170,9 @@ export function RubricSettings({
       : (assessmentQuestion.max_manual_points ?? 0)) + (maxExtraPoints ?? 0),
   );
 
-  const pointsWarnings: string[] = useMemo(() => {
-    const warnings: string[] = [];
-    // Don't alarm users on the empty state before they've added any items.
-    if (rubricItems.length === 0) return warnings;
-    if (totalPositive < maxPoints) {
-      warnings.push(
-        `Rubric item points reach at most ${totalPositive} points. ${roundPoints(
-          maxPoints - totalPositive,
-        )} left to reach maximum.`,
-      );
-    }
-    if (totalNegative > (minPoints ?? 0)) {
-      warnings.push(`Minimum grade from rubric item penalties is ${totalNegative} points.`);
-    }
-    return warnings;
-  }, [rubricItems.length, totalPositive, totalNegative, maxPoints, minPoints]);
+  const minRubricScore = roundPoints(minPoints ?? 0);
+  const maxPointsShortfall = roundPoints(maxPoints - totalPositive);
+  const minPointsShortfall = roundPoints(totalNegative - minRubricScore);
 
   const defaultRubricItems = defaultRubricItemsRef.current;
   const isDirty = run(() => {
@@ -881,17 +868,37 @@ export function RubricSettings({
                   </tr>
                 )}
               </tbody>
+              <tfoot className="table-light">
+                <tr>
+                  <td colSpan={7}>
+                    <div className="d-flex flex-wrap column-gap-4 row-gap-1 small">
+                      <span>
+                        <span className="fw-semibold">Max score from items:</span> {totalPositive} /{' '}
+                        {maxPoints} points
+                        {maxPointsShortfall > 0 && rubricItems.length > 0 && (
+                          <span className="text-muted ms-2">
+                            <i className="fas fa-triangle-exclamation" aria-hidden="true" />{' '}
+                            {maxPointsShortfall} below maximum
+                          </span>
+                        )}
+                      </span>
+                      <span>
+                        <span className="fw-semibold">Min score from items:</span> {totalNegative} /{' '}
+                        {minRubricScore} points
+                        {minPointsShortfall > 0 && rubricItems.length > 0 && (
+                          <span className="text-muted ms-2">
+                            <i className="fas fa-triangle-exclamation" aria-hidden="true" />{' '}
+                            {minPointsShortfall} above minimum
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tfoot>
             </table>
           </div>
 
-          {/* Warnings derive from state; no dismiss button (a previous
-              data-bs-dismiss made Bootstrap remove a React-owned node and
-              crashed the component on the next reconcile). */}
-          {pointsWarnings.map((warning) => (
-            <Alert key={warning} variant="warning">
-              {warning}
-            </Alert>
-          ))}
           <Alert
             show={showSavedNotification}
             variant="success"


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Replaced the alert with a table footer warning.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
Used for generating the html code change. It was later refactored manually.

closes https://github.com/PrairieLearn/PrairieLearn/issues/15009

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

**before**

<img width="1456" height="654" alt="image" src="https://github.com/user-attachments/assets/0c99e161-ee2d-4f86-8db7-a8e3af773af5" />


**after**

<img width="1088" height="604" alt="image" src="https://github.com/user-attachments/assets/40d77737-847b-4592-9a62-9a77113c10f7" />
