### PR TITLE
Fix type of variant_seed in QuestionData class

### DIFF
--- a/apps/prairielearn/python/prairielearn/question_utils.py
+++ b/apps/prairielearn/python/prairielearn/question_utils.py
@@ -85,7 +85,7 @@ class QuestionData(TypedDict):
     feedback: dict[str, Any]
     """Any feedback to the student on their submitted answer. Elements will never read or write to this dictionary, with the exception of the `<pl-external-grader-results>` element."""
 
-    variant_seed: str
+    variant_seed: int
     """The random seed for this question variant."""
 
     options: dict[str, Any]

--- a/apps/prairielearn/python/test/conftest.py
+++ b/apps/prairielearn/python/test/conftest.py
@@ -14,7 +14,7 @@ def question_data() -> QuestionData:
         "partial_scores": {},
         "score": 0.0,
         "feedback": {},
-        "variant_seed": "",
+        "variant_seed": 0,
         "options": {},
         "raw_submitted_answers": {},
         "editable": False,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

The type annotation for the `variant_seed` property of `QuestionData` was incorrectly set to a string, even though the value is an integer, as evident in:

https://github.com/PrairieLearn/PrairieLearn/blob/90be5c9b20dbf809a5229122de4eb8efdc4c74d4/apps/prairielearn/python/prairielearn/internal/check_data.py#L35-L39
https://github.com/PrairieLearn/PrairieLearn/blob/90be5c9b20dbf809a5229122de4eb8efdc4c74d4/apps/prairielearn/src/question-servers/freeform.ts#L840-L850
and other similar calls in freeform. Note that the `variant_seed` column in the `variants` table is stored as string, but the value is converted to an integer before the python code is called.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Relying on CI.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
