### PR TITLE
Admit students from exact LTI roster launches

### DIFF
--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
@@ -13,6 +13,7 @@ import { assertNever } from '@prairielearn/utils';
 
 import * as authnLib from '../../../lib/authn.js';
 import { clearCookie, setCookie } from '../../../lib/cookie.js';
+import { clearCourseInstanceAdmissionContinuation } from '../../../lib/course-instance-admission-continuation.js';
 import type { Lti13Instance } from '../../../lib/db-types.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import { getUsableLti13Uin } from '../../lib/lti13-identity.js';
@@ -225,6 +226,7 @@ router.post(
     // session. If this launch also needs secondary authentication, fresh state
     // and a fresh redirect cookie are installed below.
     clearPendingLti13Auth(req.session);
+    clearCourseInstanceAdmissionContinuation(req.session);
     clearCookie(res, ['preAuthUrl', 'pl2_pre_auth_url']);
 
     // Put the LTI 1.3 claims in the session

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -274,6 +274,11 @@ export class Lti13Claim {
     return this.claims.sub;
   }
 
+  get exp() {
+    this.assertValid();
+    return this.claims.exp;
+  }
+
   get deployment_id() {
     this.assertValid();
     return this.claims['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -269,6 +269,11 @@ export class Lti13Claim {
     return this.claims['https://purl.imsglobal.org/spec/lti/claim/roles'];
   }
 
+  get sub() {
+    this.assertValid();
+    return this.claims.sub;
+  }
+
   get deployment_id() {
     this.assertValid();
     return this.claims['https://purl.imsglobal.org/spec/lti/claim/deployment_id'];

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -12,8 +12,11 @@ import {
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { admitUserFromLti13RosterInvitation } from '../../../models/course-instance-admission.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
+import { selectEnrollmentAdmissionDecision } from '../../../models/enrollment-identity.js';
+import { EnrollmentInvitationRequiredError } from '../../../models/enrollment-reconciliation.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {
@@ -134,6 +137,18 @@ router.get(
     );
 
     if (lti13_course_instance) {
+      const lti13AdmissionContext = !role_instructor
+        ? Object.freeze({
+            courseInstanceId: lti13_course_instance.course_instance_id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            lti13CourseInstanceId: lti13_course_instance.id,
+            reqDate: res.locals.req_date,
+            sub: ltiClaim.sub,
+            userId: res.locals.authn_user.id,
+          })
+        : null;
+
       // Update lti13_course_instance on instructor login
       // helpful as LMS updates or we add features
       if (role_instructor) {
@@ -155,11 +170,43 @@ router.get(
       // LTI claims are not used after this page so remove them from the session
       ltiClaim.remove();
 
+      if (lti13AdmissionContext !== null) {
+        const source = Object.freeze({
+          type: 'lti13' as const,
+          lti13CourseInstanceId: lti13AdmissionContext.lti13CourseInstanceId,
+          sub: lti13AdmissionContext.sub,
+        });
+        const decision = await selectEnrollmentAdmissionDecision(
+          {
+            courseInstanceId: lti13AdmissionContext.courseInstanceId,
+            lti13Identity: {
+              lti13CourseInstanceId: lti13AdmissionContext.lti13CourseInstanceId,
+              sub: lti13AdmissionContext.sub,
+            },
+            userId: lti13AdmissionContext.userId,
+          },
+          source,
+        );
+
+        if (decision.allowed) {
+          try {
+            await admitUserFromLti13RosterInvitation(lti13AdmissionContext);
+          } catch (error) {
+            if (error instanceof EnrollmentInvitationRequiredError) {
+              // The exact invitation can disappear before the locked check. Continue
+              // to the ordinary course-instance admission path in that case.
+            } else {
+              throw error;
+            }
+          }
+        }
+      }
+
       // Redirect to linked course instance
+      const courseInstanceId =
+        lti13AdmissionContext?.courseInstanceId ?? lti13_course_instance.course_instance_id;
       res.redirect(
-        `/pl/course_instance/${lti13_course_instance.course_instance_id}/${
-          role_instructor ? 'instructor/' : ''
-        }`,
+        `/pl/course_instance/${courseInstanceId}/${role_instructor ? 'instructor/' : ''}`,
       );
       return;
     }

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -7,16 +7,21 @@ import { execute, loadSqlEquiv, queryOptionalRow } from '@prairielearn/postgres'
 import { type PageAuthzData, hasRole, makePageAuthzData } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
 import {
+  clearCourseInstanceAdmissionContinuation,
+  replaceLti13ContinuationWithOrdinary,
+  setLti13CourseInstanceAdmissionContinuation,
+} from '../../../lib/course-instance-admission-continuation.js';
+import {
   type Course,
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
+import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
-import { admitUserFromLti13RosterInvitation } from '../../../models/course-instance-admission.js';
+import { admitUserWithCourseInstanceAdmissionSelection } from '../../../models/course-instance-admission-continuation.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
 import { selectEnrollmentAdmissionDecision } from '../../../models/enrollment-identity.js';
-import { EnrollmentInvitationRequiredError } from '../../../models/enrollment-reconciliation.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {
@@ -122,6 +127,16 @@ router.get(
     }
 
     const ltiClaim = new Lti13Claim(req);
+    const authnLti13InstanceId = req.session.authn_lti13_instance_id;
+    if (
+      (typeof authnLti13InstanceId !== 'string' && typeof authnLti13InstanceId !== 'number') ||
+      !idsEqual(authnLti13InstanceId, req.params.lti13_instance_id)
+    ) {
+      clearCourseInstanceAdmissionContinuation(req.session);
+      ltiClaim.remove();
+      throw new HttpStatusError(403, 'Access denied');
+    }
+
     const courseName = prettyCourseName(ltiClaim);
     const role_instructor = ltiClaim.isRoleInstructor();
 
@@ -142,6 +157,7 @@ router.get(
             courseInstanceId: lti13_course_instance.course_instance_id,
             ip: req.ip ?? null,
             isAdministrator: res.locals.is_administrator,
+            launchExpiresAtSeconds: ltiClaim.exp,
             lti13CourseInstanceId: lti13_course_instance.id,
             reqDate: res.locals.req_date,
             sub: ltiClaim.sub,
@@ -171,6 +187,14 @@ router.get(
       ltiClaim.remove();
 
       if (lti13AdmissionContext !== null) {
+        const continuation = setLti13CourseInstanceAdmissionContinuation({
+          courseInstanceId: lti13AdmissionContext.courseInstanceId,
+          launchExpiresAtSeconds: lti13AdmissionContext.launchExpiresAtSeconds,
+          lti13CourseInstanceId: lti13AdmissionContext.lti13CourseInstanceId,
+          session: req.session,
+          sub: lti13AdmissionContext.sub,
+          userId: lti13AdmissionContext.userId,
+        });
         const source = Object.freeze({
           type: 'lti13' as const,
           lti13CourseInstanceId: lti13AdmissionContext.lti13CourseInstanceId,
@@ -189,16 +213,26 @@ router.get(
         );
 
         if (decision.allowed) {
-          try {
-            await admitUserFromLti13RosterInvitation(lti13AdmissionContext);
-          } catch (error) {
-            if (error instanceof EnrollmentInvitationRequiredError) {
-              // The exact invitation can disappear before the locked check. Continue
-              // to the ordinary course-instance admission path in that case.
-            } else {
-              throw error;
-            }
+          const result = await admitUserWithCourseInstanceAdmissionSelection({
+            courseInstanceId: lti13AdmissionContext.courseInstanceId,
+            ip: lti13AdmissionContext.ip,
+            isAdministrator: lti13AdmissionContext.isAdministrator,
+            reqDate: lti13AdmissionContext.reqDate,
+            selection: {
+              continuation,
+              plan: { source, type: 'lti13_roster_invitation' },
+              type: 'lti13',
+            },
+            session: req.session,
+            userId: lti13AdmissionContext.userId,
+          });
+          if (result.type === 'blocked') {
+            clearCourseInstanceAdmissionContinuation(req.session);
           }
+        } else if (decision.reason === 'already_joined' || decision.reason === 'blocked') {
+          clearCourseInstanceAdmissionContinuation(req.session);
+        } else {
+          replaceLti13ContinuationWithOrdinary({ continuation, session: req.session });
         }
       }
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { type Request, Router } from 'express';
 import type Stripe from 'stripe';
 import { z } from 'zod';
 
@@ -7,10 +7,14 @@ import { runInTransactionAsync } from '@prairielearn/postgres';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
 import { config } from '../../../lib/config.js';
+import { getCourseInstanceAdmissionContinuation } from '../../../lib/course-instance-admission-continuation.js';
 import {
+  type Course,
+  type CourseInstance,
   CourseInstanceSchema,
   CourseSchema,
   InstitutionSchema,
+  type User,
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
@@ -20,9 +24,11 @@ import {
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import {
-  type CourseInstanceAdmissionPlan,
-  selectCourseInstanceAdmissionPlan,
-} from '../../../models/course-instance-admission.js';
+  type CourseInstanceAdmissionSelection,
+  admitUserWithCourseInstanceAdmissionSelection,
+  selectCourseInstanceAdmissionForRequest,
+} from '../../../models/course-instance-admission-continuation.js';
+import type { CourseInstanceAdmissionPlan } from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,
@@ -58,6 +64,62 @@ function getAdmissionIneligibilityReason(
   return null;
 }
 
+async function completeAdmissionContinuation({
+  course,
+  courseInstance,
+  isAdministrator,
+  req,
+  reqDate,
+  user,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  isAdministrator: boolean;
+  req: Request;
+  reqDate: Date;
+  user: User;
+}) {
+  const continuation = getCourseInstanceAdmissionContinuation({
+    courseInstanceId: courseInstance.id,
+    session: req.session,
+    userId: user.id,
+  });
+  if (continuation === null) return;
+
+  const selection = await selectCourseInstanceAdmissionForRequest({
+    course,
+    courseInstance,
+    session: req.session,
+    user,
+  });
+  if (selection.plan.type === 'blocked') {
+    throw new error.HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+  }
+  if (!isActionableAdmissionSelection(selection)) return;
+
+  const result = await admitUserWithCourseInstanceAdmissionSelection({
+    courseInstanceId: courseInstance.id,
+    ip: req.ip ?? null,
+    isAdministrator,
+    reqDate,
+    selection,
+    session: req.session,
+    userId: user.id,
+  });
+  if (result.type === 'blocked') {
+    throw new error.HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+  }
+}
+
+function isActionableAdmissionSelection(selection: CourseInstanceAdmissionSelection): boolean {
+  return (
+    selection.plan.type === 'conventional_invitation' ||
+    selection.plan.type === 'institution_roster_invitation' ||
+    selection.plan.type === 'lti13_roster_invitation' ||
+    selection.plan.type === 'self_enrollment'
+  );
+}
+
 router.get(
   '/',
   typedAsyncHandler<'course-instance'>(async (req, res) => {
@@ -65,11 +127,13 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
 
-    const admissionPlan = await selectCourseInstanceAdmissionPlan({
+    const admissionSelection = await selectCourseInstanceAdmissionForRequest({
       course,
       courseInstance,
+      session: req.session,
       user,
     });
+    const admissionPlan = admissionSelection.plan;
     const ineligibilityReason = getAdmissionIneligibilityReason(admissionPlan);
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
@@ -129,11 +193,13 @@ router.post(
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
 
-      const admissionPlan = await selectCourseInstanceAdmissionPlan({
+      const admissionSelection = await selectCourseInstanceAdmissionForRequest({
         course,
         courseInstance,
+        session: req.session,
         user,
       });
+      const admissionPlan = admissionSelection.plan;
       const ineligibilityReason = getAdmissionIneligibilityReason(admissionPlan);
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
@@ -248,7 +314,27 @@ router.get(
     if (!localSession) {
       throw new Error(`Unknown Stripe session: ${stripeSessionId}`);
     }
+
+    // Verify that the session is associated with the current course instance
+    // and user. We shouldn't hit this during normal operations, but an attacker
+    // could try to replay a session ID from a different course instance or user.
+    if (
+      localSession.course_instance_id !== courseInstance.id ||
+      localSession.agent_user_id !== res.locals.authn_user.id
+    ) {
+      throw new error.HttpStatusError(400, 'Invalid session');
+    }
+
     if (localSession.completed_at) {
+      await completeAdmissionContinuation({
+        course,
+        courseInstance,
+        isAdministrator: res.locals.authz_data.authn_is_administrator,
+        req,
+        reqDate: res.locals.req_date,
+        user: authn_user,
+      });
+
       // We already processed this session; just show them the success page.
       res.send(
         CourseInstanceStudentUpdateSuccess({
@@ -263,16 +349,6 @@ router.get(
 
     const stripe = getStripeClient();
     const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
-
-    // Verify that the session is associated with the current course instance
-    // and user. We shouldn't hit this during normal operations, but an attacker
-    // could try to replay a session ID from a different course instance or user.
-    if (
-      localSession.course_instance_id !== courseInstance.id ||
-      localSession.agent_user_id !== res.locals.authn_user.id
-    ) {
-      throw new error.HttpStatusError(400, 'Invalid session');
-    }
 
     if (session.payment_status === 'paid') {
       if (!localSession.plan_grants_created) {
@@ -303,6 +379,15 @@ router.get(
           await markStripeCheckoutSessionCompleted(session.id);
         });
       }
+
+      await completeAdmissionContinuation({
+        course,
+        courseInstance,
+        isAdministrator: res.locals.authz_data.authn_is_administrator,
+        req,
+        reqDate: res.locals.req_date,
+        user: authn_user,
+      });
 
       res.send(
         CourseInstanceStudentUpdateSuccess({

--- a/apps/prairielearn/src/lib/authn.test.ts
+++ b/apps/prairielearn/src/lib/authn.test.ts
@@ -114,6 +114,30 @@ describe('loadUser', () => {
     assert.deepEqual(req.session.lti13_claims, { sub: 'pending-sub' });
   });
 
+  it('does not transfer an admission continuation across identity transitions', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    await loadTestUser(req, res);
+
+    req.session.course_instance_admission_continuation = {
+      course_instance_id: '1',
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+      lti13_course_instance_id: '1',
+      sub: 'launch-sub',
+      type: 'lti13',
+      user_id: req.session.user_id,
+    };
+
+    await loadUser(req, res, {
+      uid: 'different-browser-session-user@example.com',
+      name: 'Different Browser Session User',
+      uin: null,
+      provider: 'dev',
+    });
+
+    assert.notProperty(req.session, 'course_instance_admission_continuation');
+  });
+
   it('regenerates the session when elevating to LockDown Browser state', async () => {
     let regenerateCount = 0;
     const req = makeReq(() => {

--- a/apps/prairielearn/src/lib/course-instance-admission-continuation.test.ts
+++ b/apps/prairielearn/src/lib/course-instance-admission-continuation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clearCourseInstanceAdmissionContinuation,
+  getCourseInstanceAdmissionContinuation,
+  replaceLti13ContinuationWithOrdinary,
+  setLti13CourseInstanceAdmissionContinuation,
+} from './course-instance-admission-continuation.js';
+
+describe('course instance admission continuation', () => {
+  it('stores an exact LTI continuation and replaces it with pinned ordinary policy', () => {
+    const session: Record<string, unknown> = {};
+    const exact = setLti13CourseInstanceAdmissionContinuation({
+      courseInstanceId: '10',
+      launchExpiresAtSeconds: 2_000_000_000,
+      lti13CourseInstanceId: '20',
+      session,
+      sub: 'launch-sub',
+      userId: '30',
+    });
+
+    expect(
+      getCourseInstanceAdmissionContinuation({
+        courseInstanceId: '10',
+        now: new Date('2030-01-01T00:00:00Z'),
+        session,
+        userId: '30',
+      }),
+    ).toEqual(exact);
+
+    const ordinary = replaceLti13ContinuationWithOrdinary({
+      continuation: exact,
+      session,
+    });
+    expect(ordinary).toEqual({
+      course_instance_id: '10',
+      expires_at: exact.expires_at,
+      type: 'ordinary',
+      user_id: '30',
+    });
+  });
+
+  it.each([
+    {
+      continuation: { marker: 'invalid' },
+      courseInstanceId: '10',
+      now: new Date('2030-01-01T00:00:00Z'),
+      userId: '30',
+    },
+    {
+      continuation: {
+        course_instance_id: '10',
+        expires_at: '2040-01-01T00:00:00.000Z',
+        retained_claims: { sub: 'must-not-survive' },
+        type: 'ordinary',
+        user_id: '30',
+      },
+      courseInstanceId: '10',
+      now: new Date('2030-01-01T00:00:00Z'),
+      userId: '30',
+    },
+    {
+      continuation: {
+        course_instance_id: '10',
+        expires_at: '2030-01-01T00:00:00.000Z',
+        type: 'ordinary',
+        user_id: '30',
+      },
+      courseInstanceId: '10',
+      now: new Date('2030-01-01T00:00:00Z'),
+      userId: '30',
+    },
+    {
+      continuation: {
+        course_instance_id: '10',
+        expires_at: '2040-01-01T00:00:00.000Z',
+        type: 'ordinary',
+        user_id: '30',
+      },
+      courseInstanceId: '11',
+      now: new Date('2030-01-01T00:00:00Z'),
+      userId: '30',
+    },
+    {
+      continuation: {
+        course_instance_id: '10',
+        expires_at: '2040-01-01T00:00:00.000Z',
+        type: 'ordinary',
+        user_id: '30',
+      },
+      courseInstanceId: '10',
+      now: new Date('2030-01-01T00:00:00Z'),
+      userId: '31',
+    },
+  ])('clears invalid, expired, or mismatched state: %#', (testCase) => {
+    const session: Record<string, unknown> = {
+      course_instance_admission_continuation: testCase.continuation,
+    };
+
+    expect(
+      getCourseInstanceAdmissionContinuation({
+        courseInstanceId: testCase.courseInstanceId,
+        now: testCase.now,
+        session,
+        userId: testCase.userId,
+      }),
+    ).toBeNull();
+    expect(session).not.toHaveProperty('course_instance_admission_continuation');
+  });
+
+  it('allows a new launch to replace an older continuation', () => {
+    const session: Record<string, unknown> = {};
+    setLti13CourseInstanceAdmissionContinuation({
+      courseInstanceId: '10',
+      launchExpiresAtSeconds: 2_000_000_000,
+      lti13CourseInstanceId: '20',
+      session,
+      sub: 'old-sub',
+      userId: '30',
+    });
+    const replacement = setLti13CourseInstanceAdmissionContinuation({
+      courseInstanceId: '11',
+      launchExpiresAtSeconds: 2_000_000_100,
+      lti13CourseInstanceId: '21',
+      session,
+      sub: 'new-sub',
+      userId: '30',
+    });
+
+    expect(session.course_instance_admission_continuation).toEqual(replacement);
+    clearCourseInstanceAdmissionContinuation(session);
+    expect(session).not.toHaveProperty('course_instance_admission_continuation');
+  });
+});

--- a/apps/prairielearn/src/lib/course-instance-admission-continuation.ts
+++ b/apps/prairielearn/src/lib/course-instance-admission-continuation.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod';
+
+import { IdSchema } from '@prairielearn/zod';
+
+const SESSION_KEY = 'course_instance_admission_continuation';
+
+const AdmissionContinuationBaseSchema = z.object({
+  course_instance_id: IdSchema,
+  expires_at: z.iso.datetime(),
+  user_id: IdSchema,
+});
+
+const OrdinaryAdmissionContinuationSchema = AdmissionContinuationBaseSchema.extend({
+  type: z.literal('ordinary'),
+}).strict();
+
+const Lti13AdmissionContinuationSchema = AdmissionContinuationBaseSchema.extend({
+  lti13_course_instance_id: IdSchema,
+  sub: z.string().min(1),
+  type: z.literal('lti13'),
+}).strict();
+
+export const CourseInstanceAdmissionContinuationSchema = z.discriminatedUnion('type', [
+  OrdinaryAdmissionContinuationSchema,
+  Lti13AdmissionContinuationSchema,
+]);
+
+export type CourseInstanceAdmissionContinuation = z.infer<
+  typeof CourseInstanceAdmissionContinuationSchema
+>;
+export type OrdinaryAdmissionContinuation = z.infer<typeof OrdinaryAdmissionContinuationSchema>;
+export type Lti13AdmissionContinuation = z.infer<typeof Lti13AdmissionContinuationSchema>;
+
+type SessionData = Record<string, unknown>;
+
+export function clearCourseInstanceAdmissionContinuation(session: SessionData) {
+  delete session[SESSION_KEY];
+}
+
+export function setLti13CourseInstanceAdmissionContinuation({
+  courseInstanceId,
+  launchExpiresAtSeconds,
+  lti13CourseInstanceId,
+  session,
+  sub,
+  userId,
+}: {
+  courseInstanceId: string;
+  launchExpiresAtSeconds: number;
+  lti13CourseInstanceId: string;
+  session: SessionData;
+  sub: string;
+  userId: string;
+}): Lti13AdmissionContinuation {
+  const continuation = Lti13AdmissionContinuationSchema.parse({
+    course_instance_id: courseInstanceId,
+    expires_at: new Date(launchExpiresAtSeconds * 1000).toISOString(),
+    lti13_course_instance_id: lti13CourseInstanceId,
+    sub,
+    type: 'lti13',
+    user_id: userId,
+  });
+  session[SESSION_KEY] = continuation;
+  return continuation;
+}
+
+export function replaceLti13ContinuationWithOrdinary({
+  continuation,
+  session,
+}: {
+  continuation: Lti13AdmissionContinuation;
+  session: SessionData;
+}): OrdinaryAdmissionContinuation {
+  const ordinaryContinuation = OrdinaryAdmissionContinuationSchema.parse({
+    course_instance_id: continuation.course_instance_id,
+    expires_at: continuation.expires_at,
+    type: 'ordinary',
+    user_id: continuation.user_id,
+  });
+  session[SESSION_KEY] = ordinaryContinuation;
+  return ordinaryContinuation;
+}
+
+export function getCourseInstanceAdmissionContinuation({
+  courseInstanceId,
+  now = new Date(),
+  session,
+  userId,
+}: {
+  courseInstanceId: string;
+  now?: Date;
+  session: SessionData;
+  userId: string;
+}): CourseInstanceAdmissionContinuation | null {
+  const parsed = CourseInstanceAdmissionContinuationSchema.safeParse(session[SESSION_KEY]);
+  if (
+    !parsed.success ||
+    new Date(parsed.data.expires_at).getTime() <= now.getTime() ||
+    parsed.data.course_instance_id !== courseInstanceId ||
+    parsed.data.user_id !== userId
+  ) {
+    clearCourseInstanceAdmissionContinuation(session);
+    return null;
+  }
+  return parsed.data;
+}

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -2,87 +2,99 @@ import { EnrollmentPage } from '../components/EnrollmentPage.js';
 import { idsEqual } from '../lib/id.js';
 import { typedAsyncHandler } from '../lib/res-locals.js';
 import {
+  type CourseInstanceAdmissionSelectionLocals as AdmissionSelectionLocals,
+  admitUserWithCourseInstanceAdmissionSelection,
+  selectCourseInstanceAdmissionForRequest,
+} from '../models/course-instance-admission-continuation.js';
+import {
   CourseInstanceAdmissionEligibilityError,
   CourseInstanceEnrollmentCodeRequiredError,
-  type CourseInstanceAdmissionPlanLocals as PlanLocals,
-  admitUserWithCourseInstanceAdmissionPlan,
-  selectCourseInstanceAdmissionPlan,
 } from '../models/course-instance-admission.js';
-import { EnrollmentAdmissionBlockedError } from '../models/enrollment-reconciliation.js';
 
-const autoEnroll = typedAsyncHandler<'course-instance', PlanLocals>(async (req, res, next) => {
-  // If the user does not currently have access to the course, but could if
-  // they were enrolled, automatically enroll them. However, we will not
-  // attempt to enroll them if they are an instructor (that is, if they have
-  // a specific role in the course or course instance) or if they are
-  // impersonating another user.
-
-  if (
-    idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
-    res.locals.authz_data.authn_course_role === 'None' &&
-    res.locals.authz_data.authn_course_instance_role === 'None' &&
-    res.locals.authz_data.authn_has_student_access &&
-    !res.locals.authz_data.authn_has_student_access_with_enrollment
-  ) {
-    const admissionPlan =
-      res.locals.course_instance_admission_plan ??
-      (await selectCourseInstanceAdmissionPlan({
-        course: res.locals.course,
-        courseInstance: res.locals.course_instance,
-        user: res.locals.authn_user,
-      }));
+const autoEnroll = typedAsyncHandler<'course-instance', AdmissionSelectionLocals>(
+  async (req, res, next) => {
+    // If the user does not currently have access to the course, but could if
+    // they were enrolled, automatically enroll them. However, we will not
+    // attempt to enroll them if they are an instructor (that is, if they have
+    // a specific role in the course or course instance) or if they are
+    // impersonating another user.
 
     if (
-      admissionPlan.type === 'conventional_invitation' ||
-      admissionPlan.type === 'institution_roster_invitation' ||
-      admissionPlan.type === 'self_enrollment'
+      idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
+      res.locals.authz_data.authn_course_role === 'None' &&
+      res.locals.authz_data.authn_course_instance_role === 'None' &&
+      res.locals.authz_data.authn_has_student_access &&
+      !res.locals.authz_data.authn_has_student_access_with_enrollment
     ) {
-      try {
-        await admitUserWithCourseInstanceAdmissionPlan({
-          courseInstanceId: res.locals.course_instance.id,
-          ip: req.ip ?? null,
-          isAdministrator: res.locals.authz_data.authn_is_administrator,
-          plan: admissionPlan,
-          reqDate: res.locals.req_date,
-          userId: res.locals.authn_user.id,
-        });
-      } catch (error) {
-        if (error instanceof CourseInstanceAdmissionEligibilityError) {
-          res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: error.reason }));
-          return;
-        } else if (error instanceof EnrollmentAdmissionBlockedError) {
-          res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
-          return;
-        } else if (error instanceof CourseInstanceEnrollmentCodeRequiredError) {
-          res.redirect(
-            `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
-          );
-          return;
-        } else {
-          throw error;
+      const admissionSelection =
+        res.locals.course_instance_admission_selection ??
+        (await selectCourseInstanceAdmissionForRequest({
+          course: res.locals.course,
+          courseInstance: res.locals.course_instance,
+          session: req.session,
+          user: res.locals.authn_user,
+        }));
+      const admissionPlan = admissionSelection.plan;
+
+      if (
+        admissionPlan.type === 'conventional_invitation' ||
+        admissionPlan.type === 'institution_roster_invitation' ||
+        admissionPlan.type === 'lti13_roster_invitation' ||
+        admissionPlan.type === 'self_enrollment'
+      ) {
+        try {
+          const result = await admitUserWithCourseInstanceAdmissionSelection({
+            courseInstanceId: res.locals.course_instance.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.authz_data.authn_is_administrator,
+            reqDate: res.locals.req_date,
+            selection: admissionSelection,
+            session: req.session,
+            userId: res.locals.authn_user.id,
+          });
+          if (result.type === 'retry_ordinary') {
+            res.redirect(req.originalUrl);
+            return;
+          }
+          if (result.type === 'blocked') {
+            res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
+            return;
+          }
+        } catch (error) {
+          if (error instanceof CourseInstanceAdmissionEligibilityError) {
+            res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: error.reason }));
+            return;
+          } else if (error instanceof CourseInstanceEnrollmentCodeRequiredError) {
+            res.redirect(
+              `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
+            );
+            return;
+          } else {
+            throw error;
+          }
         }
+
+        res.locals.authz_data.has_student_access_with_enrollment = true;
+        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+      } else if (admissionPlan.type === 'already_joined') {
+        res.locals.authz_data.has_student_access_with_enrollment = true;
+        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+      } else if (admissionPlan.type === 'blocked') {
+        res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
+        return;
+      } else if (admissionPlan.type === 'ineligible') {
+        res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: admissionPlan.reason }));
+        return;
+      } else {
+        res.redirect(
+          `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
+        );
+        return;
       }
-
-      res.locals.authz_data.has_student_access_with_enrollment = true;
-      res.locals.authz_data.authn_has_student_access_with_enrollment = true;
-    } else if (admissionPlan.type === 'already_joined') {
-      res.locals.authz_data.has_student_access_with_enrollment = true;
-      res.locals.authz_data.authn_has_student_access_with_enrollment = true;
-    } else if (admissionPlan.type === 'blocked') {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
-      return;
-    } else if (admissionPlan.type === 'ineligible') {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: admissionPlan.reason }));
-      return;
-    } else {
-      res.redirect(
-        `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
-      );
-      return;
     }
-  }
 
-  next();
-});
+    next();
+  },
+);
 
 export default autoEnroll;

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,61 +1,64 @@
 import { extractPageContext } from '../lib/client/page-context.js';
 import { typedAsyncHandler } from '../lib/res-locals.js';
 import {
-  type CourseInstanceAdmissionPlanLocals as PlanLocals,
-  selectCourseInstanceAdmissionPlan,
-} from '../models/course-instance-admission.js';
+  type CourseInstanceAdmissionSelectionLocals as AdmissionSelectionLocals,
+  selectCourseInstanceAdmissionForRequest,
+} from '../models/course-instance-admission-continuation.js';
 
-const requireCode = typedAsyncHandler<'course-instance', PlanLocals>(async (req, res, next) => {
-  // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
+const requireCode = typedAsyncHandler<'course-instance', AdmissionSelectionLocals>(
+  async (req, res, next) => {
+    // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
 
-  // Check if the user needs an enrollment code to access the course instance.
-  const { course_instance: courseInstance } = extractPageContext(res.locals, {
-    pageType: 'courseInstance',
-    accessType: 'instructor',
-  });
+    // Check if the user needs an enrollment code to access the course instance.
+    const { course_instance: courseInstance } = extractPageContext(res.locals, {
+      pageType: 'courseInstance',
+      accessType: 'instructor',
+    });
 
-  // Skip if user already has student access with enrollment
-  if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
-    next();
+    // Skip if user already has student access with enrollment
+    if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
+      next();
+      return;
+    }
+
+    // Skip if user is an instructor or administrator
+    if (
+      res.locals.authz_data.authn_course_role !== 'None' ||
+      res.locals.authz_data.authn_course_instance_role !== 'None' ||
+      res.locals.is_administrator
+    ) {
+      next();
+      return;
+    }
+
+    // Check if user has student access (they should be able to enroll)
+    // This checks if access rules would allow them to enroll.
+    if (!res.locals.authz_data.authn_has_student_access) {
+      next();
+      return;
+    }
+
+    const admissionSelection = await selectCourseInstanceAdmissionForRequest({
+      course: res.locals.course,
+      courseInstance,
+      session: req.session,
+      user: res.locals.authn_user,
+    });
+    res.locals.course_instance_admission_selection = admissionSelection;
+
+    if (admissionSelection.plan.type !== 'enrollment_code_required') {
+      next();
+      return;
+    }
+
+    // User needs an enrollment code - redirect to the enrollment code page
+    // Preserve the current URL as a query parameter so they can return after enrollment
+    const currentUrl = req.originalUrl;
+    const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
+
+    res.redirect(redirectUrl);
     return;
-  }
-
-  // Skip if user is an instructor or administrator
-  if (
-    res.locals.authz_data.authn_course_role !== 'None' ||
-    res.locals.authz_data.authn_course_instance_role !== 'None' ||
-    res.locals.is_administrator
-  ) {
-    next();
-    return;
-  }
-
-  // Check if user has student access (they should be able to enroll)
-  // This checks if access rules would allow them to enroll.
-  if (!res.locals.authz_data.authn_has_student_access) {
-    next();
-    return;
-  }
-
-  const admissionPlan = await selectCourseInstanceAdmissionPlan({
-    course: res.locals.course,
-    courseInstance,
-    user: res.locals.authn_user,
-  });
-  res.locals.course_instance_admission_plan = admissionPlan;
-
-  if (admissionPlan.type !== 'enrollment_code_required') {
-    next();
-    return;
-  }
-
-  // User needs an enrollment code - redirect to the enrollment code page
-  // Preserve the current URL as a query parameter so they can return after enrollment
-  const currentUrl = req.originalUrl;
-  const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
-
-  res.redirect(redirectUrl);
-  return;
-});
+  },
+);
 
 export default requireCode;

--- a/apps/prairielearn/src/models/course-instance-admission-continuation.ts
+++ b/apps/prairielearn/src/models/course-instance-admission-continuation.ts
@@ -1,0 +1,285 @@
+import {
+  type Lti13AdmissionContinuation,
+  type OrdinaryAdmissionContinuation,
+  clearCourseInstanceAdmissionContinuation,
+  getCourseInstanceAdmissionContinuation,
+  replaceLti13ContinuationWithOrdinary,
+} from '../lib/course-instance-admission-continuation.js';
+import type { Course, CourseInstance, Enrollment, User } from '../lib/db-types.js';
+import { HttpRedirect } from '../lib/redirect.js';
+
+import {
+  type ActionableCourseInstanceAdmissionPlan,
+  CourseInstanceAdmissionEligibilityError,
+  type CourseInstanceAdmissionPlan,
+  CourseInstanceEnrollmentCodeRequiredError,
+  type Lti13RosterInvitationAdmissionPlan,
+  admitUserFromLti13RosterInvitation,
+  admitUserFromOrdinarySelfEnrollment,
+  admitUserWithCourseInstanceAdmissionPlan,
+  selectCourseInstanceAdmissionPlan,
+  selectOrdinaryCourseInstanceAdmissionPlan,
+} from './course-instance-admission.js';
+import { selectEnrollmentAdmissionDecision } from './enrollment-identity.js';
+import {
+  EnrollmentAdmissionBlockedError,
+  EnrollmentInvitationRequiredError,
+} from './enrollment-reconciliation.js';
+
+type SessionData = Record<string, unknown>;
+
+export type CourseInstanceAdmissionSelection =
+  | {
+      plan: CourseInstanceAdmissionPlan;
+      type: 'dynamic';
+    }
+  | {
+      continuation: OrdinaryAdmissionContinuation;
+      plan: CourseInstanceAdmissionPlan;
+      type: 'ordinary';
+    }
+  | {
+      continuation: Lti13AdmissionContinuation;
+      plan: Lti13RosterInvitationAdmissionPlan;
+      type: 'lti13';
+    };
+
+export interface CourseInstanceAdmissionSelectionLocals {
+  course_instance_admission_selection?: CourseInstanceAdmissionSelection;
+}
+
+export type CourseInstanceAdmissionResult =
+  | { enrollment: Enrollment; type: 'admitted' }
+  | { type: 'blocked' }
+  | { type: 'retry_ordinary' };
+
+async function selectOrdinaryAdmission({
+  continuation,
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  continuation: OrdinaryAdmissionContinuation;
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): Promise<CourseInstanceAdmissionSelection> {
+  return {
+    continuation,
+    plan: await selectOrdinaryCourseInstanceAdmissionPlan({
+      course,
+      courseInstance,
+      enrollmentCode,
+      user,
+    }),
+    type: 'ordinary',
+  };
+}
+
+export async function selectCourseInstanceAdmissionForRequest({
+  course,
+  courseInstance,
+  enrollmentCode,
+  session,
+  user,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  session: SessionData;
+  user: User;
+}): Promise<CourseInstanceAdmissionSelection> {
+  const continuation = getCourseInstanceAdmissionContinuation({
+    courseInstanceId: courseInstance.id,
+    session,
+    userId: user.id,
+  });
+  if (continuation === null) {
+    return {
+      plan: await selectCourseInstanceAdmissionPlan({
+        course,
+        courseInstance,
+        enrollmentCode,
+        user,
+      }),
+      type: 'dynamic',
+    };
+  }
+  if (continuation.type === 'ordinary') {
+    const selection = await selectOrdinaryAdmission({
+      continuation,
+      course,
+      courseInstance,
+      enrollmentCode,
+      user,
+    });
+    if (selection.plan.type === 'already_joined' || selection.plan.type === 'blocked') {
+      clearCourseInstanceAdmissionContinuation(session);
+    }
+    return selection;
+  }
+
+  const source = {
+    type: 'lti13' as const,
+    lti13CourseInstanceId: continuation.lti13_course_instance_id,
+    sub: continuation.sub,
+  };
+  const decision = await selectEnrollmentAdmissionDecision(
+    {
+      courseInstanceId: courseInstance.id,
+      lti13Identity: {
+        lti13CourseInstanceId: continuation.lti13_course_instance_id,
+        sub: continuation.sub,
+      },
+      userId: user.id,
+    },
+    source,
+  );
+  if (decision.allowed) {
+    return {
+      continuation,
+      plan: { source, type: 'lti13_roster_invitation' },
+      type: 'lti13',
+    };
+  }
+  if (decision.reason === 'already_joined') {
+    clearCourseInstanceAdmissionContinuation(session);
+    return { plan: { type: 'already_joined' }, type: 'dynamic' };
+  }
+  if (decision.reason === 'blocked') {
+    clearCourseInstanceAdmissionContinuation(session);
+    return { plan: { type: 'blocked' }, type: 'dynamic' };
+  }
+
+  return await selectOrdinaryAdmission({
+    continuation: replaceLti13ContinuationWithOrdinary({ continuation, session }),
+    course,
+    courseInstance,
+    enrollmentCode,
+    user,
+  });
+}
+
+function isActionableDynamicPlan(
+  plan: CourseInstanceAdmissionPlan,
+): plan is ActionableCourseInstanceAdmissionPlan {
+  return (
+    plan.type === 'conventional_invitation' ||
+    plan.type === 'institution_roster_invitation' ||
+    plan.type === 'self_enrollment'
+  );
+}
+
+export async function admitUserWithCourseInstanceAdmissionSelection({
+  courseInstanceId,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  reqDate,
+  selection,
+  session,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  selection: CourseInstanceAdmissionSelection;
+  session: SessionData;
+  userId: string;
+}): Promise<CourseInstanceAdmissionResult> {
+  if (selection.type === 'dynamic') {
+    if (!isActionableDynamicPlan(selection.plan)) {
+      throw new Error(`Admission plan ${selection.plan.type} is not actionable`);
+    }
+    try {
+      return {
+        enrollment: await admitUserWithCourseInstanceAdmissionPlan({
+          courseInstanceId,
+          enrollmentCode,
+          ip,
+          isAdministrator,
+          plan: selection.plan,
+          reqDate,
+          userId,
+        }),
+        type: 'admitted',
+      };
+    } catch (error) {
+      if (error instanceof EnrollmentAdmissionBlockedError) {
+        return { type: 'blocked' };
+      }
+      throw error;
+    }
+  }
+
+  if (selection.type === 'ordinary') {
+    if (selection.plan.type !== 'self_enrollment') {
+      throw new Error(`Pinned ordinary plan ${selection.plan.type} is not actionable`);
+    }
+    try {
+      const enrollment = await admitUserFromOrdinarySelfEnrollment({
+        courseInstanceId,
+        enrollmentCode,
+        ip,
+        isAdministrator,
+        reqDate,
+        userId,
+      });
+      clearCourseInstanceAdmissionContinuation(session);
+      return { enrollment, type: 'admitted' };
+    } catch (error) {
+      if (error instanceof EnrollmentAdmissionBlockedError) {
+        clearCourseInstanceAdmissionContinuation(session);
+        return { type: 'blocked' };
+      }
+      if (
+        error instanceof CourseInstanceAdmissionEligibilityError ||
+        error instanceof CourseInstanceEnrollmentCodeRequiredError ||
+        (error instanceof HttpRedirect &&
+          error.url === `/pl/course_instance/${courseInstanceId}/upgrade`)
+      ) {
+        throw error;
+      }
+      clearCourseInstanceAdmissionContinuation(session);
+      throw error;
+    }
+  }
+
+  try {
+    const enrollment = await admitUserFromLti13RosterInvitation({
+      courseInstanceId,
+      ip,
+      isAdministrator,
+      lti13CourseInstanceId: selection.continuation.lti13_course_instance_id,
+      reqDate,
+      sub: selection.continuation.sub,
+      userId,
+    });
+    clearCourseInstanceAdmissionContinuation(session);
+    return { enrollment, type: 'admitted' };
+  } catch (error) {
+    if (error instanceof EnrollmentInvitationRequiredError) {
+      replaceLti13ContinuationWithOrdinary({
+        continuation: selection.continuation,
+        session,
+      });
+      return { type: 'retry_ordinary' };
+    }
+    if (error instanceof EnrollmentAdmissionBlockedError) {
+      clearCourseInstanceAdmissionContinuation(session);
+      return { type: 'blocked' };
+    }
+    if (
+      error instanceof HttpRedirect &&
+      error.url === `/pl/course_instance/${courseInstanceId}/upgrade`
+    ) {
+      throw error;
+    }
+    clearCourseInstanceAdmissionContinuation(session);
+    throw error;
+  }
+}

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -208,16 +208,11 @@ async function validateEnterpriseAdmission({
   }
 }
 
-/**
- * Treats the supplied plan as a render-time hint. The canonical checked
- * admission chooses its authoritative source from the locked classification.
- */
-export async function admitUserWithCourseInstanceAdmissionPlan({
+function createCourseInstanceAdmissionValidator({
   courseInstanceId,
   enrollmentCode,
   ip,
   isAdministrator,
-  plan,
   reqDate,
   userId,
 }: {
@@ -225,11 +220,10 @@ export async function admitUserWithCourseInstanceAdmissionPlan({
   enrollmentCode?: string;
   ip: string | null;
   isAdministrator: boolean;
-  plan: ActionableCourseInstanceAdmissionPlan;
   reqDate: Date;
   userId: string;
 }) {
-  async function validateAdmission({ source }: { source: EnrollmentAdmissionSource }) {
+  return async ({ source }: { source: EnrollmentAdmissionSource }) => {
     const user = await selectUserById(userId);
     const { authzData, course, courseInstance, institution } =
       await constructCourseOrInstanceContext({
@@ -278,8 +272,30 @@ export async function admitUserWithCourseInstanceAdmissionPlan({
       courseInstance,
       institution,
     });
-  }
+  };
+}
 
+/**
+ * Treats the supplied plan as a render-time hint. The canonical checked
+ * admission chooses its authoritative source from the locked classification.
+ */
+export async function admitUserWithCourseInstanceAdmissionPlan({
+  courseInstanceId,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  plan,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  plan: ActionableCourseInstanceAdmissionPlan;
+  reqDate: Date;
+  userId: string;
+}) {
   return await admitUserToCourseInstance({
     agentAuthnUserId: userId,
     agentUserId: userId,
@@ -295,6 +311,54 @@ export async function admitUserWithCourseInstanceAdmissionPlan({
     },
     source: plan.source,
     userId,
-    validateAdmission,
+    validateAdmission: createCourseInstanceAdmissionValidator({
+      courseInstanceId,
+      enrollmentCode,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+/**
+ * Admits only from the exact LTI roster source supplied by a verified launch.
+ * The canonical checked path revalidates the fixed source after locking.
+ */
+export async function admitUserFromLti13RosterInvitation({
+  courseInstanceId,
+  ip,
+  isAdministrator,
+  lti13CourseInstanceId,
+  reqDate,
+  sub,
+  userId,
+}: {
+  courseInstanceId: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  lti13CourseInstanceId: string;
+  reqDate: Date;
+  sub: string;
+  userId: string;
+}) {
+  return await admitUserToCourseInstance({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    source: {
+      type: 'lti13',
+      lti13CourseInstanceId,
+      sub,
+    },
+    userId,
+    validateAdmission: createCourseInstanceAdmissionValidator({
+      courseInstanceId,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
   });
 }

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -41,6 +41,11 @@ interface InstitutionRosterInvitationAdmissionPlan {
   readonly type: 'institution_roster_invitation';
 }
 
+export interface Lti13RosterInvitationAdmissionPlan {
+  readonly source: Extract<EnrollmentAdmissionSource, { type: 'lti13' }>;
+  readonly type: 'lti13_roster_invitation';
+}
+
 interface SelfEnrollmentAdmissionPlan {
   readonly enrollmentCodeValidated: boolean;
   readonly source: Extract<EnrollmentAdmissionSource, { type: 'ordinary' }>;
@@ -61,13 +66,10 @@ export type CourseInstanceAdmissionPlan =
   | BlockedAdmissionPlan
   | ConventionalInvitationAdmissionPlan
   | InstitutionRosterInvitationAdmissionPlan
+  | Lti13RosterInvitationAdmissionPlan
   | SelfEnrollmentAdmissionPlan
   | EnrollmentCodeRequiredAdmissionPlan
   | IneligibleAdmissionPlan;
-
-export interface CourseInstanceAdmissionPlanLocals {
-  course_instance_admission_plan?: CourseInstanceAdmissionPlan;
-}
 
 export type ActionableCourseInstanceAdmissionPlan =
   | ConventionalInvitationAdmissionPlan
@@ -129,7 +131,34 @@ function getCourseInstanceAdmissionPlan({
       type: 'conventional_invitation',
     };
   }
+  return getOrdinaryCourseInstanceAdmissionPlan({
+    classification,
+    course,
+    courseInstance,
+    enrollmentCode,
+    user,
+  });
+}
 
+function getOrdinaryCourseInstanceAdmissionPlan({
+  classification,
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  classification: EnrollmentIdentityClassification;
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): CourseInstanceAdmissionPlan {
+  if (classification.kind === 'joined') {
+    return { type: 'already_joined' };
+  }
+  if (classification.kind === 'blocked') {
+    return { type: 'blocked' };
+  }
   const eligibility = checkEnrollmentEligibility({
     user,
     course,
@@ -169,6 +198,34 @@ export async function selectCourseInstanceAdmissionPlan({
     userId: user.id,
   });
   return getCourseInstanceAdmissionPlan({
+    classification,
+    course,
+    courseInstance,
+    enrollmentCode,
+    user,
+  });
+}
+
+/**
+ * Selects only ordinary self-enrollment policy. Pending identity candidates
+ * remain available for reconciliation but cannot supply invitation authority.
+ */
+export async function selectOrdinaryCourseInstanceAdmissionPlan({
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): Promise<CourseInstanceAdmissionPlan> {
+  const classification = await selectEnrollmentIdentityClassification({
+    courseInstanceId: courseInstance.id,
+    userId: user.id,
+  });
+  return getOrdinaryCourseInstanceAdmissionPlan({
     classification,
     course,
     courseInstance,
@@ -310,6 +367,42 @@ export async function admitUserWithCourseInstanceAdmissionPlan({
       return { type: 'ordinary' };
     },
     source: plan.source,
+    userId,
+    validateAdmission: createCourseInstanceAdmissionValidator({
+      courseInstanceId,
+      enrollmentCode,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+/**
+ * Admits only through independently validated ordinary self-enrollment policy.
+ * Unlike the ordinary web path, no locked invitation source selector runs.
+ */
+export async function admitUserFromOrdinarySelfEnrollment({
+  courseInstanceId,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return await admitUserToCourseInstance({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    source: { type: 'ordinary' },
     userId,
     validateAdmission: createCourseInstanceAdmissionValidator({
       courseInstanceId,

--- a/apps/prairielearn/src/models/enrollment-reconciliation-concurrency.test.sql
+++ b/apps/prairielearn/src/models/enrollment-reconciliation-concurrency.test.sql
@@ -139,6 +139,21 @@ DELETE FROM enrollments
 WHERE
   id = $enrollment_id;
 
+-- BLOCK block_enrollment_for_user
+UPDATE enrollments
+SET
+  first_joined_at = CURRENT_TIMESTAMP,
+  pending_email = NULL,
+  pending_lti13_course_instance_id = NULL,
+  pending_lti13_sub = NULL,
+  pending_name = NULL,
+  pending_uid = NULL,
+  pending_uin = NULL,
+  status = 'blocked',
+  user_id = $user_id
+WHERE
+  id = $enrollment_id;
+
 -- BLOCK set_local_application_name
 SELECT
   set_config('application_name', $application_name, true);

--- a/apps/prairielearn/src/models/enrollment-reconciliation-concurrency.test.ts
+++ b/apps/prairielearn/src/models/enrollment-reconciliation-concurrency.test.ts
@@ -15,6 +15,7 @@ import {
 } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
+import { setLti13CourseInstanceAdmissionContinuation } from '../lib/course-instance-admission-continuation.js';
 import {
   AssessmentAccessControlRuleSchema,
   type CourseInstance,
@@ -27,8 +28,10 @@ import * as helperCourse from '../tests/helperCourse.js';
 import * as helperDb from '../tests/helperDb.js';
 
 import { selectAssessmentByTid } from './assessment.js';
+import { admitUserWithCourseInstanceAdmissionSelection } from './course-instance-admission-continuation.js';
 import { deletePublishingExtension } from './course-instance-publishing-extensions.js';
 import { selectCourseInstanceById } from './course-instances.js';
+import { selectEnrollmentAdmissionDecision } from './enrollment-identity.js';
 import {
   admitUserFromEnrollmentInvitation,
   admitUserToCourseInstance,
@@ -37,6 +40,7 @@ import {
 import {
   actorFor,
   createEnrollment,
+  createLti13CourseInstance,
   createUser,
   nextFixtureName,
   nextFixtureNumber,
@@ -526,6 +530,113 @@ describe('enrollment reconciliation concurrency and retry', { concurrent: false 
       failure ??= { error };
     } finally {
       releaseParent.resolve();
+      const workerResults = await Promise.allSettled([
+        blockerPromise,
+        ...(admissionPromise ? [admissionPromise] : []),
+      ]);
+      failure = preserveFirstFailure(failure, workerResults);
+    }
+
+    if (failure) throw failure.error;
+  });
+
+  it('returns a blocked result when exact LTI admission becomes blocked under its lock', async () => {
+    const user = await createUser({ prefix: 'exact-lti-blocked-race' });
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
+    const sub = nextFixtureName('exact-lti-blocked-race-sub');
+    const invitation = await createEnrollment({
+      courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: sub,
+      pendingUin: user.uin,
+    });
+    const source = {
+      type: 'lti13' as const,
+      lti13CourseInstanceId: lti13CourseInstance.id,
+      sub,
+    };
+    const decision = await selectEnrollmentAdmissionDecision(
+      {
+        courseInstanceId: courseInstance.id,
+        lti13Identity: { lti13CourseInstanceId: lti13CourseInstance.id, sub },
+        userId: user.id,
+      },
+      source,
+    );
+    expect(decision.allowed).toBe(true);
+
+    const session: Record<string, unknown> = {};
+    const continuation = setLti13CourseInstanceAdmissionContinuation({
+      courseInstanceId: courseInstance.id,
+      launchExpiresAtSeconds: Math.floor(Date.now() / 1000) + 3600,
+      lti13CourseInstanceId: lti13CourseInstance.id,
+      session,
+      sub,
+      userId: user.id,
+    });
+    const invitationLocked = deferred();
+    const releaseInvitation = deferred();
+    let failure: { error: unknown } | undefined;
+    const blockerPromise = runInTransactionAsync(async () => {
+      await queryRow(
+        sql.lock_enrollment,
+        { enrollment_id: invitation.id },
+        z.object({ id: IdSchema }),
+      );
+      invitationLocked.resolve();
+      await releaseInvitation.promise;
+      await execute(sql.block_enrollment_for_user, {
+        enrollment_id: invitation.id,
+        user_id: user.id,
+      });
+    }).catch((error) => {
+      failure ??= { error };
+      invitationLocked.reject(error);
+      throw error;
+    });
+    void blockerPromise.catch(() => undefined);
+
+    let admissionPromise:
+      | Promise<Awaited<ReturnType<typeof admitUserWithCourseInstanceAdmissionSelection>>>
+      | undefined;
+    try {
+      await invitationLocked.promise;
+      const applicationName = `exact-lti-blocked-${crypto.randomUUID()}`;
+      admissionPromise = runInTransactionAsync(async () => {
+        await setLocalApplicationName(applicationName);
+        return await admitUserWithCourseInstanceAdmissionSelection({
+          courseInstanceId: courseInstance.id,
+          ip: null,
+          isAdministrator: false,
+          reqDate: new Date(),
+          selection: {
+            continuation,
+            plan: { source, type: 'lti13_roster_invitation' },
+            type: 'lti13',
+          },
+          session,
+          userId: user.id,
+        });
+      });
+      void admissionPromise.catch((error) => {
+        failure ??= { error };
+      });
+      await waitForApplicationLock(applicationName, '%lock_enrollments_by_id%');
+      releaseInvitation.resolve();
+
+      await expect(admissionPromise).resolves.toEqual({ type: 'blocked' });
+      expect(session).not.toHaveProperty('course_instance_admission_continuation');
+      expect(await selectEnrollments([invitation.id])).toEqual([
+        expect.objectContaining({
+          id: invitation.id,
+          status: 'blocked',
+          user_id: user.id,
+        }),
+      ]);
+    } catch (error) {
+      failure ??= { error };
+    } finally {
+      releaseInvitation.resolve();
       const workerResults = await Promise.allSettled([
         blockerPromise,
         ...(admissionPromise ? [admissionPromise] : []),

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -8,12 +8,13 @@ import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { idsEqual } from '../../lib/id.js';
 import {
+  admitUserWithCourseInstanceAdmissionSelection,
+  selectCourseInstanceAdmissionForRequest,
+} from '../../models/course-instance-admission-continuation.js';
+import {
   CourseInstanceAdmissionEligibilityError,
   CourseInstanceEnrollmentCodeRequiredError,
-  admitUserWithCourseInstanceAdmissionPlan,
-  selectCourseInstanceAdmissionPlan,
 } from '../../models/course-instance-admission.js';
-import { EnrollmentAdmissionBlockedError } from '../../models/enrollment-reconciliation.js';
 
 import { EnrollmentCodeRequired } from './enrollmentCodeRequired.html.js';
 
@@ -52,12 +53,14 @@ router.get(
       return;
     }
 
-    const admissionPlan = await selectCourseInstanceAdmissionPlan({
+    const admissionSelection = await selectCourseInstanceAdmissionForRequest({
       course: res.locals.course,
       courseInstance,
       enrollmentCode: code,
+      session: req.session,
       user: res.locals.authn_user,
     });
+    const admissionPlan = admissionSelection.plan;
 
     if (admissionPlan.type === 'blocked') {
       res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
@@ -76,24 +79,31 @@ router.get(
     if (
       admissionPlan.type === 'conventional_invitation' ||
       admissionPlan.type === 'institution_roster_invitation' ||
+      admissionPlan.type === 'lti13_roster_invitation' ||
       (admissionPlan.type === 'self_enrollment' && admissionPlan.enrollmentCodeValidated)
     ) {
       try {
-        await admitUserWithCourseInstanceAdmissionPlan({
+        const result = await admitUserWithCourseInstanceAdmissionSelection({
           courseInstanceId: courseInstance.id,
           enrollmentCode: code,
           ip: req.ip ?? null,
           isAdministrator: res.locals.authz_data.authn_is_administrator,
-          plan: admissionPlan,
           reqDate: res.locals.req_date,
+          selection: admissionSelection,
+          session: req.session,
           userId: res.locals.authn_user.id,
         });
+        if (result.type === 'retry_ordinary') {
+          res.redirect(req.originalUrl);
+          return;
+        }
+        if (result.type === 'blocked') {
+          res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
+          return;
+        }
       } catch (error) {
         if (error instanceof CourseInstanceAdmissionEligibilityError) {
           res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: error.reason }));
-          return;
-        } else if (error instanceof EnrollmentAdmissionBlockedError) {
-          res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
           return;
         } else if (!(error instanceof CourseInstanceEnrollmentCodeRequiredError)) {
           throw error;

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,14 +6,17 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { z } from 'zod';
 
-import { execute, queryOptionalRow, queryRow } from '@prairielearn/postgres';
+import { execute, queryOptionalRow, queryRow, queryScalar } from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import { Lti13CombinedInstanceSchema, inspectRoster } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
-import { Lti13CourseInstanceSchema } from '../lib/db-types.js';
+import { EnrollmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
+import { selectAuditEventsByEnrollmentId } from '../models/audit-event.js';
 import { selectOptionalUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
@@ -34,6 +37,64 @@ const siteUrl = 'http://localhost:' + config.serverPort;
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
+
+  async function selectLinkedLtiCourseInstance(contextId = LTI_CONTEXT_ID) {
+    return await queryRow(
+      `SELECT *
+       FROM lti13_course_instances
+       WHERE lti13_instance_id = '1'
+       AND deployment_id = $deployment_id
+       AND context_id = $context_id`,
+      { deployment_id: LTI_DEPLOYMENT_ID, context_id: contextId },
+      Lti13CourseInstanceSchema,
+    );
+  }
+
+  async function insertLtiRosterInvitation({
+    lti13CourseInstanceId,
+    pendingUin,
+    sub,
+  }: {
+    lti13CourseInstanceId: string;
+    pendingUin: string;
+    sub: string;
+  }) {
+    return await queryRow(
+      `INSERT INTO enrollments (
+         course_instance_id,
+         pending_lti13_course_instance_id,
+         pending_lti13_sub,
+         pending_uin,
+         status
+       )
+       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
+       RETURNING *`,
+      {
+        lti13_course_instance_id: lti13CourseInstanceId,
+        pending_uin: pendingUin,
+        sub,
+      },
+      EnrollmentSchema,
+    );
+  }
+
+  async function selectLatestSessionData(userId: string) {
+    return await queryScalar(
+      `SELECT data
+       FROM user_sessions
+       WHERE user_id = $user_id
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      { user_id: userId },
+      z.record(z.string(), z.unknown()),
+    );
+  }
+
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await selectLatestSessionData(userId);
+    assert.notProperty(sessionData, 'lti13_claims');
+    assert.notProperty(sessionData, 'authn_lti13_instance_id');
+  }
 
   beforeAll(async () => {
     config.isEnterprise = true;
@@ -274,6 +335,15 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     const fetchWithCookies = fetchCookie(fetch);
     const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
 
+    await execute(
+      `UPDATE lti13_course_instances
+       SET context_title = 'Stale title'
+       WHERE lti13_instance_id = '1'
+       AND deployment_id = $deployment_id
+       AND context_id = $context_id`,
+      { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+    );
+
     // Grant permissions before LTI login. Use dev admin user (ID 1) as authn_user
     // since the target user doesn't exist yet - grantCoursePermissions will create them.
     await grantCoursePermissions({
@@ -305,6 +375,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     const res = await executor.login();
     assert.equal(res.status, 200);
     assert.include(res.url, '/pl/course_instance/1/instructor/');
+
+    const linkRecord = await selectLinkedLtiCourseInstance();
+    assert.equal(linkRecord.context_title, 'Test Course');
+    const user = await selectOptionalUserByUid('linked-instructor@example.com');
+    assert.ok(user);
+    await assertLtiLaunchConsumed(user.id);
   });
 
   test('already linked context redirects student to course instance', async () => {
@@ -331,6 +407,375 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.equal(res.status, 200);
     assert.include(res.url, '/pl/course_instance/1/');
     assert.notInclude(res.url, '/instructor/');
+  });
+
+  describe('LTI 1.3 roster admission', () => {
+    afterEach(async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = NULL,
+           self_enrollment_enabled = TRUE,
+           self_enrollment_use_enrollment_code = FALSE
+         WHERE id = '1'`,
+      );
+    });
+
+    test('admits an exact link and sub without self-enrollment authority', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'exact-roster-admission-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'exact-roster-admission-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Exact Roster Admission',
+          email: 'exact-roster-admission@example.com',
+          uin: 'exact-roster-admission-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const res = await executor.login();
+      assert.equal(res.status, 200);
+      assert.include(res.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      assert.ok(user);
+      const enrollment = await queryRow(
+        `SELECT *
+         FROM enrollments
+         WHERE course_instance_id = '1'
+         AND user_id = $user_id`,
+        { user_id: user.id },
+        EnrollmentSchema,
+      );
+      expect(enrollment).toMatchObject({
+        id: invitation.id,
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: enrollment.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).toContainEqual(
+        expect.objectContaining({
+          action_detail: 'roster_admitted',
+          context: expect.objectContaining({ admission_source: 'lti13' }),
+        }),
+      );
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchRes = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchRes.status, 403);
+    });
+
+    test('does not grant LTI roster authority to a wrong sub', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'wrong-sub-unmatched-uin',
+        sub: 'expected-roster-sub',
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Wrong Sub Student',
+          email: 'wrong-sub-student@example.com',
+          uin: 'wrong-sub-student-user-uin',
+          sub: 'actual-roster-sub',
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const res = await executor.login();
+      assert.equal(res.status, 403);
+      assert.include(res.url, '/pl/course_instance/1/assessments');
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: 'expected-roster-sub',
+        status: 'invited',
+        user_id: null,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: invitation.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action_detail: 'roster_admitted' }),
+      );
+      const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+    });
+
+    test('falls back to independently allowed ordinary self-enrollment for a wrong sub', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = TRUE,
+           self_enrollment_use_enrollment_code = FALSE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'ordinary-fallback-unmatched-uin',
+        sub: 'ordinary-fallback-expected-sub',
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Ordinary Fallback Student',
+          email: 'ordinary-fallback-student@example.com',
+          uin: 'ordinary-fallback-student-user-uin',
+          sub: 'ordinary-fallback-actual-sub',
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const res = await executor.login();
+      assert.equal(res.status, 200);
+      assert.include(res.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('ordinary-fallback-student@example.com');
+      assert.ok(user);
+      const enrollment = await queryRow(
+        `SELECT *
+         FROM enrollments
+         WHERE course_instance_id = '1'
+         AND user_id = $user_id`,
+        { user_id: user.id },
+        EnrollmentSchema,
+      );
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: enrollment.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).toContainEqual(
+        expect.objectContaining({
+          action_detail: 'implicit_joined',
+          context: expect.objectContaining({ admission_source: 'ordinary' }),
+        }),
+      );
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action_detail: 'roster_admitted' }),
+      );
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: 'ordinary-fallback-expected-sub',
+        status: 'invited',
+        user_id: null,
+      });
+      await assertLtiLaunchConsumed(user.id);
+    });
+
+    test('does not grant LTI roster authority through another course-instance link', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const otherCourseInstanceId = await queryScalar(
+        `INSERT INTO course_instances (
+           course_id,
+           display_timezone,
+           enrollment_code,
+           long_name,
+           publishing_end_date,
+           publishing_start_date,
+           short_name
+         )
+         SELECT
+           course_id,
+           display_timezone,
+           'OTHER-LTI-LINK',
+           'Other LTI link',
+           publishing_end_date,
+           publishing_start_date,
+           'Other LTI link'
+         FROM course_instances
+         WHERE id = '1'
+         RETURNING id`,
+        {},
+        IdSchema,
+      );
+      const otherContextId = `${LTI_CONTEXT_ID}-other`;
+      await linkLtiContext({
+        lti13InstanceId: '1',
+        deploymentId: LTI_DEPLOYMENT_ID,
+        contextId: otherContextId,
+        courseInstanceId: otherCourseInstanceId,
+      });
+      const otherLti13CourseInstance = await selectLinkedLtiCourseInstance(otherContextId);
+      const sub = 'same-sub-other-link';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: otherLti13CourseInstance.id,
+        pendingUin: 'same-sub-other-link-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Same Sub Other Link',
+          email: 'same-sub-other-link@example.com',
+          uin: 'same-sub-other-link-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const res = await executor.login();
+      assert.equal(res.status, 403);
+      assert.include(res.url, '/pl/course_instance/1/assessments');
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: otherLti13CourseInstance.id,
+        pending_lti13_sub: sub,
+        status: 'invited',
+        user_id: null,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: invitation.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action_detail: 'roster_admitted' }),
+      );
+      const user = await selectOptionalUserByUid('same-sub-other-link@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+    });
+
+    test('consumes the launch before an exact admission limit redirect', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = 0,
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'limited-exact-roster-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'limited-exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Limited Exact Roster',
+          email: 'limited-exact-roster@example.com',
+          uin: 'limited-exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const res = await executor.login();
+      assert.equal(res.status, 200);
+      assert.include(res.url, '/pl/enroll/limit_exceeded');
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: sub,
+        status: 'invited',
+        user_id: null,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: invitation.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action_detail: 'roster_admitted' }),
+      );
+      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchRes = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchRes.status, 403);
+    });
   });
 
   describe('LTI 1.3 linking authorization', () => {

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -12,11 +12,18 @@ import { z } from 'zod';
 import { execute, queryOptionalRow, queryRow, queryScalar } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
+import {
+  reconcilePlanGrantsForCourseInstanceUser,
+  updateRequiredPlansForCourseInstance,
+} from '../ee/lib/billing/plans.js';
 import { Lti13CombinedInstanceSchema, inspectRoster } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
+import { CourseInstanceAdmissionContinuationSchema } from '../lib/course-instance-admission-continuation.js';
 import { EnrollmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
+import { generateCsrfToken } from '../middlewares/csrfToken.js';
 import { selectAuditEventsByEnrollmentId } from '../models/audit-event.js';
+import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectOptionalUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
@@ -31,6 +38,7 @@ import {
   makeLoginExecutor,
   withServer,
 } from './lti13TestHelpers.js';
+import { updateCourseInstanceSettings } from './utils/auth.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 
@@ -38,14 +46,18 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
 
-  async function selectLinkedLtiCourseInstance(contextId = LTI_CONTEXT_ID) {
+  async function selectLinkedLtiCourseInstance(contextId = LTI_CONTEXT_ID, lti13InstanceId = '1') {
     return await queryRow(
       `SELECT *
        FROM lti13_course_instances
-       WHERE lti13_instance_id = '1'
+       WHERE lti13_instance_id = $lti13_instance_id
        AND deployment_id = $deployment_id
        AND context_id = $context_id`,
-      { deployment_id: LTI_DEPLOYMENT_ID, context_id: contextId },
+      {
+        deployment_id: LTI_DEPLOYMENT_ID,
+        context_id: contextId,
+        lti13_instance_id: lti13InstanceId,
+      },
       Lti13CourseInstanceSchema,
     );
   }
@@ -381,6 +393,10 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     const user = await selectOptionalUserByUid('linked-instructor@example.com');
     assert.ok(user);
     await assertLtiLaunchConsumed(user.id);
+    assert.notProperty(
+      await selectLatestSessionData(user.id),
+      'course_instance_admission_continuation',
+    );
   });
 
   test('already linked context redirects student to course instance', async () => {
@@ -411,6 +427,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
   describe('LTI 1.3 roster admission', () => {
     afterEach(async () => {
+      await updateRequiredPlansForCourseInstance('1', [], '1');
       await execute(
         `UPDATE course_instances
          SET
@@ -418,6 +435,82 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
            self_enrollment_enabled = TRUE,
            self_enrollment_use_enrollment_code = FALSE
          WHERE id = '1'`,
+      );
+    });
+
+    test('binds a verified launch to its LTI instance', async () => {
+      const secondLti13InstanceId = await createLti13Instance({
+        siteUrl,
+        issuer_params: {
+          issuer: `http://localhost:${oidcProviderPort}`,
+          authorization_endpoint: `http://localhost:${oidcProviderPort}/auth`,
+          jwks_uri: `http://localhost:${oidcProviderPort}/jwks`,
+          token_endpoint: `http://localhost:${oidcProviderPort}/token`,
+        },
+      });
+      await linkLtiContext({
+        lti13InstanceId: secondLti13InstanceId,
+        deploymentId: LTI_DEPLOYMENT_ID,
+        contextId: LTI_CONTEXT_ID,
+        courseInstanceId: '1',
+      });
+      const secondLti13CourseInstance = await selectLinkedLtiCourseInstance(
+        LTI_CONTEXT_ID,
+        secondLti13InstanceId,
+      );
+      const sub = 'cross-instance-launch-sub';
+      const uin = 'cross-instance-launch-uin';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: secondLti13CourseInstance.id,
+        pendingUin: uin,
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/${secondLti13InstanceId}/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Cross-instance Launch Student',
+          email: 'cross-instance-launch@example.com',
+          uin,
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 403);
+      assert.equal(response.url, targetLinkUri);
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: secondLti13CourseInstance.id,
+        pending_lti13_sub: sub,
+        status: 'invited',
+        user_id: null,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: invitation.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action_detail: 'roster_admitted' }),
+      );
+      const user = await selectOptionalUserByUid('cross-instance-launch@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+      assert.notProperty(
+        await selectLatestSessionData(user.id),
+        'course_instance_admission_continuation',
       );
     });
 
@@ -487,8 +580,125 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         }),
       );
       await assertLtiLaunchConsumed(user.id);
+      assert.notProperty(
+        await selectLatestSessionData(user.id),
+        'course_instance_admission_continuation',
+      );
       const consumedLaunchRes = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
       assert.equal(consumedLaunchRes.status, 403);
+    });
+
+    test('preserves exact LTI admission across a required-plan upgrade', async () => {
+      await updateRequiredPlansForCourseInstance('1', ['compute'], '1');
+      await updateCourseInstanceSettings('1', {
+        restrictToInstitution: false,
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+      });
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'upgrade-exact-roster-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'upgrade-exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Upgrade Exact Roster',
+          email: 'upgrade-exact-roster@example.com',
+          uin: 'upgrade-exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const upgradeResponse = await executor.login();
+      assert.equal(upgradeResponse.status, 200);
+      assert.include(upgradeResponse.url, '/pl/course_instance/1/upgrade');
+
+      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
+      assert.ok(user);
+      const sessionData = await selectLatestSessionData(user.id);
+      assert.notProperty(sessionData, 'lti13_claims');
+      assert.notProperty(sessionData, 'authn_lti13_instance_id');
+      expect(
+        CourseInstanceAdmissionContinuationSchema.parse(
+          sessionData.course_instance_admission_continuation,
+        ),
+      ).toMatchObject({
+        course_instance_id: '1',
+        lti13_course_instance_id: lti13CourseInstance.id,
+        sub,
+        type: 'lti13',
+        user_id: user.id,
+      });
+
+      const csrfToken = generateCsrfToken({
+        authnUserId: user.id,
+        url: '/pl/course_instance/1/upgrade',
+      });
+      const upgradePostResponse = await fetchWithCookies(
+        `${siteUrl}/pl/course_instance/1/upgrade`,
+        {
+          method: 'POST',
+          body: new URLSearchParams({
+            __action: 'upgrade',
+            __csrf_token: csrfToken,
+            unsafe_plan_names: 'compute',
+          }),
+        },
+      );
+      assert.equal(upgradePostResponse.status, 400);
+      assert.property(
+        await selectLatestSessionData(user.id),
+        'course_instance_admission_continuation',
+      );
+
+      await reconcilePlanGrantsForCourseInstanceUser(
+        { institution_id: '1', course_instance_id: '1', user_id: user.id },
+        [{ plan: 'compute', grantType: 'invoice' }],
+        '1',
+      );
+      const assessmentsResponse = await fetchWithCookies(
+        `${siteUrl}/pl/course_instance/1/assessments`,
+      );
+      assert.equal(assessmentsResponse.status, 200);
+      assert.include(assessmentsResponse.url, '/pl/course_instance/1/assessments');
+
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(enrollment).toMatchObject({
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: enrollment.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).toContainEqual(
+        expect.objectContaining({
+          action_detail: 'roster_admitted',
+          context: expect.objectContaining({ admission_source: 'lti13' }),
+        }),
+      );
+      assert.notProperty(
+        await selectLatestSessionData(user.id),
+        'course_instance_admission_continuation',
+      );
     });
 
     test('does not grant LTI roster authority to a wrong sub', async () => {
@@ -500,9 +710,10 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const uin = 'wrong-sub-matching-uin';
       const invitation = await insertLtiRosterInvitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'wrong-sub-unmatched-uin',
+        pendingUin: uin,
         sub: 'expected-roster-sub',
       });
       const fetchWithCookies = fetchCookie(fetch);
@@ -511,7 +722,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         user: {
           name: 'Wrong Sub Student',
           email: 'wrong-sub-student@example.com',
-          uin: 'wrong-sub-student-user-uin',
+          uin,
           sub: 'actual-roster-sub',
         },
         fetchWithCookies,
@@ -548,6 +759,16 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
+      const sessionData = await selectLatestSessionData(user.id);
+      expect(
+        CourseInstanceAdmissionContinuationSchema.parse(
+          sessionData.course_instance_admission_continuation,
+        ),
+      ).toMatchObject({
+        course_instance_id: '1',
+        type: 'ordinary',
+        user_id: user.id,
+      });
     });
 
     test('falls back to independently allowed ordinary self-enrollment for a wrong sub', async () => {
@@ -559,9 +780,10 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const uin = 'ordinary-fallback-matching-uin';
       const invitation = await insertLtiRosterInvitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'ordinary-fallback-unmatched-uin',
+        pendingUin: uin,
         sub: 'ordinary-fallback-expected-sub',
       });
       const fetchWithCookies = fetchCookie(fetch);
@@ -570,7 +792,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         user: {
           name: 'Ordinary Fallback Student',
           email: 'ordinary-fallback-student@example.com',
-          uin: 'ordinary-fallback-student-user-uin',
+          uin,
           sub: 'ordinary-fallback-actual-sub',
         },
         fetchWithCookies,
@@ -615,12 +837,98 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         EnrollmentSchema,
       );
       expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: 'ordinary-fallback-expected-sub',
-        status: 'invited',
-        user_id: null,
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
       });
+      assert.equal(persistedInvitation.id, enrollment.id);
       await assertLtiLaunchConsumed(user.id);
+      const sessionData = await selectLatestSessionData(user.id);
+      assert.notProperty(sessionData, 'course_instance_admission_continuation');
+    });
+
+    test('preserves enrollment-code policy after exact LTI denial', async () => {
+      await updateCourseInstanceSettings('1', {
+        restrictToInstitution: false,
+        selfEnrollmentEnabled: true,
+        selfEnrollmentUseEnrollmentCode: true,
+      });
+      const enrollmentCode = (await selectCourseInstanceById('1')).enrollment_code;
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const uin = 'code-fallback-matching-uin';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: uin,
+        sub: 'code-fallback-expected-sub',
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Code Fallback Student',
+          email: 'code-fallback-student@example.com',
+          uin,
+          sub: 'code-fallback-actual-sub',
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const loginResponse = await executor.login();
+      assert.equal(loginResponse.status, 200);
+      assert.include(loginResponse.url, '/pl/course_instance/1/join');
+
+      const user = await selectOptionalUserByUid('code-fallback-student@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+      expect(
+        CourseInstanceAdmissionContinuationSchema.parse(
+          (await selectLatestSessionData(user.id)).course_instance_admission_continuation,
+        ),
+      ).toMatchObject({ type: 'ordinary', user_id: user.id });
+
+      const joinResponse = await fetchWithCookies(
+        `${siteUrl}/pl/course_instance/1/join/${enrollmentCode}`,
+      );
+      assert.equal(joinResponse.status, 200);
+      assert.include(joinResponse.url, '/pl/course_instance/1/assessments');
+
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(enrollment).toMatchObject({
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
+      });
+      const auditEvents = await selectAuditEventsByEnrollmentId({
+        enrollment_id: enrollment.id,
+        table_names: ['enrollments'],
+      });
+      expect(auditEvents).toContainEqual(
+        expect.objectContaining({
+          action_detail: 'implicit_joined',
+          context: expect.objectContaining({ admission_source: 'ordinary' }),
+        }),
+      );
+      expect(auditEvents).not.toContainEqual(
+        expect.objectContaining({ action_detail: 'roster_admitted' }),
+      );
+      assert.notProperty(
+        await selectLatestSessionData(user.id),
+        'course_instance_admission_continuation',
+      );
     });
 
     test('does not grant LTI roster authority through another course-instance link', async () => {
@@ -664,9 +972,10 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
       const otherLti13CourseInstance = await selectLinkedLtiCourseInstance(otherContextId);
       const sub = 'same-sub-other-link';
+      const uin = 'same-sub-other-link-matching-uin';
       const invitation = await insertLtiRosterInvitation({
         lti13CourseInstanceId: otherLti13CourseInstance.id,
-        pendingUin: 'same-sub-other-link-unmatched-uin',
+        pendingUin: uin,
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
@@ -675,7 +984,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         user: {
           name: 'Same Sub Other Link',
           email: 'same-sub-other-link@example.com',
-          uin: 'same-sub-other-link-user-uin',
+          uin,
           sub,
         },
         fetchWithCookies,
@@ -712,6 +1021,16 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const user = await selectOptionalUserByUid('same-sub-other-link@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
+      const sessionData = await selectLatestSessionData(user.id);
+      expect(
+        CourseInstanceAdmissionContinuationSchema.parse(
+          sessionData.course_instance_admission_continuation,
+        ),
+      ).toMatchObject({
+        course_instance_id: '1',
+        type: 'ordinary',
+        user_id: user.id,
+      });
     });
 
     test('consumes the launch before an exact admission limit redirect', async () => {
@@ -773,6 +1092,10 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
+      assert.notProperty(
+        await selectLatestSessionData(user.id),
+        'course_instance_admission_continuation',
+      );
       const consumedLaunchRes = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
       assert.equal(consumedLaunchRes.status, 403);
     });

--- a/apps/prairielearn/src/tests/lti13TestHelpers.ts
+++ b/apps/prairielearn/src/tests/lti13TestHelpers.ts
@@ -298,6 +298,8 @@ export async function createLti13Instance({
     }),
   });
   assert.equal(createKeyResponse.status, 200);
+
+  return IdSchema.parse(new URL(instanceUrl).pathname.split('/').at(-1));
 }
 
 /**


### PR DESCRIPTION
# Description

Implements slice 5 of 6 for [PrairieLearnInc/planning#51](https://github.com/PrairieLearnInc/planning/issues/51).

Adds exact transient LTI 1.3 roster admission to course navigation. Student launches bind the verified authentication instance to the requested link, copy the signed link-plus-sub context locally, remove raw launch claims before any redirect or error path, and authorize only an actionable invitation from that exact source; instructor launches are unchanged.

A strict, expiring continuation preserves the verified exact source across enrollment-code and enterprise plan-grant redirects without retaining raw claims. It is scoped to the authenticated user and PrairieLearn course instance, validates Stripe checkout replay ownership, clears on terminal paths and identity transitions, and downgrades invitation loss to pinned ordinary policy rather than allowing a UIN candidate to substitute authority.

Wrong-sub, other-link, cross-instance, expired, malformed, and concurrent blocked-state cases fail closed through ordinary or blocked behavior instead of producing an enrollment or a server error.

Stack: 5 of 6. Depends on #15512. Next: #15514.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance disclosure: Codex produced the majority of the implementation and tests under human-directed design, manager inspection, and independent adversarial review.

# Testing

Focused LTI route, continuation, authentication, upgrade, and admission coverage uses matching-UIN adversarial fixtures to prove wrong-sub and other-link launches cannot borrow roster authority. Additional cases cover cross-instance session binding, claim cleanup, plan-grant continuation, checkout replay ownership, invitation loss, and a concurrent transition to blocked.
