### PR TITLE
Enforce unique workspace ownership

### DIFF
--- a/apps/prairielearn/src/migrations/20260711180010_variants__workspace_id__unique_index.sql
+++ b/apps/prairielearn/src/migrations/20260711180010_variants__workspace_id__unique_index.sql
@@ -1,0 +1,6 @@
+-- prairielearn:migrations NO TRANSACTION
+-- Intentionally omit IF NOT EXISTS so a failed concurrent build's invalid index is not silently accepted.
+-- squawk-ignore prefer-robust-stmts
+CREATE UNIQUE INDEX CONCURRENTLY variants_workspace_id_unique_idx ON variants (workspace_id)
+WHERE
+  workspace_id IS NOT NULL;

--- a/apps/prairielearn/src/migrations/20260711180011_variants__workspace_id__drop_old_index.sql
+++ b/apps/prairielearn/src/migrations/20260711180011_variants__workspace_id__drop_old_index.sql
@@ -1,0 +1,2 @@
+-- prairielearn:migrations NO TRANSACTION
+DROP INDEX CONCURRENTLY variants_workspace_id_key;

--- a/database/tables/variants.pg
+++ b/database/tables/variants.pg
@@ -28,7 +28,7 @@ columns
 indexes
     variants_pkey: PRIMARY KEY (id) USING btree (id)
     variants_instance_question_id_number_key: UNIQUE (instance_question_id, number) USING btree (instance_question_id, number)
-    variants_workspace_id_key: USING btree (workspace_id)
+    variants_workspace_id_unique_idx: UNIQUE USING btree (workspace_id) WHERE workspace_id IS NOT NULL
 
 check constraints
     user_team_xor: CHECK (user_id IS NOT NULL AND team_id IS NULL OR team_id IS NOT NULL AND user_id IS NULL)


### PR DESCRIPTION
# Description

Enforce the intended one-to-one ownership invariant that a workspace can belong to at most one variant. This follows up on [PR #15424](https://github.com/PrairieLearn/PrairieLearn/pull/15424) and its [CodeRabbit review finding](https://github.com/PrairieLearn/PrairieLearn/pull/15424#discussion_r3564704862), which identified that current scalar workspace-to-variant reads are not protected by the database schema.

The historical workspace RFC describes creating one corresponding workspace for each workspace-backed variant and explicitly considers a unique constraint on `variants.workspace_id`. The current primary write path creates a fresh workspace and its variant together in one transaction, submission uploads leave `workspace_id` null, and there are no production update paths that reuse a workspace ID. Existing read paths already assume this relationship is scalar.

## Zero-downtime rollout

- Build a partial unique index on `variants (workspace_id)` with `CREATE UNIQUE INDEX CONCURRENTLY`, enforcing uniqueness only when `workspace_id IS NOT NULL` while continuing to allow normal reads and writes.
- Keep the existing non-unique index in place until the unique build succeeds, then remove it with a separate `DROP INDEX CONCURRENTLY` migration.
- Run each concurrent operation outside a migration transaction, as PostgreSQL requires.
- Intentionally omit `IF NOT EXISTS` from the unique build so a failed concurrent build cannot leave an invalid index that a retry silently accepts as enforcement.

If historical duplicates exist, the unique build fails before the old index is removed, so existing application servers and their current index continue operating. Recovery is to inspect and repair the duplicate ownership, drop the invalid `variants_workspace_id_unique_idx` concurrently, and retry the migration. No additional deployment phase is required when the build succeeds.

The generated database schema description now records the partial unique index. `VariantSchema.workspace_id` remains nullable, so no database type update is needed.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: The majority of the implementation was produced with AI assistance.

# Testing

Exercised both migrations against a dedicated PostgreSQL database. Verified that the concurrent build rejects pre-existing duplicate non-null workspace IDs without removing the old valid index, the completed index rejects new duplicate non-null IDs, multiple null values remain accepted, and the final schema contains only the new partial unique index.
