### PR TITLE
Add LTI 1.3 roster sync readiness inventory

### DIFF
--- a/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.sql
+++ b/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.sql
@@ -1,0 +1,55 @@
+-- BLOCK select_lti13_roster_sync_readiness
+SELECT
+  i.id AS institution_id,
+  i.short_name AS institution_short_name,
+  i.long_name AS institution_long_name,
+  li.id AS lti13_instance_id,
+  li.name AS lti13_instance_name,
+  li.platform,
+  NULLIF(btrim(li.uin_attribute), '') AS lti13_uin_attribute,
+  NULLIF(btrim(sp.uin_attribute), '') AS saml_uin_attribute,
+  COALESCE(
+    (
+      SELECT
+        array_agg(
+          ap.name
+          ORDER BY
+            ap.id
+        )
+      FROM
+        institution_authn_providers AS iap
+        JOIN authn_providers AS ap ON (ap.id = iap.authn_provider_id)
+      WHERE
+        iap.institution_id = i.id
+    ),
+    ARRAY[]::text[]
+  ) AS enabled_authn_provider_names,
+  (
+    SELECT
+      count(*)
+    FROM
+      lti13_instances AS institution_li
+    WHERE
+      institution_li.institution_id = i.id
+      AND institution_li.deleted_at IS NULL
+      AND NULLIF(btrim(institution_li.uin_attribute), '') IS NULL
+  ) AS active_lti13_instances_without_uin_count,
+  (
+    SELECT
+      count(*)
+    FROM
+      users AS u
+    WHERE
+      u.institution_id = i.id
+      AND NULLIF(btrim(u.uin), '') IS NULL
+  ) AS users_without_uin_count
+FROM
+  lti13_instances AS li
+  JOIN institutions AS i ON (i.id = li.institution_id)
+  LEFT JOIN saml_providers AS sp ON (sp.institution_id = i.id)
+WHERE
+  li.deleted_at IS NULL
+ORDER BY
+  i.short_name,
+  i.id,
+  li.id;

--- a/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.sql
+++ b/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.sql
@@ -21,8 +21,9 @@ WITH
       institution_id,
       CASE
         WHEN uin IS NULL THEN 'missing'
-        -- PrairieLearn historically stored Google OIDC subjects as UINs, and those
-        -- subjects are 21-digit decimals. Azure object IDs are UUID-shaped, but some
+        -- PrairieLearn stores Google OIDC subjects as UINs, and those subjects are
+        -- 21-digit decimals. These values may remain after an institution switches
+        -- authentication providers. Azure object IDs are UUID-shaped, but some
         -- institutions intentionally use GUIDs as their canonical SAML UIN, so these
         -- categories identify likely provenance rather than validity.
         WHEN uin ~ '^[0-9]{21}$' THEN '21-digit decimal (Google subject candidate)'

--- a/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.sql
+++ b/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.sql
@@ -1,4 +1,86 @@
 -- BLOCK select_lti13_roster_sync_readiness
+WITH
+  active_lti13_institutions AS (
+    SELECT DISTINCT
+      institution_id
+    FROM
+      lti13_instances
+    WHERE
+      deleted_at IS NULL
+  ),
+  normalized_user_uins AS (
+    SELECT
+      u.institution_id,
+      NULLIF(btrim(u.uin), '') AS uin
+    FROM
+      users AS u
+      JOIN active_lti13_institutions AS ali ON (ali.institution_id = u.institution_id)
+  ),
+  categorized_user_uins AS (
+    SELECT
+      institution_id,
+      CASE
+        WHEN uin IS NULL THEN 'missing'
+        -- PrairieLearn historically stored Google OIDC subjects as UINs, and those
+        -- subjects are 21-digit decimals. Azure object IDs are UUID-shaped, but some
+        -- institutions intentionally use GUIDs as their canonical SAML UIN, so these
+        -- categories identify likely provenance rather than validity.
+        WHEN uin ~ '^[0-9]{21}$' THEN '21-digit decimal (Google subject candidate)'
+        WHEN uin ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN 'GUID-shaped'
+        WHEN uin ~* '^[0-9a-f]{32}$'
+        AND uin ~* '[a-f]' THEN '32-character hexadecimal'
+        WHEN uin ~ '^[0-9]+$' THEN length(uin) || '-digit decimal'
+        WHEN uin ~ '^[A-Za-z0-9]+$' THEN length(uin) || '-character alphanumeric'
+        ELSE length(uin) || '-character other'
+      END AS category
+    FROM
+      normalized_user_uins
+  ),
+  user_uin_category_counts AS (
+    SELECT
+      institution_id,
+      category,
+      count(*) AS user_count
+    FROM
+      categorized_user_uins
+    GROUP BY
+      institution_id,
+      category
+  ),
+  user_uin_stats AS (
+    SELECT
+      institution_id,
+      COALESCE(
+        sum(user_count) FILTER (
+          WHERE
+            category = 'missing'
+        ),
+        0
+      ) AS users_without_uin_count,
+      COALESCE(
+        sum(user_count) FILTER (
+          WHERE
+            category = '21-digit decimal (Google subject candidate)'
+        ),
+        0
+      ) AS google_subject_candidate_count,
+      COALESCE(
+        jsonb_object_agg(
+          category,
+          user_count
+          ORDER BY
+            category
+        ) FILTER (
+          WHERE
+            category != 'missing'
+        ),
+        '{}'::jsonb
+      ) AS uin_category_counts
+    FROM
+      user_uin_category_counts
+    GROUP BY
+      institution_id
+  )
 SELECT
   i.id AS institution_id,
   i.short_name AS institution_short_name,
