### PR TITLE
Change default for workspace autoscaling config

### DIFF
--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -426,7 +426,7 @@ export const ConfigSchema = z.object({
   workspaceMaxGradedFilesCount: z.number().default(100),
   /** Controls the maximum size of all graded files in bytes. */
   workspaceMaxGradedFilesSize: z.number().default(100 * 1024 * 1024),
-  workspaceAutoscalingEnabled: z.boolean().default(true),
+  workspaceAutoscalingEnabled: z.boolean().default(false),
 
   chunksS3Bucket: z.string().default('chunks'),
   /** Enables chunk generation. */

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -361,23 +361,24 @@ async function startup(workspace_id: string): Promise<void> {
   // already trying to assign this host to a workspace.
   if (!shouldAssignHost) return;
 
-  let workspace_host_id: string | null = null;
   let attempt = 0;
   while (true) {
     if (attempt > config.workspaceLaunchingRetryAttempts) {
       throw new Error('Time exceeded to deploy more computational resources');
     }
-    workspace_host_id = await assignHost(workspace_id);
-    if (workspace_host_id != null) {
-      break; // success, we got a host
+
+    if (await assignHost(workspace_id)) {
+      // Success, we got a host.
+      break;
     }
-    if (!config.workspaceAutoscalingEnabled || !config.workspaceLoadLaunchTemplateId) {
-      // in local development, when no autoscaler is configured
-      // to launch new hosts, none will become available after retrying
+
+    if (!config.workspaceAutoscalingEnabled) {
+      // If no autoscaler is running, there won't be any new hosts after retrying.
       throw new Error(
         'No workspace host is available. Ensure the workspace-host process is running ',
       );
     }
+
     const t = attempt * config.workspaceLaunchingRetryIntervalSec;
     await workspaceUtils.updateWorkspaceMessage(
       workspace_id,
@@ -386,6 +387,7 @@ async function startup(workspace_id: string): Promise<void> {
     await sleep(config.workspaceLaunchingRetryIntervalSec * 1000);
     attempt++;
   }
+
   await workspaceUtils.updateWorkspaceMessage(workspace_id, 'Sending launch command to host');
   await controlContainer(workspace_id, 'init', { useInitialZip });
 }

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -1088,7 +1088,7 @@
       "type": "number"
     },
     "workspaceAutoscalingEnabled": {
-      "default": true,
+      "default": false,
       "type": "boolean"
     },
     "chunksS3Bucket": {

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -1316,7 +1316,7 @@
       "type": "string"
     },
     "workspaceAutoscalingEnabled": {
-      "default": true,
+      "default": false,
       "type": "boolean"
     },
     "chunksS3Bucket": {


### PR DESCRIPTION
# Description

Improves on the changes from #15339. `workspaceAutoscalingEnabled` now defaults to `false`, and must be set appropriately on all hosts that (a) perform autoscaling or (b) serve traffic for the workspace shell page. This simplifies the conditional we use when deciding if we should show a message in the "no autoscaling" case.

In prod, the issue here manifested as the "No workspace host is available." message showing in production, when really it should have been the "Deploying more computational resources" message.

# Testing

Trivial change.
