### PR TITLE
Remove application reads of users.deleted_at

### DIFF
--- a/apps/prairielearn/src/admin_queries/instructors_by_institution.sql
+++ b/apps/prairielearn/src/admin_queries/instructors_by_institution.sql
@@ -23,7 +23,6 @@ FROM
   LEFT JOIN course_instances AS ci ON (ci.id = cip.course_instance_id)
 WHERE
   i.short_name = $institution_shortname
-  AND u.deleted_at IS NULL
   AND plc.deleted_at IS NULL
   AND ci.deleted_at IS NULL
   AND cp.course_role = ANY ($course_roles::enum_course_role[])

--- a/apps/prairielearn/src/lib/db-types.test.ts
+++ b/apps/prairielearn/src/lib/db-types.test.ts
@@ -16,6 +16,11 @@ const schemaNameOverrides: Record<string, string | null> = {
   time_series: 'TimeSeriesSchema',
 };
 
+const extraDatabaseColumnExceptions: Record<string, string[]> = {
+  // Retained temporarily while removing `users.deleted_at` in a staged migration.
+  users: ['deleted_at'],
+};
+
 // Schemas not associated with a table.
 const customSchemas = new Set(['IdSchema', 'IntervalSchema', 'QuestionPreferenceValuesSchema']);
 const unusedSchemas = new Set([
@@ -90,7 +95,10 @@ describe('Database Schema Sync Test', () => {
 
       const dbColumnNames = data.tables[tableName].columns.map((column) => column.name);
       const schemaKeys = Object.keys((schema as z.ZodObject<any>).shape);
-      const extraColumns = difference(dbColumnNames, schemaKeys);
+      const extraColumns = difference(
+        difference(dbColumnNames, schemaKeys),
+        extraDatabaseColumnExceptions[tableName] ?? [],
+      );
       const missingColumns = difference(schemaKeys, dbColumnNames);
 
       if (extraColumns.length > 0 || missingColumns.length > 0) {

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -1640,7 +1640,6 @@ export const TopicSchema = z.object({
 export type Topic = z.infer<typeof TopicSchema>;
 
 export const UserSchema = z.object({
-  deleted_at: DateFromISOString.nullable(),
   email: z.string().nullable(),
   id: IdSchema,
   institution_id: IdSchema,

--- a/apps/prairielearn/src/models/audit-event.test.ts
+++ b/apps/prairielearn/src/models/audit-event.test.ts
@@ -58,7 +58,6 @@ describe('audit-event', () => {
           "id": "1",
           "institution_id": "1",
           "new_row": {
-            "deleted_at": null,
             "email": "student@example.com",
             "id": "1",
             "institution_id": "1",


### PR DESCRIPTION
# Description

Remove the remaining application dependency on `users.deleted_at` ahead of a follow-up migration that will physically drop the column. The instructors-by-institution admin query no longer filters on the column, `UserSchema` no longer exposes it, and the affected audit-event snapshot now matches the parsed user shape.

This is intentionally the base PR in a two-PR stack. The physical column, migration history, `database/tables/users.pg`, and operational documentation remain for the follow-up, while this base PR includes a narrow temporary schema-sync exception for `users.deleted_at` that the stacked PR removes.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

The majority of the investigation and implementation was completed with AI assistance.

# Testing

- Updated and ran the audit-event model tests (14 tests) to verify serialized user rows no longer include `deleted_at`.
- Ran the focused database schema-sync test and typechecked `db-types.test.ts` to verify the temporary exception accepts only `users.deleted_at`.
