### PR TITLE
Allow full-credit grace periods in modern access controls

### DIFF
--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -554,24 +554,12 @@ describe('Deadline credit schema validation', () => {
       dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 101 }] },
     },
     {
-      label: 'maximum bonus credit on an early deadline',
-      dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 200 }] },
-    },
-    {
       label: '100% credit on a late deadline',
       dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 100 }] },
     },
     {
-      label: '0% credit on a late deadline',
-      dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 0 }] },
-    },
-    {
       label: '100% credit after the due date',
       dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: 100 } },
-    },
-    {
-      label: '0% credit after the due date',
-      dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: 0 } },
     },
   ])('accepts $label', ({ dateControl }) => {
     assert.isTrue(AccessControlJsonSchema.safeParse({ dateControl }).success);
@@ -583,24 +571,12 @@ describe('Deadline credit schema validation', () => {
       dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 100 }] },
     },
     {
-      label: 'early deadline credit above 200%',
-      dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 201 }] },
-    },
-    {
       label: 'late deadline credit above 100%',
       dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 101 }] },
     },
     {
-      label: 'late deadline credit below 0%',
-      dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: -1 }] },
-    },
-    {
       label: 'after-due credit above 100%',
       dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: 101 } },
-    },
-    {
-      label: 'after-due credit below 0%',
-      dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: -1 } },
     },
   ])('rejects $label', ({ dateControl }) => {
     assert.isFalse(AccessControlJsonSchema.safeParse({ dateControl }).success);
@@ -924,7 +900,6 @@ describe('Credit ordering validation', () => {
           ],
         },
       },
-      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'equal early deadline credits',
@@ -936,7 +911,6 @@ describe('Credit ordering validation', () => {
           ],
         },
       },
-      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'increasing late deadline credits',
@@ -948,7 +922,6 @@ describe('Credit ordering validation', () => {
           ],
         },
       },
-      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'afterLastDeadline credit exceeding last late deadline',
@@ -962,7 +935,6 @@ describe('Credit ordering validation', () => {
           afterLastDeadline: { allowSubmissions: true, credit: 60 },
         },
       },
-      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'consecutive late deadlines with equal credit',
@@ -975,7 +947,6 @@ describe('Credit ordering validation', () => {
           ],
         },
       },
-      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'afterLastDeadline credit equal to last late deadline',
@@ -986,12 +957,11 @@ describe('Credit ordering validation', () => {
           afterLastDeadline: { allowSubmissions: true, credit: 100 },
         },
       },
-      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
-  ])('rejects $label', ({ config, errorMatch }) => {
+  ])('rejects $label', ({ config }) => {
     const rule = AccessControlJsonSchema.parse(config);
     const errors = validateRuleCreditOrdering(rule);
-    assert.isTrue(errors.includes(errorMatch));
+    assert.isTrue(errors.includes(CREDIT_ORDERING_MESSAGE));
   });
 
   it.each([

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -20,8 +20,6 @@ import {
   validateRuleStructuralDependencyIssues,
 } from './validation.js';
 
-const CREDIT_ORDERING_MESSAGE = 'Credit must strictly decrease over time.';
-
 function uuidForIndex(index: number): string {
   return `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`;
 }
@@ -960,7 +958,7 @@ describe('Credit ordering validation', () => {
   ])('rejects $label', ({ config }) => {
     const rule = AccessControlJsonSchema.parse(config);
     const errors = validateRuleCreditOrdering(rule);
-    assert.isTrue(errors.includes(CREDIT_ORDERING_MESSAGE));
+    assert.isTrue(errors.includes('Credit must strictly decrease over time.'));
   });
 
   it.each([
@@ -1273,7 +1271,7 @@ describe('Global credit validation', () => {
       },
     );
 
-    assert.isTrue(messages.includes(CREDIT_ORDERING_MESSAGE));
+    assert.isTrue(messages.includes('Credit must strictly decrease over time.'));
   });
 
   it('accepts override late deadline credit equal to inherited due credit', () => {
@@ -1356,7 +1354,7 @@ describe('Global credit validation', () => {
       },
     );
 
-    assert.isTrue(messages.includes(CREDIT_ORDERING_MESSAGE));
+    assert.isTrue(messages.includes('Credit must strictly decrease over time.'));
   });
 
   it('accepts afterLastDeadline credit equal to inherited due credit without late deadlines', () => {

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -15,7 +15,7 @@ import {
   validateGlobalDateConsistencyIssues,
   validateGlobalStructuralDependencyIssues,
   validateRule,
-  validateRuleCreditOrdering,
+  validateRuleCreditOrderingIssues,
   validateRuleDateOrdering,
   validateRuleStructuralDependencyIssues,
 } from './validation.js';
@@ -957,8 +957,14 @@ describe('Credit ordering validation', () => {
     },
   ])('rejects $label', ({ config }) => {
     const rule = AccessControlJsonSchema.parse(config);
-    const errors = validateRuleCreditOrdering(rule);
-    assert.isTrue(errors.includes('Credit must strictly decrease over time.'));
+    const issues = validateRuleCreditOrderingIssues({
+      rule,
+      targetType: 'none',
+      ruleIndex: 0,
+    });
+    assert.isTrue(
+      issues.some((issue) => issue.message === 'Credit must strictly decrease over time.'),
+    );
   });
 
   it.each([
@@ -1061,7 +1067,14 @@ describe('Credit ordering validation', () => {
     },
   ])('accepts $label', ({ config }) => {
     const rule = AccessControlJsonSchema.parse(config);
-    assert.deepEqual(validateRuleCreditOrdering(rule), []);
+    assert.deepEqual(
+      validateRuleCreditOrderingIssues({
+        rule,
+        targetType: 'none',
+        ruleIndex: 0,
+      }),
+      [],
+    );
   });
 });
 

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -967,6 +967,30 @@ describe('Credit ordering validation', () => {
     );
   });
 
+  it('reports every post-due credit above 100%', () => {
+    const issues = validateRuleCreditOrderingIssues({
+      rule: {
+        dateControl: {
+          due: { date: '2024-03-21T00:00:00' },
+          lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 101 }],
+          afterLastDeadline: { allowSubmissions: true, credit: 102 },
+        },
+      },
+      targetType: 'none',
+      ruleIndex: 0,
+    });
+
+    assert.deepEqual(
+      issues
+        .filter((issue) => issue.message === 'Credit after the due date must be at most 100%.')
+        .map((issue) => issue.path),
+      [
+        ['dateControl', 'lateDeadlines', 0, 'credit'],
+        ['dateControl', 'afterLastDeadline', 'credit'],
+      ],
+    );
+  });
+
   it.each([
     {
       label: 'early deadline credit above default due credit',
@@ -1268,6 +1292,39 @@ describe('Global credit validation', () => {
     validateGlobalCreditConsistencyIssues(
       rules.map((rule, ruleIndex) => validationRule(rule, ruleIndex)),
     ).map((issue) => issue.message);
+
+  it('reports every post-due credit above 100% on an override', () => {
+    const issues = validateGlobalCreditConsistencyIssues([
+      {
+        rule: {
+          dateControl: { due: { date: '2024-04-10T00:00:00', credit: 110 } },
+        },
+        targetType: 'none',
+        ruleIndex: 0,
+      },
+      {
+        rule: {
+          labels: ['Section A'],
+          dateControl: {
+            lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 101 }],
+            afterLastDeadline: { allowSubmissions: true, credit: 102 },
+          },
+        },
+        targetType: 'student_label',
+        ruleIndex: 1,
+      },
+    ]);
+
+    assert.deepEqual(
+      issues
+        .filter((issue) => issue.message === 'Credit after the due date must be at most 100%.')
+        .map((issue) => issue.path),
+      [
+        ['dateControl', 'lateDeadlines', 0, 'credit'],
+        ['dateControl', 'afterLastDeadline', 'credit'],
+      ],
+    );
+  });
 
   it('rejects override late deadline credit above inherited due credit', () => {
     const messages = messagesFor(

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -20,6 +20,9 @@ import {
   validateRuleStructuralDependencyIssues,
 } from './validation.js';
 
+const CREDIT_ORDERING_MESSAGE =
+  'Credit must strictly decrease at every boundary, except that the first late deadline—or after-due credit when there are no late deadlines—may match due-date credit.';
+
 function uuidForIndex(index: number): string {
   return `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`;
 }
@@ -517,7 +520,7 @@ describe('Date fields must be dates', () => {
     },
     {
       label: 'early deadline date',
-      config: { dateControl: { earlyDeadlines: [{ date: 'NOTADATE', credit: 100 }] } },
+      config: { dateControl: { earlyDeadlines: [{ date: 'NOTADATE', credit: 101 }] } },
       expectedPath: ['dateControl', 'earlyDeadlines', 0, 'date'],
     },
     {
@@ -541,6 +544,66 @@ describe('Date fields must be dates', () => {
         (issue) => JSON.stringify(issue.path) === JSON.stringify(expectedPath),
       ),
     );
+  });
+});
+
+describe('Deadline credit schema validation', () => {
+  it.each([
+    {
+      label: 'minimum bonus credit on an early deadline',
+      dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 101 }] },
+    },
+    {
+      label: 'maximum bonus credit on an early deadline',
+      dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 200 }] },
+    },
+    {
+      label: '100% credit on a late deadline',
+      dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 100 }] },
+    },
+    {
+      label: '0% credit on a late deadline',
+      dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 0 }] },
+    },
+    {
+      label: '100% credit after the due date',
+      dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: 100 } },
+    },
+    {
+      label: '0% credit after the due date',
+      dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: 0 } },
+    },
+  ])('accepts $label', ({ dateControl }) => {
+    assert.isTrue(AccessControlJsonSchema.safeParse({ dateControl }).success);
+  });
+
+  it.each([
+    {
+      label: 'early deadline credit at or below 100%',
+      dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 100 }] },
+    },
+    {
+      label: 'early deadline credit above 200%',
+      dateControl: { earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 201 }] },
+    },
+    {
+      label: 'late deadline credit above 100%',
+      dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 101 }] },
+    },
+    {
+      label: 'late deadline credit below 0%',
+      dateControl: { lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: -1 }] },
+    },
+    {
+      label: 'after-due credit above 100%',
+      dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: 101 } },
+    },
+    {
+      label: 'after-due credit below 0%',
+      dateControl: { afterLastDeadline: { allowSubmissions: true as const, credit: -1 } },
+    },
+  ])('rejects $label', ({ dateControl }) => {
+    assert.isFalse(AccessControlJsonSchema.safeParse({ dateControl }).success);
   });
 });
 
@@ -861,7 +924,19 @@ describe('Credit ordering validation', () => {
           ],
         },
       },
