### PR TITLE
Allow PrairieTest sign-in during LockDown Browser reservations

### DIFF
--- a/apps/prairielearn/src/middlewares/enforceLockdownBrowser.ts
+++ b/apps/prairielearn/src/middlewares/enforceLockdownBrowser.ts
@@ -2,16 +2,28 @@ import asyncHandler from 'express-async-handler';
 
 import { LockdownBrowserRequiredError, isLockdownBrowserBlocked } from '../lib/exam-mode.js';
 
+function isPrairieTestAuthRequest(req: { method: string; path: string }): boolean {
+  return (
+    req.method === 'GET' &&
+    (req.path === '/pl/prairietest/auth' || req.path === '/pl/prairietest/auth/')
+  );
+}
+
 /**
  * Denies all PrairieLearn access to a user with an active
  * LockDown-Browser-required reservation whose session was not established from
  * inside LockDown Browser. This runs against the authenticated user right after
  * authentication so the denial applies to every page, not just exam-scoped
  * ones. Staff emulating a student are unaffected: emulation overrides the
- * effective user, not the authenticated user, and staff hold no reservation.
+ * effective user, not the authenticated user, and staff hold no reservation. The
+ * PrairieLearn-to-PrairieTest authentication handoff is exempt because students
+ * must complete it before they can launch LockDown Browser.
  */
 export default asyncHandler(async (req, res, next) => {
-  if (!res.locals.authn_user) {
+  // Students begin the PrairieTest sign-in flow in a regular browser, then launch
+  // LockDown Browser from PrairieTest. This route only hands the authenticated user
+  // off to PrairieTest, so it must remain reachable after the student is checked in.
+  if (!res.locals.authn_user || isPrairieTestAuthRequest(req)) {
     next();
     return;
   }

--- a/apps/prairielearn/src/middlewares/enforceLockdownBrowser.ts
+++ b/apps/prairielearn/src/middlewares/enforceLockdownBrowser.ts
@@ -1,8 +1,9 @@
+import type { Request } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { LockdownBrowserRequiredError, isLockdownBrowserBlocked } from '../lib/exam-mode.js';
 
-function isPrairieTestAuthRequest(req: { method: string; path: string }): boolean {
+function isPrairieTestAuthRequest(req: Request): boolean {
   return (
     req.method === 'GET' &&
     (req.path === '/pl/prairietest/auth' || req.path === '/pl/prairietest/auth/')
@@ -23,6 +24,10 @@ export default asyncHandler(async (req, res, next) => {
   // Students begin the PrairieTest sign-in flow in a regular browser, then launch
   // LockDown Browser from PrairieTest. This route only hands the authenticated user
   // off to PrairieTest, so it must remain reachable after the student is checked in.
+  //
+  // We do not limit access even after the student has started their reservation.
+  // They may need to resume on a different machine during an in-progress session,
+  // e.g. because of hardware failure.
   if (!res.locals.authn_user || isPrairieTestAuthRequest(req)) {
     next();
     return;


### PR DESCRIPTION
# Description

Students using personal devices often already have an authenticated PrairieTest session before they are checked in. On a shared center-managed computer, however, the student starts without an existing PrairieTest session and must authenticate after sitting down at the machine.

Once the student is checked in to a LockDown Browser-required reservation, PrairieLearn considers the reservation active and globally blocks regular-browser sessions. Because the PrairieLearn-to-PrairieTest authentication handoff currently runs behind that guard, the student receives a 403 before they can sign in to PrairieTest and reach the page that launches LockDown Browser.

This change exempts only `GET /pl/prairietest/auth` from the global LockDown Browser guard. The route only hands the authenticated user off to PrairieTest, where the LockDown Browser launch remains enforced; all other PrairieLearn routes continue to require an LDB-established session while the reservation is active.

- [x] I have disclosed the level of AI assistance used (majority of implementation; Codex, with human direction and review).

# Testing

Not manually tested against a live PrairieTest and LockDown Browser session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PrairieTest authentication handoffs can now complete successfully when Lockdown Browser enforcement is active.
  * Lockdown Browser requirements continue to apply to other authenticated requests as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->