### PR TITLE
Fix pl-drawing error boxes using different tolerance than grading

### DIFF
--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.py
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.py
@@ -266,7 +266,8 @@ def render_drawing_items(elem, curid=0, defaults=None, tol=None):
         else:
             if tol is not None:
                 generated_el = copy.copy(el)
-                generated_el.attrib.setdefault("tol", str(tol))
+                if "tol" not in generated_el.attrib:
+                    generated_el.attrib["tol"] = str(tol)
             else:
                 generated_el = el
             obj = elements.generate(generated_el, generated_el.tag, defaults)

--- a/apps/prairielearn/elements/pl-drawing/pl-drawing.py
+++ b/apps/prairielearn/elements/pl-drawing/pl-drawing.py
@@ -77,6 +77,18 @@ def check_attributes_rec(element: lxml.html.HtmlElement) -> None:
         check_attributes_rec(child)
 
 
+def get_grid_size_and_tol(element: lxml.html.HtmlElement) -> tuple[int, float]:
+    grid_size = pl.get_integer_attrib(
+        element, "grid-size", defaults.element_defaults["grid-size"]
+    )
+    tol = pl.get_float_attrib(
+        element,
+        "tol",
+        grid_size / 2 if grid_size != 0 else defaults.element_defaults["grid-size"] / 2,
+    )
+    return grid_size, tol
+
+
 def prepare(element_html: str, data: pl.QuestionData) -> None:
     element = lxml.html.fragment_fromstring(element_html)
     check_attributes_rec(element)
@@ -147,11 +159,13 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
                 'You do not have any "pl-drawing-answer" inside pl-drawing where gradable=True. You should either specify the "pl-drawing-answer" if you want to grade objects, or make gradable=False'
             )
 
+        _, tol = get_grid_size_and_tol(element)
+
         # Generate these in order so that answer elements are displayed on top of initial elements
         init = None
         if initial_child is not None:
-            init, n_id = render_drawing_items(initial_child, n_id)
-        ans, n_id = render_drawing_items(answer_child, n_id)
+            init, n_id = render_drawing_items(initial_child, n_id, tol=tol)
+        ans, n_id = render_drawing_items(answer_child, n_id, tol=tol)
 
         # Makes sure that all objects in pl-drawing-answer are graded
         # and all the objects in pl-drawing-initial are not graded
@@ -231,7 +245,7 @@ def render_controls(template: str, elem: lxml.html.HtmlElement) -> str:
         return "unknown tag " + elem.tag
 
 
-def render_drawing_items(elem, curid=0, defaults=None):
+def render_drawing_items(elem, curid=0, defaults=None, tol=None):
     # Convert a set of drawing items defined as html elements into an array of
     # objects that can be sent to mechanicsObjects.js
     # Some helpers to get attributes from elements.  If there is no default argument passed in,
@@ -245,12 +259,17 @@ def render_drawing_items(elem, curid=0, defaults=None):
         if el.tag == "pl-drawing-group":
             if pl.get_boolean_attrib(el, "visible", True):
                 curid += 1
-                raw, _ = render_drawing_items(el, curid, {"groupid": curid})
+                raw, _ = render_drawing_items(el, curid, {"groupid": curid}, tol)
                 objs = raw
                 curid += len(objs)
                 objects.extend(objs)
         else:
-            obj = elements.generate(el, el.tag, defaults)
+            if tol is not None:
+                generated_el = copy.copy(el)
+                generated_el.attrib.setdefault("tol", str(tol))
+            else:
+                generated_el = el
+            obj = elements.generate(generated_el, generated_el.tag, defaults)
             if obj is not None:
                 obj["id"] = curid
                 objects.append(obj)
@@ -281,13 +300,15 @@ def render(element_html: str, data: pl.QuestionData) -> str:
 
     load_extensions(data)
 
+    grid_size, tol = get_grid_size_and_tol(element)
+
     for el in element:
         if el.tag is lxml.etree.Comment:
             continue
         if el.tag == "pl-controls" and not preview_mode:
             btn_markup = render_controls(template, el)
         elif el.tag == "pl-drawing-initial":
-            init, _ = render_drawing_items(el)
+            init, _ = render_drawing_items(el, tol=tol)
             draw_error_box = pl.get_boolean_attrib(
                 el, "draw-error-box", defaults.element_defaults["draw-error-box"]
             )
