### PR TITLE
Modernize resistorCapacitorCircuit question to use schemdraw and pl-units-input

### DIFF
--- a/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/question.html
+++ b/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/question.html
@@ -1,27 +1,13 @@
 <pl-question-panel>
 
-    <pl-drawing width="440" height="260" grid-size="0" answers-name="answer">
-        <pl-drawing-initial>
-            <pl-battery x1="{{params.pA.0}}" y1="{{params.pA.1}}" x2="{{params.pB.0}}" y2="{{params.pB.1}}" label="{{params.V}} V"></pl-battery>
-            <pl-resistor x1="{{params.pB.0}}" y1="{{params.pB.1}}" x2="{{params.pC.0}}" y2="{{params.pC.1}}" label="{{params.R1}}\\Omega"></pl-resistor>
-            <pl-resistor x1="{{params.pL.0}}" y1="{{params.pL.1}}" x2="{{params.pH.0}}" y2="{{params.pH.1}}" label="{{params.R2}}\\Omega"></pl-resistor>
-            <pl-capacitor x1="{{params.pK.0}}" y1="{{params.pK.1}}" x2="{{params.pI.0}}" y2="{{params.pI.1}}" label="{{params.C}} \\mu F"></pl-capacitor>
-            <pl-switch x1="{{params.pA.0}}" y1="{{params.pA.1}}" x2="{{params.pF.0}}" y2="{{params.pF.1}}" label="A" switch-angle="0"></pl-switch>
-            <pl-switch x1="{{params.pL.0}}" y1="{{params.pL.1}}" x2="{{params.pJ.0}}" y2="{{params.pJ.1}}" label="B" offsetx="-10" offsety="-5"></pl-switch>
-            <pl-line x1="{{params.pC.0}}" y1="{{params.pC.1}}" x2="{{params.pD.0}}" y2="{{params.pD.1}}"></pl-line>
-            <pl-line x1="{{params.pE.0}}" y1="{{params.pE.1}}" x2="{{params.pD.0}}" y2="{{params.pD.1}}"></pl-line>
-            <pl-line x1="{{params.pF.0}}" y1="{{params.pF.1}}" x2="{{params.pG.0}}" y2="{{params.pG.1}}"></pl-line>
-            <pl-line x1="{{params.pH.0}}" y1="{{params.pH.1}}" x2="{{params.pI.0}}" y2="{{params.pI.1}}"></pl-line>
-            <pl-line x1="{{params.pJ.0}}" y1="{{params.pJ.1}}" x2="{{params.pK.0}}" y2="{{params.pK.1}}"></pl-line>
-        </pl-drawing-initial>
-    </pl-drawing>
+<p>Consider the circuit below. Switch $B$ is open and switch $A$ has been closed for a long time.</p>
 
-    <p> 
-        Switch $B$ is open and switch $A$ has been closed for a long time. What is the charge on the capacitor?
-    </p>
-    
+<pl-figure file-name="figure.svg" type="dynamic" alt="{{params.alt}}"></pl-figure>
+
+<p>What is the charge $Q$ on the capacitor? Make sure to include a magnitude and unit in your answer.</p>
+
 </pl-question-panel>
 
 <p>
-    <pl-number-input aria-label="Capacitor charge" answers-name="charge" suffix="$\mu C$"></pl-number-input>
+    <pl-units-input answers-name="ans" label="$Q = $" placeholder="charge + unit"></pl-units-input>
 </p>

--- a/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/server.py
+++ b/exampleCourse/questions/demo/drawing/resistorCapacitorCircuit/server.py
@@ -1,46 +1,62 @@
 import random
 
+import prairielearn as pl
+import schemdraw.elements as elm
+from schemdraw import Drawing
+
+
+def file(data):
+    if data["filename"] != "figure.svg":
+        return None
+
+    params_dict = data["params"]
+
+    drawing = Drawing()
+    # Outer loop: battery on the left edge, switch A and R1 along the top edge
+    drawing += elm.BatteryCell().up().label(["$-$", params_dict["V_label"], "$+$"])
+    drawing += elm.Switch().right().length(4).label("$A$")
+    drawing += elm.Resistor().right().length(4).label(params_dict["R1_label"])
+    drawing += elm.Line().down()
+    drawing += elm.Line().left().length(1)
+
+    # Interior section between two bottom nodes:
+    # capacitor in parallel with (switch B + R2)
+    drawing.push()
+    drawing += elm.Capacitor().left().length(6).label(params_dict["C_label"], loc="bottom")
+    drawing.pop()
+    drawing += elm.Line().up().length(1.5)
+    drawing += elm.Resistor().left().label(params_dict["R2_label"])
+    drawing += elm.Switch().left().label("$B$")
+    drawing += elm.Line().down().length(1.5)
+
+    drawing += elm.Line().left().length(1)
+
+    return drawing.get_imagedata()
+
 
 def generate(data):
