### PR TITLE
Replace bundled Redis with Valkey

### DIFF
--- a/docs/dev-guide/installingNative.md
+++ b/docs/dev-guide/installingNative.md
@@ -10,7 +10,7 @@ This page describes the procedure to install and run PrairieLearn fully natively
   - [pnpm](https://pnpm.io)
   - [uv](https://docs.astral.sh/uv/) (Python version manager and package installer)
   - [PostgreSQL 17](https://www.postgresql.org)
-  - [Redis 6](https://redis.io)
+  - [Redis 7](https://redis.io) or [Valkey](https://valkey.io)
   - [Graphviz](https://graphviz.org)
   - [d2](https://d2lang.com)
   - [pgvector](https://github.com/pgvector/pgvector)

--- a/scripts/pl-install.sh
+++ b/scripts/pl-install.sh
@@ -28,16 +28,16 @@ dnf -y install \
     postgresql17-server \
     postgresql17-contrib \
     procps-ng \
-    redis6 \
+    valkey \
     tar \
     texlive \
     texlive-dvipng \
     texlive-type1cm \
     tmux
 
-# Redis 7 isn't available on Amazon Linux 2023. Symlink the versioned
-# executables to make them work with scripts that expect unversioned ones.
-ln -s /usr/bin/redis6-cli /usr/bin/redis-cli && ln -s /usr/bin/redis6-server /usr/bin/redis-server
+# Valkey uses different executable names than Redis. Symlink them to the names
+# expected by the existing startup scripts.
+ln -s /usr/bin/valkey-cli /usr/bin/redis-cli && ln -s /usr/bin/valkey-server /usr/bin/redis-server
 
 echo "installing node via nvm"
 git clone https://github.com/creationix/nvm.git /nvm


### PR DESCRIPTION
# Description

Replace the Redis 6 package in the Amazon Linux 2023 image with Amazon's native Valkey package, while preserving the `redis-server` and `redis-cli` names expected by existing startup scripts. Update native-development prerequisites to require Redis 7 or Valkey.

The Redis-backed rate limiter uses `EXPIRE ... NX`, which Redis 6 rejects while queuing the `MULTI` transaction and consequently aborts the increment. Valkey provides the Redis 7-compatible command surface, avoids a source build or unsupported package repository, and is already used by PrairieLearn's production non-volatile cache.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance was used for implementation, compatibility research, and validation.

# Testing

Installed the Amazon Linux Valkey package in a disposable PrairieLearn container, verified that the existing startup script worked through the compatibility symlinks, and exercised the rate limiter's `MULTI`/`INCRBYFLOAT`/`EXPIRE NX` sequence successfully.
