### PR TITLE
Enforce pending enrollment LTI provenance

### DIFF
--- a/apps/prairielearn/src/migrations/20260720173928_enrollments__lti_managed__null_backfill__finalize.ts
+++ b/apps/prairielearn/src/migrations/20260720173928_enrollments__lti_managed__null_backfill__finalize.ts
@@ -1,0 +1,5 @@
+import { finalizeBatchedMigration } from '@prairielearn/migrations';
+
+export default async function () {
+  await finalizeBatchedMigration('20260720173206_enrollments__lti_managed__null_backfill');
+}

--- a/apps/prairielearn/src/migrations/20260720173929_enrollments__pending_lti_managed__constraint_add.sql
+++ b/apps/prairielearn/src/migrations/20260720173929_enrollments__pending_lti_managed__constraint_add.sql
@@ -1,0 +1,5 @@
+ALTER TABLE enrollments
+ADD CONSTRAINT enrollments_pending_lti_managed_not_false CHECK (
+  user_id IS NOT NULL
+  OR lti_managed IS DISTINCT FROM FALSE
+) NOT VALID;

--- a/apps/prairielearn/src/migrations/20260720173930_enrollments__pending_lti_managed__constraint_validate.sql
+++ b/apps/prairielearn/src/migrations/20260720173930_enrollments__pending_lti_managed__constraint_validate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE enrollments VALIDATE CONSTRAINT enrollments_pending_lti_managed_not_false;

--- a/apps/prairielearn/src/models/enrollment.test.ts
+++ b/apps/prairielearn/src/models/enrollment.test.ts
@@ -474,13 +474,14 @@ describe('DB validation of enrollment', () => {
         pending_uid: null,
         pending_uin: 'rejected-uin',
       },
-      // status is 'joined', first_joined_at must not be null
+      // Resolved non-LTI enrollments are allowed; joined rows require first_joined_at
       {
         user_id: user3.id,
         status: 'joined',
         created_at: '2025-01-01',
         first_joined_at: '2025-01-01',
         pending_uid: null,
+        lti_managed: false,
       },
       // status is 'left', first_joined_at must not be null
       {
@@ -659,6 +660,16 @@ describe('DB validation of enrollment', () => {
         pending_uid: null,
         pending_uin: 'rejected-lti-managed-uin',
         lti_managed: true,
+      },
+      // Pending enrollments cannot be explicitly marked as non-LTI-managed
+      {
+        constraint: 'enrollments_pending_lti_managed_not_false',
+        user_id: null,
+        status: 'invited',
+        created_at: '2025-01-01',
+        first_joined_at: null,
+        pending_uid: 'pending-non-lti-managed@example.com',
+        lti_managed: false,
       },
     ];
 

--- a/database/tables/enrollments.pg
+++ b/database/tables/enrollments.pg
@@ -30,6 +30,7 @@ check constraints
     enrollments_lti13_sub_requires_uin: CHECK (pending_lti13_sub IS NULL OR pending_uin IS NOT NULL)
     enrollments_pending_fields_null_if_resolved: CHECK (user_id IS NULL OR pending_uid IS NULL AND pending_uin IS NULL AND pending_name IS NULL AND pending_email IS NULL AND pending_lti13_name IS NULL AND pending_lti13_email IS NULL AND pending_lti13_sub IS NULL AND pending_lti13_course_instance_id IS NULL AND pending_lti13_instance_id IS NULL)
     enrollments_pending_identity_required: CHECK (user_id IS NOT NULL OR pending_uid IS NOT NULL OR pending_uin IS NOT NULL)
+    enrollments_pending_lti_managed_not_false: CHECK (user_id IS NOT NULL OR lti_managed IS DISTINCT FROM false)
     enrollments_rejected_not_lti_managed: CHECK (status <> 'rejected'::enum_enrollment_status OR lti_managed IS NOT TRUE)
     enrollments_status_not_lti13_pending: CHECK (status <> 'lti13_pending'::enum_enrollment_status)
     enrollments_user_id_null_only_if_invited_rejected: CHECK ((status = ANY (ARRAY['invited'::enum_enrollment_status, 'rejected'::enum_enrollment_status])) = (user_id IS NULL))


### PR DESCRIPTION
# Description

Parent PR: [#15472](https://github.com/PrairieLearn/PrairieLearn/pull/15472).

This stacked PR finalizes `20260720173206_enrollments__lti_managed__null_backfill`, adds the `enrollments_pending_lti_managed_not_false` check constraint as `NOT VALID`, and validates that single constraint in a separate subsequent migration.

The constraint allows `TRUE` or `NULL` for pending enrollments and allows `FALSE` for resolved enrollments while preserving the expected-identity constraints and pending UID behavior.

This PR intentionally retains the legacy `pending_lti13_name`, `pending_lti13_email`, and `pending_lti13_instance_id` columns and their constraints, and it does not remove the `lti13_pending` enum value.

**Deployment dependency:** This PR must not deploy until `20260720173206_enrollments__lti_managed__null_backfill` has completed in production.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex performed the majority of implementation and validation under human direction.

# Testing

- Added focused enrollment database coverage proving pending + `FALSE` is rejected while resolved + `FALSE` remains allowed.
- Verified the committed database description against a freshly migrated database.