@@ -34,19 +116,14 @@ SELECT
       AND institution_li.deleted_at IS NULL
       AND NULLIF(btrim(institution_li.uin_attribute), '') IS NULL
   ) AS active_lti13_instances_without_uin_count,
-  (
-    SELECT
-      count(*)
-    FROM
-      users AS u
-    WHERE
-      u.institution_id = i.id
-      AND NULLIF(btrim(u.uin), '') IS NULL
-  ) AS users_without_uin_count
+  COALESCE(uus.users_without_uin_count, 0) AS users_without_uin_count,
+  COALESCE(uus.google_subject_candidate_count, 0) AS google_subject_candidate_count,
+  COALESCE(uus.uin_category_counts, '{}'::jsonb) AS uin_category_counts
 FROM
   lti13_instances AS li
   JOIN institutions AS i ON (i.id = li.institution_id)
   LEFT JOIN saml_providers AS sp ON (sp.institution_id = i.id)
+  LEFT JOIN user_uin_stats AS uus ON (uus.institution_id = i.id)
 WHERE
   li.deleted_at IS NULL
 ORDER BY

--- a/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.ts
+++ b/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
+
+import { AuthnProviderSchema } from '../lib/db-types.js';
+
+import type { AdministratorQueryResult, AdministratorQuerySpecs } from './lib/util.js';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+const ReadinessRowSchema = z.object({
+  institution_id: IdSchema,
+  institution_short_name: z.string(),
+  institution_long_name: z.string(),
+  lti13_instance_id: IdSchema,
+  lti13_instance_name: z.string(),
+  platform: z.string(),
+  lti13_uin_attribute: z.string().nullable(),
+  saml_uin_attribute: z.string().nullable(),
+  enabled_authn_provider_names: AuthnProviderSchema.shape.name.array(),
+  active_lti13_instances_without_uin_count: z.coerce.number(),
+  users_without_uin_count: z.coerce.number(),
+});
+
+export const specs: AdministratorQuerySpecs = {
+  description:
+    'Inventory active LTI 1.3 instances, institution identity prerequisites, and UIN backfill gaps before roster-sync rollout.',
+  resultFormats: { follow_up_tasks: 'pre' },
+};
+
+export default async function (): Promise<AdministratorQueryResult> {
+  const rows = await queryRows(sql.select_lti13_roster_sync_readiness, ReadinessRowSchema);
+
+  return {
+    columns: [
+      'institution_id',
+      'institution',
+      'lti13_instance_id',
+      'lti13_instance',
+      'platform',
+      'lti13_uin_attribute',
+      'saml_uin_attribute',
+      'enabled_institutional_authn_providers',
+      'users_without_uin',
+      'readiness_status',
+      'follow_up_tasks',
+    ],
+    rows: rows.map((row) => {
+      const enabledInstitutionalAuthnProviderNames = row.enabled_authn_provider_names.filter(
+        (name) => name !== 'LTI' && name !== 'LTI 1.3',
+      );
+      const issues: string[] = [];
+
+      if (
+        enabledInstitutionalAuthnProviderNames.length !== 1 ||
+        enabledInstitutionalAuthnProviderNames[0] !== 'SAML'
+      ) {
+        issues.push('SAML must be the sole enabled institutional authentication provider');
+      }
+      if (!row.saml_uin_attribute) {
+        issues.push('SAML must have a UIN attribute configured');
+      }
+      if (row.active_lti13_instances_without_uin_count > 0) {
+        issues.push(
+          `${row.active_lti13_instances_without_uin_count} active LTI 1.3 instance(s) need a UIN attribute`,
+        );
+      }
+      if (row.users_without_uin_count > 0) {
+        issues.push(`${row.users_without_uin_count} existing user record(s) need a UIN backfill`);
+      }
+      const needsManualReview = issues.length === 0;
+      const followUpTasks = [
+        ...issues,
+        'Confirm that the configured SAML and LTI attributes represent the same canonical UIN',
+        'Confirm that existing user UIN values are compatible with both providers',
+        'Confirm that every in-scope roster member has a usable UIN',
+      ];
+
+      return {
+        institution_id: row.institution_id,
+        institution: `${row.institution_short_name}: ${row.institution_long_name}`,
+        lti13_instance_id: row.lti13_instance_id,
+        lti13_instance: row.lti13_instance_name,
+        platform: row.platform,
+        lti13_uin_attribute: row.lti13_uin_attribute,
+        saml_uin_attribute: row.saml_uin_attribute,
+        enabled_institutional_authn_providers: enabledInstitutionalAuthnProviderNames
+          .map((name) => name ?? '(unknown)')
+          .join(', '),
+        users_without_uin: row.users_without_uin_count,
+        readiness_status: needsManualReview ? 'manual review required' : 'follow-up required',
+        follow_up_tasks: followUpTasks.join('\n'),
+      };
+    }),
+  };
+}

