### PR TITLE
Surface copy-course-instance errors and simplify migration step

### DIFF
--- a/apps/prairielearn/src/lib/course-instances.shared.ts
+++ b/apps/prairielearn/src/lib/course-instances.shared.ts
@@ -1,0 +1,7 @@
+/**
+ * Error message thrown by the server when a course instance short name collides
+ * with an existing one. Shared with the client so the copy modal can recognize
+ * the server response without duplicating the string.
+ */
+export const DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR =
+  'A course instance with this short name already exists';

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.sql
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.sql
@@ -13,8 +13,7 @@ GROUP BY
 
 -- BLOCK select_names
 SELECT
-  ci.short_name,
-  ci.long_name
+  ci.short_name
 FROM
   course_instances AS ci
 WHERE

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
@@ -153,7 +153,7 @@ router.post(
       const existingNames = await sqldb.queryRows(
         sql.select_names,
         { course_id: course.id },
-        z.object({ short_name: z.string(), long_name: z.string().nullable() }),
+        z.object({ short_name: z.string() }),
       );
       const existingShortNames = existingNames.map((name) => name.short_name.toLowerCase());
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
@@ -9,6 +9,7 @@ import { Hydrate } from '@prairielearn/react/server';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
+import { DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR } from '../../lib/course-instances.shared.js';
 import { CourseInstanceSchema, EnumCourseInstanceRoleSchema } from '../../lib/db-types.js';
 import { propertyValueWithDefault } from '../../lib/editorUtil.shared.js';
 import { CourseInstanceAddEditor } from '../../lib/editors.js';
@@ -155,22 +156,9 @@ router.post(
         z.object({ short_name: z.string(), long_name: z.string().nullable() }),
       );
       const existingShortNames = existingNames.map((name) => name.short_name.toLowerCase());
-      const existingLongNames = existingNames
-        .map((name) => name.long_name?.toLowerCase())
-        .filter((name) => name != null);
 
       if (existingShortNames.includes(short_name.toLowerCase())) {
-        throw new error.HttpStatusError(
-          400,
-          'A course instance with this short name already exists',
-        );
-      }
-
-      if (existingLongNames.includes(long_name.toLowerCase())) {
-        throw new error.HttpStatusError(
-          400,
-          'A course instance with this long name already exists',
-        );
+        throw new error.HttpStatusError(400, DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR);
       }
 
       // Parse dates if provided (empty strings mean unpublished)

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -60,7 +60,7 @@ export function CopyCourseInstanceModal({
   courseShortName: string;
   isAdministrator: boolean;
   accessControlMigrationNeeded: boolean;
-  names: { short_name: string; long_name: string | null }[];
+  names: { short_name: string }[];
 }) {
   const [step, setStep] = useState<Step>('settings');
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -433,6 +433,7 @@ function AccessControlStep({
   const assessmentsNeedingAttention = assessments.filter(
     (a) => a.errors.length > 0 || a.notes.length > 0,
   );
+  const cleanlyMigratableCount = assessments.length - assessmentsNeedingAttention.length;
 
   if (!appError && assessments.length === 0) {
     return (
@@ -460,8 +461,14 @@ function AccessControlStep({
             <strong>
               {assessments.length} assessment{assessments.length !== 1 ? 's' : ''}
             </strong>{' '}
-            with legacy access control rules. Choose how to handle them in the copy. Learn more
-            about{' '}
+            with legacy access control rules. Choose how to handle copying them.{' '}
+            {cleanlyMigratableCount > 0 && assessmentsNeedingAttention.length > 0 && (
+              <>
+                <strong>{cleanlyMigratableCount}</strong> will migrate cleanly and{' '}
+                {cleanlyMigratableCount === 1 ? 'is' : 'are'} not listed below.{' '}
+              </>
+            )}
+            Learn more about{' '}
             <a
               href="https://docs.prairielearn.com/assessment/accessControl/"
               target="_blank"

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -24,6 +24,7 @@ import {
   getCourseInstanceEditErrorUrl,
   getCourseInstanceSettingsUrl,
 } from '../../../lib/client/url.js';
+import { DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR } from '../../../lib/course-instances.shared.js';
 import { validateShortName } from '../../../lib/short-name.js';
 import { useTRPC } from '../../../trpc/courseInstance/context.js';
 import type { InstanceAdminSettingsError } from '../../../trpc/courseInstance/instance-admin-settings.js';
@@ -155,11 +156,13 @@ export function CopyCourseInstanceModal({
     },
     onError: (error, variables) => {
       // Map the short-name conflict back to its field, block the rejected value,
-      // and return to the settings step so the user lands where the fix is.
-      if (error.message === 'A course instance with this short name already exists') {
+      // and return to the settings step so the user lands where the fix is. Reset
+      // the mutation so the message shows only on the field, not also in the alert.
+      if (error.message === DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR) {
         setTakenShortNames((prev) => new Set(prev).add(variables.short_name.trim().toLowerCase()));
         setError('short_name', { type: 'server', message: error.message });
         setStep('settings');
+        copyMutation.reset();
       }
     },
   });
@@ -341,7 +344,7 @@ function SettingsStep({
               },
               duplicate: (value) =>
                 !takenShortNames.has(value.trim().toLowerCase()) ||
-                'A course instance with this short name already exists',
+                DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR,
             },
           })}
         />

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/CopyCourseInstanceModal.tsx
@@ -50,6 +50,7 @@ export function CopyCourseInstanceModal({
   courseShortName,
   isAdministrator,
   accessControlMigrationNeeded,
+  names,
 }: {
   show: boolean;
   onHide: () => void;
@@ -58,8 +59,16 @@ export function CopyCourseInstanceModal({
   courseShortName: string;
   isAdministrator: boolean;
   accessControlMigrationNeeded: boolean;
+  names: { short_name: string; long_name: string | null }[];
 }) {
   const [step, setStep] = useState<Step>('settings');
+
+  // Seeded from the short names known at page load and extended whenever the
+  // server rejects one (e.g. a race where another instance took it), so a
+  // rejected short name is blocked client-side and can't be re-submitted.
+  const [takenShortNames, setTakenShortNames] = useState(
+    () => new Set(names.map((name) => name.short_name.toLowerCase())),
+  );
 
   const trpc = useTRPC();
   const methods = useForm<CopyFormValues>({
@@ -83,6 +92,7 @@ export function CopyCourseInstanceModal({
     reset,
     control,
     trigger,
+    setError,
     formState: { errors },
   } = methods;
 
@@ -143,6 +153,15 @@ export function CopyCourseInstanceModal({
         window.location.href = getCourseInstanceSettingsUrl(data.course_instance_id);
       }
     },
+    onError: (error, variables) => {
+      // Map the short-name conflict back to its field, block the rejected value,
+      // and return to the settings step so the user lands where the fix is.
+      if (error.message === 'A course instance with this short name already exists') {
+        setTakenShortNames((prev) => new Set(prev).add(variables.short_name.trim().toLowerCase()));
+        setError('short_name', { type: 'server', message: error.message });
+        setStep('settings');
+      }
+    },
   });
 
   const handleClose = () => {
@@ -168,6 +187,7 @@ export function CopyCourseInstanceModal({
   };
 
   const isPending = copyMutation.isPending;
+  const copyErrorMessage = copyMutation.error?.message;
 
   return (
     <Modal show={show} backdrop="static" size="lg" onHide={handleClose}>
@@ -193,6 +213,7 @@ export function CopyCourseInstanceModal({
               courseShortName={courseShortName}
               errors={errors}
               register={register}
+              takenShortNames={takenShortNames}
             />
           )}
           {step === 'access-control' && (
@@ -202,6 +223,17 @@ export function CopyCourseInstanceModal({
               accessControlStrategy={accessControlStrategy}
               register={register}
             />
+          )}
+
+          {copyErrorMessage && (
+            <Alert
+              variant="danger"
+              className="mx-3 mb-0"
+              dismissible
+              onClose={() => copyMutation.reset()}
+            >
+              {copyErrorMessage}
+            </Alert>
           )}
 
           <Modal.Footer>
@@ -250,11 +282,13 @@ function SettingsStep({
   courseShortName,
   errors,
   register,
+  takenShortNames,
 }: {
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   courseShortName: string;
   errors: ReturnType<typeof useForm<CopyFormValues>>['formState']['errors'];
   register: ReturnType<typeof useForm<CopyFormValues>>['register'];
+  takenShortNames: Set<string>;
 }) {
   return (
     <Modal.Body>
@@ -300,9 +334,14 @@ function SettingsStep({
           defaultValue=""
           {...register('short_name', {
             required: 'Short name is required',
-            validate: (value) => {
-              const result = validateShortName(value);
-              return result.valid || result.message;
+            validate: {
+              format: (value) => {
+                const result = validateShortName(value);
+                return result.valid || result.message;
+              },
+              duplicate: (value) =>
+                !takenShortNames.has(value.trim().toLowerCase()) ||
+                'A course instance with this short name already exists',
             },
           })}
         />
@@ -386,6 +425,12 @@ function AccessControlStep({
   const blockedAssessments = assessments.filter((a) => a.errors.length > 0);
   const showPreserveOption = accessControlStrategy === 'migrate' && (appError || !allCanMigrate);
 
+  // Only the assessments that need attention (caveats or manual review) are listed;
+  // the ones that migrate cleanly are summarized by the count but not enumerated.
+  const assessmentsNeedingAttention = assessments.filter(
+    (a) => a.errors.length > 0 || a.notes.length > 0,
+  );
+
   if (!appError && assessments.length === 0) {
     return (
       <Modal.Body>
@@ -442,50 +487,46 @@ function AccessControlStep({
             </Alert>
           )}
 
-          <div className="border rounded mb-3" style={{ maxHeight: '240px', overflowY: 'auto' }}>
-            <table
-              className="table table-sm table-hover mb-0"
-              aria-label="Assessments with legacy access control"
-            >
-              <thead className="table-light sticky-top">
-                <tr>
-                  <th>Assessment</th>
-                  <th>Status</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {assessments.map((a) => (
-                  <tr key={a.tid}>
-                    <td>
-                      <code>{a.tid}</code>
-                      <small className="text-muted d-block">{a.title}</small>
-                    </td>
-                    <td>
-                      {a.errors.length === 0 ? (
-                        a.notes.length > 0 ? (
-                          <span className="badge text-bg-info">Migrates with notes</span>
-                        ) : (
-                          <span className="badge text-bg-success">Can migrate</span>
-                        )
-                      ) : (
-                        <span className="badge text-bg-warning">Manual review</span>
-                      )}
-                    </td>
-                    <td>
-                      {a.errors.length > 0 ? (
-                        <small className="text-danger">{a.errors.join(' ')}</small>
-                      ) : a.notes.length > 0 ? (
-                        <small className="text-muted">{a.notes.join(' ')}</small>
-                      ) : (
-                        <small className="text-muted">-</small>
-                      )}
-                    </td>
+          {assessmentsNeedingAttention.length > 0 && (
+            <div className="border rounded mb-3" style={{ maxHeight: '240px', overflowY: 'auto' }}>
+              <table
+                className="table table-sm table-hover mb-0"
+                aria-label="Assessments that need attention"
+              >
+                <thead className="table-light sticky-top">
+                  <tr>
+                    <th>Assessment</th>
+                    <th>Status</th>
+                    <th>Notes</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody>
+                  {assessmentsNeedingAttention.map((a) => (
+                    <tr key={a.tid}>
+                      <td>
+                        <code>{a.tid}</code>
+                        <small className="text-muted d-block">{a.title}</small>
+                      </td>
+                      <td>
+                        {a.errors.length > 0 ? (
+                          <span className="badge text-bg-warning">Manual review</span>
+                        ) : (
+                          <span className="badge text-bg-info">Migrates with notes</span>
+                        )}
+                      </td>
+                      <td>
+                        {a.errors.length > 0 ? (
+                          <small className="text-danger">{a.errors.join(' ')}</small>
+                        ) : (
+                          <small className="text-muted">{a.notes.join(' ')}</small>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </>
       )}
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -29,7 +29,7 @@ interface InstructorInstanceAdminSettingsProps {
   course: PageContext<'courseInstance', 'instructor'>['course'];
   courseInstance: PageContext<'courseInstance', 'instructor'>['course_instance'];
   institution: PageContext<'courseInstance', 'instructor'>['institution'];
-  names: { short_name: string; long_name: string | null }[];
+  names: { short_name: string }[];
   availableTimezones: Timezone[];
   origHash: string;
   instanceGHLink: string | undefined | null;

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -131,6 +131,7 @@ function InstructorInstanceAdminSettingsInner({
         courseInstance={courseInstance}
         isAdministrator={isAdministrator}
         accessControlMigrationNeeded={accessControlMigrationNeeded}
+        names={names}
         onHide={() => setShowCopyModal(false)}
       />
       <form

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -88,7 +88,7 @@ function InstructorInstanceAdminSettingsInner({
 }: Omit<InstructorInstanceAdminSettingsProps, 'trpcCsrfToken' | 'isDevMode'>) {
   const [showCopyModal, setShowCopyModal] = useState(false);
 
-  const shortNames = new Set(names.map((name) => name.short_name));
+  const shortNames = new Set(names.map((name) => name.short_name.toLowerCase()));
 
   const defaultValues: SettingsFormValues = {
     ciid: courseInstance.short_name,
@@ -174,7 +174,10 @@ function InstructorInstanceAdminSettingsInner({
                         return result.valid || result.message;
                       },
                       duplicate: (value) => {
-                        if (shortNames.has(value) && value !== defaultValues.ciid) {
+                        if (
+                          shortNames.has(value.toLowerCase()) &&
+                          value.toLowerCase() !== defaultValues.ciid.toLowerCase()
+                        ) {
                           return 'This ID is already in use';
                         }
                         return true;

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.sql
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.sql
@@ -1,7 +1,6 @@
 -- BLOCK select_names
 SELECT
-  ci.short_name,
-  ci.long_name
+  ci.short_name
 FROM
   course_instances AS ci
 WHERE

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -238,21 +238,11 @@ router.post(
         z.object({ short_name: z.string(), long_name: z.string().nullable() }),
       );
       const existingShortNames = existingNames.map((name) => name.short_name.toLowerCase());
-      const existingLongNames = existingNames
-        .map((name) => name.long_name?.toLowerCase())
-        .filter((name) => name != null);
 
       if (existingShortNames.includes(short_name.toLowerCase())) {
         throw new error.HttpStatusError(
           400,
           'A course instance with this short name already exists',
-        );
-      }
-
-      if (existingLongNames.includes(long_name.toLowerCase())) {
-        throw new error.HttpStatusError(
-          400,
-          'A course instance with this long name already exists',
         );
       }
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -72,7 +72,7 @@ router.get(
     const names = await sqldb.queryRows(
       sql.select_names,
       { course_id: course.id },
-      z.object({ short_name: z.string(), long_name: z.string().nullable() }),
+      z.object({ short_name: z.string() }),
     );
     const enrollmentCount = await sqldb.queryScalar(
       sql.select_enrollment_count,
@@ -236,7 +236,7 @@ router.post(
       const existingNames = await sqldb.queryRows(
         sql.select_names,
         { course_id: course.id },
-        z.object({ short_name: z.string(), long_name: z.string().nullable() }),
+        z.object({ short_name: z.string() }),
       );
       const existingShortNames = existingNames.map((name) => name.short_name.toLowerCase());
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -21,6 +21,7 @@ import {
   getSelfEnrollmentLinkUrl,
 } from '../../lib/client/url.js';
 import { config } from '../../lib/config.js';
+import { DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR } from '../../lib/course-instances.shared.js';
 import { EnumCourseInstanceRoleSchema } from '../../lib/db-types.js';
 import { getOriginalHash } from '../../lib/editorUtil.js';
 import { propertyValueWithDefault } from '../../lib/editorUtil.shared.js';
@@ -240,10 +241,7 @@ router.post(
       const existingShortNames = existingNames.map((name) => name.short_name.toLowerCase());
 
       if (existingShortNames.includes(short_name.toLowerCase())) {
-        throw new error.HttpStatusError(
-          400,
-          'A course instance with this short name already exists',
-        );
+        throw new error.HttpStatusError(400, DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR);
       }
 
       const updatedCourseInstance = {


### PR DESCRIPTION
# Description

Fixes the silent failure in the in-browser "Copy course instance" tool and cleans up the access-control migration step.

- Copy errors are now surfaced. Previously a failed copy (e.g. a duplicate short name) threw an error the modal never displayed, so the button just reset with no feedback. The server message is now shown in an alert on every step; a short-name conflict also highlights the field and returns the user to the settings step, and the rejected value is blocked client-side so it can't be re-submitted (covers the race where another instance takes the name between page load and submit).
- Short-name uniqueness is validated client-side on the settings step, gating advancement before the server round-trip.
- Removed the long-name uniqueness check from both the copy and create flows (server and client). Long name is a display field, is not unique anywhere else (rename form, DB), and shouldn't be enforced here.
- The short-name conflict message is now a shared constant (`DUPLICATE_COURSE_INSTANCE_SHORT_NAME_ERROR`) used by both server handlers and the client, so there's a single source of truth.
- The access-control migration step now always lists only the assessments that need attention (errors or notes) instead of the full list, which was unusable for instances with many assessments.

Closes #15456

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: majority of implementation.

# Testing

- Copy a course instance with a duplicate short name: the settings step blocks advancing; if it reaches the server, the error is shown, the field is flagged, and the user is returned to the settings step.
- Copy an instance whose assessments have legacy `allowAccess` rules: the migration step lists only the assessments with caveats or blockers. Verified outcomes ("Migrates with notes" / "Manual review") against `analyzeCourseInstanceAssessments`.