-      errorMatch: 'Deadline credits must strictly decrease over time.',
+      errorMatch: CREDIT_ORDERING_MESSAGE,
+    },
+    {
+      label: 'equal early deadline credits',
+      config: {
+        dateControl: {
+          earlyDeadlines: [
+            { date: '2024-03-12T00:00:00', credit: 120 },
+            { date: '2024-03-15T00:00:00', credit: 120 },
+          ],
+        },
+      },
+      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'increasing late deadline credits',
@@ -873,16 +948,7 @@ describe('Credit ordering validation', () => {
           ],
         },
       },
-      errorMatch: 'Deadline credits must strictly decrease over time.',
-    },
-    {
-      label: 'early deadline credit equal to implicit due credit',
-      config: {
-        dateControl: {
-          earlyDeadlines: [{ date: '2024-03-15T00:00:00', credit: 100 }],
-        },
-      },
-      errorMatch: 'Deadline credits must strictly decrease over time.',
+      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'afterLastDeadline credit exceeding last late deadline',
@@ -896,38 +962,31 @@ describe('Credit ordering validation', () => {
           afterLastDeadline: { allowSubmissions: true, credit: 60 },
         },
       },
-      errorMatch: 'Deadline credits must strictly decrease over time.',
+      errorMatch: CREDIT_ORDERING_MESSAGE,
+    },
+    {
+      label: 'consecutive late deadlines with equal credit',
+      config: {
+        dateControl: {
+          due: { date: '2024-03-21T00:00:00' },
+          lateDeadlines: [
+            { date: '2024-03-25T00:00:00', credit: 100 },
+            { date: '2024-03-28T00:00:00', credit: 100 },
+          ],
+        },
+      },
+      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
     {
       label: 'afterLastDeadline credit equal to last late deadline',
       config: {
         dateControl: {
           due: { date: '2024-03-21T00:00:00' },
-          lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 50 }],
-          afterLastDeadline: { allowSubmissions: true, credit: 50 },
-        },
-      },
-      errorMatch: 'Deadline credits must strictly decrease over time.',
-    },
-    {
-      label: 'late deadline credit equal to custom due credit',
-      config: {
-        dateControl: {
-          due: { date: '2024-03-21T00:00:00', credit: 80 },
-          lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 80 }],
-        },
-      },
-      errorMatch: 'Deadline credits must strictly decrease over time.',
-    },
-    {
-      label: 'late deadline credit at 100% under bonus due credit',
-      config: {
-        dateControl: {
-          due: { date: '2024-03-21T00:00:00', credit: 110 },
           lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 100 }],
+          afterLastDeadline: { allowSubmissions: true, credit: 100 },
         },
       },
-      errorMatch: 'Credit after the due date must be less than 100%.',
+      errorMatch: CREDIT_ORDERING_MESSAGE,
     },
   ])('rejects $label', ({ config, errorMatch }) => {
     const rule = AccessControlJsonSchema.parse(config);
@@ -946,6 +1005,24 @@ describe('Credit ordering validation', () => {
         dateControl: {
           due: { date: '2024-03-21T00:00:00', credit: 110 },
           lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 99 }],
+        },
+      },
+    },
+    {
+      label: 'late deadline credit at 100% under bonus due credit',
+      config: {
+        dateControl: {
+          due: { date: '2024-03-21T00:00:00', credit: 110 },
+          lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 100 }],
+        },
+      },
+    },
+    {
+      label: 'late deadline credit equal to custom due credit',
+      config: {
+        dateControl: {
+          due: { date: '2024-03-21T00:00:00', credit: 80 },
+          lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 80 }],
         },
       },
     },
@@ -980,6 +1057,24 @@ describe('Credit ordering validation', () => {
           due: { date: '2024-03-21T00:00:00' },
           lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 50 }],
           afterLastDeadline: { allowSubmissions: true, credit: 30 },
+        },
+      },
+    },
+    {
+      label: 'full-credit grace period until a late deadline',
+      config: {
+        dateControl: {
+          due: { date: '2024-03-21T00:00:00' },
+          lateDeadlines: [{ date: '2024-03-25T00:00:00', credit: 100 }],
+        },
+      },
+    },
+    {
+      label: 'full credit after the due date without late deadlines',
+      config: {
+        dateControl: {
+          due: { date: '2024-03-21T00:00:00' },
+          afterLastDeadline: { allowSubmissions: true, credit: 100 },
         },
       },
     },
