### PR TITLE
Pin pnpm to 11.11.0 in CI to avoid 11.12.0 self-install crash

### DIFF
--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -31,7 +31,11 @@ runs:
 
     - uses: pnpm/action-setup@v6
       with:
-        version: 11
+        # Pinned below 11.12.0, whose self-install crashes with
+        # "Cannot use 'in' operator to search for 'integrity' in undefined".
+        # https://github.com/pnpm/action-setup/issues/276
+        # https://github.com/pnpm/pnpm/issues/12959
+        version: 11.11.0
     - name: Set up Node
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0, whose self-install crashes with
+          # "Cannot use 'in' operator to search for 'integrity' in undefined".
+          # https://github.com/pnpm/action-setup/issues/276
+          # https://github.com/pnpm/pnpm/issues/12959
+          version: 11.11.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -200,7 +204,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0, whose self-install crashes with
+          # "Cannot use 'in' operator to search for 'integrity' in undefined".
+          # https://github.com/pnpm/action-setup/issues/276
+          # https://github.com/pnpm/pnpm/issues/12959
+          version: 11.11.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -34,7 +34,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0, whose self-install crashes with
+          # "Cannot use 'in' operator to search for 'integrity' in undefined".
+          # https://github.com/pnpm/action-setup/issues/276
+          # https://github.com/pnpm/pnpm/issues/12959
+          version: 11.11.0
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -80,7 +80,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0, whose self-install crashes with
+          # "Cannot use 'in' operator to search for 'integrity' in undefined".
+          # https://github.com/pnpm/action-setup/issues/276
+          # https://github.com/pnpm/pnpm/issues/12959
+          version: 11.11.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,11 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0, whose self-install crashes with
+          # "Cannot use 'in' operator to search for 'integrity' in undefined".
+          # https://github.com/pnpm/action-setup/issues/276
+          # https://github.com/pnpm/pnpm/issues/12959
+          version: 11.11.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,11 @@ jobs:
           show-progress: false
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0, whose self-install crashes with
+          # "Cannot use 'in' operator to search for 'integrity' in undefined".
+          # https://github.com/pnpm/action-setup/issues/276
+          # https://github.com/pnpm/pnpm/issues/12959
+          version: 11.11.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
# Description

pnpm 11.12.0's self-install crashes with `Cannot use 'in' operator to search for 'integrity' in undefined`, which breaks our CI pipeline. This pins the pnpm version used by every `pnpm/action-setup@v6` step to `11.11.0` (previously the floating `version: 11`), with an inline comment linking to the upstream issues. We can revert the pin once the regression is fixed upstream.

See:
- https://github.com/pnpm/action-setup/issues/276
- https://github.com/pnpm/pnpm/issues/12959

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

CI on this branch exercises the pinned version across the affected workflows.