--- a/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.ts
+++ b/apps/prairielearn/src/admin_queries/lti13_roster_sync_readiness.ts
@@ -21,12 +21,14 @@ const ReadinessRowSchema = z.object({
   enabled_authn_provider_names: AuthnProviderSchema.shape.name.array(),
   active_lti13_instances_without_uin_count: z.coerce.number(),
   users_without_uin_count: z.coerce.number(),
+  google_subject_candidate_count: z.coerce.number(),
+  uin_category_counts: z.record(z.string(), z.coerce.number()),
 });
 
 export const specs: AdministratorQuerySpecs = {
   description:
     'Inventory active LTI 1.3 instances, institution identity prerequisites, and UIN backfill gaps before roster-sync rollout.',
-  resultFormats: { follow_up_tasks: 'pre' },
+  resultFormats: { uin_format_categories: 'pre', follow_up_tasks: 'pre' },
 };
 
 export default async function (): Promise<AdministratorQueryResult> {
@@ -43,6 +45,7 @@ export default async function (): Promise<AdministratorQueryResult> {
       'saml_uin_attribute',
       'enabled_institutional_authn_providers',
       'users_without_uin',
+      'uin_format_categories',
       'readiness_status',
       'follow_up_tasks',
     ],
@@ -69,6 +72,23 @@ export default async function (): Promise<AdministratorQueryResult> {
       if (row.users_without_uin_count > 0) {
         issues.push(`${row.users_without_uin_count} existing user record(s) need a UIN backfill`);
       }
+      if (row.google_subject_candidate_count > 0) {
+        issues.push(
+          `${row.google_subject_candidate_count} existing UIN(s) are 21-digit decimal Google subject candidates; reconcile them with the canonical SAML UIN`,
+        );
+      }
+      const uinCategoryCounts = Object.entries(row.uin_category_counts).sort(
+        ([categoryA, countA], [categoryB, countB]) =>
+          countB - countA || categoryA.localeCompare(categoryB),
+      );
+      // Format categories are heuristic provenance signals, not validation rules. For example,
+      // an institution may intentionally use GUID-shaped SAML UINs; a second populated category
+      // is the useful warning that legacy identities may still be present.
+      if (uinCategoryCounts.length > 1) {
+        issues.push(
+          `Existing UINs span ${uinCategoryCounts.length} format categories; confirm which format is canonical and reconcile the others`,
+        );
+      }
       const needsManualReview = issues.length === 0;
       const followUpTasks = [
         ...issues,
@@ -89,6 +109,12 @@ export default async function (): Promise<AdministratorQueryResult> {
           .map((name) => name ?? '(unknown)')
           .join(', '),
         users_without_uin: row.users_without_uin_count,
+        uin_format_categories:
+          uinCategoryCounts.length > 0
+            ? uinCategoryCounts
+                .map(([category, count]) => `${category}: ${count.toLocaleString('en-US')}`)
+                .join('\n')
+            : '(none)',
         readiness_status: needsManualReview ? 'manual review required' : 'follow-up required',
         follow_up_tasks: followUpTasks.join('\n'),
       };


### PR DESCRIPTION
# Description

Adds an administrator query that inventories active LTI 1.3 instances and the institution identity prerequisites required before roster-sync rollout.

For each instance, the query reports its configured LTI UIN attribute, the institution's SAML UIN attribute and enabled institutional authentication providers, the number of active LTI 1.3 instances still missing a UIN attribute, and the number of existing institution users needing a UIN backfill.

The query also summarizes existing UINs by format, including 21-digit decimal Google subject candidates, GUID-shaped values, 32-character hexadecimal values, and other decimal or alphanumeric lengths. Google subject candidates and multiple populated formats produce concrete follow-up tasks, while the implementation explicitly treats these formats as likely provenance signals rather than validity rules because an institution may intentionally use GUID-shaped SAML UINs.

Each result is classified as either `manual review required` or `follow-up required` and always identifies the remaining manual compatibility checks. The query does not decide which format is canonical or perform any backfill.

This is a narrowly scoped extraction from the broader LTI 1.3 roster-sync prerequisites work in support of [PrairieLearnInc/planning#56](https://github.com/PrairieLearnInc/planning/issues/56). It intentionally does not include configuration guardrails, UI changes, production backfills, or feature-flag policy enforcement.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex prepared the majority of this implementation by extracting and narrowing existing work, validating repository conventions, investigating aggregate UIN format distributions, and preparing the pull request.

# Testing

Executed the administrator query against the local development database and verified that it returns per-institution UIN category counts while preserving missing-UIN totals. No dedicated query test was added because administrator queries use representative route-level coverage rather than per-query tests.
