### PR TITLE
Add shared Conductor config source for workspace env vars

### DIFF
--- a/.changeset/share-conductor-config.md
+++ b/.changeset/share-conductor-config.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/config': minor
+---
+
+Add a shared config source for Conductor workspace environment variables.

--- a/apps/grader-host/src/lib/config.ts
+++ b/apps/grader-host/src/lib/config.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import {
   ConfigLoader,
   type ConfigSource,
+  makeConductorConfigSource,
   makeImdsConfigSource,
   makeKmsConfigSource,
   makeSecretsManagerConfigSource,
@@ -175,6 +176,7 @@ export const config = loader.config;
 
 export async function loadConfig() {
   await loader.loadAndValidate([
+    makeConductorConfigSource(),
     makeProductionConfigSource(),
     makeImdsConfigSource(),
     makeSecretsManagerConfigSource('ConfSecret'),

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -2,8 +2,7 @@ import { z } from 'zod';
 
 import {
   ConfigLoader,
-  type ConfigSource,
-  makeEnvConfigSource,
+  makeConductorConfigSource,
   makeFileConfigSource,
   makeImdsConfigSource,
   makeKmsConfigSource,
@@ -720,41 +719,9 @@ const loader = new ConfigLoader(ConfigSchema);
 
 export const config = loader.config;
 
-/**
- * Creates a config source that derives database and Redis settings from
- * CONDUCTOR_WORKSPACE_NAME and CONDUCTOR_PORT.
- * This enables isolated databases per Conductor workspace.
- */
-function makeConductorConfigSource(): ConfigSource<Config> {
-  return {
-    load: async (existingConfig) => {
-      const workspaceName = process.env.CONDUCTOR_WORKSPACE_NAME;
-      if (!workspaceName) return {};
-
-      const dbSuffix = workspaceName
-        .toLowerCase()
-        .replaceAll(/[^a-z0-9_]/g, '_')
-        .slice(0, 50);
-      const port = Number.parseInt(existingConfig.serverPort);
-      // Redis supports DBs 0-15 by default. With CONDUCTOR_PORT allocated in
-      // increments of 10, collisions occur after ~8 workspaces. This is acceptable
-      // since Redis stores transient data while Postgres databases remain fully isolated.
-      const redisDb = (port - 3000) % 16;
-
-      return {
-        postgresqlDatabase: `prairielearn_${dbSuffix}`,
-        redisUrl: `redis://localhost:6379/${redisDb}`,
-      };
-    },
-  };
-}
-
 export async function loadConfig(paths: string[]) {
   await loader.loadAndValidate([
-    makeEnvConfigSource<typeof ConfigSchema>({
-      serverPort: 'CONDUCTOR_PORT',
-    }),
-    makeConductorConfigSource(),
+    makeConductorConfigSource({ portConfigKey: 'serverPort' }),
     ...paths.map((path) => makeFileConfigSource(path)),
     makeImdsConfigSource(),
     makeSecretsManagerConfigSource('ConfSecret'),

--- a/apps/workspace-host/src/lib/config.ts
+++ b/apps/workspace-host/src/lib/config.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import {
   ConfigLoader,
+  makeConductorConfigSource,
   makeFileConfigSource,
   makeImdsConfigSource,
   makeKmsConfigSource,
@@ -110,6 +111,7 @@ export const config = loader.config;
 
 export async function loadConfig(paths: string[]) {
   await loader.loadAndValidate([
+    makeConductorConfigSource(),
     ...paths.map((path) => makeFileConfigSource(path)),
     makeImdsConfigSource(),
     makeSecretsManagerConfigSource('ConfSecret'),

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -37,6 +37,17 @@ export async function loadAndValidate(path: string) {
 export default configLoader.config;
 ```
 
+### Loading config in Conductor
+
+`makeConductorConfigSource()` derives `postgresqlDatabase` and `redisUrl` from `CONDUCTOR_WORKSPACE_NAME` and `CONDUCTOR_PORT`, allowing multiple Conductor workspaces to use isolated local services. Applications that should listen on `CONDUCTOR_PORT` can pass the corresponding config key:
+
+```ts
+await configLoader.loadAndValidate([
+  makeConductorConfigSource({ portConfigKey: 'serverPort' }),
+  makeFileConfigSource('config.json'),
+]);
+```
+
 ### Loading config from AWS
 
 If you're running in AWS, you can use `makeImdsConfigSource()`, `makeSecretsManagerConfigSource()`, and `makeKmsConfigSource()` to load config from IMDS, Secrets Manager, and AWS KMS, respectively:

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -8,6 +8,7 @@ import { fetchInstanceHostname, fetchInstanceIdentity } from '@prairielearn/aws-
 
 import type { AbstractConfig, ConfigSource } from './types.js';
 
+export { makeConductorConfigSource } from './sources/conductor.js';
 export { makeKmsConfigSource } from './sources/kms.js';
 export type { AbstractConfig, ConfigSource } from './types.js';
 

--- a/packages/config/src/sources/conductor.test.ts
+++ b/packages/config/src/sources/conductor.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { makeConductorConfigSource } from './conductor.js';
+
+describe('makeConductorConfigSource', () => {
+  const originalPort = process.env.CONDUCTOR_PORT;
+  const originalWorkspaceName = process.env.CONDUCTOR_WORKSPACE_NAME;
+
+  beforeEach(() => {
+    delete process.env.CONDUCTOR_PORT;
+    delete process.env.CONDUCTOR_WORKSPACE_NAME;
+  });
+
+  afterEach(() => {
+    if (originalPort === undefined) {
+      delete process.env.CONDUCTOR_PORT;
+    } else {
+      process.env.CONDUCTOR_PORT = originalPort;
+    }
+
+    if (originalWorkspaceName === undefined) {
+      delete process.env.CONDUCTOR_WORKSPACE_NAME;
+    } else {
+      process.env.CONDUCTOR_WORKSPACE_NAME = originalWorkspaceName;
+    }
+  });
+
+  it('does nothing outside a Conductor workspace', async () => {
+    await expect(makeConductorConfigSource().load({})).resolves.toEqual({});
+  });
+
+  it('maps the Conductor port to the configured key', async () => {
+    process.env.CONDUCTOR_PORT = '4010';
+
+    await expect(
+      makeConductorConfigSource({ portConfigKey: 'serverPort' }).load({}),
+    ).resolves.toEqual({ serverPort: '4010' });
+  });
+
+  it('derives workspace-specific database and Redis config', async () => {
+    process.env.CONDUCTOR_PORT = '4010';
+    process.env.CONDUCTOR_WORKSPACE_NAME = 'Feature/My Branch!';
+
+    await expect(makeConductorConfigSource().load({})).resolves.toEqual({
+      postgresqlDatabase: 'prairielearn_feature_my_branch_',
+      redisUrl: 'redis://localhost:6379/2',
+    });
+  });
+
+  it('uses the default PrairieLearn port when deriving Redis config without a port', async () => {
+    process.env.CONDUCTOR_WORKSPACE_NAME = 'my-workspace';
+
+    await expect(makeConductorConfigSource().load({})).resolves.toEqual({
+      postgresqlDatabase: 'prairielearn_my_workspace',
+      redisUrl: 'redis://localhost:6379/0',
+    });
+  });
+});

--- a/packages/config/src/sources/conductor.test.ts
+++ b/packages/config/src/sources/conductor.test.ts
@@ -29,30 +29,25 @@ describe('makeConductorConfigSource', () => {
     await expect(makeConductorConfigSource().load({})).resolves.toEqual({});
   });
 
-  it('maps the Conductor port to the configured key', async () => {
-    process.env.CONDUCTOR_PORT = '4010';
-
-    await expect(
-      makeConductorConfigSource({ portConfigKey: 'serverPort' }).load({}),
-    ).resolves.toEqual({ serverPort: '4010' });
-  });
-
-  it('derives workspace-specific database and Redis config', async () => {
+  it('derives expected config', async () => {
     process.env.CONDUCTOR_PORT = '4010';
     process.env.CONDUCTOR_WORKSPACE_NAME = 'Feature/My Branch!';
 
-    await expect(makeConductorConfigSource().load({})).resolves.toEqual({
+    await expect(
+      makeConductorConfigSource({ portConfigKey: 'serverPort' }).load({}),
+    ).resolves.toEqual({
+      serverPort: '4010',
       postgresqlDatabase: 'prairielearn_feature_my_branch_',
       redisUrl: 'redis://localhost:6379/2',
     });
   });
 
-  it('uses the default PrairieLearn port when deriving Redis config without a port', async () => {
+  it('normalizes Redis config for a Conductor port below 3000', async () => {
+    process.env.CONDUCTOR_PORT = '2999';
     process.env.CONDUCTOR_WORKSPACE_NAME = 'my-workspace';
 
-    await expect(makeConductorConfigSource().load({})).resolves.toEqual({
-      postgresqlDatabase: 'prairielearn_my_workspace',
-      redisUrl: 'redis://localhost:6379/0',
+    await expect(makeConductorConfigSource().load({})).resolves.toMatchObject({
+      redisUrl: 'redis://localhost:6379/15',
     });
   });
 });

--- a/packages/config/src/sources/conductor.ts
+++ b/packages/config/src/sources/conductor.ts
@@ -1,4 +1,12 @@
+import { z } from 'zod';
+
 import type { AbstractConfig, ConfigSource } from '../types.js';
+
+const PortSchema = z.coerce
+  .number('CONDUCTOR_PORT must be a number')
+  .int('CONDUCTOR_PORT must be an integer')
+  .min(1, 'CONDUCTOR_PORT must be at least 1')
+  .max(65535, 'CONDUCTOR_PORT must be at most 65535');
 
 export function makeConductorConfigSource({
   portConfigKey,
@@ -7,25 +15,27 @@ export function makeConductorConfigSource({
 } = {}): ConfigSource {
   return {
     load: async () => {
-      const config: AbstractConfig = {};
-      const port = process.env.CONDUCTOR_PORT;
-
-      if (portConfigKey && port !== undefined) {
-        config[portConfigKey] = port;
+      if (!process.env.CONDUCTOR_PORT || !process.env.CONDUCTOR_WORKSPACE_NAME) {
+        // Probably not running in Conductor.
+        return {};
       }
 
-      const workspaceName = process.env.CONDUCTOR_WORKSPACE_NAME;
-      if (!workspaceName) return config;
+      const config: AbstractConfig = {};
+      const conductorPort = process.env.CONDUCTOR_PORT;
+      const parsedConductorPort = PortSchema.parse(Number(conductorPort));
 
-      const dbSuffix = workspaceName
-        .toLowerCase()
+      if (portConfigKey) {
+        config[portConfigKey] = conductorPort;
+      }
+
+      const dbSuffix = process.env.CONDUCTOR_WORKSPACE_NAME.toLowerCase()
         .replaceAll(/[^a-z0-9_]/g, '_')
         .slice(0, 50);
-      const redisPort = Number.parseInt(port ?? '3000');
+
       // Redis supports DBs 0-15 by default. With CONDUCTOR_PORT allocated in
       // increments of 10, collisions occur after ~8 workspaces. This is acceptable
       // since Redis stores transient data while Postgres databases remain fully isolated.
-      const redisDb = (redisPort - 3000) % 16;
+      const redisDb = (((parsedConductorPort - 3000) % 16) + 16) % 16;
 
       return {
         ...config,

--- a/packages/config/src/sources/conductor.ts
+++ b/packages/config/src/sources/conductor.ts
@@ -1,0 +1,37 @@
+import type { AbstractConfig, ConfigSource } from '../types.js';
+
+export function makeConductorConfigSource({
+  portConfigKey,
+}: {
+  portConfigKey?: string;
+} = {}): ConfigSource {
+  return {
+    load: async () => {
+      const config: AbstractConfig = {};
+      const port = process.env.CONDUCTOR_PORT;
+
+      if (portConfigKey && port !== undefined) {
+        config[portConfigKey] = port;
+      }
+
+      const workspaceName = process.env.CONDUCTOR_WORKSPACE_NAME;
+      if (!workspaceName) return config;
+
+      const dbSuffix = workspaceName
+        .toLowerCase()
+        .replaceAll(/[^a-z0-9_]/g, '_')
+        .slice(0, 50);
+      const redisPort = Number.parseInt(port ?? '3000');
+      // Redis supports DBs 0-15 by default. With CONDUCTOR_PORT allocated in
+      // increments of 10, collisions occur after ~8 workspaces. This is acceptable
+      // since Redis stores transient data while Postgres databases remain fully isolated.
+      const redisDb = (redisPort - 3000) % 16;
+
+      return {
+        ...config,
+        postgresqlDatabase: `prairielearn_${dbSuffix}`,
+        redisUrl: `redis://localhost:6379/${redisDb}`,
+      };
+    },
+  };
+}


### PR DESCRIPTION
# Description

Add a shared `makeConductorConfigSource` to `@prairielearn/config` and use it in PrairieLearn, grader-host, and workspace-host so all three applications select the same workspace-specific PostgreSQL database and Redis database when running under Conductor.

PrairieLearn maps `CONDUCTOR_PORT` to `serverPort`, while the grader and workspace hosts retain their distinct listening ports to avoid collisions when the processes run together. The shared source is documented and published with a minor changeset.

AI assistance: Codex authored the majority of the implementation and tests under Nathan's direction.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Added focused unit coverage for inactive Conductor environments, optional listening-port mapping, workspace-name normalization, and workspace-specific PostgreSQL and Redis configuration.
