### PR TITLE
Fix duplicate question ID in preferences docs example

### DIFF
--- a/docs/question/preferences.md
+++ b/docs/question/preferences.md
@@ -100,12 +100,12 @@ Preferences can also be set on individual alternatives within a question alterna
   "numberChoose": 1,
   "alternatives": [
     {
-      "id": "forces/fallingObjectEarth",
+      "id": "forces/fallingObject",
       "preferences": { "gravitational_constant": 9.8 }
     },
     {
-      "id": "forces/fallingObjectMoon",
-      "preferences": { "gravitational_constant": 1.6 }
+      "id": "kinematics/projectileRange",
+      "preferences": { "unit_system": "imperial" }
     }
   ]
 }

--- a/docs/question/preferences.md
+++ b/docs/question/preferences.md
@@ -100,11 +100,11 @@ Preferences can also be set on individual alternatives within a question alterna
   "numberChoose": 1,
   "alternatives": [
     {
-      "id": "forces/fallingObject",
+      "id": "forces/fallingObjectEarth",
       "preferences": { "gravitational_constant": 9.8 }
     },
     {
-      "id": "forces/fallingObject",
+      "id": "forces/fallingObjectMoon",
       "preferences": { "gravitational_constant": 1.6 }
     }
   ]


### PR DESCRIPTION
# Description

The alternative pool example in the question preferences docs used the same question ID (`forces/fallingObject`) for both alternatives, which fails to sync (duplicate QID / `UNIQUE (question_id, assessment_id)`). Uses distinct IDs so each alternative is a valid question.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Majority of implementation.

# Testing

Docs-only change. Verified the corrected example renders in the preferences page via `make dev-docs`.