### PR TITLE
Fix after-deadline practice submission selection

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -242,7 +242,6 @@ function AfterLastDeadlineInput({
                 isInvalid={!!creditError}
                 disabled={!ruleEditable}
                 {...register(creditFieldPath, {
-                  shouldUnregister: true,
                   valueAsNumber: true,
                   deps: creditDeps,
                 })}

--- a/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
@@ -183,6 +183,38 @@ test.describe('Access control UI', () => {
     await expect(panel.getByText('Exam UUID is required')).toBeVisible();
   });
 
+  test('can switch after-due-date submissions from partial credit to practice', async ({
+    page,
+    courseInstance,
+  }) => {
+    const assessment = await selectAssessmentByTid({
+      course_instance_id: courseInstance.id,
+      tid: ASSESSMENT_TID,
+    });
+    await navigateToAccessPage(page, courseInstance.id, assessment.id);
+
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+
+    const panel = getDetailPanel(page);
+    const afterDueDateSelect = panel.getByRole('button', { name: 'After due date' });
+    const creditInput = panel.getByRole('spinbutton', {
+      name: 'Credit percentage after last deadline',
+    });
+
+    await afterDueDateSelect.click();
+    await page.getByRole('option', { name: /Allow submissions for partial credit/ }).click();
+    await expect(creditInput).toBeVisible();
+
+    // Regression check: switching to practice hides the credit input but must preserve
+    // `credit: 0`, otherwise the mode immediately reverts to partial credit.
+    await afterDueDateSelect.click();
+    await page.getByRole('option', { name: /Allow practice submissions/ }).click();
+
+    await expect(afterDueDateSelect).toContainText('Allow practice submissions');
+    await expect(creditInput).toBeHidden();
+    await expect(panel.getByText('Credit is required')).toBeHidden();
+  });
+
   test('can delete an override', async ({ page, courseInstance, testCoursePath }) => {
     const assessment = await selectAssessmentByTid({
       course_instance_id: courseInstance.id,


### PR DESCRIPTION
# Description

Fix the after-due-date access-control selector so switching from partial-credit submissions to practice submissions preserves `credit: 0` and keeps the credit field hidden.

The credit input used `shouldUnregister: true`, so hiding it removed the nested credit value. The form then interpreted the incomplete value as partial-credit mode, remounted the input, and displayed a validation error. Keep the registered value when the conditional input unmounts and add an end-to-end regression test for the direct transition.

- [x] AI assistance: majority of implementation.

# Testing

- Added a Playwright regression that selects partial-credit submissions, switches to practice submissions, and verifies the practice mode remains selected with no credit field or validation error.
- Confirmed the regression fails with the fix temporarily removed and passes with the fix applied.
