### PR TITLE
Improve workspace placement using image locality

### DIFF
--- a/apps/prairielearn/src/lib/workspaceHost.sql
+++ b/apps/prairielearn/src/lib/workspaceHost.sql
@@ -41,6 +41,32 @@ WITH
       wh.state = 'ready'
       AND wh.load_count < $capacity
     ORDER BY
+      -- Prefer a host with a workspace that is launching or running the requested image.
+      -- Randomize among equally preferred hosts to distribute their load.
+      EXISTS (
+        SELECT
+          1
+        FROM
+          workspaces AS existing_workspace
+          JOIN variants AS existing_variant ON (
+            existing_variant.workspace_id = existing_workspace.id
+          )
+          JOIN questions AS existing_question ON (
+            existing_question.id = existing_variant.question_id
+          )
+        WHERE
+          existing_workspace.workspace_host_id = wh.id
+          AND existing_workspace.state IN ('launching', 'running')
+          AND existing_question.workspace_image = (
+            SELECT
+              target_question.workspace_image
+            FROM
+              variants AS target_variant
+              JOIN questions AS target_question ON (target_question.id = target_variant.question_id)
+            WHERE
+              target_variant.workspace_id = $workspace_id
+          )
+      ) DESC,
       random()
     LIMIT
       1

--- a/apps/prairielearn/src/lib/workspaceHost.sql
+++ b/apps/prairielearn/src/lib/workspaceHost.sql
@@ -68,8 +68,11 @@ WITH
           )
       ) DESC,
       random()
+      -- Serialize assignments so capacity is rechecked after concurrent updates.
     LIMIT
       1
+    FOR NO KEY UPDATE OF
+      wh
   ),
   updated_workspace AS (
     UPDATE workspaces AS w
@@ -85,20 +88,12 @@ WITH
   updated_workspace_host AS (
     UPDATE workspace_hosts AS wh
     SET
-      load_count = (
-        SELECT
-          count(*)
-        FROM
-          workspaces AS w
-        WHERE
-          w.workspace_host_id = wh.id
-          AND (
-            w.state = 'running'
-            OR w.state = 'launching'
-          )
-      )
+      -- Data-modifying CTEs share a snapshot, so a count would not include the
+      -- assignment in `updated_workspace`. The host row lock makes this increment safe.
+      load_count = wh.load_count + 1
     FROM
       available_host AS ah
+      JOIN updated_workspace AS uw ON (uw.workspace_host_id = ah.id)
     WHERE
       wh.id = ah.id
     RETURNING
@@ -130,7 +125,7 @@ WITH
 SELECT
   id AS workspace_host_id
 FROM
-  available_host;
+  updated_workspace_host;
 
 -- BLOCK recapture_draining_hosts
 WITH

--- a/apps/prairielearn/src/tests/workspaceHost.test.ts
+++ b/apps/prairielearn/src/tests/workspaceHost.test.ts
@@ -10,6 +10,7 @@ import * as helperDb from './helperDb.js';
 const WorkspaceHostSchema = z.object({
   id: z.string(),
   instance_id: z.string(),
+  load_count: z.number().nullable(),
   state: z.string(),
 });
 
@@ -164,6 +165,9 @@ describe('workspaceHost utilities', function () {
 
       const workspace = await selectWorkspace('1');
       assert.equal(workspace.workspace_host_id, '1');
+
+      const workspaceHost = await selectWorkspaceHost(1);
+      assert.equal(workspaceHost.load_count, 1);
 
       const workspaceLogs = await getWorkspaceLogs(1);
       assert.lengthOf(workspaceLogs, 1);

--- a/apps/workspace-host/src/interface.sql
+++ b/apps/workspace-host/src/interface.sql
@@ -68,6 +68,15 @@ SET
   state_changed_at = EXCLUDED.state_changed_at,
   ready_at = EXCLUDED.ready_at;
 
+-- BLOCK lock_workspace_host_for_load_count_update
+SELECT
+  id
+FROM
+  workspace_hosts
+WHERE
+  instance_id = $instance_id
+FOR NO KEY UPDATE;
+
 -- BLOCK update_load_count
 UPDATE workspace_hosts AS wh
 SET

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -107,6 +107,17 @@ const sql = sqldb.loadSqlEquiv(import.meta.url);
 const debug = debugfn('prairielearn:interface');
 const docker = new Docker();
 
+async function updateLoadCount() {
+  const params = { instance_id: workspace_server_settings.instance_id };
+
+  await sqldb.runInTransactionAsync(async () => {
+    // Lock in a separate statement so the recount gets a fresh snapshot after
+    // any concurrent workspace assignment finishes.
+    await sqldb.execute(sql.lock_workspace_host_for_load_count_update, params);
+    await sqldb.execute(sql.update_load_count, params);
+  });
+}
+
 const app = express();
 app.use(Sentry.requestHandler());
 app.use(bodyParser.urlencoded({ extended: false }));
@@ -119,9 +130,7 @@ app.get(
 
     let db_status: string | null | undefined;
     try {
-      await sqldb.execute(sql.update_load_count, {
-        instance_id: workspace_server_settings.instance_id,
-      });
+      await updateLoadCount();
       db_status = 'ok';
     } catch {
       db_status = null;
@@ -257,9 +266,7 @@ async
         try {
           await pruneStoppedContainers();
           await pruneRunawayContainers();
-          await sqldb.execute(sql.update_load_count, {
-            instance_id: workspace_server_settings.instance_id,
-          });
+          await updateLoadCount();
         } catch (err) {
           logger.error('Error pruning containers', err);
           Sentry.captureException(err);
@@ -959,9 +966,7 @@ async function _createContainer(workspace: Workspace): Promise<Docker.Container>
     },
   });
 
-  await sqldb.execute(sql.update_load_count, {
-    instance_id: workspace_server_settings.instance_id,
-  });
+  await updateLoadCount();
 
   return container;
 }


### PR DESCRIPTION
# Description

Prefer ready workspace hosts that already have a launching or running workspace using the requested image. This increases the chance that Docker can reuse cached layers or an in-progress image pull while retaining random placement among equally preferred hosts.

Serialize assignments with a row lock on the selected host so concurrent requests recheck its state and capacity before assigning a workspace. Update the locked host's `load_count` by incrementing it after assignment; a recount in the same statement would not observe the newly updated workspace because PostgreSQL data-modifying CTEs share a snapshot.

Workspace-host load recounts now acquire the same host-row lock in a separate statement before counting. This gives the recount a fresh `READ COMMITTED` snapshot after any concurrent assignment finishes, preventing it from overwriting the assignment's increment with a stale count.

This requires no schema or workspace-host protocol changes. Hosts must still be ready and below capacity before image locality affects their ordering.

Partially addresses #9621.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: The majority of the implementation was produced with AI assistance.

# Testing

Manually exercised the full assignment query against transactional PostgreSQL fixtures. Verified that placement prefers hosts with matching launching and running workspaces, falls back to an eligible host without image affinity, and ignores a matching host at capacity; all fixtures were rolled back.

Ran two assignments concurrently against a capacity-one host and verified that exactly one assignment succeeded after lock contention, with the stored load count matching the actual active workspace count.

Manually reproduced the pre-existing recount race with two PostgreSQL sessions: without the lock-before-recount transaction, a recount that waited on an assignment stored `0` while the actual active count was `1`. With this change, the recount waited before taking its counting snapshot and both values were `1`; the disposable schema was removed afterward.
