### PR TITLE
Clarify wording in assessment access control UI

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/AfterCompleteForm.tsx
@@ -411,7 +411,8 @@ function AfterCompleteCard({
           </OverlayTrigger>
         </div>
         <div className="text-muted small mt-1">
-          What students can see once they can no longer answer questions on the assessment.
+          Control question and score visibility once students can no longer make submissions to the
+          assessment.
         </div>
       </div>
       <div className="d-flex flex-column gap-3">{children}</div>
@@ -493,7 +494,7 @@ export function DefaultAfterCompleteForm({
       )}
       <div>
         <Form.Label className="fw-bold" htmlFor="defaultRule-score-visibility-mode">
-          Score visibility
+          Score visibility after completion
         </Form.Label>
         <ScoreVisibilityInput
           value={svField.value}
@@ -506,7 +507,7 @@ export function DefaultAfterCompleteForm({
       </div>
       <div>
         <Form.Label className="fw-bold" htmlFor="defaultRule-question-visibility-mode">
-          Question visibility
+          Question visibility after completion
         </Form.Label>
         <QuestionVisibilityInput
           value={qvField.value}
@@ -591,7 +592,7 @@ export function OverrideAfterCompleteForm({
       <div>
         <FieldWrapper
           isOverridden={svOverridden}
-          label="Score visibility"
+          label="Score visibility after completion"
           onOverride={() => {
             svField.onChange({ ...defaultRuleSV });
             addSvOverride();
@@ -615,7 +616,7 @@ export function OverrideAfterCompleteForm({
       <div>
         <FieldWrapper
           isOverridden={qvOverridden}
-          label="Question visibility"
+          label="Question visibility after completion"
           onOverride={() => {
             qvField.onChange({ ...defaultRuleQV });
             addQvOverride();

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -309,7 +309,7 @@ export function generateDefaultRuleDateTableRows(
       access: afterLastDeadline.allowSubmissions
         ? afterLastDeadline.credit > 0
           ? formatCreditPercent(afterLastDeadline.credit)
-          : 'Practice'
+          : 'Practice for zero credit'
         : 'No submissions allowed',
       error: get(formErrors, 'afterLastDeadline.credit')?.message,
       current: isAfterLastSegment,
@@ -539,7 +539,9 @@ function formatAfterLastDeadline(afterLastDeadline: AfterLastDeadlineValue): str
     parts.push(`${afterLastDeadline.credit}% credit`);
   }
   if (afterLastDeadline.allowSubmissions) {
-    parts.push(parts.length > 0 ? 'submissions allowed' : 'Practice submissions allowed');
+    parts.push(
+      parts.length > 0 ? 'submissions allowed' : 'Practice submissions allowed for zero credit',
+    );
   } else {
     parts.push('No submissions allowed');
   }

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/AfterLastDeadlineField.tsx
@@ -24,17 +24,14 @@ const AFTER_LAST_DEADLINE_ITEMS: RichSelectItem<AfterLastDeadlineMode>[] = [
   {
     value: 'no_submissions',
     label: 'No submissions allowed',
-    description: 'Students can review what after-completion visibility allows',
   },
   {
     value: 'practice_submissions',
-    label: 'Allow practice submissions',
-    description: 'No credit is given for practice submissions',
+    label: 'Allow practice submissions for zero credit',
   },
   {
     value: 'partial_credit',
     label: 'Allow submissions for partial credit',
-    description: 'Students receive partial credit for submissions',
   },
 ];
 
@@ -161,8 +158,7 @@ function AfterLastDeadlineInput({
         <>
           This controls the ability to submit after{' '}
           <FriendlyDate date={lastDate} timezone={displayTimezone} options={{ includeTz: false }} />
-          , until the course instance end date. Visibility is controlled by the after-completion
-          settings.
+          , until the course instance end date.
         </>
       );
     }
@@ -170,7 +166,7 @@ function AfterLastDeadlineInput({
     // TODO: we want to update the UI to completely hide the "after last deadline" options
     // when there are in fact no deadlines. That'll render this branch obsolete, but in the
     // meantime we have to show something here.
-    return 'This controls the ability to submit until the course instance end date. Visibility is controlled by the after-completion settings.';
+    return 'This controls the ability to submit until the course instance end date.';
   };
 
   const handleModeChange = (newMode: AfterLastDeadlineMode) => {

--- a/docs/assessment/accessControl.md
+++ b/docs/assessment/accessControl.md
@@ -141,7 +141,7 @@ Disable it when the assessment should be completely hidden until release.
 
 Use **Question visibility** and **Score visibility** to decide what students can see after the assessment is complete.
 
-These settings apply once submissions are no longer allowed: after the final deadline, when a timed assessment closes, when an Exam assessment auto-closes after inactivity, or when an instructor closes it. If after-deadline submissions are allowed, **After completion** applies only after the student's assessment instance closes or its time limit expires.
+An assessment instance is considered to be complete once submissions are no longer allowed: after the final deadline, when a timed assessment closes, when an Exam assessment auto-closes after inactivity, or when an instructor closes it. If after-deadline submissions are allowed, **After completion** applies only after the student's assessment instance closes or its time limit expires.
 
 Question visibility options:
 


### PR DESCRIPTION
# Description

Applies the UI and docs wording improvements proposed in #15457 to make the assessment access control settings clearer. On the **After completion** section this reworks the header, appends "after completion" to the score/question visibility subheadings, and clarifies in the docs when an assessment instance is considered complete. On the "after last deadline" options this drops the confusing muted help text (including the "Visibility is controlled by the after-completion settings" sentence), renames the practice option to "Allow practice submissions for zero credit", and updates the matching "Practice for zero credit" summary badge. Closes #15457.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation): majority of implementation.

# Testing

Copy-only changes; verified via typecheck, lint, and existing access-control unit/e2e tests, which target the unchanged summary column headers and RichSelect aria-labels rather than the reworded copy.