@@ -298,14 +319,6 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         if "objectDrawErrorBox" in obj and obj["objectDrawErrorBox"] is not None:
             obj["drawErrorBox"] = obj["objectDrawErrorBox"]
 
-    grid_size = pl.get_integer_attrib(
-        element, "grid-size", defaults.element_defaults["grid-size"]
-    )
-    tol = pl.get_float_attrib(
-        element,
-        "tol",
-        grid_size / 2 if grid_size != 0 else defaults.element_defaults["grid-size"] / 2,
-    )
     angle_tol = pl.get_float_attrib(
         element, "angle-tol", defaults.element_defaults["angle-tol"]
     )
@@ -462,14 +475,7 @@ def grade(element_html: str, data: pl.QuestionData) -> None:
 
     allow_blank = pl.get_boolean_attrib(element, "allow-blank", ALLOW_BLANK_DEFAULT)
     weight = pl.get_integer_attrib(element, "weight", WEIGHT_DEFAULT)
-    grid_size = pl.get_integer_attrib(
-        element, "grid-size", defaults.element_defaults["grid-size"]
-    )
-    tol = pl.get_float_attrib(
-        element,
-        "tol",
-        grid_size / 2 if grid_size != 0 else defaults.element_defaults["grid-size"] / 2,
-    )
+    _, tol = get_grid_size_and_tol(element)
     angtol = pl.get_float_attrib(
         element, "angle-tol", defaults.element_defaults["angle-tol"]
     )
@@ -630,16 +636,7 @@ def test(element_html: str, data: pl.ElementTestData) -> None:
         }
 
     elif result == "incorrect":
-        grid_size = pl.get_integer_attrib(
-            element, "grid-size", defaults.element_defaults["grid-size"]
-        )
-        tol = pl.get_float_attrib(
-            element,
-            "tol",
-            grid_size / 2
-            if grid_size != 0
-            else defaults.element_defaults["grid-size"] / 2,
-        )
+        _, tol = get_grid_size_and_tol(element)
         angtol = pl.get_float_attrib(
             element, "angle-tol", defaults.element_defaults["angle-tol"]
         )

--- a/apps/prairielearn/elements/pl-drawing/pl_drawing_test.py
+++ b/apps/prairielearn/elements/pl-drawing/pl_drawing_test.py
@@ -91,6 +91,73 @@ def test_parse_valid_submission_works_with_allow_blank() -> None:
     assert data["submitted_answers"]["test"] == valid_answer
 
 
