### PR TITLE
Propagate PostgreSQL SSL config to host services

### DIFF
--- a/apps/grader-host/src/index.ts
+++ b/apps/grader-host/src/index.ts
@@ -83,6 +83,7 @@ async.series(
         password: config.postgresqlPassword ?? undefined,
         max: config.postgresqlPoolSize,
         idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
+        ssl: config.postgresqlSsl,
       };
 
       function idleErrorHandler(err: Error & { data?: { lastQuery?: string } }) {

--- a/apps/grader-host/src/lib/config.ts
+++ b/apps/grader-host/src/lib/config.ts
@@ -47,6 +47,30 @@ export const ConfigSchema = z.object({
   postgresqlPassword: z.string().nullable().default(null),
   postgresqlPoolSize: z.number().default(2),
   postgresqlIdleTimeoutMillis: z.number().default(30000),
+  postgresqlSsl: z
+    .union([
+      z.boolean(),
+      // A subset of the options that can be provided to the `TLSSocket` constructor.
+      // https://node-postgres.com/features/ssl
+      z
+        .object({
+          rejectUnauthorized: z.boolean().default(true),
+          ca: z
+            .string()
+            .nullish()
+            .transform((x) => x ?? undefined),
+          key: z
+            .string()
+            .nullish()
+            .transform((x) => x ?? undefined),
+          cert: z
+            .string()
+            .nullish()
+            .transform((x) => x ?? undefined),
+        })
+        .strict(),
+    ])
+    .default(false),
   autoScalingGroupName: z.string().nullable().default(null),
   // Will be automatically detected when running in EC2.
   instanceId: z.string().default('server'),

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -224,6 +224,7 @@ async
         password: config.postgresqlPassword ?? undefined,
         max: config.postgresqlPoolSize,
         idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
+        ssl: config.postgresqlSsl,
       };
       logger.verbose(
         `Connecting to database ${pgConfig.user}@${pgConfig.host}:${pgConfig.database}`,

--- a/apps/workspace-host/src/lib/config.ts
+++ b/apps/workspace-host/src/lib/config.ts
@@ -15,6 +15,30 @@ export const ConfigSchema = z.object({
   postgresqlHost: z.string().default('localhost'),
   postgresqlPoolSize: z.number().default(100),
   postgresqlIdleTimeoutMillis: z.number().default(30_000),
+  postgresqlSsl: z
+    .union([
+      z.boolean(),
+      // A subset of the options that can be provided to the `TLSSocket` constructor.
+      // https://node-postgres.com/features/ssl
+      z
+        .object({
+          rejectUnauthorized: z.boolean().default(true),
+          ca: z
+            .string()
+            .nullish()
+            .transform((x) => x ?? undefined),
+          key: z
+            .string()
+            .nullish()
+            .transform((x) => x ?? undefined),
+          cert: z
+            .string()
+            .nullish()
+            .transform((x) => x ?? undefined),
+        })
+        .strict(),
+    ])
+    .default(false),
   cacheType: z.enum(['none', 'redis', 'memory']).default('none'),
   cacheKeyPrefix: z.string().default('workspace-host-cache:'),
   redisUrl: z.string().default('redis://localhost:6379/'),

--- a/docs/assets/config-grader-host.schema.json
+++ b/docs/assets/config-grader-host.schema.json
@@ -154,6 +154,53 @@
       "default": 30000,
       "type": "number"
     },
+    "postgresqlSsl": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "rejectUnauthorized": {
+              "default": true,
+              "type": "boolean"
+            },
+            "ca": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "cert": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "autoScalingGroupName": {
       "default": null,
       "anyOf": [

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -154,6 +154,53 @@
       "default": 30000,
       "type": "number"
     },
+    "postgresqlSsl": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "rejectUnauthorized": {
+              "default": true,
+              "type": "boolean"
+            },
+            "ca": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "cert": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "autoScalingGroupName": {
       "default": null,
       "anyOf": [
@@ -342,53 +389,6 @@
     "startServer": {
       "default": true,
       "type": "boolean"
-    },
-    "postgresqlSsl": {
-      "anyOf": [
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "rejectUnauthorized": {
-              "default": true,
-              "type": "boolean"
-            },
-            "ca": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "key": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "cert": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
     },
     "namedLocksRenewIntervalMs": {
       "default": 60000,

--- a/docs/assets/config-workspace-host.schema.json
+++ b/docs/assets/config-workspace-host.schema.json
@@ -33,6 +33,53 @@
       "default": 30000,
       "type": "number"
     },
+    "postgresqlSsl": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "rejectUnauthorized": {
+              "default": true,
+              "type": "boolean"
+            },
+            "ca": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "key": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "cert": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "cacheType": {
       "default": "none",
       "type": "string",


### PR DESCRIPTION
# Description

Adds the existing `postgresqlSsl` config option to the grader-host and workspace-host schemas and passes it through to their Postgres pool config, matching `apps/prairielearn`.

This fixes host services ignoring SSL configuration loaded from JSON, Secrets Manager, or KMS when connecting to Postgres.

Regenerated the affected config JSON schemas so the docs assets reflect the new host-service config surface.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Generated schemas were checked with `make check-jsonschema`.
