### PR TITLE
Resume using latest pnpm 11.x in CI

### DIFF
--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -31,7 +31,9 @@ runs:
 
     - uses: pnpm/action-setup@v6
       with:
-        version: 11
+        # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+        # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+        version: 11.13.0
     - name: Set up Node
       uses: actions/setup-node@v6
       with:

--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -31,9 +31,7 @@ runs:
 
     - uses: pnpm/action-setup@v6
       with:
-        # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-        # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-        version: 11.13.0
+        version: 11
     - name: Set up Node
       uses: actions/setup-node@v6
       with:

--- a/.github/actions/native-test-setup/action.yml
+++ b/.github/actions/native-test-setup/action.yml
@@ -31,11 +31,7 @@ runs:
 
     - uses: pnpm/action-setup@v6
       with:
-        # Pinned below 11.12.0, whose self-install crashes with
-        # "Cannot use 'in' operator to search for 'integrity' in undefined".
-        # https://github.com/pnpm/action-setup/issues/276
-        # https://github.com/pnpm/pnpm/issues/12959
-        version: 11.11.0
+        version: 11
     - name: Set up Node
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,11 +59,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0, whose self-install crashes with
-          # "Cannot use 'in' operator to search for 'integrity' in undefined".
-          # https://github.com/pnpm/action-setup/issues/276
-          # https://github.com/pnpm/pnpm/issues/12959
-          version: 11.11.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -204,11 +200,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0, whose self-install crashes with
-          # "Cannot use 'in' operator to search for 'integrity' in undefined".
-          # https://github.com/pnpm/action-setup/issues/276
-          # https://github.com/pnpm/pnpm/issues/12959
-          version: 11.11.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,9 +59,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-          version: 11.13.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -202,9 +200,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-          version: 11.13.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,7 +59,9 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+          version: 11.13.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
@@ -200,7 +202,9 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+          version: 11.13.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -34,11 +34,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0, whose self-install crashes with
-          # "Cannot use 'in' operator to search for 'integrity' in undefined".
-          # https://github.com/pnpm/action-setup/issues/276
-          # https://github.com/pnpm/pnpm/issues/12959
-          version: 11.11.0
+          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -34,9 +34,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-          version: 11.13.0
+          version: 11
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -34,7 +34,9 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+          version: 11.13.0
       - uses: actions/setup-node@v6
         with:
           node-version: '24'

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -80,7 +80,9 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+          version: 11.13.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -80,11 +80,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0, whose self-install crashes with
-          # "Cannot use 'in' operator to search for 'integrity' in undefined".
-          # https://github.com/pnpm/action-setup/issues/276
-          # https://github.com/pnpm/pnpm/issues/12959
-          version: 11.11.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -80,9 +80,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-          version: 11.13.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,9 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+          version: 11.13.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-          version: 11.13.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0, whose self-install crashes with
-          # "Cannot use 'in' operator to search for 'integrity' in undefined".
-          # https://github.com/pnpm/action-setup/issues/276
-          # https://github.com/pnpm/pnpm/issues/12959
-          version: 11.11.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,11 +249,7 @@ jobs:
           show-progress: false
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0, whose self-install crashes with
-          # "Cannot use 'in' operator to search for 'integrity' in undefined".
-          # https://github.com/pnpm/action-setup/issues/276
-          # https://github.com/pnpm/pnpm/issues/12959
-          version: 11.11.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,7 +249,9 @@ jobs:
           show-progress: false
       - uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
+          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
+          version: 11.13.0
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,9 +249,7 @@ jobs:
           show-progress: false
       - uses: pnpm/action-setup@v6
         with:
-          # Pinned to 11.13.0: action-setup resolves "11" to the broken 11.12.0,
-          # whose self-installer crashes. https://github.com/pnpm/action-setup/issues/276
-          version: 11.13.0
+          version: 11
       - name: Set up Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
# Description

Reverts #15430, which pinned pnpm to `11.11.0` in CI to work around the `pnpm/action-setup` self-install crash (`Cannot use 'in' operator to search for 'integrity' in undefined`, [action-setup#276](https://github.com/pnpm/action-setup/issues/276)). pnpm 11.13.0 resolves that crash in practice, so this restores `version: 11` in all seven `pnpm/action-setup` invocations so CI tracks the latest 11.x again. Note the upstream issue and underlying [pnpm#12959](https://github.com/pnpm/pnpm/issues/12959) remain technically open, but the current `latest` (11.13.0) is confirmed working by the community.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation.

# Testing

CI on this PR exercises the change directly: a green run confirms `pnpm/action-setup` installs the latest 11.x without the self-install crash.