@@ -1194,7 +1289,25 @@ describe('Global credit validation', () => {
       rules.map((rule, ruleIndex) => validationRule(rule, ruleIndex)),
     ).map((issue) => issue.message);
 
-  it('rejects override late deadline credit equal to inherited due credit', () => {
+  it('rejects override late deadline credit above inherited due credit', () => {
+    const messages = messagesFor(
+      {
+        dateControl: {
+          due: { date: '2024-04-10T00:00:00', credit: 80 },
+        },
+      },
+      {
+        labels: ['Section A'],
+        dateControl: {
+          lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 90 }],
+        },
+      },
+    );
+
+    assert.isTrue(messages.includes(CREDIT_ORDERING_MESSAGE));
+  });
+
+  it('accepts override late deadline credit equal to inherited due credit', () => {
     const messages = messagesFor(
       {
         dateControl: {
@@ -1209,7 +1322,7 @@ describe('Global credit validation', () => {
       },
     );
 
-    assert.isTrue(messages.includes('Deadline credits must strictly decrease over time.'));
+    assert.deepEqual(messages, []);
   });
 
   it('uses inherited default due credit to reject override early deadlines', () => {
@@ -1222,7 +1335,7 @@ describe('Global credit validation', () => {
       {
         labels: ['Section A'],
         dateControl: {
-          earlyDeadlines: [{ date: '2024-04-09T00:00:00', credit: 90 }],
+          earlyDeadlines: [{ date: '2024-04-09T00:00:00', credit: 110 }],
         },
       },
     );
@@ -1230,38 +1343,6 @@ describe('Global credit validation', () => {
     assert.isTrue(
       messages.includes('Early deadlines are not allowed when due date credit is below 100%.'),
     );
-  });
-
-  it('rejects an override late deadline credit above 100% when inherited due credit is higher', () => {
-    const messages = messagesFor(
-      {
-        dateControl: {
-          due: { date: '2024-04-10T00:00:00', credit: 110 },
-        },
-      },
-      {
-        labels: ['Section A'],
-        dateControl: {
-          lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 105 }],
-        },
-      },
-    );
-
-    assert.isTrue(messages.includes('Credit after the due date must be less than 100%.'));
-  });
-
-  it('rejects override early deadline credit equal to an implicit inherited due credit', () => {
-    const messages = messagesFor(
-      {},
-      {
-        labels: ['Section A'],
-        dateControl: {
-          earlyDeadlines: [{ date: '2024-04-09T00:00:00', credit: 100 }],
-        },
-      },
-    );
-
-    assert.isTrue(messages.includes('Deadline credits must strictly decrease over time.'));
   });
 
   it('does not check enrollment rules against unrelated student-label overrides', () => {
@@ -1306,7 +1387,25 @@ describe('Global credit validation', () => {
       },
     );
 
-    assert.isTrue(messages.includes('Deadline credits must strictly decrease over time.'));
+    assert.isTrue(messages.includes(CREDIT_ORDERING_MESSAGE));
+  });
+
+  it('accepts afterLastDeadline credit equal to inherited due credit without late deadlines', () => {
+    const messages = messagesFor(
+      {
+        dateControl: {
+          due: { date: '2024-04-10T00:00:00' },
+        },
+      },
+      {
+        labels: ['Section A'],
+        dateControl: {
+          afterLastDeadline: { allowSubmissions: true, credit: 100 },
+        },
+      },
+    );
+
+    assert.deepEqual(messages, []);
   });
 });
 

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.test.ts
@@ -20,8 +20,7 @@ import {
   validateRuleStructuralDependencyIssues,
 } from './validation.js';
 
-const CREDIT_ORDERING_MESSAGE =
-  'Credit must strictly decrease at every boundary, except that the first late deadline—or after-due credit when there are no late deadlines—may match due-date credit.';
+const CREDIT_ORDERING_MESSAGE = 'Credit must strictly decrease over time.';
 
 function uuidForIndex(index: number): string {
   return `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`;

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -1,10 +1,13 @@
 import {
   type AccessControlJson,
+  MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
   MAX_ENROLLMENT_ACCESS_CONTROL_RULES,
   MAX_STUDENT_LABEL_ACCESS_CONTROL_RULES,
 } from '../../schemas/accessControl.js';
 
-const POST_DUE_CREDIT_MESSAGE = 'Credit after the due date must be less than 100%.';
+const POST_DUE_CREDIT_MESSAGE = `Credit after the due date must be at most ${MAX_ACCESS_CONTROL_POST_DUE_CREDIT}%.`;
+const CREDIT_ORDERING_MESSAGE =
+  'Credit must strictly decrease at every boundary, except that the first late deadline—or after-due credit when there are no late deadlines—may match due-date credit.';
 
 export type AccessControlRuleTargetType = 'none' | 'student_label' | 'enrollment';
 
@@ -415,7 +418,8 @@ export function validateGlobalDateConsistencyIssues(
 
 /**
  * Checks each override's effective deadline sequence, after inheriting default
- * fields, for post-due credit below 100% and strictly decreasing credit.
+ * fields, for post-due credit at most 100% and decreasing credit, with one
+ * equal-credit window allowed immediately after the due date.
  */
 export function validateGlobalCreditConsistencyIssues(
   validationRules: AccessControlValidationRule[],
@@ -445,7 +449,7 @@ export function validateGlobalCreditConsistencyIssues(
     const postDueEntry = effectiveEntries.find(
       (entry) =>
         (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') &&
-        entry.credit >= 100 &&
+        entry.credit > MAX_ACCESS_CONTROL_POST_DUE_CREDIT &&
         entry.validationRule === validationRule,
     );
     if (postDueEntry) {
@@ -456,16 +460,13 @@ export function validateGlobalCreditConsistencyIssues(
     for (let i = 1; i < effectiveEntries.length; i++) {
       const previous = effectiveEntries[i - 1];
       const current = effectiveEntries[i];
-      if (current.credit < previous.credit) continue;
+      if (isValidCreditTransition(previous, current)) {
+        continue;
+      }
 
       const issueEntry = chooseEffectiveIssueEntry(validationRule, current, previous);
       if (!issueEntry) continue;
-      pushIssue(
-        issues,
-        issueEntry.validationRule,
-        issueEntry.path,
-        'Deadline credits must strictly decrease over time.',
-      );
+      pushIssue(issues, issueEntry.validationRule, issueEntry.path, CREDIT_ORDERING_MESSAGE);
       break;
     }
   }
@@ -478,16 +479,31 @@ type CreditEntryKind = 'earlyDeadline' | 'due' | 'lateDeadline' | 'afterLastDead
 /**
  * One credit-bearing point in a rule's deadline timeline. The list of entries
  * for a rule, in chronological order, is the model the credit validators
- * operate on: post-due credit must be < 100% and credits must strictly
- * decrease across the list. `validationRule` records which rule supplied the
- * entry — under inheritance the source may differ from the rule being
- * validated, and the path is relative to that source.
+ * operate on: post-due credit must be at most 100%, credits must decrease
+ * across the list, and the first post-due entry may equal the due credit.
+ * `validationRule` records which rule supplied the entry — under inheritance
+ * the source may differ from the rule being validated, and the path is
+ * relative to that source.
  */
 interface CreditEntry {
   kind: CreditEntryKind;
   credit: number;
   validationRule: AccessControlValidationRule;
   path: AccessControlIssuePath;
+}
+
+/**
+ * Credit may stay constant only from the due window into the immediately
+ * following window. Adjacency to `due` is what prevents consecutive equal
+ * late deadlines or equal credit after a late deadline.
+ */
+function isValidCreditTransition(previous: CreditEntry, current: CreditEntry): boolean {
+  if (current.credit < previous.credit) return true;
+  return (
+    current.credit === previous.credit &&
+    previous.kind === 'due' &&
+    (current.kind === 'lateDeadline' || current.kind === 'afterLastDeadline')
+  );
 }
 
 type DateControlField = keyof NonNullable<AccessControlJson['dateControl']>;
@@ -499,7 +515,7 @@ type DateControlField = keyof NonNullable<AccessControlJson['dateControl']>;
  *
  * When `synthesizeImplicitDue` is true and the rule has any other credit
  * field set without a `due`, an implicit 100% due entry is inserted so the
- * strict-decrease check has an anchor. Per-rule validation only synthesizes
+ * credit-ordering check has an anchor. Per-rule validation only synthesizes
  * for the default rule (overrides may legitimately omit `due` and inherit
  * it); cross-rule validation always synthesizes since any override's
  * effective timeline includes the inherited due.
@@ -726,8 +742,8 @@ export function validateRuleDateOrdering(rule: AccessControlJson): string[] {
 
 /**
  * Validates credit ordering within a single access control rule: post-due
- * credits must be below 100%, and credits must strictly decrease across the
- * timeline.
+ * credits must be at most 100%, and credits must strictly decrease except for
+ * the first credit window after the due date, which may equal the due credit.
  */
 export function validateRuleCreditOrderingIssues(
   validationRule: AccessControlValidationRule,
@@ -737,7 +753,8 @@ export function validateRuleCreditOrderingIssues(
 
   const postDueEntry = entries.find(
     (entry) =>
-      (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') && entry.credit >= 100,
+      (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') &&
+      entry.credit > MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
   );
   if (postDueEntry) {
     pushIssue(issues, validationRule, postDueEntry.path, POST_DUE_CREDIT_MESSAGE);
@@ -745,13 +762,10 @@ export function validateRuleCreditOrderingIssues(
   }
 
   for (let i = 1; i < entries.length; i++) {
-    if (entries[i].credit < entries[i - 1].credit) continue;
-    pushIssue(
-      issues,
-      validationRule,
-      entries[i].path,
-      'Deadline credits must strictly decrease over time.',
-    );
+    if (isValidCreditTransition(entries[i - 1], entries[i])) {
+      continue;
+    }
+    pushIssue(issues, validationRule, entries[i].path, CREDIT_ORDERING_MESSAGE);
     break;
   }
 
@@ -881,7 +895,7 @@ export function validateRule(
   const dateErrors = validateRuleDateOrdering(rule);
   errors.push(...dateErrors);
   // Credit ordering assumes deadlines are chronological; skip if dates are
-  // out of order to avoid misleading "credits must strictly decrease" errors.
+  // out of order to avoid misleading credit-ordering errors.
   if (dateErrors.length === 0) {
     errors.push(...validateRuleCreditOrdering(rule, targetType));
   }

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -5,7 +5,6 @@ import {
 } from '../../schemas/accessControl.js';
 
 const POST_DUE_CREDIT_MESSAGE = 'Credit after the due date must be at most 100%.';
-const CREDIT_ORDERING_MESSAGE = 'Credit must strictly decrease over time.';
 
 export type AccessControlRuleTargetType = 'none' | 'student_label' | 'enrollment';
 
@@ -452,7 +451,6 @@ export function validateGlobalCreditConsistencyIssues(
     );
     if (postDueEntry) {
       pushIssue(issues, validationRule, postDueEntry.path, POST_DUE_CREDIT_MESSAGE);
-      continue;
     }
 
     for (let i = 1; i < effectiveEntries.length; i++) {
@@ -464,8 +462,12 @@ export function validateGlobalCreditConsistencyIssues(
 
       const issueEntry = chooseEffectiveIssueEntry(validationRule, current, previous);
       if (!issueEntry) continue;
-      pushIssue(issues, issueEntry.validationRule, issueEntry.path, CREDIT_ORDERING_MESSAGE);
-      break;
+      pushIssue(
+        issues,
+        issueEntry.validationRule,
+        issueEntry.path,
+        'Credit must strictly decrease over time.',
+      );
     }
   }
 
@@ -755,15 +757,13 @@ export function validateRuleCreditOrderingIssues(
   );
   if (postDueEntry) {
     pushIssue(issues, validationRule, postDueEntry.path, POST_DUE_CREDIT_MESSAGE);
-    return issues;
   }
 
   for (let i = 1; i < entries.length; i++) {
     if (isValidCreditTransition(entries[i - 1], entries[i])) {
       continue;
     }
-    pushIssue(issues, validationRule, entries[i].path, CREDIT_ORDERING_MESSAGE);
-    break;
+    pushIssue(issues, validationRule, entries[i].path, 'Credit must strictly decrease over time.');
   }
 
   return issues;
@@ -777,11 +777,13 @@ export function validateRuleCreditOrdering(
   rule: AccessControlJson,
   targetType: AccessControlRuleTargetType = 'none',
 ): string[] {
-  return validateRuleCreditOrderingIssues({
+  // The legacy string API returns one message; path-aware callers use the issue API above.
+  const [issue] = validateRuleCreditOrderingIssues({
     rule,
     targetType,
     ruleIndex: 0,
-  }).map((issue) => issue.message);
+  });
+  return issue ? [issue.message] : [];
 }
 
 /**

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -770,23 +770,6 @@ export function validateRuleCreditOrderingIssues(
 }
 
 /**
- * Validates credit ordering within a single access control rule.
- * Returns an array of error messages (empty if valid).
- */
-export function validateRuleCreditOrdering(
-  rule: AccessControlJson,
-  targetType: AccessControlRuleTargetType = 'none',
-): string[] {
-  // The legacy string API returns one message; path-aware callers use the issue API above.
-  const [issue] = validateRuleCreditOrderingIssues({
-    rule,
-    targetType,
-    ruleIndex: 0,
-  });
-  return issue ? [issue.message] : [];
-}
-
-/**
  * Validates a single access control rule. Checks duplicates, date ordering,
  * credit ordering, and target-type constraints (e.g. integrations and
  * beforeRelease are only valid on the default rule).
@@ -896,7 +879,13 @@ export function validateRule(
   // Credit ordering assumes deadlines are chronological; skip if dates are
   // out of order to avoid misleading credit-ordering errors.
   if (dateErrors.length === 0) {
-    errors.push(...validateRuleCreditOrdering(rule, targetType));
+    errors.push(
+      ...validateRuleCreditOrderingIssues({
+        rule,
+        targetType,
+        ruleIndex: 0,
+      }).map((issue) => issue.message),
+    );
   }
 
   return errors;

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -5,8 +5,7 @@ import {
 } from '../../schemas/accessControl.js';
 
 const POST_DUE_CREDIT_MESSAGE = 'Credit after the due date must be at most 100%.';
-const CREDIT_ORDERING_MESSAGE =
-  'Credit must strictly decrease at every boundary, except that the first late deadline—or after-due credit when there are no late deadlines—may match due-date credit.';
+const CREDIT_ORDERING_MESSAGE = 'Credit must strictly decrease over time.';
 
 export type AccessControlRuleTargetType = 'none' | 'student_label' | 'enrollment';
 

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -1,11 +1,10 @@
 import {
   type AccessControlJson,
-  MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
   MAX_ENROLLMENT_ACCESS_CONTROL_RULES,
   MAX_STUDENT_LABEL_ACCESS_CONTROL_RULES,
 } from '../../schemas/accessControl.js';
 
-const POST_DUE_CREDIT_MESSAGE = `Credit after the due date must be at most ${MAX_ACCESS_CONTROL_POST_DUE_CREDIT}%.`;
+const POST_DUE_CREDIT_MESSAGE = 'Credit after the due date must be at most 100%.';
 const CREDIT_ORDERING_MESSAGE =
   'Credit must strictly decrease at every boundary, except that the first late deadline—or after-due credit when there are no late deadlines—may match due-date credit.';
 
@@ -449,7 +448,7 @@ export function validateGlobalCreditConsistencyIssues(
     const postDueEntry = effectiveEntries.find(
       (entry) =>
         (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') &&
-        entry.credit > MAX_ACCESS_CONTROL_POST_DUE_CREDIT &&
+        entry.credit > 100 &&
         entry.validationRule === validationRule,
     );
     if (postDueEntry) {
@@ -753,8 +752,7 @@ export function validateRuleCreditOrderingIssues(
 
   const postDueEntry = entries.find(
     (entry) =>
-      (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') &&
-      entry.credit > MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+      (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') && entry.credit > 100,
   );
   if (postDueEntry) {
     pushIssue(issues, validationRule, postDueEntry.path, POST_DUE_CREDIT_MESSAGE);

--- a/apps/prairielearn/src/lib/assessment-access-control/validation.ts
+++ b/apps/prairielearn/src/lib/assessment-access-control/validation.ts
@@ -443,14 +443,14 @@ export function validateGlobalCreditConsistencyIssues(
       }
     }
 
-    const postDueEntry = effectiveEntries.find(
-      (entry) =>
+    for (const entry of effectiveEntries) {
+      if (
         (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') &&
         entry.credit > 100 &&
-        entry.validationRule === validationRule,
-    );
-    if (postDueEntry) {
-      pushIssue(issues, validationRule, postDueEntry.path, POST_DUE_CREDIT_MESSAGE);
+        entry.validationRule === validationRule
+      ) {
+        pushIssue(issues, validationRule, entry.path, POST_DUE_CREDIT_MESSAGE);
+      }
     }
 
     for (let i = 1; i < effectiveEntries.length; i++) {
@@ -751,12 +751,13 @@ export function validateRuleCreditOrderingIssues(
   const issues: AccessControlValidationIssue[] = [];
   const entries = getRuleCreditEntries(validationRule);
 
-  const postDueEntry = entries.find(
-    (entry) =>
-      (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') && entry.credit > 100,
-  );
-  if (postDueEntry) {
-    pushIssue(issues, validationRule, postDueEntry.path, POST_DUE_CREDIT_MESSAGE);
+  for (const entry of entries) {
+    if (
+      (entry.kind === 'lateDeadline' || entry.kind === 'afterLastDeadline') &&
+      entry.credit > 100
+    ) {
+      pushIssue(issues, validationRule, entry.path, POST_DUE_CREDIT_MESSAGE);
+    }
   }
 
   for (let i = 1; i < entries.length; i++) {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -12,7 +12,6 @@ import {
 import { RichSelect, type RichSelectItem } from '@prairielearn/ui';
 
 import { FriendlyDate } from '../../../../components/FriendlyDate.js';
-import { MAX_ACCESS_CONTROL_POST_DUE_CREDIT } from '../../../../schemas/accessControl.js';
 import { useAccessControlRuleEditable } from '../AccessControlEditabilityContext.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
@@ -63,8 +62,8 @@ function getDefaultCredit(precedingCredit: number | undefined): number {
   // capping bonus-credit anchors and keeping the default credit positive.
   const anchor =
     precedingCredit === undefined || !Number.isFinite(precedingCredit)
-      ? MAX_ACCESS_CONTROL_POST_DUE_CREDIT
-      : Math.min(precedingCredit, MAX_ACCESS_CONTROL_POST_DUE_CREDIT);
+      ? 100
+      : Math.min(precedingCredit, 100);
   return Math.max(1, anchor - 10);
 }
 
@@ -151,9 +150,9 @@ function AfterLastDeadlineInput({
   // Credit may equal the due credit only when there are no late deadlines.
   const maximumCredit =
     precedingCredit === undefined || !Number.isFinite(precedingCredit)
-      ? MAX_ACCESS_CONTROL_POST_DUE_CREDIT
+      ? 100
       : Math.min(
-          MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+          100,
           lateDeadlines.length > 0 ? Math.max(0, precedingCredit - 1) : precedingCredit,
         );
   // Preserve an existing invalid selection so its validation error remains

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -12,13 +12,14 @@ import {
 import { RichSelect, type RichSelectItem } from '@prairielearn/ui';
 
 import { FriendlyDate } from '../../../../components/FriendlyDate.js';
+import { MAX_ACCESS_CONTROL_POST_DUE_CREDIT } from '../../../../schemas/accessControl.js';
 import { useAccessControlRuleEditable } from '../AccessControlEditabilityContext.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { useOverrideField } from '../hooks/useOverrideField.js';
 import type { AccessControlFormData, AfterLastDeadlineValue, DeadlineEntry } from '../types.js';
 import { getLastDeadlineDate } from '../utils/dateUtils.js';
 
-type AfterLastDeadlineMode = 'no_submissions' | 'practice_submissions' | 'partial_credit';
+type AfterLastDeadlineMode = 'no_submissions' | 'practice_submissions' | 'credit';
 
 const AFTER_LAST_DEADLINE_ITEMS: RichSelectItem<AfterLastDeadlineMode>[] = [
   {
@@ -32,9 +33,9 @@ const AFTER_LAST_DEADLINE_ITEMS: RichSelectItem<AfterLastDeadlineMode>[] = [
     description: 'No credit is given for practice submissions',
   },
   {
-    value: 'partial_credit',
-    label: 'Allow submissions for partial credit',
-    description: 'Students receive partial credit for submissions',
+    value: 'credit',
+    label: 'Allow submissions for credit',
+    description: 'Students receive the selected credit for submissions',
   },
 ];
 
@@ -54,14 +55,17 @@ function getLastDeadlineNoun(lateDeadlines: DeadlineEntry[]): string {
 function getMode(value: AfterLastDeadlineValue): AfterLastDeadlineMode {
   if (!value.allowSubmissions) return 'no_submissions';
   if (value.credit === 0) return 'practice_submissions';
-  return 'partial_credit';
+  return 'credit';
 }
 
-function getDefaultPartialCredit(precedingCredit: number | undefined): number {
+function getDefaultCredit(precedingCredit: number | undefined): number {
   // Match late-deadline defaults: choose 10 points below the preceding credit,
-  // capping bonus-credit anchors at 100 and keeping partial credit positive.
-  const anchor = precedingCredit === undefined ? 100 : Math.min(precedingCredit, 100);
-  return Math.max(1, Math.min(anchor - 10, 99));
+  // capping bonus-credit anchors and keeping the default credit positive.
+  const anchor =
+    precedingCredit === undefined || !Number.isFinite(precedingCredit)
+      ? MAX_ACCESS_CONTROL_POST_DUE_CREDIT
+      : Math.min(precedingCredit, MAX_ACCESS_CONTROL_POST_DUE_CREDIT);
+  return Math.max(1, anchor - 10);
 }
 
 /**
@@ -144,11 +148,25 @@ function AfterLastDeadlineInput({
   // explicitly. Use primitives (not object refs) so the effect is stable.
   const precedingCredit =
     lateDeadlines.at(-1)?.credit ?? (dueDate != null ? effectiveDueCredit : undefined);
+  // Credit may equal the due credit only when there are no late deadlines.
+  const maximumCredit =
+    precedingCredit === undefined || !Number.isFinite(precedingCredit)
+      ? MAX_ACCESS_CONTROL_POST_DUE_CREDIT
+      : Math.min(
+          MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+          lateDeadlines.length > 0 ? Math.max(0, precedingCredit - 1) : precedingCredit,
+        );
+  // Preserve an existing invalid selection so its validation error remains
+  // visible, but don't offer credit mode when only 0% practice credit is valid.
+  const modeItems =
+    maximumCredit > 0 || mode === 'credit'
+      ? AFTER_LAST_DEADLINE_ITEMS
+      : AFTER_LAST_DEADLINE_ITEMS.filter((item) => item.value !== 'credit');
   useEffect(() => {
-    if (mode === 'partial_credit') {
+    if (mode === 'credit') {
       void trigger(creditFieldPath);
     }
-  }, [trigger, creditFieldPath, mode, precedingCredit]);
+  }, [trigger, creditFieldPath, mode, precedingCredit, lateDeadlines.length]);
 
   // For overrides we can't fully reason about the effective deadlines (override
   // stacking may produce a different set), so we fall back to a generic label.
@@ -181,13 +199,13 @@ function AfterLastDeadlineInput({
       case 'practice_submissions':
         onChange({ allowSubmissions: true, credit: 0 });
         break;
-      case 'partial_credit':
+      case 'credit':
         onChange({
           allowSubmissions: true,
           credit:
             value.allowSubmissions && value.credit > 0
               ? value.credit
-              : getDefaultPartialCredit(precedingCredit),
+              : getDefaultCredit(precedingCredit),
         });
         break;
     }
@@ -201,7 +219,7 @@ function AfterLastDeadlineInput({
       <small className="text-muted d-block">{getLastDeadlineText()}</small>
       <div className="mb-2 mt-2">
         <RichSelect
-          items={AFTER_LAST_DEADLINE_ITEMS}
+          items={modeItems}
           value={mode}
           aria-label={label}
           id={`${idPrefix}-after-deadline-mode`}
@@ -216,7 +234,7 @@ function AfterLastDeadlineInput({
           unless you want students to keep working.
         </Alert>
       )}
-      {mode === 'partial_credit' && (
+      {mode === 'credit' && (
         <div className="mt-2">
           <div className="d-flex align-items-center gap-2 flex-wrap">
             <label
@@ -236,7 +254,7 @@ function AfterLastDeadlineInput({
                   creditError ? `${idPrefix}-after-deadline-credit-error` : undefined
                 }
                 min="0"
-                max="99"
+                max={maximumCredit}
                 step={1}
                 placeholder="0"
                 isInvalid={!!creditError}
@@ -251,11 +269,11 @@ function AfterLastDeadlineInput({
             </InputGroup>
           </div>
           <Form.Text className="text-muted d-block">
-            Students will receive this percentage of credit for submissions after the deadline
+            Students will receive this percentage of credit for submissions after the last deadline
           </Form.Text>
         </div>
       )}
-      {/* Outside the partial_credit block so cross-field errors (e.g. "requires a due date") show in all modes. */}
+      {/* Outside the credit block so cross-field errors (e.g. "requires a due date") show in all modes. */}
       {creditError && (
         <Form.Text
           id={`${idPrefix}-after-deadline-credit-error`}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -16,7 +16,12 @@ import {
 import { run } from '@prairielearn/run';
 
 import { FriendlyDate } from '../../../../components/FriendlyDate.js';
-import { MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE } from '../../../../schemas/accessControl.js';
+import {
+  MAX_ACCESS_CONTROL_CREDIT,
+  MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE,
+  MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+  MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT,
+} from '../../../../schemas/accessControl.js';
 import { useAccessControlRuleEditable } from '../AccessControlEditabilityContext.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { ToggleTitle } from '../ToggleTitle.js';
@@ -31,7 +36,14 @@ type DeadlineArrayFieldName =
   | `overrides.${number}.lateDeadlines`;
 
 function clampCredit(value: number, type: 'early' | 'late'): number {
-  return Math.max(0, Math.min(type === 'early' ? 200 : 99, value));
+  const minimum = type === 'early' ? MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT : 0;
+  return Math.max(
+    minimum,
+    Math.min(
+      type === 'early' ? MAX_ACCESS_CONTROL_CREDIT : MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+      value,
+    ),
+  );
 }
 
 function computeNextDeadline({
@@ -98,21 +110,41 @@ function computeNextDeadline({
         'early',
       );
     }
-    // Anchor at min(dueCredit, 100) so dueCredit > 100 still lands on a clean
-    // 90 instead of clamping to 99.
-    const anchor = previousCredit ?? Math.min(dueCredit, 100);
+    // Cap the anchor so bonus due credit still produces a conventional reduced-credit default.
+    const anchor = previousCredit ?? Math.min(dueCredit, MAX_ACCESS_CONTROL_POST_DUE_CREDIT);
     return clampCredit(anchor - 10, 'late');
   });
   return { date: defaultDate, credit: defaultCredit };
 }
 
-function getAddEarlyDisabledTitle(dueCredit: number): string | undefined {
-  if (dueCredit < 100) {
-    return 'Early deadlines are not allowed when due date credit is below 100%.';
+function getAddCreditDisabledTitle(
+  type: 'early' | 'late',
+  dueCredit: number,
+  deadlines: DeadlineEntry[],
+): string | undefined {
+  const previousCredit = deadlines.at(-1)?.credit;
+
+  if (previousCredit !== undefined && !Number.isFinite(previousCredit)) {
+    return `Enter a valid credit for the last ${type} deadline before adding another.`;
   }
-  if (dueCredit >= 200) {
-    return 'Early deadlines require credit above due credit, but due date credit is already 200%.';
+  if (!Number.isFinite(dueCredit) && (type === 'early' || previousCredit === undefined)) {
+    return 'Enter a valid due-date credit before adding a deadline.';
   }
+
+  if (type === 'early') {
+    if (dueCredit < 100) {
+      return 'Early deadlines are not allowed when due date credit is below 100%.';
+    }
+    if (dueCredit >= MAX_ACCESS_CONTROL_CREDIT) {
+      return `Early deadlines require credit above due credit, but due date credit is already ${MAX_ACCESS_CONTROL_CREDIT}%.`;
+    }
+    if (previousCredit !== undefined && previousCredit <= dueCredit + 1) {
+      return 'No valid integer credit remains between the last early-deadline credit and due-date credit.';
+    }
+  } else if (previousCredit !== undefined && previousCredit <= 0) {
+    return 'No valid credit remains below the last late-deadline credit.';
+  }
+
   return undefined;
 }
 
@@ -156,10 +188,10 @@ function DeadlineArrayInput({
   const ruleEditable = useAccessControlRuleEditable();
   const { register, trigger } = useFormContext<AccessControlFormData>();
   const isEarly = type === 'early';
-  const addEarlyDisabledTitle = isEarly ? getAddEarlyDisabledTitle(dueCredit) : undefined;
+  const addCreditDisabledTitle = getAddCreditDisabledTitle(type, dueCredit, deadlines);
   const addLimitDisabledTitle = getDeadlineLimitDisabledTitle(type, deadlineFields.length);
-  const addDisabledTitle = addEarlyDisabledTitle ?? addLimitDisabledTitle;
-  const addEarlyDisabled = addEarlyDisabledTitle !== undefined;
+  const addDisabledTitle = addCreditDisabledTitle ?? addLimitDisabledTitle;
+  const addCreditDisabled = addCreditDisabledTitle !== undefined;
   const addDisabled = addDisabledTitle !== undefined;
 
   const { errors } = useFormState();
@@ -249,9 +281,9 @@ function DeadlineArrayInput({
             id={`${idPrefix}-${type}-deadlines-enabled`}
             label={isEarly ? 'Early deadlines' : 'Late deadlines'}
             checked={deadlineFields.length > 0}
-            disabled={!ruleEditable || (addEarlyDisabled && deadlineFields.length === 0)}
+            disabled={!ruleEditable || (addCreditDisabled && deadlineFields.length === 0)}
             title={
-              addEarlyDisabled && deadlineFields.length === 0 ? addEarlyDisabledTitle : undefined
+              addCreditDisabled && deadlineFields.length === 0 ? addCreditDisabledTitle : undefined
             }
             onChange={(checked) => {
               if (checked) {
@@ -328,7 +360,9 @@ function DeadlineArrayInput({
                     if (previousCredit != null && Number.isFinite(previousCredit)) {
                       return clampCredit(previousCredit - 1, type);
                     }
-                    return type === 'early' ? 200 : clampCredit(dueCredit - 1, 'late');
+                    return type === 'early'
+                      ? MAX_ACCESS_CONTROL_CREDIT
+                      : clampCredit(dueCredit, 'late');
                   })}
                   step={1}
                   disabled={!ruleEditable}
@@ -497,10 +531,10 @@ export function OverrideDeadlineArrayField({
       displayTimezone,
     });
 
-  const addEarlyDisabledTitle = isEarly ? getAddEarlyDisabledTitle(effectiveDueCredit) : undefined;
+  const addCreditDisabledTitle = getAddCreditDisabledTitle(type, effectiveDueCredit, deadlines);
   const addLimitDisabledTitle = getDeadlineLimitDisabledTitle(type, fields.length);
-  const addDisabledTitle = addEarlyDisabledTitle ?? addLimitDisabledTitle;
-  const addEarlyDisabled = addEarlyDisabledTitle !== undefined;
+  const addDisabledTitle = addCreditDisabledTitle ?? addLimitDisabledTitle;
+  const addCreditDisabled = addCreditDisabledTitle !== undefined;
   const addDisabled = addDisabledTitle !== undefined;
 
   return (
@@ -512,8 +546,8 @@ export function OverrideDeadlineArrayField({
           id={`${idPrefix}-${type}-deadlines-enabled`}
           label={label}
           checked={fields.length > 0}
-          disabled={!ruleEditable || (addEarlyDisabled && fields.length === 0)}
-          title={addEarlyDisabled && fields.length === 0 ? addEarlyDisabledTitle : undefined}
+          disabled={!ruleEditable || (addCreditDisabled && fields.length === 0)}
+          title={addCreditDisabled && fields.length === 0 ? addCreditDisabledTitle : undefined}
           onChange={(checked) => {
             if (checked) {
               append(nextDeadline());

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/DeadlineArrayField.tsx
@@ -16,12 +16,7 @@ import {
 import { run } from '@prairielearn/run';
 
 import { FriendlyDate } from '../../../../components/FriendlyDate.js';
-import {
-  MAX_ACCESS_CONTROL_CREDIT,
-  MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE,
-  MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
-  MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT,
-} from '../../../../schemas/accessControl.js';
+import { MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE } from '../../../../schemas/accessControl.js';
 import { useAccessControlRuleEditable } from '../AccessControlEditabilityContext.js';
 import { FieldWrapper } from '../FieldWrapper.js';
 import { ToggleTitle } from '../ToggleTitle.js';
@@ -36,14 +31,8 @@ type DeadlineArrayFieldName =
   | `overrides.${number}.lateDeadlines`;
 
 function clampCredit(value: number, type: 'early' | 'late'): number {
-  const minimum = type === 'early' ? MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT : 0;
-  return Math.max(
-    minimum,
-    Math.min(
-      type === 'early' ? MAX_ACCESS_CONTROL_CREDIT : MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
-      value,
-    ),
-  );
+  const minimum = type === 'early' ? 101 : 0;
+  return Math.max(minimum, Math.min(type === 'early' ? 200 : 100, value));
 }
 
 function computeNextDeadline({
@@ -111,7 +100,7 @@ function computeNextDeadline({
       );
     }
     // Cap the anchor so bonus due credit still produces a conventional reduced-credit default.
-    const anchor = previousCredit ?? Math.min(dueCredit, MAX_ACCESS_CONTROL_POST_DUE_CREDIT);
+    const anchor = previousCredit ?? Math.min(dueCredit, 100);
     return clampCredit(anchor - 10, 'late');
   });
   return { date: defaultDate, credit: defaultCredit };
@@ -135,8 +124,8 @@ function getAddCreditDisabledTitle(
     if (dueCredit < 100) {
       return 'Early deadlines are not allowed when due date credit is below 100%.';
     }
-    if (dueCredit >= MAX_ACCESS_CONTROL_CREDIT) {
-      return `Early deadlines require credit above due credit, but due date credit is already ${MAX_ACCESS_CONTROL_CREDIT}%.`;
+    if (dueCredit >= 200) {
+      return 'Early deadlines require credit above due credit, but due date credit is already 200%.';
     }
     if (previousCredit !== undefined && previousCredit <= dueCredit + 1) {
       return 'No valid integer credit remains between the last early-deadline credit and due-date credit.';
@@ -360,9 +349,7 @@ function DeadlineArrayInput({
                     if (previousCredit != null && Number.isFinite(previousCredit)) {
                       return clampCredit(previousCredit - 1, type);
                     }
-                    return type === 'early'
-                      ? MAX_ACCESS_CONTROL_CREDIT
-                      : clampCredit(dueCredit, 'late');
+                    return type === 'early' ? 200 : clampCredit(dueCredit, 'late');
                   })}
                   step={1}
                   disabled={!ruleEditable}

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.test.ts
@@ -500,15 +500,15 @@ describe('formDataToJson', () => {
       credit: 0,
     });
 
-    const partialCredit: OverrideData = {
+    const fullCredit: OverrideData = {
       ...baseOverride,
       trackingId: 'o-ald-2',
       overriddenFields: ['afterLastDeadline'],
-      afterLastDeadline: { allowSubmissions: true, credit: 50 },
+      afterLastDeadline: { allowSubmissions: true, credit: 100 },
     };
-    expect(formDataToJson(buildFormData(partialCredit))[1].dateControl!.afterLastDeadline).toEqual({
+    expect(formDataToJson(buildFormData(fullCredit))[1].dateControl!.afterLastDeadline).toEqual({
       allowSubmissions: true,
-      credit: 50,
+      credit: 100,
     });
   });
 });

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/types.ts
@@ -374,9 +374,8 @@ export function jsonToOverrideFormData(
 /**
  * Build the JSON `due` object from form state. `customCredit = false` means
  * "use default" and credit is dropped from JSON; otherwise the explicit
- * number (including 100) is preserved — an explicit 100 is semantically
- * distinct from default because cross-rule validation (e.g. forbidding early
- * deadlines) treats any set credit as customized.
+ * number (including 100) is preserved so the editor round-trips the author's
+ * explicit choice.
  *
  * `customCredit: true` with `credit: null` is a transient editing state (the
  * user has cleared the input). The field-level validator surfaces "Credit is

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -165,33 +165,42 @@ describe('getGlobalDateValidationErrors', () => {
     expect(errors.find((e) => e.path === 'overrides.0.release.date')).toBeUndefined();
   });
 
-  it('flags default late deadline credit at 100%', () => {
+  it('allows default late deadline credit at 100%', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([], {
+        due: { date: '2024-04-10T00:00:00', credit: null, customCredit: false },
+        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 100 }],
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toEqual([]);
+  });
+
+  it('allows default after-last-deadline credit at 100%', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([], {
+        due: { date: '2024-04-10T00:00:00', credit: null, customCredit: false },
+        afterLastDeadline: { allowSubmissions: true, credit: 100 },
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toEqual([]);
+  });
+
+  it('flags default late deadline credit above 100%', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData([], {
         due: { date: '2024-04-10T00:00:00', credit: 110, customCredit: true },
-        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 100 }],
+        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 101 }],
       }),
       TEST_TIMEZONE,
     );
 
     expect(errors).toContainEqual({
       path: 'defaultRule.lateDeadlines.0.credit',
-      message: 'Credit after the due date must be less than 100%.',
-    });
-  });
-
-  it('flags default after-last-deadline credit at 100%', () => {
-    const errors = getGlobalDateValidationErrors(
-      makeFormData([], {
-        due: { date: '2024-04-10T00:00:00', credit: 110, customCredit: true },
-        afterLastDeadline: { allowSubmissions: true, credit: 100 },
-      }),
-      TEST_TIMEZONE,
-    );
-
-    expect(errors).toContainEqual({
-      path: 'defaultRule.afterLastDeadline.credit',
-      message: 'Credit after the due date must be less than 100%.',
+      message: 'Credit after the due date must be at most 100%.',
     });
   });
 
@@ -258,6 +267,79 @@ describe('getGlobalDateValidationErrors', () => {
 });
 
 describe('getAccessControlFormValidationErrors', () => {
+  it.each([101, 200])('allows early deadline form credit at %i%%', (credit) => {
+    const errors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        earlyDeadlines: [{ date: '2024-04-09T00:00:00', credit }],
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(
+      errors.find((error) => error.path === 'defaultRule.earlyDeadlines.0.credit'),
+    ).toBeUndefined();
+  });
+
+  it.each([100, 201])('rejects early deadline form credit at %i%%', (credit) => {
+    const errors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        earlyDeadlines: [{ date: '2024-04-09T00:00:00', credit }],
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'defaultRule.earlyDeadlines.0.credit',
+      message: 'Early deadline credit must be 101-200%',
+    });
+  });
+
+  it('allows 100% in either first post-due form field', () => {
+    const lateDeadlineErrors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 100 }],
+      }),
+      TEST_TIMEZONE,
+    );
+    const afterDueErrors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        afterLastDeadline: { allowSubmissions: true, credit: 100 },
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(
+      lateDeadlineErrors.find((error) => error.path === 'defaultRule.lateDeadlines.0.credit'),
+    ).toBeUndefined();
+    expect(
+      afterDueErrors.find((error) => error.path === 'defaultRule.afterLastDeadline.credit'),
+    ).toBeUndefined();
+  });
+
+  it('rejects post-due form values above 100%', () => {
+    const lateDeadlineErrors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 101 }],
+      }),
+      TEST_TIMEZONE,
+    );
+    const afterDueErrors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        afterLastDeadline: { allowSubmissions: true, credit: 101 },
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(lateDeadlineErrors).toContainEqual({
+      path: 'defaultRule.lateDeadlines.0.credit',
+      message: 'Credit after the due date must be 0-100%',
+    });
+    expect(afterDueErrors).toContainEqual({
+      path: 'defaultRule.afterLastDeadline.credit',
+      message: 'Credit after the due date must be 0-100%',
+    });
+  });
+
   it('validates default rule fields independently of mounted editors', () => {
     const errors = getAccessControlFormValidationErrors(
       makeFormData([makeOverride()], {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -180,6 +180,61 @@ describe('getGlobalDateValidationErrors', () => {
     });
   });
 
+  it('reports independent early and late credit-ordering errors', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData([], {
+        earlyDeadlines: [
+          { date: '2024-04-08T00:00:00', credit: 110 },
+          { date: '2024-04-09T00:00:00', credit: 110 },
+        ],
+        lateDeadlines: [
+          { date: '2024-04-11T00:00:00', credit: 100 },
+          { date: '2024-04-12T00:00:00', credit: 100 },
+        ],
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'defaultRule.earlyDeadlines.1.credit',
+      message: 'Credit must strictly decrease over time.',
+    });
+    expect(errors).toContainEqual({
+      path: 'defaultRule.lateDeadlines.1.credit',
+      message: 'Credit must strictly decrease over time.',
+    });
+  });
+
+  it('reports multiple inherited credit-ordering errors on an override', () => {
+    const errors = getGlobalDateValidationErrors(
+      makeFormData(
+        [
+          makeOverride({
+            overriddenFields: ['lateDeadlines'],
+            lateDeadlines: [
+              { date: '2024-04-11T00:00:00', credit: 90 },
+              { date: '2024-04-12T00:00:00', credit: 60 },
+            ],
+          }),
+        ],
+        {
+          due: { date: '2024-04-10T00:00:00', credit: 80, customCredit: true },
+          afterLastDeadline: { allowSubmissions: true, credit: 70 },
+        },
+      ),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'overrides.0.lateDeadlines.0.credit',
+      message: 'Credit must strictly decrease over time.',
+    });
+    expect(errors).toContainEqual({
+      path: 'overrides.0.lateDeadlines.1.credit',
+      message: 'Credit must strictly decrease over time.',
+    });
+  });
+
   it('allows after-complete overrides without an automatic completion mechanism', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData(
@@ -267,6 +322,28 @@ describe('getAccessControlFormValidationErrors', () => {
     expect(errors).toContainEqual({
       path: 'defaultRule.earlyDeadlines.0.credit',
       message: 'Early deadline credit must be 101-200%',
+    });
+  });
+
+  it('reports ordering errors independently of post-due range errors', () => {
+    const errors = getAccessControlFormValidationErrors(
+      makeFormData([], {
+        earlyDeadlines: [
+          { date: '2024-04-08T00:00:00', credit: 110 },
+          { date: '2024-04-09T00:00:00', credit: 110 },
+        ],
+        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 105 }],
+      }),
+      TEST_TIMEZONE,
+    );
+
+    expect(errors).toContainEqual({
+      path: 'defaultRule.earlyDeadlines.1.credit',
+      message: 'Credit must strictly decrease over time.',
+    });
+    expect(errors).toContainEqual({
+      path: 'defaultRule.lateDeadlines.0.credit',
+      message: 'Credit after the due date must be 0-100%',
     });
   });
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.test.ts
@@ -165,30 +165,6 @@ describe('getGlobalDateValidationErrors', () => {
     expect(errors.find((e) => e.path === 'overrides.0.release.date')).toBeUndefined();
   });
 
-  it('allows default late deadline credit at 100%', () => {
-    const errors = getGlobalDateValidationErrors(
-      makeFormData([], {
-        due: { date: '2024-04-10T00:00:00', credit: null, customCredit: false },
-        lateDeadlines: [{ date: '2024-04-11T00:00:00', credit: 100 }],
-      }),
-      TEST_TIMEZONE,
-    );
-
-    expect(errors).toEqual([]);
-  });
-
-  it('allows default after-last-deadline credit at 100%', () => {
-    const errors = getGlobalDateValidationErrors(
-      makeFormData([], {
-        due: { date: '2024-04-10T00:00:00', credit: null, customCredit: false },
-        afterLastDeadline: { allowSubmissions: true, credit: 100 },
-      }),
-      TEST_TIMEZONE,
-    );
-
-    expect(errors).toEqual([]);
-  });
-
   it('flags default late deadline credit above 100%', () => {
     const errors = getGlobalDateValidationErrors(
       makeFormData([], {

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -304,7 +304,7 @@ function validateDueDate(date: string | null): string | undefined {
 
 function validateIntegerCredit(
   credit: number,
-  { min = 0, max, rangeMessage }: { min?: number; max: number; rangeMessage: string },
+  { min, max, rangeMessage }: { min: number; max: number; rangeMessage: string },
 ): string | undefined {
   if (Number.isNaN(credit)) return 'Credit is required';
   if (!Number.isFinite(credit)) return 'Credit must be a finite number';
@@ -319,6 +319,7 @@ function validateDueCredit(value: number | null, customCredit: boolean): string 
     return undefined;
   }
   return validateIntegerCredit(value, {
+    min: 0,
     max: 200,
     rangeMessage: 'Credit must be between 0% and 200%',
   });
@@ -437,6 +438,7 @@ function validateDeadlineArray({
 function validateAfterLastDeadlineCredit(value: AfterLastDeadlineValue): string | undefined {
   if (!value.allowSubmissions) return undefined;
   return validateIntegerCredit(value.credit, {
+    min: 0,
     max: 100,
     rangeMessage: 'Credit after the due date must be 0-100%',
   });

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -19,13 +19,10 @@ import {
 } from '../../../lib/assessment-access-control/validation.js';
 import { UUID_REGEXP } from '../../../lib/string-util.js';
 import {
-  MAX_ACCESS_CONTROL_CREDIT,
   MAX_ACCESS_CONTROL_DURATION_MINUTES,
   MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE,
   MAX_ACCESS_CONTROL_PASSWORD_LENGTH,
-  MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
   MAX_ACCESS_CONTROL_PRAIRIETEST_EXAMS,
-  MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT,
 } from '../../../schemas/accessControl.js';
 
 import { isFormFieldPathEditable, isOverrideFieldActive } from './overrideFields.js';
@@ -322,8 +319,8 @@ function validateDueCredit(value: number | null, customCredit: boolean): string 
     return undefined;
   }
   return validateIntegerCredit(value, {
-    max: MAX_ACCESS_CONTROL_CREDIT,
-    rangeMessage: `Credit must be between 0% and ${MAX_ACCESS_CONTROL_CREDIT}%`,
+    max: 200,
+    rangeMessage: 'Credit must be between 0% and 200%',
   });
 }
 
@@ -396,12 +393,12 @@ function validateDeadlineCredit({
   value: number;
 }): string | undefined {
   return validateIntegerCredit(value, {
-    min: type === 'early' ? MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT : 0,
-    max: type === 'early' ? MAX_ACCESS_CONTROL_CREDIT : MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+    min: type === 'early' ? 101 : 0,
+    max: type === 'early' ? 200 : 100,
     rangeMessage:
       type === 'early'
-        ? `Early deadline credit must be ${MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT}-${MAX_ACCESS_CONTROL_CREDIT}%`
-        : `Credit after the due date must be 0-${MAX_ACCESS_CONTROL_POST_DUE_CREDIT}%`,
+        ? 'Early deadline credit must be 101-200%'
+        : 'Credit after the due date must be 0-100%',
   });
 }
 
@@ -440,8 +437,8 @@ function validateDeadlineArray({
 function validateAfterLastDeadlineCredit(value: AfterLastDeadlineValue): string | undefined {
   if (!value.allowSubmissions) return undefined;
   return validateIntegerCredit(value.credit, {
-    max: MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
-    rangeMessage: `Credit after the due date must be 0-${MAX_ACCESS_CONTROL_POST_DUE_CREDIT}%`,
+    max: 100,
+    rangeMessage: 'Credit after the due date must be 0-100%',
   });
 }
 

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/validation.ts
@@ -19,10 +19,13 @@ import {
 } from '../../../lib/assessment-access-control/validation.js';
 import { UUID_REGEXP } from '../../../lib/string-util.js';
 import {
+  MAX_ACCESS_CONTROL_CREDIT,
   MAX_ACCESS_CONTROL_DURATION_MINUTES,
   MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE,
   MAX_ACCESS_CONTROL_PASSWORD_LENGTH,
+  MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
   MAX_ACCESS_CONTROL_PRAIRIETEST_EXAMS,
+  MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT,
 } from '../../../schemas/accessControl.js';
 
 import { isFormFieldPathEditable, isOverrideFieldActive } from './overrideFields.js';
@@ -257,7 +260,7 @@ export function getGlobalDateValidationErrors(
     const dateIssues = validateRuleDateOrderingIssues(validationRule);
     const issueGroups = [validateRuleStructuralDependencyIssues(validationRule), dateIssues];
     // Credit ordering assumes deadlines are chronological; skip if dates are
-    // out of order to avoid misleading "credits must strictly decrease" errors.
+    // out of order to avoid misleading credit-ordering errors.
     if (dateIssues.length === 0) {
       issueGroups.push(validateRuleCreditOrderingIssues(validationRule));
     }
@@ -304,12 +307,12 @@ function validateDueDate(date: string | null): string | undefined {
 
 function validateIntegerCredit(
   credit: number,
-  { max, rangeMessage }: { max: number; rangeMessage: string },
+  { min = 0, max, rangeMessage }: { min?: number; max: number; rangeMessage: string },
 ): string | undefined {
   if (Number.isNaN(credit)) return 'Credit is required';
   if (!Number.isFinite(credit)) return 'Credit must be a finite number';
   if (!Number.isInteger(credit)) return 'Credit must be an integer';
-  if (credit < 0 || credit > max) return rangeMessage;
+  if (credit < min || credit > max) return rangeMessage;
   return undefined;
 }
 
@@ -319,8 +322,8 @@ function validateDueCredit(value: number | null, customCredit: boolean): string 
     return undefined;
   }
   return validateIntegerCredit(value, {
-    max: 200,
-    rangeMessage: 'Credit must be between 0% and 200%',
+    max: MAX_ACCESS_CONTROL_CREDIT,
+    rangeMessage: `Credit must be between 0% and ${MAX_ACCESS_CONTROL_CREDIT}%`,
   });
 }
 
@@ -393,9 +396,12 @@ function validateDeadlineCredit({
   value: number;
 }): string | undefined {
   return validateIntegerCredit(value, {
-    max: type === 'early' ? 200 : 99,
+    min: type === 'early' ? MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT : 0,
+    max: type === 'early' ? MAX_ACCESS_CONTROL_CREDIT : MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
     rangeMessage:
-      type === 'early' ? 'Credit must be 0-200%' : 'Credit after the due date must be 0-99%',
+      type === 'early'
+        ? `Early deadline credit must be ${MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT}-${MAX_ACCESS_CONTROL_CREDIT}%`
+        : `Credit after the due date must be 0-${MAX_ACCESS_CONTROL_POST_DUE_CREDIT}%`,
   });
 }
 
@@ -434,8 +440,8 @@ function validateDeadlineArray({
 function validateAfterLastDeadlineCredit(value: AfterLastDeadlineValue): string | undefined {
   if (!value.allowSubmissions) return undefined;
   return validateIntegerCredit(value.credit, {
-    max: 99,
-    rangeMessage: 'Credit after the due date must be 0-99%',
+    max: MAX_ACCESS_CONTROL_POST_DUE_CREDIT,
+    rangeMessage: `Credit after the due date must be 0-${MAX_ACCESS_CONTROL_POST_DUE_CREDIT}%`,
   });
 }
 

--- a/apps/prairielearn/src/schemas/accessControl.ts
+++ b/apps/prairielearn/src/schemas/accessControl.ts
@@ -14,11 +14,37 @@ export const MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE = 10;
 export const MAX_ACCESS_CONTROL_PRAIRIETEST_EXAMS = 10;
 export const MAX_ACCESS_CONTROL_DURATION_MINUTES = 365 * 24 * 60;
 export const MAX_ACCESS_CONTROL_PASSWORD_LENGTH = 128;
+export const MAX_ACCESS_CONTROL_CREDIT = 200;
+/**
+ * Early deadlines are only allowed when due-date credit is at least 100%, and
+ * their credit must strictly exceed due-date credit. Since credits are
+ * integers, 101% is therefore the lowest early-deadline credit that can ever
+ * be valid.
+ */
+export const MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT = 101;
+export const MAX_ACCESS_CONTROL_POST_DUE_CREDIT = 100;
 
-export const DeadlineEntryJsonSchema = z
+export const EarlyDeadlineJsonSchema = z
   .object({
     date: DatetimeLocalStringSchema.describe('Date as ISO String for additional deadline'),
-    credit: z.number().int().min(0).max(200).describe('Integer credit percentage to allow'),
+    credit: z
+      .number()
+      .int()
+      .min(MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT)
+      .max(MAX_ACCESS_CONTROL_CREDIT)
+      .describe('Integer bonus-credit percentage to allow'),
+  })
+  .strict();
+
+export const LateDeadlineJsonSchema = z
+  .object({
+    date: DatetimeLocalStringSchema.describe('Date as ISO String for additional deadline'),
+    credit: z
+      .number()
+      .int()
+      .min(0)
+      .max(MAX_ACCESS_CONTROL_POST_DUE_CREDIT)
+      .describe('Integer credit percentage to allow'),
   })
   .strict();
 
@@ -31,7 +57,7 @@ const AfterLastDeadlineJsonSchema = z.discriminatedUnion('allowSubmissions', [
   z
     .object({
       allowSubmissions: z.literal(true),
-      credit: z.number().int().min(0).max(99),
+      credit: z.number().int().min(0).max(MAX_ACCESS_CONTROL_POST_DUE_CREDIT),
     })
     .strict(),
 ]);
@@ -51,10 +77,10 @@ const DueJsonSchema = z
       .number()
       .int()
       .min(0)
-      .max(200)
+      .max(MAX_ACCESS_CONTROL_CREDIT)
       .optional()
       .describe(
-        'Custom credit percentage at the due date (0-200). Omitted means default 100% credit.',
+        `Custom credit percentage at the due date (0-${MAX_ACCESS_CONTROL_CREDIT}). Omitted means default 100% credit.`,
       ),
   })
   .strict();
@@ -68,13 +94,13 @@ const DateControlJsonSchema = z
       'Due date configuration. Overrides replace the entire due object atomically.',
     ),
     earlyDeadlines: z
-      .array(DeadlineEntryJsonSchema)
+      .array(EarlyDeadlineJsonSchema)
       .max(MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE)
       .nullable()
       .optional()
       .describe('Array of early deadlines with credit as percentages'),
     lateDeadlines: z
-      .array(DeadlineEntryJsonSchema)
+      .array(LateDeadlineJsonSchema)
       .max(MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE)
       .nullable()
       .optional()

--- a/apps/prairielearn/src/schemas/accessControl.ts
+++ b/apps/prairielearn/src/schemas/accessControl.ts
@@ -14,15 +14,6 @@ export const MAX_ACCESS_CONTROL_EARLY_OR_LATE_DEADLINES_PER_RULE = 10;
 export const MAX_ACCESS_CONTROL_PRAIRIETEST_EXAMS = 10;
 export const MAX_ACCESS_CONTROL_DURATION_MINUTES = 365 * 24 * 60;
 export const MAX_ACCESS_CONTROL_PASSWORD_LENGTH = 128;
-export const MAX_ACCESS_CONTROL_CREDIT = 200;
-/**
- * Early deadlines are only allowed when due-date credit is at least 100%, and
- * their credit must strictly exceed due-date credit. Since credits are
- * integers, 101% is therefore the lowest early-deadline credit that can ever
- * be valid.
- */
-export const MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT = 101;
-export const MAX_ACCESS_CONTROL_POST_DUE_CREDIT = 100;
 
 export const EarlyDeadlineJsonSchema = z
   .object({
@@ -30,8 +21,8 @@ export const EarlyDeadlineJsonSchema = z
     credit: z
       .number()
       .int()
-      .min(MIN_ACCESS_CONTROL_EARLY_DEADLINE_CREDIT)
-      .max(MAX_ACCESS_CONTROL_CREDIT)
+      .min(101) // Early deadlines require due credit >= 100% and must offer more credit.
+      .max(200)
       .describe('Integer bonus-credit percentage to allow'),
   })
   .strict();
@@ -39,12 +30,7 @@ export const EarlyDeadlineJsonSchema = z
 export const LateDeadlineJsonSchema = z
   .object({
     date: DatetimeLocalStringSchema.describe('Date as ISO String for additional deadline'),
-    credit: z
-      .number()
-      .int()
-      .min(0)
-      .max(MAX_ACCESS_CONTROL_POST_DUE_CREDIT)
-      .describe('Integer credit percentage to allow'),
+    credit: z.number().int().min(0).max(100).describe('Integer credit percentage to allow'),
   })
   .strict();
 
@@ -57,7 +43,7 @@ const AfterLastDeadlineJsonSchema = z.discriminatedUnion('allowSubmissions', [
   z
     .object({
       allowSubmissions: z.literal(true),
-      credit: z.number().int().min(0).max(MAX_ACCESS_CONTROL_POST_DUE_CREDIT),
+      credit: z.number().int().min(0).max(100),
     })
     .strict(),
 ]);
@@ -77,10 +63,10 @@ const DueJsonSchema = z
       .number()
       .int()
       .min(0)
-      .max(MAX_ACCESS_CONTROL_CREDIT)
+      .max(200)
       .optional()
       .describe(
-        `Custom credit percentage at the due date (0-${MAX_ACCESS_CONTROL_CREDIT}). Omitted means default 100% credit.`,
+        'Custom credit percentage at the due date (0-200). Omitted means default 100% credit.',
       ),
   })
   .strict();

--- a/apps/prairielearn/src/schemas/accessControl.ts
+++ b/apps/prairielearn/src/schemas/accessControl.ts
@@ -18,12 +18,8 @@ export const MAX_ACCESS_CONTROL_PASSWORD_LENGTH = 128;
 export const EarlyDeadlineJsonSchema = z
   .object({
     date: DatetimeLocalStringSchema.describe('Date as ISO String for additional deadline'),
-    credit: z
-      .number()
-      .int()
-      .min(101) // Early deadlines require due credit >= 100% and must offer more credit.
-      .max(200)
-      .describe('Integer bonus-credit percentage to allow'),
+    // Early deadlines require due credit >= 100% and must offer more credit.
+    credit: z.number().int().min(101).max(200).describe('Integer bonus-credit percentage to allow'),
   })
   .strict();
 

--- a/apps/prairielearn/src/schemas/jsonSchemas.ts
+++ b/apps/prairielearn/src/schemas/jsonSchemas.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 
 import { DatetimeLocalStringSchema } from '@prairielearn/zod';
 
-import { AccessControlJsonSchema, DeadlineEntryJsonSchema } from './accessControl.js';
+import {
+  AccessControlJsonSchema,
+  EarlyDeadlineJsonSchema,
+  LateDeadlineJsonSchema,
+} from './accessControl.js';
 import { CommentJsonSchema } from './comment.js';
 import {
   AdvanceScorePercJsonSchema,
@@ -56,7 +60,8 @@ const namedDefinitions = {
   CommentJsonSchema,
   DatetimeLocalStringSchema,
   AccessControlJsonSchema,
-  DeadlineEntryJsonSchema,
+  EarlyDeadlineJsonSchema,
+  LateDeadlineJsonSchema,
   ColorJsonSchema,
   PointsJsonSchema,
   PointsListJsonSchema,

--- a/apps/prairielearn/src/schemas/schemas/infoAssessment.json
+++ b/apps/prairielearn/src/schemas/schemas/infoAssessment.json
@@ -485,7 +485,7 @@
                   "maxItems": 10,
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/DeadlineEntryJsonSchema"
+                    "$ref": "#/definitions/EarlyDeadlineJsonSchema"
                   }
                 },
                 {
@@ -500,7 +500,7 @@
                   "maxItems": 10,
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/DeadlineEntryJsonSchema"
+                    "$ref": "#/definitions/LateDeadlineJsonSchema"
                   }
                 },
                 {
@@ -531,7 +531,7 @@
                     "credit": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 99
+                      "maximum": 100
                     }
                   },
                   "required": ["allowSubmissions", "credit"],
@@ -684,7 +684,24 @@
       "type": "string",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2})?$"
     },
-    "DeadlineEntryJsonSchema": {
+    "EarlyDeadlineJsonSchema": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "description": "Date as ISO String for additional deadline",
+          "$ref": "#/definitions/DatetimeLocalStringSchema"
+        },
+        "credit": {
+          "type": "integer",
+          "minimum": 101,
+          "maximum": 200,
+          "description": "Integer bonus-credit percentage to allow"
+        }
+      },
+      "required": ["date", "credit"],
+      "additionalProperties": false
+    },
+    "LateDeadlineJsonSchema": {
       "type": "object",
       "properties": {
         "date": {
@@ -694,7 +711,7 @@
         "credit": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 200,
+          "maximum": 100,
           "description": "Integer credit percentage to allow"
         }
       },

--- a/docs/assessment/accessControl.md
+++ b/docs/assessment/accessControl.md
@@ -73,7 +73,7 @@ Deadlines form one chronological credit timeline. For example, an assessment mig
 
 !!! tip
 
-    Credit must strictly decrease at every boundary, except that the first late deadline — or **After due date** credit when there are no late deadlines — may match due-date credit, up to 100%. This supports a single no-penalty grace period while still communicating the original due date. Consecutive late deadlines cannot offer the same credit.
+    Credit must strictly decrease at every boundary. The first late deadline may match the due-date credit, up to 100%. If there are no late deadlines, **After due date** credit may match it instead. This supports a single no-penalty grace period while still communicating the original due date. Consecutive late deadlines cannot offer the same credit.
 
 #### After deadlines
 
@@ -584,7 +584,7 @@ The first element is the defaults rule and must not have a `uuid`. Every element
 | `durationMinutes`   | integer | Time limit in minutes.                                                                                                                                                                      |
 | `password`          | string  | Password required to start the assessment.                                                                                                                                                  |
 
-`due.credit` defaults to 100. Early-deadline credits must be integers from 101 to 200, while late-deadline and `afterLastDeadline.credit` values must be integers from 0 to 100. The resolved credit timeline must strictly decrease at every boundary, except that the first late deadline — or `afterLastDeadline.credit` when there are no late deadlines — may equal the due credit. Early deadlines are not allowed when due credit is below 100%.
+`due.credit` defaults to 100. Early-deadline credits must be integers from 101 to 200, while late-deadline and `afterLastDeadline.credit` values must be integers from 0 to 100. The resolved credit timeline must strictly decrease at every boundary. The first late deadline may equal the due credit. If there are no late deadlines, `afterLastDeadline.credit` may equal it instead. Early deadlines are not allowed when due credit is below 100%.
 
 When `due.date` is `null`, the due credit applies indefinitely after release.
 

--- a/docs/assessment/accessControl.md
+++ b/docs/assessment/accessControl.md
@@ -62,7 +62,7 @@ For example, on a 10-point assessment with 80% available credit, a student who e
 
 #### Early and late deadlines
 
-Use **Early deadlines** for bonus-credit windows before the due date, and **Late deadlines** for reduced-credit windows after the due date.
+Use **Early deadlines** for bonus-credit windows before the due date, and **Late deadlines** for grace periods or reduced-credit windows after the due date.
 
 For each deadline, choose:
 
@@ -73,7 +73,7 @@ Deadlines form one chronological credit timeline. For example, an assessment mig
 
 !!! tip
 
-    With the default 100% due-date credit, **early deadlines must offer more than 100% credit** and **late deadlines must offer less than 100%**. More generally, early credits must exceed the due-date credit, and all credit after the due date must be below 100%.
+    Credit must strictly decrease at every boundary, except that the first late deadline — or **After due date** credit when there are no late deadlines — may match due-date credit, up to 100%. This supports a single no-penalty grace period while still communicating the original due date. Consecutive late deadlines cannot offer the same credit.
 
 #### After deadlines
 
@@ -81,7 +81,7 @@ Configure what happens after all deadlines have passed. The setting is labeled *
 
 - **No submissions allowed**: students can view only what the assessment visibility settings allow, but cannot submit.
 - **Allow practice submissions**: students can submit for feedback, but receive 0% credit.
-- **Allow submissions for partial credit**: students can submit for the credit percentage you choose.
+- **Allow submissions for credit**: students can submit for the credit percentage you choose.
 
 This setting controls submission permission only. If submissions are not allowed after the final deadline, the **After completion** visibility settings determine what students can review. If after-deadline submissions are allowed, **After completion** applies only after the student's assessment instance closes or its time limit expires.
 
@@ -578,24 +578,24 @@ The first element is the defaults rule and must not have a `uuid`. Every element
 | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `release`           | object  | Object with `date` (ISO datetime). The assessment is not open to students before this date.                                                                                                 |
 | `due`               | object  | Object with `date` (ISO datetime, or `null` for no due date) and optional integer `credit` (0-200, default 100).                                                                            |
-| `earlyDeadlines`    | array   | Array of `{date, credit}` objects. Deadlines before the due date that offer bonus credit.                                                                                                   |
-| `lateDeadlines`     | array   | Array of `{date, credit}` objects. Deadlines after the due date that offer reduced credit.                                                                                                  |
+| `earlyDeadlines`    | array   | Array of `{date, credit}` objects. Bonus-credit deadlines before the due date.                                                                                                              |
+| `lateDeadlines`     | array   | Array of `{date, credit}` objects. Grace-period or reduced-credit deadlines after the due date.                                                                                             |
 | `afterLastDeadline` | object  | Controls whether submissions are allowed after all deadlines have passed, and how much credit they receive. Omit on the default rule to disallow submissions; omit on overrides to inherit. |
 | `durationMinutes`   | integer | Time limit in minutes.                                                                                                                                                                      |
 | `password`          | string  | Password required to start the assessment.                                                                                                                                                  |
 
-`due.credit` defaults to 100. Deadline credits may use any integer percentage from 0 to 200, but the resolved sequence of early deadlines, due date, late deadlines, and `afterLastDeadline.credit` must strictly decrease over time. Early deadlines are not allowed when due credit is below 100%. Late deadlines and `afterLastDeadline.credit` must be below 100%.
+`due.credit` defaults to 100. Early-deadline credits must be integers from 101 to 200, while late-deadline and `afterLastDeadline.credit` values must be integers from 0 to 100. The resolved credit timeline must strictly decrease at every boundary, except that the first late deadline — or `afterLastDeadline.credit` when there are no late deadlines — may equal the due credit. Early deadlines are not allowed when due credit is below 100%.
 
 When `due.date` is `null`, the due credit applies indefinitely after release.
 
 ### `afterLastDeadline`
 
-| Field              | Type    | Default | Description                                                                                          |
-| ------------------ | ------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `allowSubmissions` | boolean | `false` | Whether students can still submit answers after all deadlines.                                       |
-| `credit`           | integer | -       | Required when `allowSubmissions` is `true`; credit percentage after the last deadline, from 0 to 99. |
+| Field              | Type    | Default | Description                                                                                           |
+| ------------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `allowSubmissions` | boolean | `false` | Whether students can still submit answers after all deadlines.                                        |
+| `credit`           | integer | -       | Required when `allowSubmissions` is `true`; credit percentage after the last deadline, from 0 to 100. |
 
-If `allowSubmissions` is `true`, `credit` is required and must be below 100% and below the preceding deadline's credit. Use `"credit": 0` for practice submissions.
+If `allowSubmissions` is `true`, `credit` is required and must be at most 100%. With no late deadlines, it may equal the due credit; otherwise, it must be below the last late deadline's credit. Use `"credit": 0` for practice submissions.
 
 If `afterLastDeadline` is omitted on the default rule or set to `{ "allowSubmissions": false }`, students cannot submit after the final deadline. They can still review whatever the `afterComplete` settings make visible. On overrides, omit `afterLastDeadline` to inherit from the default rule, or set `{ "allowSubmissions": false }` to explicitly disable submissions.
 

--- a/docs/assessment/accessControl.md
+++ b/docs/assessment/accessControl.md
@@ -73,7 +73,7 @@ Deadlines form one chronological credit timeline. For example, an assessment mig
 
 !!! tip
 
-    Credit must strictly decrease at every boundary. The first late deadline may match the due-date credit, up to 100%. If there are no late deadlines, **After due date** credit may match it instead. This supports a single no-penalty grace period while still communicating the original due date. Consecutive late deadlines cannot offer the same credit.
+    Credit must strictly decrease at every boundary except the first one after the due date, where it may remain unchanged at up to 100%. This exception applies to the first late deadline, or to **After due date** credit when there are no late deadlines. It supports a single no-penalty grace period while still communicating the original due date. Consecutive late deadlines cannot offer the same credit.
 
 #### After deadlines
 
@@ -584,7 +584,7 @@ The first element is the defaults rule and must not have a `uuid`. Every element
 | `durationMinutes`   | integer | Time limit in minutes.                                                                                                                                                                      |
 | `password`          | string  | Password required to start the assessment.                                                                                                                                                  |
 
-`due.credit` defaults to 100. Early-deadline credits must be integers from 101 to 200, while late-deadline and `afterLastDeadline.credit` values must be integers from 0 to 100. The resolved credit timeline must strictly decrease at every boundary. The first late deadline may equal the due credit. If there are no late deadlines, `afterLastDeadline.credit` may equal it instead. Early deadlines are not allowed when due credit is below 100%.
+`due.credit` defaults to 100. Early-deadline credits must be integers from 101 to 200, while late-deadline and `afterLastDeadline.credit` values must be integers from 0 to 100. The resolved credit timeline must strictly decrease at every boundary except the first one after the due date, where it may remain unchanged at up to 100%. This exception applies to the first late deadline, or to `afterLastDeadline.credit` when there are no late deadlines. Early deadlines are not allowed when due credit is below 100%.
 
 When `due.date` is `null`, the due credit applies indefinitely after release.
 


### PR DESCRIPTION
# Description

Modern assessment access controls previously required all credit after the due date to be below 100%, which prevented instructors from configuring a no-penalty grace period while retaining the original due date.

This allows the first late deadline to match due-date credit, capped at 100%. When there are no late deadlines, the **After due date** credit may match instead. Every later credit boundary must still strictly decrease, so consecutive full-credit late windows remain invalid.

The modern editor now uses the same limits and prevents adding another deadline when no valid integer credit remains. Raw `infoAssessment.json` configuration uses separate early- and late-deadline schemas: early credit is 101–200%, while late and after-due credit is 0–100%. Documentation and generated JSON schemas are updated accordingly.

- [x] I have disclosed the level of AI assistance used: AI was used for the majority of the implementation and tests, with iterative human-directed design and review.

# Testing

Added focused schema, semantic-validation, form-validation, and serialization coverage for both range boundaries, the single due-adjacent equal-credit transition, inherited due credit, and rejection of subsequent equal-credit windows.