-    V = random.randint(12, 40)
-    data["params"]["V"] = V
+    ureg = pl.get_unit_registry()
+    params_dict = data["params"]
 
+    V = random.randint(12, 40) * ureg.volt
     R = random.sample([10, 12, 15, 18, 22, 27, 33, 39, 47, 56, 68, 82], 2)
-    data["params"]["R1"] = R[0]
-    data["params"]["R2"] = R[1]
+    R1 = R[0] * ureg.ohm
+    R2 = R[1] * ureg.ohm
+    C = random.randint(5, 15) * ureg.microfarad
 
-    C = random.randint(5, 15)
-    data["params"]["C"] = C
+    # Labels for the schemdraw figure, "~L" is the short latex format specifier
+    params_dict["V_label"] = f"${V:~L}$"
+    params_dict["R1_label"] = f"$R_1 = {R1:~L}$"
+    params_dict["R2_label"] = f"$R_2 = {R2:~L}$"
+    params_dict["C_label"] = f"$C = {C:~L}$"
 
-    # total energy
-    data["correct_answers"]["charge"] = C * V
+    params_dict["alt"] = (
+        "A circuit in which a battery, switch A, and resistor R1 are connected in "
+        "series. This loop is closed by a capacitor C, which is connected in "
+        "parallel with the series combination of switch B and resistor R2."
+    )
 
-    # data for plotting
-    pA = [60, 60]
-    L = 300
-    h = 120
-
-    pB = [pA[0] + L / 2, pA[1]]
-    pC = [pA[0] + L, pA[1]]
-    pD = [pA[0] + L, pA[1] + h]
-    pE = [pA[0] + 4 / 5 * L, pA[1] + h]
-    pF = [pA[0], pA[1] + h]
-    pG = [pA[0] + 1 / 5 * L, pB[1] + h]
-    pH = [pE[0], pE[1] - h / 4]
-    pI = [pE[0], pE[1] + h / 4]
-    pJ = [pG[0], pG[1] - h / 4]
-    pK = [pG[0], pG[1] + h / 4]
-    pL = [pF[0] + L / 2, pG[1] - h / 4]
-
-    data["params"]["pA"] = pA
-    data["params"]["pB"] = pB
-    data["params"]["pC"] = pC
-    data["params"]["pD"] = pD
-    data["params"]["pE"] = pE
-    data["params"]["pF"] = pF
-    data["params"]["pG"] = pG
-    data["params"]["pH"] = pH
-    data["params"]["pI"] = pI
-    data["params"]["pJ"] = pJ
-    data["params"]["pK"] = pK
-    data["params"]["pL"] = pL
+    # With switch A closed and switch B open, no current flows at steady state,
+    # so the full battery voltage appears across the capacitor: Q = C * V
+    Q = (C * V).to(ureg.microcoulomb)
+    data["correct_answers"]["ans"] = str(Q)


### PR DESCRIPTION
Closes #10712.

Modernizes the `demo/drawing/resistorCapacitorCircuit` example question, following the pattern established for `engCircuit` in #8179:

- Replaces the hand-positioned `pl-drawing` circuit (12 coordinate params) with a schemdraw-generated dynamic `figure.svg`
- Switches the answer from `pl-number-input` to `pl-units-input`, with the correct answer stored as a pint quantity (`(C * V).to(ureg.microcoulomb)`), so students can answer in any compatible charge unit
- Adds descriptive alt text for the figure
- Physics, randomization ranges, and difficulty are unchanged (steady state with switch A closed, switch B open: Q = C * V)

Testing: rendered the figure locally across multiple random seeds (schemdraw matplotlib + svg backends) and verified the generated correct answers (e.g. 9 uF x 32 V = 288 uC). I don't have the full docker environment set up yet, so I'd appreciate a maintainer eye on the `pl-units-input` attributes; happy to iterate.