### PR TITLE
Remove references to pl-github-link in example course

### DIFF
--- a/.htmlmustache.jsonc
+++ b/.htmlmustache.jsonc
@@ -424,9 +424,6 @@
       ]
     },
     {
-      "name": "pl-github-link"
-    },
-    {
       "name": "pl-drawing",
       "children": [
         {

--- a/apps/prairielearn/src/lib/htmlMustacheConfig.ts
+++ b/apps/prairielearn/src/lib/htmlMustacheConfig.ts
@@ -366,8 +366,6 @@ export const htmlMustacheConfig: Config = {
       name: 'pl-matrix-output',
       children: [{ name: 'variable' }],
     },
-    // TODO: This element no longer exists https://github.com/PrairieLearn/PrairieLearn/issues/14201
-    { name: 'pl-github-link' },
     // pl-drawing
     {
       name: 'pl-drawing',

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/1-Introduction/question.html
@@ -63,6 +63,5 @@ of this triangle?</p>
   {{! This is not part of the question, and is included for documentation purposes }}
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this example question includes the introduction of a concept with corresponding short quiz questions. Read more  <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/2-Derivative/question.html
@@ -53,6 +53,5 @@ to this question using the workspace below. Click the button to open a JupyterLa
   {{! This is not part of the question, and is included for documentation purposes }}
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this example question includes the introduction of a concept with corresponding short quiz questions. Read more  <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
+++ b/exampleCourse/questions/demo/annotated/LectureVelocity/4-KnowledgeTest/question.html
@@ -93,6 +93,5 @@ The <pl-multiple-choice display="dropdown" hide-letter-keys="true" answers-name=
   {{! This is not part of the question, and is included for documentation purposes }}
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this example summarizes the concepts introduced in the previous questions. Read more  <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/lecture/selfGuided/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Gambler/question.html
@@ -29,6 +29,5 @@
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of a question including JupyterLab for a collaborative learning activity.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-Intro/question.html
@@ -28,6 +28,5 @@
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of a question including JupyterLab for a collaborative learning activity.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/question.html
+++ b/exampleCourse/questions/demo/annotated/MarkovChainGroupActivity/MarkovChains-PageRank/question.html
@@ -26,6 +26,5 @@
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of a question including JupyterLab for a collaborative learning activity.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/groupWork/jupyter/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/engBeamStress/question.html
+++ b/exampleCourse/questions/demo/annotated/engBeamStress/question.html
@@ -58,6 +58,5 @@ For the beam designations indicated below, determine the maximum normal stress $
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>repeated variant</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/engCentroid/question.html
+++ b/exampleCourse/questions/demo/annotated/engCentroid/question.html
@@ -24,7 +24,3 @@
         </pl-controls-group>
     </pl-controls>
 </pl-drawing>
-
-<pl-question-panel>
-<pl-github-link></pl-github-link>
-</pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/engCircuit/question.html
+++ b/exampleCourse/questions/demo/annotated/engCircuit/question.html
@@ -24,6 +24,5 @@
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank" rel="noreferrer">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">retry attempts for partial credit.</a>
       </small>
-      <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/engMarkovBrewing/question.html
+++ b/exampleCourse/questions/demo/annotated/engMarkovBrewing/question.html
@@ -56,6 +56,5 @@
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>fixed variant</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/engVectorDrawing/question.html
+++ b/exampleCourse/questions/demo/annotated/engVectorDrawing/question.html
@@ -32,6 +32,5 @@
   <div class="alert alert-info p-2" role="alert">
       <small>Note: this is an example of <i>repeated variant</i> question.
         Read more <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">here</a>.</small>
-        <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/mathMatrixMult/question.html
+++ b/exampleCourse/questions/demo/annotated/mathMatrixMult/question.html
@@ -19,6 +19,5 @@ Find the product of these two matrices:
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank" rel="noreferrer">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">retry attempts for partial credit.</a>
       </small>
-      <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/mathMatrixMultT/question.html
+++ b/exampleCourse/questions/demo/annotated/mathMatrixMultT/question.html
@@ -26,6 +26,5 @@ What is the matrix ${\bf B} = {\bf A}{\bf A}^T$?
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank" rel="noreferrer">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">retry attempts for partial credit.</a>
       </small>
-      <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-even/question.html
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-even/question.html
@@ -14,8 +14,3 @@
   <pl-answer correct="false">7</pl-answer>
   <pl-answer correct="false">9</pl-answer>
 </pl-checkbox>
-
-
-<pl-question-panel>
-<pl-github-link></pl-github-link>
-</pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-odd/question.html
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-odd/question.html
@@ -14,7 +14,3 @@
   <pl-answer correct="true">7</pl-answer>
   <pl-answer correct="true">9</pl-answer>
 </pl-checkbox>
-
-<pl-question-panel>
-<pl-github-link></pl-github-link>
-</pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/mathNumbersConcept-prime/question.html
+++ b/exampleCourse/questions/demo/annotated/mathNumbersConcept-prime/question.html
@@ -21,7 +21,3 @@
   <pl-answer correct="false">16</pl-answer>
   <pl-answer correct="true">17</pl-answer>
 </pl-checkbox>
-
-<pl-question-panel>
-<pl-github-link></pl-github-link>
-</pl-question-panel>

--- a/exampleCourse/questions/demo/annotated/mathOuterProduct/question.html
+++ b/exampleCourse/questions/demo/annotated/mathOuterProduct/question.html
@@ -20,6 +20,5 @@ compute the outer product ${\bf w} = \textrm{a} {\bf u} \otimes \textrm{b} {\bf 
     <small>Note: this is an example of a question generator with randomized parameters, which is used to
        generate a <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/exam/instantFeedback/__docs/docs.md" target="_blank" rel="noreferrer">fixed question variant for an exam</a>. Students receive instant feedback and have <a href="https://github.com/PrairieLearn/PrairieLearn/blob/master/exampleCourse/courseInstances/SectionA/assessments/homework/template/__docs/docs.md" target="_blank" rel="noreferrer">retry attempts for partial credit.</a>
       </small>
-      <pl-github-link></pl-github-link>
   </div>
 </pl-question-panel>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #14201.

Several example course questions had a reference to the element pl-github-link, which was an old custom element in a previous demo course. When these questions were moved to the example course in #5080, the reference to the element remained, but the element was not copied over.

Given there is a link to the GitHub source in the question settings page, this element's use-case is no longer needed. Also, the fact that its missing rendering info went unnoticed for so long means it wasn't actually missed. Besides, the method used in the original element implementation (parsing the question path using undocumented assumptions about it) is not considered safe, and it is not transferable to a proper (non-example) course.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

The mustache linter is able to catch these cases, so removing the element from the allowed elements list caught warnings before the change, and no warnings after.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
