### PR TITLE
Make pl-overlay optional aria hidden

### DIFF
--- a/apps/prairielearn/elements/pl-overlay/pl-overlay.mustache
+++ b/apps/prairielearn/elements/pl-overlay/pl-overlay.mustache
@@ -8,6 +8,11 @@
         {{/locations}}
     </div>
     {{#background}}
-        <div aria-hidden="true">{{{background}}}</div>
+        {{#background_aria_hidden}}
+            <div aria-hidden="true">{{{background}}}</div>
+        {{/background_aria_hidden}}
+        {{^background_aria_hidden}}
+            {{{background}}}
+        {{/background_aria_hidden}}
     {{/background}}
 </div>

--- a/apps/prairielearn/elements/pl-overlay/pl-overlay.mustache
+++ b/apps/prairielearn/elements/pl-overlay/pl-overlay.mustache
@@ -8,6 +8,6 @@
         {{/locations}}
     </div>
     {{#background}}
-        {{{background}}}
+        <div aria-hidden="true">{{{background}}}</div>
     {{/background}}
 </div>

--- a/apps/prairielearn/elements/pl-overlay/pl-overlay.py
+++ b/apps/prairielearn/elements/pl-overlay/pl-overlay.py
@@ -58,7 +58,9 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
             if halign not in HALIGN_VALUES:
                 raise ValueError(f'Unknown horizontal alignment "{halign}"')
         elif child.tag == "pl-background":
-            pl.check_attribs(child, required_attribs=[], optional_attribs=[])
+            pl.check_attribs(
+                child, required_attribs=[], optional_attribs=["aria-hidden"]
+            )
             num_backgrounds += 1
         else:
             raise ValueError(f'Unknown tag "{child.tag}" found as child of pl-overlay')
@@ -82,6 +84,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
     width = pl.get_float_attrib(element, "width", None)
     height = pl.get_float_attrib(element, "height", None)
     background = None
+    background_aria_hidden = False
 
     # Assign layer index in order children are defined
     # Later defined elements will be placed on top of earlier ones
@@ -95,6 +98,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         # Don't do any special processing for backgrounds
         if child.tag == "pl-background":
             background = pl.inner_html(child)
+            background_aria_hidden = pl.get_boolean_attrib(child, "aria-hidden", False)
             continue
 
         # Otherwise, continue as normal
@@ -140,6 +144,7 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         "height": height,
         "locations": locations,
         "background": background,
+        "background_aria_hidden": background_aria_hidden,
         "clip": pl.get_boolean_attrib(element, "clip", CLIP_DEFAULT),
     }
 

--- a/docs/elements/pl-overlay.md
+++ b/docs/elements/pl-overlay.md
@@ -49,7 +49,9 @@ The overlay element allows existing PrairieLearn and HTML elements to be layered
 
 ## `pl-background` Customizations
 
-The `pl-background` child tag does not have any extra attributes that need to be set. All relevant positioning and sizing information is obtained from the tag's contents.
+| Attribute     | Type    | Default | Description                                                                                      |
+| ------------- | ------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `aria-hidden` | boolean | false   | If true, hides the background from assistive technologies. Only use this for decorative content. |
 
 ## Details
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Make the `pl-overlay` background hidden to screen readers.

closes https://github.com/PrairieLearn/PrairieLearn/issues/15096

why these changes?
to help remove inconsistency between screen readers and shown content

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
ai used for implementing the opt-in attribute

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
