### PR TITLE
Remove thousands separator in calculator clipboard output

### DIFF
--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -52,6 +52,11 @@ function setCalculatorData(storageKey: string, data: CalculatorLocalData) {
   localStorage.setItem(storageKey, JSON.stringify(data));
 }
 
+function clipboardOutput(latex: string) {
+  // Remove initial =, and remove all thousands separators
+  return convertLatexToAsciiMath(latex.replace(/^=/, '').replaceAll('\\,', ''));
+}
+
 const TRIG_FUNCTIONS = new Set([
   'Sin',
   'Cos',
@@ -110,7 +115,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
   const displayModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#displayModeSwitch'));
   const angleModeSwitch = ensureElement(drawer.querySelector<HTMLElement>('#angleModeSwitch'));
 
-  const latexFieldOnExport = (_mf: Mathfield, latex: string) => convertLatexToAsciiMath(latex);
+  const latexFieldOnExport = (_mf: Mathfield, latex: string) => clipboardOutput(latex);
 
   calculatorInputElement.onExport = latexFieldOnExport;
   calculatorOutput.onExport = latexFieldOnExport;
@@ -352,7 +357,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     calculatorInputGroup.classList.remove('error');
     calculatorOutput.value = `=${displayed}`;
 
-    copyButton.dataset.clipboardText = convertLatexToAsciiMath(displayed);
+    copyButton.dataset.clipboardText = clipboardOutput(displayed);
 
     // Add to history
     if (addToHistory) {
@@ -703,10 +708,8 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
     const outputCopyBtn = ensureElement(
       clone.querySelector<HTMLElement>('.history-output .history-copy-btn'),
     );
-    inputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(input);
-    outputCopyBtn.dataset.clipboardText = convertLatexToAsciiMath(
-      outputField.value.replace(/^=/, ''),
-    );
+    inputCopyBtn.dataset.clipboardText = clipboardOutput(input);
+    outputCopyBtn.dataset.clipboardText = clipboardOutput(outputField.value);
 
     // Insert buttons
     const inputInsertBtn = ensureElement(

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -53,8 +53,8 @@ function setCalculatorData(storageKey: string, data: CalculatorLocalData) {
 }
 
 function clipboardOutput(latex: string) {
-  // Remove all thousands separators
-  return convertLatexToAsciiMath(latex.replaceAll('\\,', ''));
+  // Remove all thousands separators, represented by \, in between digits
+  return convertLatexToAsciiMath(latex.replaceAll(/(?<=\d)\\,(?=\d)/g, ''));
 }
 
 const TRIG_FUNCTIONS = new Set([

--- a/apps/prairielearn/assets/scripts/calculatorClient.ts
+++ b/apps/prairielearn/assets/scripts/calculatorClient.ts
@@ -53,8 +53,8 @@ function setCalculatorData(storageKey: string, data: CalculatorLocalData) {
 }
 
 function clipboardOutput(latex: string) {
-  // Remove initial =, and remove all thousands separators
-  return convertLatexToAsciiMath(latex.replace(/^=/, '').replaceAll('\\,', ''));
+  // Remove all thousands separators
+  return convertLatexToAsciiMath(latex.replaceAll('\\,', ''));
 }
 
 const TRIG_FUNCTIONS = new Set([
@@ -709,7 +709,7 @@ export function initCalculator(storageKey: string, { drawer, fab, fabClose }: Dr
       clone.querySelector<HTMLElement>('.history-output .history-copy-btn'),
     );
     inputCopyBtn.dataset.clipboardText = clipboardOutput(input);
-    outputCopyBtn.dataset.clipboardText = clipboardOutput(outputField.value);
+    outputCopyBtn.dataset.clipboardText = clipboardOutput(outputField.value.replace(/^=/, ''));
 
     // Insert buttons
     const inputInsertBtn = ensureElement(

--- a/apps/prairielearn/python/prairielearn/conversion_utils.py
+++ b/apps/prairielearn/python/prairielearn/conversion_utils.py
@@ -749,12 +749,15 @@ def string_to_number(
     """
     # Replace unicode minus with hyphen minus wherever it occurs
     s = s.replace("\u2212", "-")
-    # Ignore all spaces, particularly when used as thousands separators
-    s = s.replace(" ", "")
+    # Ignore all spaces when used as thousands separators (i.e., before and after a digit)
+    s = re.sub(r"(?<=\d) (?=\d)", "", s)
     # If complex numbers are allowed...
     if allow_complex:
         # Replace "i" with "j" wherever it occurs
         s = s.replace("i", "j")
+        # Strip white space on either side of "+" or "-" wherever they occur
+        s = re.sub(r" *\+ *", "+", s)
+        s = re.sub(r" *\- *", "-", s)
     # Try to parse as float
     try:
         s_float = float(s)

--- a/apps/prairielearn/python/prairielearn/conversion_utils.py
+++ b/apps/prairielearn/python/prairielearn/conversion_utils.py
@@ -750,7 +750,7 @@ def string_to_number(
     # Replace unicode minus with hyphen minus wherever it occurs
     s = s.replace("\u2212", "-")
     # Ignore all spaces when used as thousands separators (i.e., before and after a digit)
-    s = re.sub(r"(?<=\d) (?=\d)", "", s)
+    s = re.sub(r"(?<=\d)\s+(?=\d)", "", s)
     # If complex numbers are allowed...
     if allow_complex:
         # Replace "i" with "j" wherever it occurs

--- a/apps/prairielearn/python/prairielearn/conversion_utils.py
+++ b/apps/prairielearn/python/prairielearn/conversion_utils.py
@@ -749,13 +749,12 @@ def string_to_number(
     """
     # Replace unicode minus with hyphen minus wherever it occurs
     s = s.replace("\u2212", "-")
+    # Ignore all spaces, particularly when used as thousands separators
+    s = s.replace(" ", "")
     # If complex numbers are allowed...
     if allow_complex:
         # Replace "i" with "j" wherever it occurs
         s = s.replace("i", "j")
-        # Strip white space on either side of "+" or "-" wherever they occur
-        s = re.sub(r" *\+ *", "+", s)
-        s = re.sub(r" *\- *", "-", s)
     # Try to parse as float
     try:
         s_float = float(s)

--- a/apps/prairielearn/python/test/misc_test.py
+++ b/apps/prairielearn/python/test/misc_test.py
@@ -1092,6 +1092,14 @@ def test_get_color_attrib_invalid(html_str: str) -> None:
         ("1/2", True, False, 0.5, {"submitted_answers": 0.5}),
         # Basic decimals
         ("0.25", True, False, 0.25, {"submitted_answers": 0.25}),
+        # Basic decimals with thousands separators
+        (
+            "12 345.678 901 2",
+            True,
+            False,
+            12345.6789012,
+            {"submitted_answers": 12345.6789012},
+        ),
         # Complex numbers
         (
             "1+2j",


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Closes #15436. Properly handles thousands separators in calculator output in two fronts:
* Updates the copy output text to remove thousands separators. This does not affect the visual representation of the result, which continues to include the separator for visual reference. Only spaces derived from latex `\,` are removed, other spaces are not removed (e.g., `sin pi` retains the space).
* Updates the numeric conversion used by pl-number-input, pl-matrix-input and pl-matrix-component-input to accept (and ignore) spaces in the input. Spaces are removed when in-between digits.

Either option is enough to fix the issue, I implemented both for flexibility. I'm happy to undo one of the options if they are not desirable.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: regular expression for "separator between digits".

# Testing

Tested on template/number-input/fixed in the example course, input accepts spaces without issues, and calculator copy output removes spaces created by thousands separators.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
