### PR TITLE
Use `zod.prettifyError` when rendering error page

### DIFF
--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'es-toolkit/compat';
 import jsonStringifySafe from 'json-stringify-safe';
+import { z } from 'zod';
 
 import { formatErrorStack } from '@prairielearn/error';
 import { html, unsafeHtml } from '@prairielearn/html';
@@ -40,6 +41,7 @@ export function ErrorPage({
   } = error.data ?? {};
 
   const formattedSqlQuery = formatQueryWithErrorPosition(sqlQuery, sqlError?.position);
+  const formattedError = error instanceof z.ZodError ? z.prettifyError(error) : error.message;
 
   return PageLayout({
     resLocals,
@@ -55,8 +57,9 @@ export function ErrorPage({
         </div>
 
         <div class="card-body">
-          <h2 class="mb-3 h4">${error.message}</h2>
-
+          ${error instanceof z.ZodError
+            ? html`<pre class="mb-3 h4">${formattedError}</pre>`
+            : html`<h2 class="mb-3 h4">${formattedError}</h2>`}
           ${unsafeHtml(errorInfo ?? '')}
 
           <p><strong>Error ID:</strong> <code>${errorId}</code></p>

--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -57,9 +57,7 @@ export function ErrorPage({
         </div>
 
         <div class="card-body">
-          ${error instanceof z.ZodError
-            ? html`<pre class="mb-3 h4">${formattedError}</pre>`
-            : html`<h2 class="mb-3 h4">${formattedError}</h2>`}
+          <h2 class="mb-3 h4" style="white-space: pre-wrap;">${formattedError}</h2>
           ${unsafeHtml(errorInfo ?? '')}
 
           <p><strong>Error ID:</strong> <code>${errorId}</code></p>

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -739,9 +739,13 @@ async function loadAndValidateJson<T extends ZodType>({
   // use the output type.
   const result = zodSchema.safeParse(loadedJson.data);
   if (!result.success) {
-    infofile.addErrors(loadedJson, [
-      `${z.prettifyError(result.error)}\nReport this error to the PrairieLearn team, this should not happen.`,
-    ]);
+    infofile.addErrors(
+      loadedJson,
+      result.error.issues.map(
+        (e) =>
+          `code: ${e.code}, path: ${e.path.join('.')}, message: ${e.message}. Report this error to the PrairieLearn team, this should not happen.`,
+      ),
+    );
     Sentry.captureException(result.error);
     return loadedJson;
   }

--- a/apps/prairielearn/src/sync/course-db.ts
+++ b/apps/prairielearn/src/sync/course-db.ts
@@ -739,13 +739,9 @@ async function loadAndValidateJson<T extends ZodType>({
   // use the output type.
   const result = zodSchema.safeParse(loadedJson.data);
   if (!result.success) {
-    infofile.addErrors(
-      loadedJson,
-      result.error.issues.map(
-        (e) =>
-          `code: ${e.code}, path: ${e.path.join('.')}, message: ${e.message}. Report this error to the PrairieLearn team, this should not happen.`,
-      ),
-    );
+    infofile.addErrors(loadedJson, [
+      `${z.prettifyError(result.error)}\nReport this error to the PrairieLearn team, this should not happen.`,
+    ]);
     Sentry.captureException(result.error);
     return loadedJson;
   }


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Use `zod.PrettifyError()` for course sync error.
Show error prettified when it is a zod error.

~~closes~~ addresses part of https://github.com/PrairieLearn/PrairieLearn/issues/15361

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
ai used only to locate where zod.prettifyerror can be used. code changes were made manually

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
