### PR TITLE
Fix course request contact email handling

### DIFF
--- a/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
+++ b/apps/prairielearn/src/components/AdminstratorCourseFormFields.tsx
@@ -67,7 +67,8 @@ export function AdministratorCourseFormFields({
   availableTimezones,
   coursesRoot,
   prefixState,
-  emailDomain,
+  contactEmailDomain,
+  accountUidDomain,
   aiSecretsConfigured,
   autoFilledInstitutionId,
   repositoryRequired,
@@ -77,7 +78,8 @@ export function AdministratorCourseFormFields({
   availableTimezones: Timezone[];
   coursesRoot: string;
   prefixState: InstitutionPrefixState;
-  emailDomain?: string;
+  contactEmailDomain?: string;
+  accountUidDomain?: string;
   aiSecretsConfigured: boolean;
   autoFilledInstitutionId?: string | null;
   repositoryRequired: boolean;
@@ -124,7 +126,8 @@ export function AdministratorCourseFormFields({
     ...trpc.courseRequests.suggestInstitutionPrefix.queryOptions({
       institutionLongName,
       institutionShortName,
-      emailDomain: emailDomain ?? '',
+      contactEmailDomain: contactEmailDomain ?? '',
+      accountUidDomain: accountUidDomain ?? '',
     }),
     enabled: false,
   });

--- a/apps/prairielearn/src/lib/course-request-ai.ts
+++ b/apps/prairielearn/src/lib/course-request-ai.ts
@@ -93,17 +93,17 @@ export async function checkInstructorLegitimacy({
         'You are helping a PrairieLearn administrator vet a course creation request.',
         'Search the web to determine whether the person described by the user is a legitimate academic instructor or researcher at their stated institution.',
         'Use sources like faculty pages, staff directories, university websites, or professional profiles (e.g. LinkedIn, Google Scholar).',
-        'The user provides both the name entered on the course request form and the name on their PrairieLearn account. If the PrairieLearn account name or email differs significantly from the submitted name and work email, lower your confidence accordingly and treat it as a reason to doubt the request.',
+        'The user provides both the requester name and contact email and the name and UID on their PrairieLearn account. If these identities differ significantly, lower your confidence accordingly and treat it as a reason to doubt the request.',
       ]),
     },
     {
       role: 'user',
       content: formatPrompt([
         `Name (from form): ${instructorFirstName ?? 'Unknown'} ${instructorLastName ?? 'Unknown'}`,
-        `Work email (from form): ${instructorEmail ?? 'Unknown'}`,
+        `Requester / contact email: ${instructorEmail ?? 'Unknown'}`,
         `Institution (from form): ${institution ?? 'Unknown'}`,
         `PrairieLearn account name: ${userDisplayName ?? 'Unknown'}`,
-        `PrairieLearn account email/uid: ${userUid}`,
+        `PrairieLearn account (UID): ${userUid}`,
       ]),
     },
   ];

--- a/apps/prairielearn/src/lib/course-request-ai.ts
+++ b/apps/prairielearn/src/lib/course-request-ai.ts
@@ -167,11 +167,13 @@ export async function suggestTimezone({
 export async function suggestInstitutionPrefix({
   institutionLongName,
   institutionShortName,
-  emailDomain,
+  contactEmailDomain,
+  accountUidDomain,
 }: {
   institutionLongName: string;
   institutionShortName: string;
-  emailDomain: string;
+  contactEmailDomain: string;
+  accountUidDomain: string;
 }): Promise<PrefixResult> {
   const openai = createCourseRequestAiClient();
 
@@ -183,7 +185,8 @@ export async function suggestInstitutionPrefix({
         'Repository names follow the pattern "pl-{institution-prefix}-{course-name}". Your job is to determine the correct institution prefix.',
         'Identify the institution as a whole, NOT a department. For example, if the domain is "cs.illinois.edu", the prefix is "uiuc" (not "cs").',
         'Derive the prefix from the institution\'s primary domain name. For example, "berkeley.edu" gives "berkeley", "ubc.ca" gives "ubc".',
-        "Search the web to find the institution's primary domain if it is not obvious from the email domain.",
+        'The contact email and PrairieLearn account UID domains are supporting hints. The contact email may be self-reported, while the UID domain may identify an institution without being a routable email address.',
+        "Search the web to find the institution's primary domain if it is not obvious from the provided domains.",
         'You MUST always return a non-empty prefix. If the domain or institution is unfamiliar, derive the best short prefix you can from the available information (e.g. the domain name itself). Never refuse or return an empty prefix.',
       ]),
     },
@@ -192,7 +195,8 @@ export async function suggestInstitutionPrefix({
       content: formatPrompt([
         `Institution name: ${institutionLongName}`,
         `Institution short name: ${institutionShortName}`,
-        `Email domain: ${emailDomain}`,
+        `Contact email domain: ${contactEmailDomain || 'Unknown'}`,
+        `PrairieLearn account UID domain: ${accountUidDomain || 'Unknown'}`,
       ]),
     },
   ];

--- a/apps/prairielearn/src/lib/course-request.sql
+++ b/apps/prairielearn/src/lib/course-request.sql
@@ -41,6 +41,10 @@ SELECT
   r.last_name,
   r.note,
   r.work_email,
+  CASE
+    WHEN r.work_email = u.uid THEN u.email
+    ELSE r.work_email
+  END AS contact_email,
   r.institution,
   r.referral_source,
   r.approved_status,
@@ -168,6 +172,10 @@ SELECT
   r.last_name,
   r.note,
   r.work_email,
+  CASE
+    WHEN r.work_email = u.uid THEN u.email
+    ELSE r.work_email
+  END AS contact_email,
   r.institution,
   r.referral_source,
   r.approved_status,

--- a/apps/prairielearn/src/lib/course-request.sql
+++ b/apps/prairielearn/src/lib/course-request.sql
@@ -41,8 +41,11 @@ SELECT
   r.last_name,
   r.note,
   r.work_email,
+  -- Older non-default-institution requests copied the user's UID into work_email.
+  -- Prefer the account email for those rows, but retain the UID as a best-effort
+  -- contact when no account email is available.
   CASE
-    WHEN r.work_email = u.uid THEN u.email
+    WHEN r.work_email = u.uid THEN coalesce(nullif(u.email, ''), r.work_email)
     ELSE r.work_email
   END AS contact_email,
   r.institution,
@@ -172,8 +175,11 @@ SELECT
   r.last_name,
   r.note,
   r.work_email,
+  -- Older non-default-institution requests copied the user's UID into work_email.
+  -- Prefer the account email for those rows, but retain the UID as a best-effort
+  -- contact when no account email is available.
   CASE
-    WHEN r.work_email = u.uid THEN u.email
+    WHEN r.work_email = u.uid THEN coalesce(nullif(u.email, ''), r.work_email)
     ELSE r.work_email
   END AS contact_email,
   r.institution,

--- a/apps/prairielearn/src/lib/course-request.sql
+++ b/apps/prairielearn/src/lib/course-request.sql
@@ -41,10 +41,13 @@ SELECT
   r.last_name,
   r.note,
   r.work_email,
-  -- Older non-default-institution requests copied the user's UID into work_email.
-  -- Prefer the account email for those rows, but retain the UID as a best-effort
+  -- A missing work_email may mean that the auth provider had no email when the
+  -- request was created. Use a current account email if one is now available.
+  -- Older non-default-institution requests copied the user's UID into work_email;
+  -- prefer the account email for those rows, but retain the UID as a best-effort
   -- contact when no account email is available.
   CASE
+    WHEN nullif(r.work_email, '') IS NULL THEN nullif(u.email, '')
     WHEN r.work_email = u.uid THEN coalesce(nullif(u.email, ''), r.work_email)
     ELSE r.work_email
   END AS contact_email,
@@ -175,10 +178,13 @@ SELECT
   r.last_name,
   r.note,
   r.work_email,
-  -- Older non-default-institution requests copied the user's UID into work_email.
-  -- Prefer the account email for those rows, but retain the UID as a best-effort
+  -- A missing work_email may mean that the auth provider had no email when the
+  -- request was created. Use a current account email if one is now available.
+  -- Older non-default-institution requests copied the user's UID into work_email;
+  -- prefer the account email for those rows, but retain the UID as a best-effort
   -- contact when no account email is available.
   CASE
+    WHEN nullif(r.work_email, '') IS NULL THEN nullif(u.email, '')
     WHEN r.work_email = u.uid THEN coalesce(nullif(u.email, ''), r.work_email)
     ELSE r.work_email
   END AS contact_email,

--- a/apps/prairielearn/src/lib/course-request.ts
+++ b/apps/prairielearn/src/lib/course-request.ts
@@ -51,18 +51,6 @@ const CourseRequestRowSchema = z.object({
 });
 export type CourseRequestRow = z.infer<typeof CourseRequestRowSchema>;
 
-export function getNewCourseRequestContactEmail({
-  isDefaultInstitution,
-  submittedEmail,
-  accountEmail,
-}: {
-  isDefaultInstitution: boolean;
-  submittedEmail: string;
-  accountEmail: string | null;
-}) {
-  return isDefaultInstitution ? submittedEmail : accountEmail;
-}
-
 async function selectCourseRequests(show_all: boolean) {
   return await queryRows(sql.select_course_requests, { show_all }, CourseRequestRowSchema);
 }

--- a/apps/prairielearn/src/lib/course-request.ts
+++ b/apps/prairielearn/src/lib/course-request.ts
@@ -32,7 +32,6 @@ const JobsRowSchema = z.object({
 const CourseRequestRowSchema = z.object({
   approved_by_name: z.string().nullable(),
   approved_status: z.enum(['pending', 'approved', 'denied', 'creating', 'failed']),
-  contact_email: z.string().nullable(),
   created_at: DateFromISOString,
   first_name: z.string().nullable(),
   github_user: z.string().nullable(),
@@ -48,6 +47,7 @@ const CourseRequestRowSchema = z.object({
   user_name: z.string().nullable(),
   user_uid: z.string(),
   work_email: z.string().nullable(),
+  contact_email: z.string().nullable(),
 });
 export type CourseRequestRow = z.infer<typeof CourseRequestRowSchema>;
 

--- a/apps/prairielearn/src/lib/course-request.ts
+++ b/apps/prairielearn/src/lib/course-request.ts
@@ -32,6 +32,7 @@ const JobsRowSchema = z.object({
 const CourseRequestRowSchema = z.object({
   approved_by_name: z.string().nullable(),
   approved_status: z.enum(['pending', 'approved', 'denied', 'creating', 'failed']),
+  contact_email: z.string().nullable(),
   created_at: DateFromISOString,
   first_name: z.string().nullable(),
   github_user: z.string().nullable(),
@@ -49,6 +50,18 @@ const CourseRequestRowSchema = z.object({
   work_email: z.string().nullable(),
 });
 export type CourseRequestRow = z.infer<typeof CourseRequestRowSchema>;
+
+export function getNewCourseRequestContactEmail({
+  isDefaultInstitution,
+  submittedEmail,
+  accountEmail,
+}: {
+  isDefaultInstitution: boolean;
+  submittedEmail: string;
+  accountEmail: string | null;
+}) {
+  return isDefaultInstitution ? submittedEmail : accountEmail;
+}
 
 async function selectCourseRequests(show_all: boolean) {
   return await queryRows(sql.select_course_requests, { show_all }, CourseRequestRowSchema);

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -78,8 +78,8 @@ export function CourseRequestsTable({
               <th>Created At</th>
               <th>Short Name / Title</th>
               <th>Institution</th>
-              <th>Requested By</th>
-              <th>PrairieLearn User</th>
+              <th>Requester / contact email</th>
+              <th>PrairieLearn account (UID)</th>
               <th>GitHub Username</th>
               <th>Referral Source</th>
               <th>Status</th>
@@ -120,6 +120,36 @@ export function CourseRequestsTable({
 
 CourseRequestsTable.displayName = 'CourseRequestsTable';
 
+function RequesterContact({ request }: { request: CourseRequestRow }) {
+  const requesterName = [request.first_name, request.last_name].filter(Boolean).join(' ');
+
+  return (
+    <>
+      {requesterName && <div>{requesterName}</div>}
+      {request.contact_email ? (
+        request.contact_email === request.user_uid ? (
+          <span className="text-muted">Contact email is the account UID</span>
+        ) : (
+          <span>{request.contact_email}</span>
+        )
+      ) : (
+        <span className="text-muted fst-italic">Contact email unavailable</span>
+      )}
+    </>
+  );
+}
+
+function AccountIdentity({ request }: { request: CourseRequestRow }) {
+  const requesterName = [request.first_name, request.last_name].filter(Boolean).join(' ');
+
+  return (
+    <>
+      {request.user_name && request.user_name !== requesterName && <div>{request.user_name}</div>}
+      <span>{request.user_uid}</span>
+    </>
+  );
+}
+
 const CourseRequestTableRow = memo(
   ({
     row,
@@ -145,16 +175,10 @@ const CourseRequestTableRow = memo(
             <EmptyState value={row.institution} label="No institution" />
           </td>
           <td className="align-middle">
-            {row.first_name || row.last_name ? (
-              <>
-                {row.first_name} {row.last_name} {row.work_email ? `(${row.work_email})` : ''}
-              </>
-            ) : (
-              <span className="text-muted fst-italic">No contact info</span>
-            )}
+            <RequesterContact request={row} />
           </td>
           <td className="align-middle">
-            {row.user_name} ({row.user_uid})
+            <AccountIdentity request={row} />
           </td>
           <td className="align-middle">
             <EmptyState value={row.github_user} label="No GitHub user" />
@@ -466,27 +490,10 @@ function CourseRequestApproveModalContent({
             <div className="card-body py-2">
               <div className="row g-2 small">
                 <div className="col-12">
-                  <strong>Requested by:</strong>{' '}
-                  {request.first_name || request.last_name ? (
-                    <span>
-                      {request.first_name} {request.last_name}
-                      {request.work_email && ` (${request.work_email})`}
-                    </span>
-                  ) : request.work_email ? (
-                    <span>{request.work_email}</span>
-                  ) : (
-                    <span className="fst-italic text-muted">Not provided</span>
-                  )}
+                  <strong>Requester / contact email:</strong> <RequesterContact request={request} />
                 </div>
                 <div className="col-12">
-                  <strong>PrairieLearn user:</strong>{' '}
-                  {request.user_name ? (
-                    <span>
-                      {request.user_name} ({request.user_uid})
-                    </span>
-                  ) : (
-                    <span>{request.user_uid}</span>
-                  )}
+                  <strong>PrairieLearn account (UID):</strong> <AccountIdentity request={request} />
                 </div>
                 <div className="col-12">
                   <strong>Institution:</strong>{' '}
@@ -572,7 +579,7 @@ function CourseRequestApproveModalContent({
             availableTimezones={availableTimezones}
             coursesRoot={coursesRoot}
             prefixState={prefixState}
-            emailDomain={request.work_email?.split('@')[1] ?? ''}
+            emailDomain={request.contact_email?.split('@')[1] ?? ''}
             aiSecretsConfigured={aiSecretsConfigured}
             autoFilledInstitutionId={autoFilledInstitutionId}
             repositoryRequired={true}

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -579,7 +579,8 @@ function CourseRequestApproveModalContent({
             availableTimezones={availableTimezones}
             coursesRoot={coursesRoot}
             prefixState={prefixState}
-            emailDomain={request.contact_email?.split('@')[1] ?? ''}
+            contactEmailDomain={request.contact_email?.split('@')[1] ?? ''}
+            accountUidDomain={request.user_uid.split('@')[1] ?? ''}
             aiSecretsConfigured={aiSecretsConfigured}
             autoFilledInstitutionId={autoFilledInstitutionId}
             repositoryRequired={true}

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.html.ts
@@ -65,7 +65,7 @@ export function RequestCourse({
             resLocals.authn_institution.short_name === DEFAULT_INSTITUTION_SHORT_NAME,
           institutionName: resLocals.authn_institution.long_name,
           institutionMessageHtml,
-          userEmail: resLocals.authn_user.uid,
+          userEmail: resLocals.authn_user.email,
         })}
       </div>
     `,
@@ -158,7 +158,7 @@ function CourseNewRequestForm({
   isDefaultInstitution: boolean;
   institutionName: string;
   institutionMessageHtml: string;
-  userEmail: string;
+  userEmail: string | null;
 }): HtmlValue {
   return html`
     <form class="question-form" name="course-request" method="POST">
@@ -270,7 +270,7 @@ function CourseNewRequestForm({
                   name="cr-email"
                   id="cr-email"
                   disabled
-                  value="${userEmail}"
+                  value="${userEmail ?? 'Unavailable'}"
                 />
                 <small class="form-text text-muted">
                   This is determined by your sign-in account.

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
@@ -8,7 +8,7 @@ import { loadSqlEquiv, queryRows, queryScalar } from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 
 import { Lti13Claim } from '../../ee/lib/lti13.js';
-import { getNewCourseRequestContactEmail, insertCourseRequest } from '../../lib/course-request.js';
+import { insertCourseRequest } from '../../lib/course-request.js';
 import {
   GITHUB_USERNAME_VALIDATION_MESSAGE,
   isValidGithubUsername,
@@ -115,11 +115,11 @@ router.post(
     const institution = isDefaultInstitution
       ? req.body['cr-institution'] || ''
       : res.locals.authn_institution.long_name;
-    const work_email = getNewCourseRequestContactEmail({
-      isDefaultInstitution,
-      submittedEmail: req.body['cr-email'] || '',
-      accountEmail: res.locals.authn_user.email,
-    });
+    // Default-institution users explicitly provide a contact email. For institutional users,
+    // use the email supplied by their authentication provider; their UID may not be routable.
+    const work_email = isDefaultInstitution
+      ? req.body['cr-email'] || ''
+      : res.locals.authn_user.email;
 
     let error = false;
 

--- a/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
+++ b/apps/prairielearn/src/pages/instructorRequestCourse/instructorRequestCourse.ts
@@ -8,7 +8,7 @@ import { loadSqlEquiv, queryRows, queryScalar } from '@prairielearn/postgres';
 import * as Sentry from '@prairielearn/sentry';
 
 import { Lti13Claim } from '../../ee/lib/lti13.js';
-import { insertCourseRequest } from '../../lib/course-request.js';
+import { getNewCourseRequestContactEmail, insertCourseRequest } from '../../lib/course-request.js';
 import {
   GITHUB_USERNAME_VALIDATION_MESSAGE,
   isValidGithubUsername,
@@ -115,9 +115,11 @@ router.post(
     const institution = isDefaultInstitution
       ? req.body['cr-institution'] || ''
       : res.locals.authn_institution.long_name;
-    const work_email = isDefaultInstitution
-      ? req.body['cr-email'] || ''
-      : res.locals.authn_user.uid;
+    const work_email = getNewCourseRequestContactEmail({
+      isDefaultInstitution,
+      submittedEmail: req.body['cr-email'] || '',
+      accountEmail: res.locals.authn_user.email,
+    });
 
     let error = false;
 
@@ -149,7 +151,7 @@ router.post(
       error = true;
     }
 
-    if (isDefaultInstitution && work_email.length === 0) {
+    if (isDefaultInstitution && work_email?.length === 0) {
       flash('error', 'The work email should not be empty.');
       error = true;
     }
@@ -226,7 +228,7 @@ router.post(
           `Course rubric: ${short_name}\n` +
           `Course title: ${title}\n` +
           `Institution: ${institution}\n` +
-          `Requested by: ${first_name} ${last_name} (${work_email})\n` +
+          `Requested by: ${first_name} ${last_name} (${work_email ?? 'email unavailable'})\n` +
           `Logged in as: ${res.locals.authn_user.name} (${res.locals.authn_user.uid})\n` +
           `GitHub username: ${github_user || 'not provided'}`,
       );

--- a/apps/prairielearn/src/tests/courseRequest.test.ts
+++ b/apps/prairielearn/src/tests/courseRequest.test.ts
@@ -3,17 +3,11 @@ import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
-import {
-  getNewCourseRequestContactEmail,
-  insertCourseRequest,
-  selectAllCourseRequests,
-  selectCourseRequestById,
-} from '../lib/course-request.js';
+import { insertCourseRequest, selectAllCourseRequests } from '../lib/course-request.js';
 import { createAdministratorTrpcClient } from '../trpc/administrator/client.js';
 
 import * as helperClient from './helperClient.js';
 import * as helperServer from './helperServer.js';
-import { getOrCreateUser } from './utils/auth.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
 const baseUrl = `${siteUrl}/pl`;
@@ -39,159 +33,6 @@ describe('Course requests', { timeout: 60_000, concurrent: false }, function () 
   let courseRequestId: string;
   const shortName = 'TEST 101';
   const title = 'Course Request Test Course';
-
-  describe('new request contact email', () => {
-    test('uses the explicitly submitted email for the default institution', () => {
-      assert.equal(
-        getNewCourseRequestContactEmail({
-          isDefaultInstitution: true,
-          submittedEmail: 'explicit@example.edu',
-          accountEmail: 'account@example.edu',
-        }),
-        'explicit@example.edu',
-      );
-    });
-
-    test('uses the account email for a non-default institution', () => {
-      assert.equal(
-        getNewCourseRequestContactEmail({
-          isDefaultInstitution: false,
-          submittedEmail: 'ignored@example.edu',
-          accountEmail: 'account@example.edu',
-        }),
-        'account@example.edu',
-      );
-    });
-
-    test('does not substitute the UID when the account email is missing', () => {
-      assert.isNull(
-        getNewCourseRequestContactEmail({
-          isDefaultInstitution: false,
-          submittedEmail: '',
-          accountEmail: null,
-        }),
-      );
-    });
-  });
-
-  describe('admin requester identities', () => {
-    const explicitShortName = 'CONTACT 101';
-    const legacyShortName = 'CONTACT 102';
-    const missingShortName = 'CONTACT 103';
-
-    test('derives contact email without conflating it with the account UID', async () => {
-      const explicitUser = await getOrCreateUser({
-        uid: 'explicit-login-id',
-        name: 'Explicit Account Name',
-        uin: null,
-        email: 'account-address@example.edu',
-      });
-      const legacyUser = await getOrCreateUser({
-        uid: 'legacy.uid@identity.example',
-        name: 'Legacy Account Name',
-        uin: null,
-        email: 'legacy-contact@example.edu',
-      });
-      const missingEmailUser = await getOrCreateUser({
-        uid: 'missing-email-login-id',
-        name: 'Missing Email Account',
-        uin: null,
-        email: null,
-      });
-
-      const explicitRequestId = await insertCourseRequest({
-        short_name: explicitShortName,
-        title: 'Explicit contact email',
-        user_id: explicitUser.id,
-        github_user: null,
-        first_name: 'Explicit',
-        last_name: 'Requester',
-        work_email: 'explicit-contact@example.edu',
-        institution: 'Test Institution',
-        referral_source: null,
-      });
-      const legacyRequestId = await insertCourseRequest({
-        short_name: legacyShortName,
-        title: 'Legacy UID copy',
-        user_id: legacyUser.id,
-        github_user: null,
-        first_name: 'Legacy',
-        last_name: 'Requester',
-        work_email: legacyUser.uid,
-        institution: 'Test Institution',
-        referral_source: null,
-      });
-      const missingRequestId = await insertCourseRequest({
-        short_name: missingShortName,
-        title: 'Missing account email',
-        user_id: missingEmailUser.id,
-        github_user: null,
-        first_name: 'Missing',
-        last_name: 'Requester',
-        work_email: missingEmailUser.uid,
-        institution: 'Test Institution',
-        referral_source: null,
-      });
-
-      const requests = await selectAllCourseRequests();
-      const explicitRequest = requests.find((request) => request.id === explicitRequestId);
-      const legacyRequest = requests.find((request) => request.id === legacyRequestId);
-      const missingRequest = requests.find((request) => request.id === missingRequestId);
-
-      assert.isDefined(explicitRequest);
-      assert.equal(explicitRequest.work_email, 'explicit-contact@example.edu');
-      assert.equal(explicitRequest.contact_email, 'explicit-contact@example.edu');
-      assert.equal(explicitRequest.user_uid, explicitUser.uid);
-
-      assert.isDefined(legacyRequest);
-      assert.equal(legacyRequest.work_email, legacyUser.uid);
-      assert.equal(legacyRequest.contact_email, legacyUser.email);
-      assert.equal(legacyRequest.user_uid, legacyUser.uid);
-
-      const legacyRequestForLegitimacyCheck = await selectCourseRequestById({
-        courseRequestId: legacyRequestId,
-      });
-      assert.equal(legacyRequestForLegitimacyCheck.contact_email, legacyUser.email);
-      assert.equal(legacyRequestForLegitimacyCheck.user_uid, legacyUser.uid);
-
-      assert.isDefined(missingRequest);
-      assert.equal(missingRequest.work_email, missingEmailUser.uid);
-      assert.isNull(missingRequest.contact_email);
-      assert.equal(missingRequest.user_uid, missingEmailUser.uid);
-    });
-
-    test('renders distinct requester contact and account UID columns', async () => {
-      const response = await helperClient.fetchCheerio(courseRequestsAdminUrl);
-      assert.isTrue(response.ok);
-
-      const headerTexts = response
-        .$('th')
-        .toArray()
-        .map((header) => response.$(header).text());
-      assert.include(headerTexts, 'Requester / contact email');
-      assert.include(headerTexts, 'PrairieLearn account (UID)');
-
-      const explicitCells = response
-        .$(`td:contains("${explicitShortName}")`)
-        .closest('tr')
-        .find('td');
-      assert.include(explicitCells.eq(3).text(), 'explicit-contact@example.edu');
-      assert.notInclude(explicitCells.eq(3).text(), 'explicit-login-id');
-      assert.include(explicitCells.eq(4).text(), 'explicit-login-id');
-
-      const legacyCells = response.$(`td:contains("${legacyShortName}")`).closest('tr').find('td');
-      assert.include(legacyCells.eq(3).text(), 'legacy-contact@example.edu');
-      assert.notInclude(legacyCells.eq(3).text(), 'legacy.uid@identity.example');
-      assert.include(legacyCells.eq(4).text(), 'legacy.uid@identity.example');
-
-      const missingCells = response
-        .$(`td:contains("${missingShortName}")`)
-        .closest('tr')
-        .find('td');
-      assert.include(missingCells.eq(3).text(), 'Contact email unavailable');
-      assert.include(missingCells.eq(4).text(), 'missing-email-login-id');
-    });
-  });
 
   test('insert a course request', async () => {
     courseRequestId = await insertCourseRequest({

--- a/apps/prairielearn/src/tests/courseRequest.test.ts
+++ b/apps/prairielearn/src/tests/courseRequest.test.ts
@@ -3,11 +3,16 @@ import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
-import { insertCourseRequest, selectAllCourseRequests } from '../lib/course-request.js';
+import {
+  insertCourseRequest,
+  selectAllCourseRequests,
+  selectCourseRequestById,
+} from '../lib/course-request.js';
 import { createAdministratorTrpcClient } from '../trpc/administrator/client.js';
 
 import * as helperClient from './helperClient.js';
 import * as helperServer from './helperServer.js';
+import { getOrCreateUser } from './utils/auth.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
 const baseUrl = `${siteUrl}/pl`;
@@ -33,6 +38,83 @@ describe('Course requests', { timeout: 60_000, concurrent: false }, function () 
   let courseRequestId: string;
   const shortName = 'TEST 101';
   const title = 'Course Request Test Course';
+
+  test('derives the contact email without conflating it with the account UID', async () => {
+    const [userWithEmail, userWithoutEmail] = await Promise.all([
+      getOrCreateUser({
+        uid: 'contact-test-login',
+        name: 'Contact Test User',
+        uin: null,
+        email: 'account-contact@example.com',
+      }),
+      getOrCreateUser({
+        uid: 'legacy-contact-uid@example.com',
+        name: 'Legacy Contact Test User',
+        uin: null,
+        email: null,
+      }),
+    ]);
+
+    const cases = [
+      {
+        shortName: 'CONTACT EXPLICIT',
+        userId: userWithEmail.id,
+        workEmail: 'explicit-contact@example.com',
+        expectedContactEmail: 'explicit-contact@example.com',
+      },
+      {
+        shortName: 'CONTACT LEGACY',
+        userId: userWithEmail.id,
+        workEmail: userWithEmail.uid,
+        expectedContactEmail: userWithEmail.email,
+      },
+      {
+        shortName: 'CONTACT UID FALLBACK',
+        userId: userWithoutEmail.id,
+        workEmail: userWithoutEmail.uid,
+        expectedContactEmail: userWithoutEmail.uid,
+      },
+      {
+        shortName: 'CONTACT ACCOUNT FALLBACK',
+        userId: userWithEmail.id,
+        workEmail: null,
+        expectedContactEmail: userWithEmail.email,
+      },
+      {
+        shortName: 'CONTACT UNAVAILABLE',
+        userId: userWithoutEmail.id,
+        workEmail: null,
+        expectedContactEmail: null,
+      },
+    ];
+
+    const requests = await Promise.all(
+      cases.map(async ({ shortName, userId, workEmail, expectedContactEmail }) => ({
+        requestId: await insertCourseRequest({
+          short_name: shortName,
+          title: `${shortName} title`,
+          user_id: userId,
+          github_user: null,
+          first_name: 'Contact',
+          last_name: 'Test',
+          work_email: workEmail,
+          institution: 'Test Institution',
+          referral_source: null,
+        }),
+        expectedContactEmail,
+      })),
+    );
+
+    const allRequests = await selectAllCourseRequests();
+    for (const { requestId, expectedContactEmail } of requests) {
+      const listedRequest = allRequests.find((request) => request.id === requestId);
+      assert.isDefined(listedRequest);
+      assert.equal(listedRequest.contact_email, expectedContactEmail);
+
+      const selectedRequest = await selectCourseRequestById({ courseRequestId: requestId });
+      assert.equal(selectedRequest.contact_email, expectedContactEmail);
+    }
+  });
 
   test('insert a course request', async () => {
     courseRequestId = await insertCourseRequest({

--- a/apps/prairielearn/src/tests/courseRequest.test.ts
+++ b/apps/prairielearn/src/tests/courseRequest.test.ts
@@ -3,11 +3,17 @@ import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 
 import { config } from '../lib/config.js';
-import { insertCourseRequest, selectAllCourseRequests } from '../lib/course-request.js';
+import {
+  getNewCourseRequestContactEmail,
+  insertCourseRequest,
+  selectAllCourseRequests,
+  selectCourseRequestById,
+} from '../lib/course-request.js';
 import { createAdministratorTrpcClient } from '../trpc/administrator/client.js';
 
 import * as helperClient from './helperClient.js';
 import * as helperServer from './helperServer.js';
+import { getOrCreateUser } from './utils/auth.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
 const baseUrl = `${siteUrl}/pl`;
@@ -33,6 +39,159 @@ describe('Course requests', { timeout: 60_000, concurrent: false }, function () 
   let courseRequestId: string;
   const shortName = 'TEST 101';
   const title = 'Course Request Test Course';
+
+  describe('new request contact email', () => {
+    test('uses the explicitly submitted email for the default institution', () => {
+      assert.equal(
+        getNewCourseRequestContactEmail({
+          isDefaultInstitution: true,
+          submittedEmail: 'explicit@example.edu',
+          accountEmail: 'account@example.edu',
+        }),
+        'explicit@example.edu',
+      );
+    });
+
+    test('uses the account email for a non-default institution', () => {
+      assert.equal(
+        getNewCourseRequestContactEmail({
+          isDefaultInstitution: false,
+          submittedEmail: 'ignored@example.edu',
+          accountEmail: 'account@example.edu',
+        }),
+        'account@example.edu',
+      );
+    });
+
+    test('does not substitute the UID when the account email is missing', () => {
+      assert.isNull(
+        getNewCourseRequestContactEmail({
+          isDefaultInstitution: false,
+          submittedEmail: '',
+          accountEmail: null,
+        }),
+      );
+    });
+  });
+
+  describe('admin requester identities', () => {
+    const explicitShortName = 'CONTACT 101';
+    const legacyShortName = 'CONTACT 102';
+    const missingShortName = 'CONTACT 103';
+
+    test('derives contact email without conflating it with the account UID', async () => {
+      const explicitUser = await getOrCreateUser({
+        uid: 'explicit-login-id',
+        name: 'Explicit Account Name',
+        uin: null,
+        email: 'account-address@example.edu',
+      });
+      const legacyUser = await getOrCreateUser({
+        uid: 'legacy.uid@identity.example',
+        name: 'Legacy Account Name',
+        uin: null,
+        email: 'legacy-contact@example.edu',
+      });
+      const missingEmailUser = await getOrCreateUser({
+        uid: 'missing-email-login-id',
+        name: 'Missing Email Account',
+        uin: null,
+        email: null,
+      });
+
+      const explicitRequestId = await insertCourseRequest({
+        short_name: explicitShortName,
+        title: 'Explicit contact email',
+        user_id: explicitUser.id,
+        github_user: null,
+        first_name: 'Explicit',
+        last_name: 'Requester',
+        work_email: 'explicit-contact@example.edu',
+        institution: 'Test Institution',
+        referral_source: null,
+      });
+      const legacyRequestId = await insertCourseRequest({
+        short_name: legacyShortName,
+        title: 'Legacy UID copy',
+        user_id: legacyUser.id,
+        github_user: null,
+        first_name: 'Legacy',
+        last_name: 'Requester',
+        work_email: legacyUser.uid,
+        institution: 'Test Institution',
+        referral_source: null,
+      });
+      const missingRequestId = await insertCourseRequest({
+        short_name: missingShortName,
+        title: 'Missing account email',
+        user_id: missingEmailUser.id,
+        github_user: null,
+        first_name: 'Missing',
+        last_name: 'Requester',
+        work_email: missingEmailUser.uid,
+        institution: 'Test Institution',
+        referral_source: null,
+      });
+
+      const requests = await selectAllCourseRequests();
+      const explicitRequest = requests.find((request) => request.id === explicitRequestId);
+      const legacyRequest = requests.find((request) => request.id === legacyRequestId);
+      const missingRequest = requests.find((request) => request.id === missingRequestId);
+
+      assert.isDefined(explicitRequest);
+      assert.equal(explicitRequest.work_email, 'explicit-contact@example.edu');
+      assert.equal(explicitRequest.contact_email, 'explicit-contact@example.edu');
+      assert.equal(explicitRequest.user_uid, explicitUser.uid);
+
+      assert.isDefined(legacyRequest);
+      assert.equal(legacyRequest.work_email, legacyUser.uid);
+      assert.equal(legacyRequest.contact_email, legacyUser.email);
+      assert.equal(legacyRequest.user_uid, legacyUser.uid);
+
+      const legacyRequestForLegitimacyCheck = await selectCourseRequestById({
+        courseRequestId: legacyRequestId,
+      });
+      assert.equal(legacyRequestForLegitimacyCheck.contact_email, legacyUser.email);
+      assert.equal(legacyRequestForLegitimacyCheck.user_uid, legacyUser.uid);
+
+      assert.isDefined(missingRequest);
+      assert.equal(missingRequest.work_email, missingEmailUser.uid);
+      assert.isNull(missingRequest.contact_email);
+      assert.equal(missingRequest.user_uid, missingEmailUser.uid);
+    });
+
+    test('renders distinct requester contact and account UID columns', async () => {
+      const response = await helperClient.fetchCheerio(courseRequestsAdminUrl);
+      assert.isTrue(response.ok);
+
+      const headerTexts = response
+        .$('th')
+        .toArray()
+        .map((header) => response.$(header).text());
+      assert.include(headerTexts, 'Requester / contact email');
+      assert.include(headerTexts, 'PrairieLearn account (UID)');
+
+      const explicitCells = response
+        .$(`td:contains("${explicitShortName}")`)
+        .closest('tr')
+        .find('td');
+      assert.include(explicitCells.eq(3).text(), 'explicit-contact@example.edu');
+      assert.notInclude(explicitCells.eq(3).text(), 'explicit-login-id');
+      assert.include(explicitCells.eq(4).text(), 'explicit-login-id');
+
+      const legacyCells = response.$(`td:contains("${legacyShortName}")`).closest('tr').find('td');
+      assert.include(legacyCells.eq(3).text(), 'legacy-contact@example.edu');
+      assert.notInclude(legacyCells.eq(3).text(), 'legacy.uid@identity.example');
+      assert.include(legacyCells.eq(4).text(), 'legacy.uid@identity.example');
+
+      const missingCells = response
+        .$(`td:contains("${missingShortName}")`)
+        .closest('tr')
+        .find('td');
+      assert.include(missingCells.eq(3).text(), 'Contact email unavailable');
+      assert.include(missingCells.eq(4).text(), 'missing-email-login-id');
+    });
+  });
 
   test('insert a course request', async () => {
     courseRequestId = await insertCourseRequest({

--- a/apps/prairielearn/src/trpc/administrator/course-requests.ts
+++ b/apps/prairielearn/src/trpc/administrator/course-requests.ts
@@ -165,7 +165,7 @@ const checkInstructorLegitimacyProcedure = t.procedure
     return await checkInstructorLegitimacy({
       instructorFirstName: courseRequest.first_name,
       instructorLastName: courseRequest.last_name,
-      instructorEmail: courseRequest.work_email,
+      instructorEmail: courseRequest.contact_email,
       institution: courseRequest.institution,
       userDisplayName: courseRequest.user_name,
       userUid: courseRequest.user_uid,

--- a/apps/prairielearn/src/trpc/administrator/course-requests.ts
+++ b/apps/prairielearn/src/trpc/administrator/course-requests.ts
@@ -191,7 +191,8 @@ const suggestInstitutionPrefixProcedure = t.procedure
     z.object({
       institutionLongName: z.string(),
       institutionShortName: z.string(),
-      emailDomain: z.string(),
+      contactEmailDomain: z.string(),
+      accountUidDomain: z.string(),
     }),
   )
   .output(
@@ -205,7 +206,8 @@ const suggestInstitutionPrefixProcedure = t.procedure
     return await suggestInstitutionPrefix({
       institutionLongName: input.institutionLongName,
       institutionShortName: input.institutionShortName,
-      emailDomain: input.emailDomain,
+      contactEmailDomain: input.contactEmailDomain,
+      accountUidDomain: input.accountUidDomain,
     });
   });
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

PrairieLearn previously stored a non-default-institution user's UID in `course_requests.work_email`. Some institutions use email-shaped UIDs that are not routable, so administrators could see an unusable address and the legitimacy check could receive an account identifier instead of a contact email.

This change keeps the two identities separate: the request contact email is used for communication, while the PrairieLearn UID remains available for account and access debugging. New default-institution requests preserve the explicitly entered contact email, while new institutional requests use the email supplied by the authentication provider and store no contact email when the provider supplies none.

For existing requests, an explicitly entered `work_email` remains authoritative. When `work_email` matches the user's UID, it is treated as a legacy copied UID: PrairieLearn prefers `users.email` and falls back to the stored UID when no account email is available. The admin table and approval modal now label these values distinctly, avoid redundant display when they match, and show an explicit unavailable state when neither value exists. The legitimacy check receives the effective contact email and UID separately.

Repository-prefix suggestions use both the contact-email domain and account-UID domain as separately labeled supporting hints. This preserves useful institutional evidence from email-shaped UIDs without treating them as routable addresses, while retaining self-reported contact domains for default-institution users.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

The majority of the implementation was completed with AI assistance.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Reproduced the issue with legacy course requests whose `work_email` matched the associated user's UID while `users.email` differed or was absent.

Verified the effective-contact behavior for explicit request emails, legacy UID copies with and without an account email, and genuinely missing contact information. Also verified that the admin rendering keeps contact email and account UID distinct, the legitimacy-check lookup uses the same derived contact value, and institution-prefix suggestions receive both domains with their provenance intact.
