### PR TITLE
Validate that the answers-name attribute is not blank

### DIFF
--- a/apps/prairielearn/python/prairielearn/grading_utils.py
+++ b/apps/prairielearn/python/prairielearn/grading_utils.py
@@ -153,13 +153,15 @@ def is_correct_scalar_sf(a_sub: ArrayLike, a_tru: ArrayLike, digits: int = 2) ->
 
 
 def check_answers_names(data: QuestionData, name: str) -> None:
-    """Check that answers names are distinct using property in data dict.
+    """Check that answers names are provided and distinct using property in data dict.
 
     Updates the data dictionary with the name if it is not already present.
 
     Raises:
         KeyError: If the name is already present in the data dictionary.
     """
+    if name.strip() == "":
+        raise KeyError('"answers-name" attribute cannot be empty')
     if name in data["answers_names"]:
         raise KeyError(f'Duplicate "answers-name" attribute: "{name}"')
     data["answers_names"][name] = True

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -1408,6 +1408,8 @@ def test_add_submitted_file(question_data: pl.QuestionData) -> None:
     [
         ({"x": None, "y": None}, "z", False),
         ({"x": None, "y": None}, "x", True),
+        ({"x": None, "y": None}, "", True),
+        ({"x": None, "y": None}, " ", True),
         ({}, "y", False),
     ],
 )


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #15431. Validates that `answers-name` is not blank. This is done for via `pl.check_answers_name` helper, which is already in use by virtually all official elements since #5893. Elements that have optional answers-name (e.g., pl-excalidraw) already call this function on a condition, so this should not cause a problem in these elements.

I don't expect this to affect working questions, as questions with a blank answers-name are likely to cause errors elsewhere (see original issue).

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

<img width="484" height="170" alt="image" src="https://github.com/user-attachments/assets/7fda3c22-a880-41ef-bcb2-5109c454e120" />

Also added a CI test.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
