### PR TITLE
Improve docs for pl-drawing and pl-excalidraw

### DIFF
--- a/docs/elements/pl-excalidraw.md
+++ b/docs/elements/pl-excalidraw.md
@@ -36,5 +36,12 @@ The `width` and `height` attributes are used as CSS property values. Unitless nu
 
 `pl-excalidraw` is a canvas-based drawing tool and is not fully accessible. While the toolbar can be reached with the keyboard, shapes cannot be drawn using the keyboard alone, and the drawing surface is not exposed to screen readers. If you use this element, consider providing an alternative version of the question for students who cannot use it, for example a freeform text input where they can describe the diagram in words.
 
+## Example implementation
+
+- [element/excalidraw]
+
+---
+
 [css-height-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/height
 [css-width-mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/width
+[element/excalidraw]: https://github.com/PrairieLearn/PrairieLearn/tree/master/exampleCourse/questions/element/excalidraw

--- a/docs/elements/pl-excalidraw.md
+++ b/docs/elements/pl-excalidraw.md
@@ -36,7 +36,7 @@ The `width` and `height` attributes are used as CSS property values. Unitless nu
 
 `pl-excalidraw` is a canvas-based drawing tool and is not fully accessible. While the toolbar can be reached with the keyboard, shapes cannot be drawn using the keyboard alone, and the drawing surface is not exposed to screen readers. If you use this element, consider providing an alternative version of the question for students who cannot use it, for example a freeform text input where they can describe the diagram in words.
 
-## Example implementation
+## Example implementations
 
 - [element/excalidraw]
 

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -465,6 +465,8 @@ The element `pl-drawing-group` combines several elements as a group, to allow gr
       <pl-drawing-group visible="false">
           <!-- objects here will not be displayed -->
       </pl-drawing-group>
+
+  </pl-drawing-initial>
 </pl-drawing>
 ```
 

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -457,15 +457,13 @@ The element `pl-drawing-group` combines several elements as a group, to allow gr
 ```html
 <pl-drawing>
   <pl-drawing-initial>
+    <pl-drawing-group visible="true">
+      <!-- objects here will be displayed -->
+    </pl-drawing-group>
 
-      <pl-drawing-group visible="true">
-          <!-- objects here will be displayed -->
-      </pl-drawing-group>
-
-      <pl-drawing-group visible="false">
-          <!-- objects here will not be displayed -->
-      </pl-drawing-group>
-
+    <pl-drawing-group visible="false">
+      <!-- objects here will not be displayed -->
+    </pl-drawing-group>
   </pl-drawing-initial>
 </pl-drawing>
 ```


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description


Added a missing closing tag in pl-drawing-group and added the missing example section for pl-excalidraw

Why the changes? 
Copy pasting pl-drawing-group element example would be incorrect, hence added the change.
pl-excalidraw already had an example in example course, so added it to the docs.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).
no ai used

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
