### PR TITLE
Improve Zod error page accessibility

### DIFF
--- a/apps/prairielearn/src/pages/error/error.html.ts
+++ b/apps/prairielearn/src/pages/error/error.html.ts
@@ -41,7 +41,9 @@ export function ErrorPage({
   } = error.data ?? {};
 
   const formattedSqlQuery = formatQueryWithErrorPosition(sqlQuery, sqlError?.position);
-  const formattedError = error instanceof z.ZodError ? z.prettifyError(error) : error.message;
+  const isZodError = error instanceof z.ZodError;
+  const errorHeading = isZodError ? 'Validation error' : error.message;
+  const zodErrorDetails = isZodError ? z.prettifyError(error) : undefined;
 
   return PageLayout({
     resLocals,
@@ -57,7 +59,10 @@ export function ErrorPage({
         </div>
 
         <div class="card-body">
-          <h2 class="mb-3 h4" style="white-space: pre-wrap;">${formattedError}</h2>
+          <h2 class="mb-3 h4">${errorHeading}</h2>
+          ${isZodError
+            ? html` <pre class="bg-light border rounded p-2">${zodErrorDetails}</pre> `
+            : ''}
           ${unsafeHtml(errorInfo ?? '')}
 
           <p><strong>Error ID:</strong> <code>${errorId}</code></p>
@@ -89,7 +94,7 @@ export function ErrorPage({
             : ''}
           ${error.stack
             ? html`
-                <p><strong>Stack trace:</strong></p>
+                <p class="mt-3"><strong>Stack trace:</strong></p>
                 <pre class="bg-dark text-white rounded p-2">${formatErrorStack(error)}</pre>
               `
             : ''}


### PR DESCRIPTION
# Description

Zod's `prettifyError()` output can contain multiline, symbol-heavy diagnostics. Rendering that entire output inside the error page's `<h2>` makes screen-reader heading navigation unnecessarily verbose and conflates the concise error summary with implementation details.

This renders a concise "Validation error" heading for Zod errors and moves the full diagnostic into a separate preformatted block. Non-Zod error messages retain their existing heading behavior, and the stack trace receives a small amount of spacing from the preceding navigation controls.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex was used for the majority of the implementation and PR drafting, with the final design reviewed interactively.

# Testing

- Manually triggered a real Zod error at `/pl/login?service=one&service=two`, where the duplicate query parameter produces an array that fails the route's string schema.
- Verified in the browser that heading navigation remains concise while the complete Zod diagnostic is displayed separately as preformatted text.
