### PR TITLE
Fix handling of asset hashing for pnpm virtual paths

### DIFF
--- a/apps/prairielearn/src/lib/assets.ts
+++ b/apps/prairielearn/src/lib/assets.ts
@@ -58,6 +58,15 @@ function getHashForPath(hashes: HashElementNode, assetPath: string): string {
  * returns `@scope/foo`.
  */
 function getPackageNameForAssetPath(assetPath: string): string {
+  if (assetPath.startsWith('.pnpm/')) {
+    // This is likely a pnpm virtual store path, which has the form
+    // `.pnpm/<package-name>@<version>/node_modules/<package-name>/...`.
+    // We'll strip off the pnpm prefix.
+    const secondNodeModulesIndex = assetPath.indexOf('/node_modules/');
+    if (secondNodeModulesIndex !== -1) {
+      assetPath = assetPath.slice(secondNodeModulesIndex + '/node_modules/'.length);
+    }
+  }
   const [maybeScope, maybeModule] = assetPath.split('/');
   if (maybeScope.startsWith('@')) {
     // This is a scoped module


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

In some pages such as the instructor questions page (I believe related to ESM bundles), an error was being shown in the server output with a message like "Cannot find module '.pnpm/package.json'". The error seems to be related to the fact that assets were being retrieved using pnpm virtual store paths (e.g., `/node_modules/.pnpm/search-string@4.1.0/node_modules/search-string/src/searchString.ts`), which caused the cachebuster handling to attempt to retrieve the incorrect package name for hashing.

This PR fixes the handling of such packages so that the appropriate package name is retrieved for version identification. The process uses a pnpm-specific handling of the path. An alternative I considered was to replace the entire code of `getPackageNameForAssetPath` with code that checks the directory of the asset path and parents until it finds a package.json, but I didn't use that as the code is intended to avoid FS operations in this context, since the package name will be used as a key to a cached version of the hash, and FS operations are expensive (particularly since this is supposed to by a sync function).

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: codex was used to help find the problem and the cause, with heavy human guidance.

# Testing

Open the instructor questions page for the example course, preferably with cache disabled (via developer mode). Then check the output in the PrairieLearn console. In master, this causes errors like:

```
error: Error page {"id":"KI978TM1GD4U","msg":"Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts","referrer":null,"stack":"Error: Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts\n    at node:internal/modules/cjs/loader:1421:15\n    at nextResolveSimple (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1017)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:4613\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:3894\n    at resolveTsPaths (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:770)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1171\n    at T._resolveFilename (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:15244)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)\n    at defaultResolve (node:internal/modules/cjs/loader:1094:31)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolve (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:13077)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolveWithHooks (node:internal/modules/customization_hooks:417:10)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1103:25)\n    at Module._load (node:internal/modules/cjs/loader:1227:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:328:14)","status":500,"url":"/node_modules/.pnpm/superjson@2.2.6/node_modules/superjson/src/accessDeep.ts"}
error: Error page {"id":"2KPGSRUB6HOQ","msg":"Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts","referrer":null,"stack":"Error: Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts\n    at node:internal/modules/cjs/loader:1421:15\n    at nextResolveSimple (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1017)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:4613\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:3894\n    at resolveTsPaths (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:770)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1171\n    at T._resolveFilename (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:15244)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)\n    at defaultResolve (node:internal/modules/cjs/loader:1094:31)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolve (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:13077)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolveWithHooks (node:internal/modules/customization_hooks:417:10)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1103:25)\n    at Module._load (node:internal/modules/cjs/loader:1227:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:328:14)","status":500,"url":"/node_modules/.pnpm/superjson@2.2.6/node_modules/superjson/src/plainer.ts"}
error: Error page {"id":"E94ND70CFXYZ","msg":"Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts","referrer":null,"stack":"Error: Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts\n    at node:internal/modules/cjs/loader:1421:15\n    at nextResolveSimple (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1017)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:4613\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:3894\n    at resolveTsPaths (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:770)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1171\n    at T._resolveFilename (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:15244)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)\n    at defaultResolve (node:internal/modules/cjs/loader:1094:31)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolve (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:13077)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolveWithHooks (node:internal/modules/customization_hooks:417:10)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1103:25)\n    at Module._load (node:internal/modules/cjs/loader:1227:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:328:14)","status":500,"url":"/node_modules/.pnpm/superjson@2.2.6/node_modules/superjson/src/index.ts"}
error: Error page {"id":"E649RT2QSXYD","msg":"Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts","referrer":null,"stack":"Error: Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts\n    at node:internal/modules/cjs/loader:1421:15\n    at nextResolveSimple (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1017)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:4613\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:3894\n    at resolveTsPaths (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:770)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1171\n    at T._resolveFilename (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:15244)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)\n    at defaultResolve (node:internal/modules/cjs/loader:1094:31)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolve (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:13077)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolveWithHooks (node:internal/modules/customization_hooks:417:10)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1103:25)\n    at Module._load (node:internal/modules/cjs/loader:1227:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:328:14)","status":500,"url":"/node_modules/.pnpm/search-string@4.1.0/node_modules/search-string/src/utils.ts"}
error: Error page {"id":"E83RANTVB4QZ","msg":"Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts","referrer":null,"stack":"Error: Cannot find module '.pnpm/package.json'\nRequire stack:\n- /home/jonatan/pl/apps/prairielearn/src/lib/assets.ts\n    at node:internal/modules/cjs/loader:1421:15\n    at nextResolveSimple (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1017)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:4613\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:9:3894\n    at resolveTsPaths (/home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:770)\n    at /home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-BLUABhh3.cjs:10:1171\n    at T._resolveFilename (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:15244)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1059:19)\n    at defaultResolve (node:internal/modules/cjs/loader:1094:31)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolve (file:///home/jonatan/pl/node_modules/.pnpm/tsx@4.23.0/node_modules/tsx/dist/register-D5KIhaFJ.mjs:2:13077)\n    at nextStep (node:internal/modules/customization_hooks:189:26)\n    at resolveWithHooks (node:internal/modules/customization_hooks:417:10)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1103:25)\n    at Module._load (node:internal/modules/cjs/loader:1227:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:328:14)","status":500,"url":"/node_modules/.pnpm/search-string@4.1.0/node_modules/search-string/src/searchString.ts"}
```

In this branch the errors don't show up.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