+def test_prepare_uses_parent_tolerance_for_error_boxes() -> None:
+    element_html = """
+    <pl-drawing answers-name="test" gradable="true" grid-size="20" tol="5">
+        <pl-drawing-answer draw-error-box="true">
+            <pl-point x1="100" y1="100"></pl-point>
+            <pl-drawing-group>
+                <pl-controlled-line
+                    x1="20"
+                    y1="40"
+                    x2="60"
+                    y2="40"
+                    offset-tol-x="3"
+                    offset-tol-y="4"
+                ></pl-controlled-line>
+            </pl-drawing-group>
+        </pl-drawing-answer>
+    </pl-drawing>
+    """
+    data = make_question_data()
+
+    pl_drawing.prepare(element_html, data)
+
+    point, line = data["correct_answers"]["test"]
+    assert point["drawErrorBox"] is True
+    assert point["widthErrorBox"] == 10
+    assert point["heightErrorBox"] == 10
+    assert line["drawErrorBox"] is True
+    assert line["widthErrorBox"] == 16
+    assert line["heightErrorBox"] == 18
+
+
+def test_prepare_uses_parent_grid_size_for_default_tolerance() -> None:
+    element_html = """
+    <pl-drawing answers-name="test" gradable="true" grid-size="12">
+        <pl-drawing-answer draw-error-box="true">
+            <pl-point x1="100" y1="100"></pl-point>
+        </pl-drawing-answer>
+    </pl-drawing>
+    """
+    data = make_question_data()
+
+    pl_drawing.prepare(element_html, data)
+
+    point = data["correct_answers"]["test"][0]
+    assert point["widthErrorBox"] == 12
+    assert point["heightErrorBox"] == 12
+
+
+def test_parent_grid_size_does_not_change_paired_vector_position_defaults() -> None:
+    element_html = """
+    <pl-drawing answers-name="test" gradable="true" grid-size="0" tol="5">
+        <pl-drawing-answer>
+            <pl-paired-vector></pl-paired-vector>
+        </pl-drawing-answer>
+    </pl-drawing>
+    """
+    data = make_question_data()
+
+    pl_drawing.prepare(element_html, data)
+
+    paired_vector = data["correct_answers"]["test"][0]
+    assert paired_vector["x1"] == 40
+    assert paired_vector["y1"] == 20
+    assert paired_vector["x2"] == 60
+    assert paired_vector["y2"] == 40
+
+
 def test_grade_blank_submission_without_allow_blank_sets_error() -> None:
     element_html = build_element_html(allow_blank=False)
     data = make_question_data(

--- a/apps/prairielearn/elements/pl-drawing/pl_drawing_test.py
+++ b/apps/prairielearn/elements/pl-drawing/pl_drawing_test.py
@@ -93,8 +93,8 @@ def test_parse_valid_submission_works_with_allow_blank() -> None:
 
 def test_prepare_uses_parent_tolerance_for_error_boxes() -> None:
     element_html = """
-    <pl-drawing answers-name="test" gradable="true" grid-size="20" tol="5">
-        <pl-drawing-answer draw-error-box="true">
+    <pl-drawing answers-name="test" gradable="true" tol="5">
+        <pl-drawing-answer>
             <pl-point x1="100" y1="100"></pl-point>
             <pl-drawing-group>
                 <pl-controlled-line
@@ -114,18 +114,14 @@ def test_prepare_uses_parent_tolerance_for_error_boxes() -> None:
     pl_drawing.prepare(element_html, data)
 
     point, line = data["correct_answers"]["test"]
-    assert point["drawErrorBox"] is True
-    assert point["widthErrorBox"] == 10
-    assert point["heightErrorBox"] == 10
-    assert line["drawErrorBox"] is True
-    assert line["widthErrorBox"] == 16
-    assert line["heightErrorBox"] == 18
+    assert (point["widthErrorBox"], point["heightErrorBox"]) == (10, 10)
+    assert (line["widthErrorBox"], line["heightErrorBox"]) == (16, 18)
 
 
 def test_prepare_uses_parent_grid_size_for_default_tolerance() -> None:
     element_html = """
     <pl-drawing answers-name="test" gradable="true" grid-size="12">
-        <pl-drawing-answer draw-error-box="true">
+        <pl-drawing-answer>
             <pl-point x1="100" y1="100"></pl-point>
         </pl-drawing-answer>
     </pl-drawing>
@@ -135,8 +131,7 @@ def test_prepare_uses_parent_grid_size_for_default_tolerance() -> None:
     pl_drawing.prepare(element_html, data)
 
     point = data["correct_answers"]["test"][0]
-    assert point["widthErrorBox"] == 12
-    assert point["heightErrorBox"] == 12
+    assert (point["widthErrorBox"], point["heightErrorBox"]) == (12, 12)
 
 
 def test_parent_grid_size_does_not_change_paired_vector_position_defaults() -> None:
@@ -152,10 +147,12 @@ def test_parent_grid_size_does_not_change_paired_vector_position_defaults() -> N
     pl_drawing.prepare(element_html, data)
 
     paired_vector = data["correct_answers"]["test"][0]
-    assert paired_vector["x1"] == 40
-    assert paired_vector["y1"] == 20
-    assert paired_vector["x2"] == 60
-    assert paired_vector["y2"] == 40
+    assert (
+        paired_vector["x1"],
+        paired_vector["y1"],
+        paired_vector["x2"],
+        paired_vector["y2"],
+    ) == (40, 20, 60, 40)
 
 
 def test_grade_blank_submission_without_allow_blank_sets_error() -> None:


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Pass the calculated tolerance to all children.

closes https://github.com/PrairieLearn/PrairieLearn/issues/15245

why the changes?
answer panel error box uses a different tolerance than the one specified (see the image below), hence wanted to fix it.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
AI generated the first code which i later simplified and refactored manually.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

| Before | After |
|--------|--------|
| <img width="1325" height="1341" alt="image" src="https://github.com/user-attachments/assets/fd557097-48ee-4507-8603-590f1b97e2e8" /> | <img width="1325" height="1341" alt="image" src="https://github.com/user-attachments/assets/c89d2e08-9b7c-49f2-99f8-b1c41c7ac1b9" /> | 