### PR TITLE
Show roster invitations on the homepage

### DIFF
--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from 'node:crypto';
 
-import { afterAll, assert, beforeAll, beforeEach, describe, it, vi } from 'vitest';
+import { afterAll, assert, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 
 import * as publishingExtensionsModel from '../models/course-instance-publishing-extensions.js';
+import * as enrollmentIdentityModel from '../models/enrollment-identity.js';
+import type {
+  EnrollmentIdentityCandidate,
+  EnrollmentIdentityClassification,
+} from '../models/enrollment-identity.js';
 import * as enrollmentModel from '../models/enrollment.js';
 import * as helperDb from '../tests/helperDb.js';
 
@@ -184,6 +189,53 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
     };
   }
 
+  function createMockIdentityCandidate({
+    enrollment = {},
+    matches = {},
+  }: {
+    enrollment?: Partial<Enrollment>;
+    matches?: Partial<EnrollmentIdentityCandidate['matches']>;
+  } = {}): EnrollmentIdentityCandidate {
+    return {
+      enrollment: createMockEnrollment(enrollment),
+      matches: {
+        boundUser: false,
+        institutionUin: false,
+        lti13: false,
+        pendingUid: false,
+        ...matches,
+      },
+    };
+  }
+
+  function createMockIdentityClassification({
+    actionableConventionalInvitationCandidates = [],
+    actionableInstitutionRosterInvitationCandidates = [],
+    boundCandidate = null,
+    candidates = [],
+    kind,
+  }: {
+    actionableConventionalInvitationCandidates?: EnrollmentIdentityCandidate[];
+    actionableInstitutionRosterInvitationCandidates?: EnrollmentIdentityCandidate[];
+    boundCandidate?: EnrollmentIdentityCandidate | null;
+    candidates?: EnrollmentIdentityCandidate[];
+    kind: EnrollmentIdentityClassification['kind'];
+  }): EnrollmentIdentityClassification {
+    return {
+      actionableConventionalInvitationCandidates,
+      actionableInstitutionRosterInvitationCandidates,
+      actionableLti13RosterInvitationCandidates: [],
+      actionableRosterInvitationCandidates: actionableInstitutionRosterInvitationCandidates,
+      boundCandidate,
+      candidates,
+      conventionalInvitationCandidates: actionableConventionalInvitationCandidates,
+      institutionRosterInvitationCandidates: actionableInstitutionRosterInvitationCandidates,
+      kind,
+      lti13RosterInvitationCandidates: [],
+      rosterInvitationCandidates: actionableInstitutionRosterInvitationCandidates,
+    };
+  }
+
   function createMockPublishingExtension(
     overrides: Partial<CourseInstancePublishingExtension> = {},
   ): CourseInstancePublishingExtension {
@@ -308,6 +360,11 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2026-01-01T00:00:00Z');
 
       vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+        createMockIdentityClassification({
+          kind: 'none',
+        }),
+      );
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -326,11 +383,22 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2026-01-01T00:00:00Z');
       const enrollment = createMockEnrollment();
+      const boundCandidate = createMockIdentityCandidate({
+        enrollment,
+        matches: { boundUser: true },
+      });
 
       vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+        createMockIdentityClassification({
+          boundCandidate,
+          candidates: [boundCandidate],
+          kind: 'joined',
+        }),
+      );
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
@@ -345,23 +413,43 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
-    it('allows access when the request date is before the latest extension end date', async () => {
+    it('allows joined access using the latest extension across all matching candidates', async () => {
       const courseInstance = createMockCourseInstance({
         publishing_start_date: new Date('2025-01-01T00:00:00Z'),
         publishing_end_date: new Date('2025-12-31T23:59:59Z'),
       });
       const reqDate = new Date('2026-02-15T12:00:00Z');
       const enrollment = createMockEnrollment();
+      const boundCandidate = createMockIdentityCandidate({
+        enrollment,
+        matches: { boundUser: true },
+      });
+      const invitationCandidate = createMockIdentityCandidate({
+        enrollment: {
+          id: 'invitation-enrollment-id',
+          status: 'invited',
+          user_id: null,
+        },
+        matches: { institutionUin: true },
+      });
       const extension = createMockPublishingExtension({
         id: 'extension',
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
       vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
-      vi.spyOn(
+      vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+        createMockIdentityClassification({
+          boundCandidate,
+          candidates: [boundCandidate, invitationCandidate],
+          kind: 'joined',
+        }),
+      );
+      const selectLatestExtension = vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
-      ).mockResolvedValue(extension);
+        'selectLatestPublishingExtensionByEnrollmentIds',
+      );
+      selectLatestExtension.mockResolvedValue(extension);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -369,9 +457,12 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         reqDate,
       );
 
-      // Request date is 2026-02-15 12:00:00, latest extension is 2026-02-28 23:59:59
       assert.isTrue(result.has_student_access);
       assert.isTrue(result.has_student_access_with_enrollment);
+      expect(selectLatestExtension).toHaveBeenCalledWith({
+        courseInstance,
+        enrollmentIds: ['test-enrollment-id', 'invitation-enrollment-id'],
+      });
     });
 
     it('forbids access when request date is after all extensions', async () => {
@@ -381,15 +472,26 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2026-03-01T00:00:00Z');
       const enrollment = createMockEnrollment();
+      const boundCandidate = createMockIdentityCandidate({
+        enrollment,
+        matches: { boundUser: true },
+      });
       const extension = createMockPublishingExtension({
         id: 'extension',
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
       vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+        createMockIdentityClassification({
+          boundCandidate,
+          candidates: [boundCandidate],
+          kind: 'joined',
+        }),
+      );
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(extension);
 
       const result = await calculateModernCourseInstanceStudentAccess(
@@ -400,6 +502,160 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
 
       assert.isFalse(result.has_student_access);
       assert.isFalse(result.has_student_access_with_enrollment);
+    });
+
+    it('allows an actionable roster invitation without treating it as joined', async () => {
+      const courseInstance = createMockCourseInstance();
+      const boundCandidate = createMockIdentityCandidate({
+        enrollment: { status: 'left' },
+        matches: { boundUser: true },
+      });
+      const rosterCandidate = createMockIdentityCandidate({
+        enrollment: {
+          id: 'roster-enrollment-id',
+          status: 'invited',
+          user_id: null,
+        },
+        matches: { institutionUin: true },
+      });
+      const extension = createMockPublishingExtension();
+
+      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(
+        boundCandidate.enrollment,
+      );
+      vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+        createMockIdentityClassification({
+          actionableInstitutionRosterInvitationCandidates: [rosterCandidate],
+          boundCandidate,
+          candidates: [boundCandidate, rosterCandidate],
+          kind: 'actionable_roster_invitation',
+        }),
+      );
+      const selectLatestExtension = vi
+        .spyOn(publishingExtensionsModel, 'selectLatestPublishingExtensionByEnrollmentIds')
+        .mockResolvedValue(extension);
+
+      const result = await calculateModernCourseInstanceStudentAccess(
+        courseInstance,
+        'test-user-id',
+        new Date('2026-01-01T00:00:00Z'),
+      );
+
+      assert.isTrue(result.has_student_access);
+      assert.isFalse(result.has_student_access_with_enrollment);
+      expect(selectLatestExtension).toHaveBeenCalledWith({
+        courseInstance,
+        enrollmentIds: ['test-enrollment-id', 'roster-enrollment-id'],
+      });
+    });
+
+    it('allows an actionable conventional invitation without treating it as joined', async () => {
+      const courseInstance = createMockCourseInstance();
+      const invitationCandidate = createMockIdentityCandidate({
+        enrollment: {
+          status: 'invited',
+          user_id: null,
+        },
+        matches: { pendingUid: true },
+      });
+
+      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+        createMockIdentityClassification({
+          actionableConventionalInvitationCandidates: [invitationCandidate],
+          candidates: [invitationCandidate],
+          kind: 'actionable_conventional_invitation',
+        }),
+      );
+      vi.spyOn(
+        publishingExtensionsModel,
+        'selectLatestPublishingExtensionByEnrollmentIds',
+      ).mockResolvedValue(createMockPublishingExtension());
+
+      const result = await calculateModernCourseInstanceStudentAccess(
+        courseInstance,
+        'test-user-id',
+        new Date('2026-01-01T00:00:00Z'),
+      );
+
+      assert.isTrue(result.has_student_access);
+      assert.isFalse(result.has_student_access_with_enrollment);
+    });
+
+    it('does not use extensions from non-actionable or guest roster candidates', async () => {
+      const courseInstance = createMockCourseInstance();
+      const cases: EnrollmentIdentityClassification[] = [
+        createMockIdentityClassification({
+          boundCandidate: createMockIdentityCandidate({
+            enrollment: { status: 'removed' },
+            matches: { boundUser: true },
+          }),
+          candidates: [
+            createMockIdentityCandidate({
+              enrollment: { status: 'removed' },
+              matches: { boundUser: true },
+            }),
+            createMockIdentityCandidate({
+              enrollment: { id: 'removed-roster', status: 'invited', user_id: null },
+              matches: { institutionUin: true },
+            }),
+          ],
+          kind: 'ordinary',
+        }),
+        createMockIdentityClassification({
+          boundCandidate: createMockIdentityCandidate({
+            enrollment: { status: 'blocked' },
+            matches: { boundUser: true },
+          }),
+          candidates: [
+            createMockIdentityCandidate({
+              enrollment: { status: 'blocked' },
+              matches: { boundUser: true },
+            }),
+          ],
+          kind: 'blocked',
+        }),
+        createMockIdentityClassification({
+          candidates: [
+            createMockIdentityCandidate({
+              enrollment: { status: 'rejected', user_id: null },
+              matches: { pendingUid: true },
+            }),
+          ],
+          kind: 'ordinary',
+        }),
+        createMockIdentityClassification({
+          candidates: [
+            createMockIdentityCandidate({
+              enrollment: { is_guest: true, status: 'invited', user_id: null },
+              matches: { institutionUin: true },
+            }),
+          ],
+          kind: 'ordinary',
+        }),
+      ];
+
+      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      const selectClassification = vi.spyOn(
+        enrollmentIdentityModel,
+        'selectEnrollmentIdentityClassification',
+      );
+      const selectLatestExtension = vi.spyOn(
+        publishingExtensionsModel,
+        'selectLatestPublishingExtensionByEnrollmentIds',
+      );
+
+      for (const classification of cases) {
+        selectClassification.mockResolvedValueOnce(classification);
+        const result = await calculateModernCourseInstanceStudentAccess(
+          courseInstance,
+          'test-user-id',
+          new Date('2026-01-01T00:00:00Z'),
+        );
+        assert.isFalse(result.has_student_access);
+        assert.isFalse(result.has_student_access_with_enrollment);
+      }
+      expect(selectLatestExtension).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -7,7 +7,8 @@ import { run } from '@prairielearn/run';
 import { withBrand } from '@prairielearn/utils';
 import { IdSchema } from '@prairielearn/zod';
 
-import { selectLatestPublishingExtensionByEnrollment } from '../models/course-instance-publishing-extensions.js';
+import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
+import { selectEnrollmentIdentityClassification } from '../models/enrollment-identity.js';
 import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
 
 import {
@@ -134,14 +135,25 @@ export async function calculateModernCourseInstanceStudentAccess(
     };
   }
 
-  // We are after the end date. We might have access if we have an extension.
-  // Only enrolled students can have extensions.
-  if (enrollment?.status !== 'joined') {
+  // We are after the end date. Joined students and actionable invitations
+  // might have access through an extension on any matching identity candidate.
+  // Exact LTI invitation authority is intentionally not available in this
+  // ordinary course-entry context.
+  const classification = await selectEnrollmentIdentityClassification({
+    courseInstanceId: courseInstance.id,
+    userId,
+  });
+  const isJoined = classification.kind === 'joined';
+  const hasActionableInvitation =
+    classification.actionableConventionalInvitationCandidates.length > 0 ||
+    classification.actionableInstitutionRosterInvitationCandidates.length > 0;
+  if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }
 
-  const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollment({
-    enrollment,
+  const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollmentIds({
+    courseInstance,
+    enrollmentIds: classification.candidates.map((candidate) => candidate.enrollment.id),
   });
 
   // Check if we have access via extension.
@@ -150,7 +162,7 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   return {
     has_student_access: hasAccessViaExtension,
-    has_student_access_with_enrollment: hasAccessViaExtension,
+    has_student_access_with_enrollment: hasAccessViaExtension && isJoined,
   };
 }
 

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -20,7 +20,10 @@ import {
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './enrollment-identity.js';
-import { admitUserToCourseInstance } from './enrollment-reconciliation.js';
+import {
+  admitUserFromEnrollmentInvitation,
+  admitUserToCourseInstance,
+} from './enrollment-reconciliation.js';
 import { selectUserById } from './user.js';
 
 interface AlreadyJoinedAdmissionPlan {
@@ -407,6 +410,43 @@ export async function admitUserFromOrdinarySelfEnrollment({
     validateAdmission: createCourseInstanceAdmissionValidator({
       courseInstanceId,
       enrollmentCode,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+/**
+ * Admits only from the exact conventional invitation rendered to the user.
+ * The canonical checked path revalidates both its pending-UID provenance and
+ * its enrollment ID after locking the complete candidate set.
+ */
+export async function admitUserFromConventionalEnrollmentInvitation({
+  courseInstanceId,
+  enrollmentId,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentId: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return await admitUserFromEnrollmentInvitation({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    expectedInvitationEnrollmentId: enrollmentId,
+    source: { type: 'pending_uid' },
+    userId,
+    validateAdmission: createCourseInstanceAdmissionValidator({
+      courseInstanceId,
       ip,
       isAdministrator,
       reqDate,

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.sql
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.sql
@@ -13,6 +13,23 @@ ORDER BY
 LIMIT
   1;
 
+-- BLOCK select_latest_publishing_extension_by_enrollment_ids
+SELECT
+  ci_extensions.*
+FROM
+  course_instance_publishing_extensions AS ci_extensions
+  JOIN course_instance_publishing_extension_enrollments AS ci_enrollment_extensions ON (
+    ci_enrollment_extensions.course_instance_publishing_extension_id = ci_extensions.id
+  )
+WHERE
+  ci_extensions.course_instance_id = $course_instance_id
+  AND ci_enrollment_extensions.enrollment_id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  ci_extensions.end_date DESC,
+  ci_extensions.id DESC
+LIMIT
+  1;
+
 -- BLOCK select_publishing_extension_by_id
 SELECT
   *

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
@@ -74,6 +74,29 @@ export async function selectLatestPublishingExtensionByEnrollment({
 }
 
 /**
+ * Finds the latest publishing extension across a complete set of enrollment
+ * identity candidates for a course instance.
+ */
+export async function selectLatestPublishingExtensionByEnrollmentIds({
+  courseInstance,
+  enrollmentIds,
+}: {
+  courseInstance: CourseInstance;
+  enrollmentIds: string[];
+}) {
+  if (enrollmentIds.length === 0) return null;
+
+  return await queryOptionalRow(
+    sql.select_latest_publishing_extension_by_enrollment_ids,
+    {
+      course_instance_id: courseInstance.id,
+      enrollment_ids: enrollmentIds,
+    },
+    CourseInstancePublishingExtensionSchema,
+  );
+}
+
+/**
  * Finds a publishing extension by name within a course instance.
  */
 export async function selectPublishingExtensionByName({

--- a/apps/prairielearn/src/models/enrollment-identity.sql
+++ b/apps/prairielearn/src/models/enrollment-identity.sql
@@ -67,3 +67,51 @@ WHERE
   OR matches_lti13
 ORDER BY
   (enrollment ->> 'id')::bigint;
+
+-- Homepage-style read consumers can classify many course instances without
+-- issuing one candidate query per course instance. Exact LTI provenance is
+-- intentionally unavailable without a source-specific LTI context.
+-- BLOCK select_enrollment_identity_candidates_for_course_instances
+WITH
+  identity AS (
+    SELECT
+      id AS user_id,
+      institution_id,
+      uid,
+      uin
+    FROM
+      users
+    WHERE
+      id = $user_id
+  ),
+  candidate_matches AS (
+    SELECT
+      to_jsonb(e.*) AS enrollment,
+      coalesce(e.user_id = identity.user_id, FALSE) AS matches_bound_user,
+      coalesce(e.pending_uid = identity.uid, FALSE) AS matches_pending_uid,
+      coalesce(
+        identity.institution_id = c.institution_id
+        AND identity.uin IS NOT NULL
+        AND e.pending_uin = identity.uin,
+        FALSE
+      ) AS matches_institution_uin,
+      FALSE AS matches_lti13
+    FROM
+      enrollments AS e
+      JOIN course_instances AS ci ON (ci.id = e.course_instance_id)
+      JOIN courses AS c ON (c.id = ci.course_id)
+      CROSS JOIN identity
+    WHERE
+      e.course_instance_id = ANY ($course_instance_ids::bigint[])
+  )
+SELECT
+  *
+FROM
+  candidate_matches
+WHERE
+  matches_bound_user
+  OR matches_pending_uid
+  OR matches_institution_uin
+ORDER BY
+  (enrollment ->> 'course_instance_id')::bigint,
+  (enrollment ->> 'id')::bigint;

--- a/apps/prairielearn/src/models/enrollment-identity.test.ts
+++ b/apps/prairielearn/src/models/enrollment-identity.test.ts
@@ -10,6 +10,7 @@ import { selectCourseInstanceById } from './course-instances.js';
 import {
   selectEnrollmentAdmissionDecision,
   selectEnrollmentIdentityClassification,
+  selectEnrollmentIdentityClassifications,
 } from './enrollment-identity.js';
 import {
   EnrollmentInvitationRequiredError,
@@ -78,6 +79,25 @@ describe('enrollment identity full-set selection and decisions', { concurrent: f
     expect(classification.conventionalInvitationCandidates).toHaveLength(1);
     expect(classification.institutionRosterInvitationCandidates).toHaveLength(1);
     expect(classification.lti13RosterInvitationCandidates).toHaveLength(1);
+
+    const classifications = await selectEnrollmentIdentityClassifications({
+      courseInstanceIds: [courseInstance.id, otherCourseInstance.id],
+      userId: user.id,
+    });
+    expect(classifications.get(courseInstance.id)).toMatchObject({
+      candidates: [
+        {
+          enrollment: { id: enrollment.id },
+          matches: {
+            boundUser: false,
+            institutionUin: true,
+            lti13: false,
+            pendingUid: true,
+          },
+        },
+      ],
+    });
+    expect(classifications.get(otherCourseInstance.id)?.kind).toBe('none');
   });
 
   it('keeps conventional pending-UID invitations distinct from roster authorization', async () => {
@@ -96,6 +116,62 @@ describe('enrollment identity full-set selection and decisions', { concurrent: f
     expect(classification.kind).toBe('actionable_conventional_invitation');
     expect(classification.conventionalInvitationCandidates).toHaveLength(1);
     expect(classification.rosterInvitationCandidates).toHaveLength(0);
+  });
+
+  it('pins conventional authority to the expected enrollment and preserves guest invitations', async () => {
+    const user = await createUser({ prefix: 'pinned-conventional-guest' });
+    const conventionalInvitation = await createEnrollment({
+      courseInstance,
+      pendingUid: user.uid,
+      isGuest: true,
+    });
+    const rosterInvitation = await createEnrollment({
+      courseInstance,
+      pendingUin: user.uin,
+    });
+    const context = { courseInstanceId: courseInstance.id, userId: user.id };
+
+    expect(
+      await selectEnrollmentAdmissionDecision(
+        context,
+        { type: 'pending_uid' },
+        {
+          expectedInvitationEnrollmentId: conventionalInvitation.id,
+        },
+      ),
+    ).toMatchObject({
+      allowed: true,
+      invitationCandidate: { enrollment: { id: conventionalInvitation.id, is_guest: true } },
+    });
+    expect(
+      await selectEnrollmentAdmissionDecision(
+        context,
+        { type: 'pending_uid' },
+        {
+          expectedInvitationEnrollmentId: rosterInvitation.id,
+        },
+      ),
+    ).toEqual({
+      allowed: false,
+      reason: 'no_matching_invitation',
+      source: { type: 'pending_uid' },
+    });
+
+    const admitted = await admitUserFromEnrollmentInvitation({
+      courseInstanceId: courseInstance.id,
+      expectedInvitationEnrollmentId: conventionalInvitation.id,
+      userId: user.id,
+      source: { type: 'pending_uid' },
+      ...checkedAdmissionFor(user),
+    });
+    expect(admitted).toMatchObject({
+      id: conventionalInvitation.id,
+      is_guest: true,
+      status: 'joined',
+    });
+    expect(await selectEnrollments([conventionalInvitation.id, rosterInvitation.id])).toEqual([
+      admitted,
+    ]);
   });
 
   it('scopes pending UIN matches to the course institution', async () => {

--- a/apps/prairielearn/src/models/enrollment-identity.ts
+++ b/apps/prairielearn/src/models/enrollment-identity.ts
@@ -96,6 +96,10 @@ export type EnrollmentAdmissionDecision =
       readonly source: EnrollmentAdmissionSource;
     };
 
+export interface EnrollmentInvitationDecisionConstraints {
+  readonly expectedInvitationEnrollmentId?: string;
+}
+
 function identityQueryParams(
   { courseInstanceId, userId, lti13Identity }: EnrollmentIdentityContext,
   enrollmentIds: string[] | null,
@@ -253,6 +257,17 @@ function sourceCandidates(
   return candidates.filter((candidate) => matchesAdmissionSource(candidate, source));
 }
 
+function constrainInvitationCandidates(
+  candidates: readonly EnrollmentIdentityCandidate[],
+  constraints: EnrollmentInvitationDecisionConstraints,
+): readonly EnrollmentIdentityCandidate[] {
+  return candidates.filter(
+    (candidate) =>
+      constraints.expectedInvitationEnrollmentId === undefined ||
+      candidate.enrollment.id === constraints.expectedInvitationEnrollmentId,
+  );
+}
+
 /**
  * Produces the source-specific authorization decision used by render and
  * mutation consumers. In particular, independently actionable UIN provenance
@@ -261,6 +276,7 @@ function sourceCandidates(
 function getEnrollmentAdmissionDecision(
   classification: EnrollmentIdentityClassification,
   source: EnrollmentAdmissionSource,
+  constraints: EnrollmentInvitationDecisionConstraints = {},
 ): EnrollmentAdmissionDecision {
   if (classification.kind === 'blocked') {
     return { allowed: false, reason: 'blocked', source };
@@ -269,10 +285,21 @@ function getEnrollmentAdmissionDecision(
     return { allowed: false, reason: 'already_joined', source };
   }
   if (source.type === 'ordinary') {
+    if (constraints.expectedInvitationEnrollmentId !== undefined) {
+      return { allowed: false, reason: 'no_matching_invitation', source };
+    }
     return { allowed: true, invitationCandidate: null, source };
   }
 
-  const actionableCandidates = sourceCandidates(classification, source, true);
+  const sourceProvenanceCandidates = constrainInvitationCandidates(
+    classification.candidates.filter((candidate) => matchesAdmissionSource(candidate, source)),
+    constraints,
+  );
+
+  const actionableCandidates = constrainInvitationCandidates(
+    sourceCandidates(classification, source, true),
+    constraints,
+  );
   if (actionableCandidates.length > 0) {
     return {
       allowed: true,
@@ -281,10 +308,7 @@ function getEnrollmentAdmissionDecision(
     };
   }
 
-  const hasSourceProvenance = classification.candidates.some((candidate) =>
-    matchesAdmissionSource(candidate, source),
-  );
-  if (!hasSourceProvenance) {
+  if (sourceProvenanceCandidates.length === 0) {
     return { allowed: false, reason: 'no_matching_invitation', source };
   }
   if (
@@ -314,15 +338,55 @@ export async function selectEnrollmentIdentityClassification(
 }
 
 /**
+ * Selects complete read-only classifications for multiple course instances in
+ * one query. Exact LTI provenance requires the single-instance API.
+ */
+export async function selectEnrollmentIdentityClassifications({
+  courseInstanceIds,
+  userId,
+}: {
+  courseInstanceIds: string[];
+  userId: string;
+}): Promise<ReadonlyMap<string, EnrollmentIdentityClassification>> {
+  const uniqueCourseInstanceIds = [...new Set(courseInstanceIds)];
+  if (uniqueCourseInstanceIds.length === 0) return new Map();
+
+  const rows = await queryRows(
+    sql.select_enrollment_identity_candidates_for_course_instances,
+    {
+      course_instance_ids: uniqueCourseInstanceIds,
+      user_id: userId,
+    },
+    EnrollmentIdentityCandidateRowSchema,
+  );
+  const candidatesByCourseInstance = new Map<string, EnrollmentIdentityCandidate[]>();
+  for (const candidate of mapCandidateRows(rows)) {
+    const candidates =
+      candidatesByCourseInstance.get(candidate.enrollment.course_instance_id) ?? [];
+    candidates.push(candidate);
+    candidatesByCourseInstance.set(candidate.enrollment.course_instance_id, candidates);
+  }
+
+  return new Map(
+    uniqueCourseInstanceIds.map((courseInstanceId) => [
+      courseInstanceId,
+      classifyEnrollmentIdentityCandidates(candidatesByCourseInstance.get(courseInstanceId) ?? []),
+    ]),
+  );
+}
+
+/**
  * Produces a source-specific decision from a fresh, complete identity set.
  */
 export async function selectEnrollmentAdmissionDecision(
   context: EnrollmentIdentityContext,
   source: EnrollmentAdmissionSource,
+  constraints?: EnrollmentInvitationDecisionConstraints,
 ): Promise<EnrollmentAdmissionDecision> {
   return getEnrollmentAdmissionDecision(
     await selectEnrollmentIdentityClassification(context),
     source,
+    constraints,
   );
 }
 
@@ -358,6 +422,7 @@ export async function selectLockedEnrollmentIdentityDecision(
   context: EnrollmentIdentityContext,
   source: EnrollmentAdmissionSource,
   selectSource?: LockedEnrollmentAdmissionSourceSelector,
+  constraints?: EnrollmentInvitationDecisionConstraints,
 ): Promise<LockedEnrollmentIdentityDecision> {
   const initialCandidates = await selectEnrollmentIdentityCandidates(context, null);
   const initialCandidateIds = initialCandidates.map((candidate) => candidate.enrollment.id);
@@ -370,7 +435,7 @@ export async function selectLockedEnrollmentIdentityDecision(
   }) as EnrollmentAdmissionSource;
   return {
     classification,
-    decision: getEnrollmentAdmissionDecision(classification, selectedSource),
+    decision: getEnrollmentAdmissionDecision(classification, selectedSource, constraints),
     source: selectedSource,
   };
 }

--- a/apps/prairielearn/src/models/enrollment-reconciliation.sql
+++ b/apps/prairielearn/src/models/enrollment-reconciliation.sql
@@ -196,6 +196,16 @@ VALUES
 RETURNING
   *;
 
+-- BLOCK reject_conventional_invitation
+UPDATE enrollments
+SET
+  status = 'rejected'
+WHERE
+  id = $enrollment_id
+  AND status = 'invited'
+RETURNING
+  *;
+
 -- BLOCK delete_loser_enrollments
 DELETE FROM enrollments
 WHERE

--- a/apps/prairielearn/src/models/enrollment-reconciliation.ts
+++ b/apps/prairielearn/src/models/enrollment-reconciliation.ts
@@ -58,6 +58,11 @@ export type ValidateEnrollmentAdmission = (
 export interface CheckedEnrollmentAdmissionInput extends EnrollmentAuditActor {
   readonly courseInstanceId: string;
   /**
+   * Pins invitation authority to the enrollment selected by a rendered or
+   * otherwise previously resolved action.
+   */
+  readonly expectedInvitationEnrollmentId?: string;
+  /**
    * Selects the authoritative source synchronously from the locked complete
    * classification. This may run again after a uniqueness retry and must not
    * perform side effects.
@@ -694,16 +699,22 @@ function immutableValidationContext({
 function planCheckedAdmission({
   classification,
   decision,
+  expectedInvitationEnrollmentId,
   source,
   userId,
 }: {
   classification: EnrollmentIdentityClassification;
   decision: EnrollmentAdmissionDecision;
+  expectedInvitationEnrollmentId?: string;
   source: EnrollmentAdmissionSource;
   userId: string;
 }): CheckedAdmissionPlan {
   if (!decision.allowed) {
-    if (decision.reason === 'already_joined' && classification.boundCandidate !== null) {
+    if (
+      decision.reason === 'already_joined' &&
+      classification.boundCandidate !== null &&
+      expectedInvitationEnrollmentId === undefined
+    ) {
       return {
         enrollment: classification.boundCandidate.enrollment,
         type: 'already_joined',
@@ -744,12 +755,14 @@ function planCheckedAdmission({
 async function executeCheckedAdmissionAttempt({
   actor,
   context,
+  expectedInvitationEnrollmentId,
   selectSource,
   source,
   validateAdmission,
 }: {
   actor: EnrollmentAuditActor;
   context: EnrollmentIdentityContext;
+  expectedInvitationEnrollmentId?: string;
   selectSource?: LockedEnrollmentAdmissionSourceSelector;
   source: EnrollmentAdmissionSource;
   validateAdmission: ValidateEnrollmentAdmission;
@@ -758,10 +771,13 @@ async function executeCheckedAdmissionAttempt({
     classification,
     decision,
     source: selectedSource,
-  } = await selectLockedEnrollmentIdentityDecision(context, source, selectSource);
+  } = await selectLockedEnrollmentIdentityDecision(context, source, selectSource, {
+    expectedInvitationEnrollmentId,
+  });
   const plan = planCheckedAdmission({
     classification,
     decision,
+    expectedInvitationEnrollmentId,
     source: selectedSource,
     userId: context.userId,
   });
@@ -829,6 +845,7 @@ export async function reconcileEnrollmentIdentities({
 export async function admitUserToCourseInstance({
   userId,
   courseInstanceId,
+  expectedInvitationEnrollmentId,
   source,
   selectSource,
   validateAdmission,
@@ -849,6 +866,7 @@ export async function admitUserToCourseInstance({
     attempt: async () =>
       await executeCheckedAdmissionAttempt({
         context,
+        expectedInvitationEnrollmentId,
         source: immutableSource,
         selectSource,
         validateAdmission,
@@ -867,4 +885,55 @@ export async function admitUserFromEnrollmentInvitation(
   },
 ): Promise<Enrollment> {
   return await admitUserToCourseInstance(input);
+}
+
+/**
+ * Rejects only the exact actionable conventional invitation selected by the
+ * caller. Roster provenance cannot authorize this mutation.
+ */
+export async function rejectConventionalEnrollmentInvitation({
+  agentAuthnUserId,
+  agentUserId,
+  courseInstanceId,
+  enrollmentId,
+  userId,
+}: EnrollmentAuditActor & {
+  courseInstanceId: string;
+  enrollmentId: string;
+  userId: string;
+}): Promise<Enrollment> {
+  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
+    const { decision } = await selectLockedEnrollmentIdentityDecision(
+      { courseInstanceId, userId },
+      { type: 'pending_uid' },
+      undefined,
+      {
+        expectedInvitationEnrollmentId: enrollmentId,
+      },
+    );
+    if (!decision.allowed) {
+      throwAdmissionDenied(decision);
+    }
+    if (decision.invitationCandidate === null) {
+      throw new Error('Conventional invitation decision has no candidate');
+    }
+
+    const oldEnrollment = decision.invitationCandidate.enrollment;
+    const enrollment = await queryRow(
+      sql.reject_conventional_invitation,
+      { enrollment_id: oldEnrollment.id },
+      EnrollmentSchema,
+    );
+    await insertAuditEvent({
+      tableName: 'enrollments',
+      action: 'update',
+      actionDetail: 'invitation_rejected',
+      rowId: enrollment.id,
+      oldRow: oldEnrollment,
+      newRow: enrollment,
+      agentAuthnUserId,
+      agentUserId,
+    });
+    return enrollment;
+  });
 }

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -21,15 +21,20 @@ export function StudentCoursesCard({
   setShowJoinModal: (value: boolean) => void;
 }) {
   const heading = hasInstructorCourses ? 'Courses with student access' : 'Courses';
-  const [rejectingCourseId, setRejectingCourseId] = useState<string | null>(null);
+  const [rejectingInvitation, setRejectingInvitation] = useState<{
+    courseInstanceId: string;
+    enrollmentId: string;
+  } | null>(null);
   const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
 
-  const invited: StudentHomePageCourse[] = studentCourses.filter(
-    (ci) => ci.enrollment.status === 'invited',
+  const conventionalInvitations = studentCourses.filter(
+    (course): course is StudentHomePageCourse & { access_type: 'conventional_invitation' } =>
+      course.access_type === 'conventional_invitation',
   );
-  const joined: StudentHomePageCourse[] = studentCourses.filter(
-    (ci) => ci.enrollment.status === 'joined',
+  const rosterInvitations = studentCourses.filter(
+    (course) => course.access_type === 'roster_invitation',
   );
+  const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
   return (
     <div className="card mb-4">
@@ -69,7 +74,7 @@ export function StudentCoursesCard({
         <div className="table-responsive">
           <table className="table table-sm table-hover table-striped" aria-label={heading}>
             <tbody>
-              {invited.map((entry: StudentHomePageCourse) => (
+              {conventionalInvitations.map((entry) => (
                 <tr key={`invite-${entry.course_instance.id}`} className="table-warning">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -86,6 +91,11 @@ export function StudentCoursesCard({
                           <input type="hidden" name="__csrf_token" value={csrfToken} />
                           <input
                             type="hidden"
+                            name="enrollment_id"
+                            value={entry.invitation_enrollment_id}
+                          />
+                          <input
+                            type="hidden"
                             name="course_instance_id"
                             value={entry.course_instance.id}
                           />
@@ -96,11 +106,37 @@ export function StudentCoursesCard({
                         <button
                           type="button"
                           className="btn btn-danger btn-sm"
-                          onClick={() => setRejectingCourseId(entry.course_instance.id)}
+                          onClick={() =>
+                            setRejectingInvitation({
+                              courseInstanceId: entry.course_instance.id,
+                              enrollmentId: entry.invitation_enrollment_id,
+                            })
+                          }
                         >
                           Reject
                         </button>
                       </div>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {rosterInvitations.map((entry) => (
+                <tr key={`roster-${entry.course_instance.id}`} className="table-info">
+                  <td className="align-middle">
+                    <div className="d-flex align-items-center justify-content-between gap-2">
+                      <div>
+                        <span className="fw-semibold">
+                          {entry.course_short_name}: {entry.course_title},{' '}
+                          {entry.course_instance.long_name}
+                        </span>
+                        <span className="ms-2 badge bg-info text-dark">Roster invitation</span>
+                      </div>
+                      <a
+                        href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}
+                        className="btn btn-primary btn-sm"
+                      >
+                        Open course
+                      </a>
                     </div>
                   </td>
                 </tr>
@@ -130,9 +166,9 @@ export function StudentCoursesCard({
       )}
 
       <Modal
-        show={rejectingCourseId !== null}
+        show={rejectingInvitation !== null}
         backdrop="static"
-        onHide={() => setRejectingCourseId(null)}
+        onHide={() => setRejectingInvitation(null)}
       >
         <Modal.Header closeButton>
           <Modal.Title>Reject invitation</Modal.Title>
@@ -147,14 +183,23 @@ export function StudentCoursesCard({
           <button
             type="button"
             className="btn btn-secondary"
-            onClick={() => setRejectingCourseId(null)}
+            onClick={() => setRejectingInvitation(null)}
           >
             Cancel
           </button>
           <form method="POST">
             <input type="hidden" name="__csrf_token" value={csrfToken} />
             <input type="hidden" name="__action" value="reject_invitation" />
-            <input type="hidden" name="course_instance_id" value={rejectingCourseId ?? ''} />
+            <input
+              type="hidden"
+              name="course_instance_id"
+              value={rejectingInvitation?.courseInstanceId ?? ''}
+            />
+            <input
+              type="hidden"
+              name="enrollment_id"
+              value={rejectingInvitation?.enrollmentId ?? ''}
+            />
             <button type="submit" className="btn btn-danger">
               Reject invitation
             </button>

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -34,19 +34,16 @@ export function Home({
   now: Date;
 }) {
   const listedStudentCourses = studentCourses.filter((ci) => {
-    if (ci.enrollment.status === 'joined') return true;
-    if (ci.enrollment.status === 'invited') {
-      if (!ci.course_instance.modern_publishing) {
-        return false;
-      }
-      return (
-        computeStatus(
-          ci.course_instance.publishing_start_date,
-          ci.course_instance.publishing_end_date,
-        ) === 'published'
-      );
+    if (ci.access_type === 'joined') return true;
+    if (!ci.course_instance.modern_publishing) {
+      return false;
     }
-    return false;
+    return (
+      computeStatus(
+        ci.course_instance.publishing_start_date,
+        ci.course_instance.publishing_end_date,
+      ) === 'published'
+    );
   });
 
   return (

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -2,7 +2,6 @@ import { Hydrate } from '@prairielearn/react/server';
 
 import { type StaffInstitution } from '../../lib/client/safe-db-types.js';
 import { type NewsItem } from '../../lib/db-types.js';
-import { computeStatus } from '../../lib/publishing.js';
 
 import { HomeCards } from './components/HomeCards.js';
 import { NewsAlert } from './components/NewsAlert.js';
@@ -35,15 +34,7 @@ export function Home({
 }) {
   const listedStudentCourses = studentCourses.filter((ci) => {
     if (ci.access_type === 'joined') return true;
-    if (!ci.course_instance.modern_publishing) {
-      return false;
-    }
-    return (
-      computeStatus(
-        ci.course_instance.publishing_start_date,
-        ci.course_instance.publishing_end_date,
-      ) === 'published'
-    );
+    return ci.course_instance.modern_publishing;
   });
 
   return (

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -166,24 +166,36 @@ ORDER BY
 
 -- BLOCK select_student_courses
 WITH
-  -- Base query: all enrollments for this user with course/course_instance data
-  base_enrollments AS (
+  user_identity AS (
     SELECT
-      e.id AS enrollment_id,
+      id,
+      institution_id,
+      uid,
+      uin
+    FROM
+      users
+    WHERE
+      id = $user_id
+  ),
+  -- Collect every enrollment candidate before collapsing to one row per course
+  -- instance. UIN provenance is valid only within the course's institution.
+  base_course_instances AS (
+    SELECT
       c.id AS course_id,
       c.short_name AS course_short_name,
       c.title AS course_title,
+      to_jsonb(ci) AS course_instance,
       ci.id AS course_instance_id,
       ci.modern_publishing,
-      ci.publishing_start_date,
       ci.publishing_end_date,
-      to_jsonb(ci) AS course_instance,
-      to_jsonb(e) AS enrollment,
-      u.uid,
-      u.institution_id
+      ci.publishing_start_date,
+      array_agg(
+        e.id
+        ORDER BY
+          e.id
+      ) AS candidate_enrollment_ids
     FROM
       enrollments AS e
-      LEFT JOIN users AS u ON (u.id = e.user_id)
       JOIN course_instances AS ci ON (
         ci.id = e.course_instance_id
         AND ci.deleted_at IS NULL
@@ -196,24 +208,32 @@ WITH
           OR $include_example_course_enrollments
         )
       )
+      CROSS JOIN user_identity AS identity
     WHERE
-      e.user_id = $user_id
-      OR e.pending_uid = $pending_uid
+      e.user_id = identity.id
+      OR e.pending_uid = identity.uid
+      OR (
+        identity.institution_id = c.institution_id
+        AND identity.uin IS NOT NULL
+        AND e.pending_uin = identity.uin
+      )
+    GROUP BY
+      c.id,
+      ci.id
   ),
   -- Legacy courses: use access rules for dates and initial filtering
   legacy_courses AS (
     SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
+      base.course_id,
+      base.course_short_name,
+      base.course_title,
+      base.course_instance,
       NULL::jsonb AS latest_publishing_extension,
       NULLIF(d.min_start_date, '-infinity'::timestamptz) AS start_date,
       NULLIF(d.max_end_date, 'infinity'::timestamptz) AS end_date,
-      be.course_instance_id
+      base.course_instance_id
     FROM
-      base_enrollments AS be,
+      base_course_instances AS base,
       LATERAL (
         SELECT
           min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
@@ -221,44 +241,44 @@ WITH
         FROM
           course_instance_access_rules AS ar
         WHERE
-          ar.course_instance_id = be.course_instance_id
+          ar.course_instance_id = base.course_instance_id
       ) AS d
     WHERE
-      be.modern_publishing IS FALSE
+      base.modern_publishing IS FALSE
       AND $req_date BETWEEN d.min_start_date AND d.max_end_date
   ),
   -- Modern courses: use publishing dates directly and fetch extension data
   modern_courses AS (
     SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      to_jsonb(cie) AS latest_publishing_extension,
-      be.publishing_start_date AS start_date,
-      be.publishing_end_date AS end_date,
-      be.course_instance_id
+      base.course_id,
+      base.course_short_name,
+      base.course_title,
+      base.course_instance,
+      to_jsonb(extension) AS latest_publishing_extension,
+      base.publishing_start_date AS start_date,
+      base.publishing_end_date AS end_date,
+      base.course_instance_id
     FROM
-      base_enrollments AS be
+      base_course_instances AS base
       LEFT JOIN LATERAL (
         SELECT
-          cie.*
+          publishing_extension.*
         FROM
           course_instance_publishing_extension_enrollments AS ciee
-          JOIN course_instance_publishing_extensions AS cie ON (
-            cie.id = ciee.course_instance_publishing_extension_id
+          JOIN course_instance_publishing_extensions AS publishing_extension ON (
+            publishing_extension.id = ciee.course_instance_publishing_extension_id
           )
         WHERE
-          ciee.enrollment_id = be.enrollment_id
+          ciee.enrollment_id = ANY (base.candidate_enrollment_ids)
+          AND publishing_extension.course_instance_id = base.course_instance_id
         ORDER BY
-          cie.end_date DESC NULLS LAST,
-          cie.id DESC
+          publishing_extension.end_date DESC,
+          publishing_extension.id DESC
         LIMIT
           1
-      ) AS cie ON TRUE
+      ) AS extension ON TRUE
     WHERE
-      be.modern_publishing IS TRUE
+      base.modern_publishing IS TRUE
   )
 SELECT
   *

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -9,6 +9,7 @@ import { assertNever } from '@prairielearn/utils';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
+import { hasRole } from '../../lib/authz-data-lib.js';
 import {
   checkCourseInstanceLegacyAccess,
   constructCourseOrInstanceContext,
@@ -21,18 +22,24 @@ import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
+import { admitUserFromConventionalEnrollmentInvitation } from '../../models/course-instance-admission.js';
+import { selectEnrollmentIdentityClassifications } from '../../models/enrollment-identity.js';
 import {
-  ensureEnrollment,
-  selectOptionalEnrollmentByUid,
-  setEnrollmentStatus,
-} from '../../models/enrollment.js';
+  EnrollmentAdmissionDeniedError,
+  rejectConventionalEnrollmentInvitation,
+} from '../../models/enrollment-reconciliation.js';
+import { selectOptionalEnrollmentByUserId, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
 } from '../../models/news-items.js';
 
 import { Home } from './home.html.js';
-import { InstructorHomePageCourseSchema, StudentHomePageCourseSchema } from './home.types.js';
+import {
+  InstructorHomePageCourseSchema,
+  type StudentHomePageCourse,
+  StudentHomePageCourseDataSchema,
+} from './home.types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
@@ -60,13 +67,12 @@ router.get(
       InstructorHomePageCourseSchema,
     );
 
-    // Query all student courses (both legacy and modern publishing) in a single query
+    // Query and collapse matching course instances for both legacy and modern publishing.
     const allStudentCourses = await queryRows(
       sql.select_student_courses,
       {
         // Use the authenticated user, not the authorized user.
         user_id: res.locals.authn_user.id,
-        pending_uid: res.locals.authn_user.uid,
         // This is a somewhat ugly escape hatch specifically for load testing. In
         // general, we don't want to clutter the home page with example course
         // enrollments, but for load testing we want to enroll a large number of
@@ -76,7 +82,7 @@ router.get(
         include_example_course_enrollments: req.query.include_example_course_enrollments === 'true',
         req_date: res.locals.req_date,
       },
-      StudentHomePageCourseSchema,
+      StudentHomePageCourseDataSchema,
     );
 
     const legacyCourseInstancesWithAccess = await checkCourseInstanceLegacyAccess({
@@ -87,7 +93,7 @@ router.get(
       reqDate: res.locals.req_date,
     });
 
-    const studentCourses = allStudentCourses.filter((entry) => {
+    const visibleStudentCourseData = allStudentCourses.filter((entry) => {
       // Filter out courses where user also has instructor access.
       if (instructorCourses.some((course) => idsEqual(course.id, entry.course_id))) return false;
 
@@ -120,6 +126,43 @@ router.get(
         res.locals.req_date < endDate
       );
     });
+
+    const studentCourseClassifications = await selectEnrollmentIdentityClassifications({
+      courseInstanceIds: visibleStudentCourseData.map((entry) => entry.course_instance.id),
+      userId: res.locals.authn_user.id,
+    });
+    const studentCourses = visibleStudentCourseData
+      .map((entry): StudentHomePageCourse | null => {
+        const classification = studentCourseClassifications.get(entry.course_instance.id);
+        if (classification === undefined) return null;
+        const course = {
+          course_id: entry.course_id,
+          course_instance: entry.course_instance,
+          course_short_name: entry.course_short_name,
+          course_title: entry.course_title,
+          end_date: entry.end_date,
+          latest_publishing_extension: entry.latest_publishing_extension,
+          start_date: entry.start_date,
+        };
+
+        if (classification.kind === 'joined') {
+          return { ...course, access_type: 'joined' };
+        }
+        if (classification.actionableInstitutionRosterInvitationCandidates.length > 0) {
+          return { ...course, access_type: 'roster_invitation' };
+        }
+        const conventionalInvitation =
+          classification.actionableConventionalInvitationCandidates.at(0);
+        if (conventionalInvitation !== undefined) {
+          return {
+            ...course,
+            access_type: 'conventional_invitation',
+            invitation_enrollment_id: conventionalInvitation.enrollment.id,
+          };
+        }
+        return null;
+      })
+      .filter((entry): entry is StudentHomePageCourse => entry !== null);
 
     const adminInstitutions = await queryRows(
       sql.select_admin_institutions,
@@ -175,18 +218,15 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const {
-      authn_user: { uid },
-    } = extractPageContext(res.locals, {
-      pageType: 'plain',
-      accessType: 'student',
-      withAuthzData: false,
-    });
-
     const BodySchema = z.discriminatedUnion('__action', [
       z.object({ __action: z.literal('dismiss_news_alert') }),
       z.object({
-        __action: z.enum(['accept_invitation', 'reject_invitation', 'unenroll']),
+        __action: z.enum(['accept_invitation', 'reject_invitation']),
+        course_instance_id: z.string().min(1),
+        enrollment_id: z.string().min(1),
+      }),
+      z.object({
+        __action: z.literal('unenroll'),
         course_instance_id: z.string().min(1),
       }),
     ]);
@@ -207,7 +247,7 @@ router.post(
       is_administrator: res.locals.is_administrator,
     });
 
-    if (authzData === null || courseInstance === null) {
+    if (authzData === null || courseInstance === null || !hasRole(authzData, ['Student'])) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
@@ -236,53 +276,40 @@ router.post(
 
     switch (body.__action) {
       case 'accept_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
-          authzData,
-        });
-        if (
-          !enrollment ||
-          !['left', 'removed', 'rejected', 'invited', 'joined'].includes(enrollment.status)
-        ) {
+        try {
+          await admitUserFromConventionalEnrollmentInvitation({
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            reqDate: res.locals.req_date,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
           flash('error', 'Failed to accept invitation');
-          break;
         }
-
-        await ensureEnrollment({
-          courseInstance,
-          authzData,
-          requiredRole: ['Student'],
-          actionDetail: 'invitation_accepted',
-        });
         break;
       }
       case 'reject_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
-          authzData,
-        });
-
-        if (!enrollment || !['invited', 'rejected'].includes(enrollment.status)) {
+        try {
+          await rejectConventionalEnrollmentInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
           flash('error', 'Failed to reject invitation');
-          break;
         }
-
-        await setEnrollmentStatus({
-          enrollment,
-          status: 'rejected',
-          authzData,
-          requiredRole: ['Student'],
-        });
         break;
       }
       case 'unenroll': {
-        const enrollment = await selectOptionalEnrollmentByUid({
+        const enrollment = await selectOptionalEnrollmentByUserId({
           courseInstance,
-          uid,
+          userId: res.locals.authn_user.id,
           requiredRole: ['Student'],
           authzData,
         });

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -19,7 +19,6 @@ import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
-import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import { admitUserFromConventionalEnrollmentInvitation } from '../../models/course-instance-admission.js';
@@ -264,11 +263,7 @@ router.post(
       return;
     }
 
-    if (
-      courseInstance.modern_publishing &&
-      computeStatus(courseInstance.publishing_start_date, courseInstance.publishing_end_date) !==
-        'published'
-    ) {
+    if (courseInstance.modern_publishing && !authzData.has_student_access) {
       flash('error', 'This course instance is not accessible to students');
       res.redirect(req.originalUrl);
       return;

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -5,7 +5,6 @@ import { DateFromISOString } from '@prairielearn/zod';
 import {
   RawStudentCourseInstanceSchema,
   RawStudentCourseSchema,
-  StudentEnrollmentSchema,
 } from '../../lib/client/safe-db-types.js';
 import { CourseInstancePublishingExtensionSchema } from '../../lib/db-types.js';
 
@@ -24,14 +23,20 @@ export const InstructorHomePageCourseSchema = z.object({
 });
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
-export const StudentHomePageCourseSchema = z.object({
+export const StudentHomePageCourseDataSchema = z.object({
   course_id: RawStudentCourseSchema.shape.id,
   course_instance: RawStudentCourseInstanceSchema,
   course_short_name: RawStudentCourseSchema.shape.short_name,
   course_title: RawStudentCourseSchema.shape.title,
-  enrollment: StudentEnrollmentSchema,
   start_date: DateFromISOString.nullable(),
   end_date: DateFromISOString.nullable(),
   latest_publishing_extension: CourseInstancePublishingExtensionSchema.nullable(),
 });
-export type StudentHomePageCourse = z.infer<typeof StudentHomePageCourseSchema>;
+export type StudentHomePageCourseData = z.infer<typeof StudentHomePageCourseDataSchema>;
+
+export type StudentHomePageCourse = StudentHomePageCourseData &
+  (
+    | { access_type: 'joined' }
+    | { access_type: 'conventional_invitation'; invitation_enrollment_id: string }
+    | { access_type: 'roster_invitation' }
+  );

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -4,7 +4,9 @@ INSERT INTO
     user_id,
     course_instance_id,
     status,
+    is_guest,
     pending_uid,
+    pending_uin,
     first_joined_at
   )
 VALUES
@@ -12,7 +14,9 @@ VALUES
     $user_id,
     $course_instance_id,
     $status,
+    $is_guest,
     $pending_uid,
+    $pending_uin,
     $first_joined_at
   )
 RETURNING
@@ -29,6 +33,51 @@ DELETE FROM enrollments
 WHERE
   course_instance_id = $course_instance_id
   AND pending_uid = $pending_uid;
+
+-- BLOCK delete_enrollment_by_id
+DELETE FROM enrollments
+WHERE
+  id = $enrollment_id;
+
+-- BLOCK select_enrollments_by_ids
+SELECT
+  *
+FROM
+  enrollments
+WHERE
+  id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  id;
+
+-- BLOCK count_enrollment_audit_events
+SELECT
+  count(*)::integer
+FROM
+  audit_events
+WHERE
+  enrollment_id = ANY ($enrollment_ids::bigint[]);
+
+-- BLOCK create_publishing_extension
+INSERT INTO
+  course_instance_publishing_extensions (course_instance_id, name, end_date)
+VALUES
+  ($course_instance_id, $name, $end_date)
+RETURNING
+  *;
+
+-- BLOCK add_publishing_extension_enrollment
+INSERT INTO
+  course_instance_publishing_extension_enrollments (
+    course_instance_publishing_extension_id,
+    enrollment_id
+  )
+VALUES
+  ($publishing_extension_id, $enrollment_id);
+
+-- BLOCK delete_publishing_extension
+DELETE FROM course_instance_publishing_extensions
+WHERE
+  id = $publishing_extension_id;
 
 -- BLOCK update_course_instance_publishing
 UPDATE course_instances

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -74,6 +74,14 @@ INSERT INTO
 VALUES
   ($publishing_extension_id, $enrollment_id);
 
+-- BLOCK select_publishing_extension_enrollment_id
+SELECT
+  enrollment_id
+FROM
+  course_instance_publishing_extension_enrollments
+WHERE
+  course_instance_publishing_extension_id = $publishing_extension_id;
+
 -- BLOCK delete_publishing_extension
 DELETE FROM course_instance_publishing_extensions
 WHERE

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -1,11 +1,18 @@
+import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+import { z } from 'zod';
 
-import { execute, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+import { execute, loadSqlEquiv, queryRow, queryRows, queryScalar } from '@prairielearn/postgres';
 
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import { type Enrollment, EnrollmentSchema, type EnumEnrollmentStatus } from '../lib/db-types.js';
+import {
+  CourseInstancePublishingExtensionSchema,
+  type Enrollment,
+  EnrollmentSchema,
+  type EnumEnrollmentStatus,
+} from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -16,7 +23,7 @@ import {
 import { assertAlert, fetchCheerio } from './helperClient.js';
 import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
-import { getOrCreateUser, withUser } from './utils/auth.js';
+import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
 
 const sql = loadSqlEquiv(import.meta.url);
@@ -24,15 +31,24 @@ const sql = loadSqlEquiv(import.meta.url);
 const siteUrl = 'http://localhost:' + config.serverPort;
 const homeUrl = siteUrl + '/';
 
+async function postHome(body: URLSearchParams) {
+  const response = await fetchCookie(fetch)(homeUrl, { method: 'POST', body });
+  return { $: cheerio.load(await response.text()), response };
+}
+
 /** Helper function to create enrollments with specific statuses for testing */
 async function createEnrollmentWithStatus({
   userId,
   courseInstanceId,
+  isGuest = false,
+  pendingUin,
   status,
   pendingUid,
 }: {
   userId: string | null;
   courseInstanceId: string;
+  isGuest?: boolean;
+  pendingUin?: string | null;
   status: EnumEnrollmentStatus;
   pendingUid?: string | null;
 }): Promise<Enrollment> {
@@ -41,9 +57,11 @@ async function createEnrollmentWithStatus({
     {
       user_id: userId,
       course_instance_id: courseInstanceId,
+      is_guest: isGuest,
       status,
       pending_uid: pendingUid,
-      first_joined_at: status === 'joined' ? new Date() : null,
+      pending_uin: pendingUin,
+      first_joined_at: ['invited', 'rejected'].includes(status) ? null : new Date(),
     },
     EnrollmentSchema,
   );
@@ -56,11 +74,12 @@ describe('Homepage enrollment actions', () => {
 
     // Set uid_regexp for the default institution to allow @example.com UIDs
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$' WHERE id = 1");
+    await createInstitution('900002', 'other.example.com', 'Other institution');
   });
 
   afterAll(helperServer.after);
 
-  it('handles double accept invitation (no-op)', async () => {
+  it('does not re-accept a joined invitation target', async () => {
     const user = await getOrCreateUser({
       uid: 'invited1@example.com',
       name: 'Invited User 1',
@@ -70,7 +89,7 @@ describe('Homepage enrollment actions', () => {
     });
 
     // Create an invited enrollment
-    await createEnrollmentWithStatus({
+    const invitation = await createEnrollmentWithStatus({
       userId: null,
       courseInstanceId: '1',
       status: 'invited',
@@ -86,6 +105,7 @@ describe('Homepage enrollment actions', () => {
         body: new URLSearchParams({
           __action: 'accept_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken,
         }),
       });
@@ -103,18 +123,19 @@ describe('Homepage enrollment actions', () => {
       assert.isNotNull(enrollment);
       assert.equal(enrollment.status, 'joined');
 
-      // Second accept (should be a no-op)
+      // The rendered invitation is no longer actionable after acceptance.
       const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
+      const secondResponse = await postHome(
+        new URLSearchParams({
           __action: 'accept_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken2,
         }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
+      );
+      assert.equal(secondResponse.response.status, 200);
+      assert.equal(secondResponse.response.url, homeUrl);
+      assertAlert(secondResponse.$, 'Failed to accept invitation');
 
       // Verify enrollment is still joined
       const finalEnrollment = await selectOptionalEnrollmentByUserId({
@@ -133,7 +154,7 @@ describe('Homepage enrollment actions', () => {
     });
   });
 
-  it('handles double reject invitation (no-op)', async () => {
+  it('does not re-reject a rejected invitation target', async () => {
     const user = await getOrCreateUser({
       uid: 'invited2@example.com',
       name: 'Invited User 2',
@@ -143,7 +164,7 @@ describe('Homepage enrollment actions', () => {
     });
 
     // Create an invited enrollment
-    await createEnrollmentWithStatus({
+    const invitation = await createEnrollmentWithStatus({
       userId: null,
       courseInstanceId: '1',
       status: 'invited',
@@ -159,6 +180,7 @@ describe('Homepage enrollment actions', () => {
         body: new URLSearchParams({
           __action: 'reject_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken,
         }),
       });
@@ -176,18 +198,19 @@ describe('Homepage enrollment actions', () => {
       assert.isNotNull(enrollment);
       assert.equal(enrollment.status, 'rejected');
 
-      // Second reject (should be a no-op)
+      // The rendered invitation is no longer actionable after rejection.
       const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
+      const secondResponse = await postHome(
+        new URLSearchParams({
           __action: 'reject_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken2,
         }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
+      );
+      assert.equal(secondResponse.response.status, 200);
+      assert.equal(secondResponse.response.url, homeUrl);
+      assertAlert(secondResponse.$, 'Failed to reject invitation');
 
       // Verify enrollment is still rejected
       const finalEnrollment = await selectOptionalEnrollmentByPendingUid({
@@ -216,7 +239,7 @@ describe('Homepage enrollment actions', () => {
     });
 
     // Create an invited enrollment
-    await createEnrollmentWithStatus({
+    const invitation = await createEnrollmentWithStatus({
       userId: null,
       courseInstanceId: '1',
       status: 'invited',
@@ -234,6 +257,7 @@ describe('Homepage enrollment actions', () => {
         body: new URLSearchParams({
           __action: 'accept_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken,
         }),
       });
@@ -247,6 +271,7 @@ describe('Homepage enrollment actions', () => {
         body: new URLSearchParams({
           __action: 'reject_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken2,
         }),
       });
@@ -279,7 +304,7 @@ describe('Homepage enrollment actions', () => {
     });
   });
 
-  it('allows accepting invitation after rejecting it', async () => {
+  it('does not accept a rejected invitation', async () => {
     const user = await getOrCreateUser({
       uid: 'invited4@example.com',
       name: 'Invited User 4',
@@ -289,7 +314,7 @@ describe('Homepage enrollment actions', () => {
     });
 
     // Create an invited enrollment
-    await createEnrollmentWithStatus({
+    const invitation = await createEnrollmentWithStatus({
       userId: null,
       courseInstanceId: '1',
       status: 'invited',
@@ -305,6 +330,7 @@ describe('Homepage enrollment actions', () => {
         body: new URLSearchParams({
           __action: 'reject_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken,
         }),
       });
@@ -322,33 +348,34 @@ describe('Homepage enrollment actions', () => {
       assert.isNotNull(rejectedEnrollment);
       assert.equal(rejectedEnrollment.status, 'rejected');
 
-      // Now accept the invitation (should succeed)
+      // A rejected invitation is no longer actionable.
       const csrfToken2 = await getCsrfToken(homeUrl);
-      const acceptResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
+      const acceptResponse = await postHome(
+        new URLSearchParams({
           __action: 'accept_invitation',
           course_instance_id: '1',
+          enrollment_id: invitation.id,
           __csrf_token: csrfToken2,
         }),
-      });
-      assert.equal(acceptResponse.status, 200);
-      assert.equal(acceptResponse.url, homeUrl);
+      );
+      assert.equal(acceptResponse.response.status, 200);
+      assert.equal(acceptResponse.response.url, homeUrl);
 
-      // Verify enrollment is now joined
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
+      assertAlert(acceptResponse.$, 'Failed to accept invitation');
+
+      const finalEnrollment = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: user.uid,
         courseInstance,
         requiredRole: ['System'],
         authzData: dangerousFullSystemAuthz(),
       });
       assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
+      assert.equal(finalEnrollment.status, 'rejected');
     });
 
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
+    await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
       course_instance_id: '1',
-      user_id: user.id,
+      pending_uid: user.uid,
     });
   });
 
@@ -482,5 +509,369 @@ describe('Homepage enrollment actions', () => {
       course_instance_id: '1',
       user_id: user.id,
     });
+  });
+
+  it('does not discover an equal-UIN roster invitation from another institution', async () => {
+    const user = await getOrCreateUser({
+      uid: 'foreign-institution@other.example.com',
+      name: 'Foreign Institution User',
+      uin: 'shared-institution-uin',
+      email: 'foreign-institution@other.example.com',
+      institutionId: '900002',
+    });
+    const invitation = await createEnrollmentWithStatus({
+      userId: null,
+      courseInstanceId: '1',
+      pendingUin: user.uin,
+      status: 'invited',
+    });
+
+    try {
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        assert.equal(response.status, 200);
+        assert.lengthOf(
+          response
+            .$('.badge')
+            .filter((_, el) => response.$(el).text().includes('Roster invitation')),
+          0,
+        );
+      });
+    } finally {
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
+  });
+
+  it('renders bound-left plus roster candidates once without mutating them', async () => {
+    const user = await getOrCreateUser({
+      uid: 'bound-left-roster@example.com',
+      name: 'Bound Left Roster User',
+      uin: 'bound-left-roster-uin',
+      email: 'bound-left-roster@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await createEnrollmentWithStatus({
+      userId: user.id,
+      courseInstanceId: '1',
+      status: 'left',
+    });
+    const rosterInvitation = await createEnrollmentWithStatus({
+      userId: null,
+      courseInstanceId: '1',
+      pendingUin: user.uin,
+      status: 'invited',
+    });
+    const enrollmentIds = [boundEnrollment.id, rosterInvitation.id];
+
+    try {
+      const beforeEnrollments = await queryRows(
+        sql.select_enrollments_by_ids,
+        { enrollment_ids: enrollmentIds },
+        EnrollmentSchema,
+      );
+      const beforeAuditCount = await queryScalar(
+        sql.count_enrollment_audit_events,
+        { enrollment_ids: enrollmentIds },
+        z.number(),
+      );
+
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const studentRows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(studentRows, 1);
+        assert.include(studentRows.text(), 'Roster invitation');
+        assert.lengthOf(studentRows.find('input[name="__action"][value="accept_invitation"]'), 0);
+        assert.lengthOf(studentRows.find('input[name="__action"][value="reject_invitation"]'), 0);
+        assert.lengthOf(
+          studentRows.find('button').filter((_, el) => response.$(el).text() === 'Remove'),
+          0,
+        );
+
+        const afterEnrollments = await queryRows(
+          sql.select_enrollments_by_ids,
+          { enrollment_ids: enrollmentIds },
+          EnrollmentSchema,
+        );
+        const afterAuditCount = await queryScalar(
+          sql.count_enrollment_audit_events,
+          { enrollment_ids: enrollmentIds },
+          z.number(),
+        );
+        assert.deepEqual(afterEnrollments, beforeEnrollments);
+        assert.equal(afterAuditCount, beforeAuditCount);
+
+        const csrfToken = await getCsrfToken(homeUrl);
+        const postResponse = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: csrfToken,
+            course_instance_id: '1',
+            enrollment_id: rosterInvitation.id,
+          }),
+        );
+        assertAlert(postResponse.$, 'Failed to accept invitation');
+      });
+
+      const afterPost = await queryRows(
+        sql.select_enrollments_by_ids,
+        { enrollment_ids: enrollmentIds },
+        EnrollmentSchema,
+      );
+      assert.deepEqual(afterPost, beforeEnrollments);
+    } finally {
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: rosterInvitation.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: boundEnrollment.id });
+    }
+  });
+
+  it('uses the latest publishing extension across the complete candidate set', async () => {
+    const user = await getOrCreateUser({
+      uid: 'candidate-extension@example.com',
+      name: 'Candidate Extension User',
+      uin: 'candidate-extension-uin',
+      email: 'candidate-extension@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await createEnrollmentWithStatus({
+      userId: user.id,
+      courseInstanceId: '1',
+      status: 'joined',
+    });
+    const rosterInvitation = await createEnrollmentWithStatus({
+      userId: null,
+      courseInstanceId: '1',
+      pendingUin: user.uin,
+      status: 'invited',
+    });
+    const existingCourseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const publishingExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
+        course_instance_id: '1',
+        name: 'Homepage complete candidate extension',
+        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: publishingExtension.id,
+      enrollment_id: rosterInvitation.id,
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: '1',
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const studentRows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(studentRows, 1);
+        assert.lengthOf(
+          studentRows.find('button').filter((_, el) => response.$(el).text() === 'Remove'),
+          1,
+        );
+        assert.notInclude(studentRows.text(), 'Roster invitation');
+      });
+    } finally {
+      await execute(sql.update_course_instance_publishing, {
+        course_instance_id: '1',
+        publishing_start_date: existingCourseInstance.publishing_start_date,
+        publishing_end_date: existingCourseInstance.publishing_end_date,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: publishingExtension.id,
+      });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: rosterInvitation.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: boundEnrollment.id });
+    }
+  });
+
+  it('does not substitute a new conventional invitation for a stale form target', async () => {
+    const user = await getOrCreateUser({
+      uid: 'stale-invitation@example.com',
+      name: 'Stale Invitation User',
+      uin: 'stale-invitation-uin',
+      email: 'stale-invitation@example.com',
+      institutionId: '1',
+    });
+    const originalInvitation = await createEnrollmentWithStatus({
+      userId: null,
+      courseInstanceId: '1',
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    let replacementInvitation: Enrollment | null = null;
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        const acceptForm = page
+          .$(`input[name="enrollment_id"][value="${originalInvitation.id}"]`)
+          .closest('form');
+        assert.equal(acceptForm.find('input[name="__action"]').attr('value'), 'accept_invitation');
+      });
+
+      await execute(sql.delete_enrollment_by_id, {
+        enrollment_id: originalInvitation.id,
+      });
+      replacementInvitation = await createEnrollmentWithStatus({
+        userId: null,
+        courseInstanceId: '1',
+        pendingUid: user.uid,
+        status: 'invited',
+      });
+
+      await withUser(user, async () => {
+        const csrfToken = await getCsrfToken(homeUrl);
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: csrfToken,
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(response.$, 'Failed to accept invitation');
+
+        const rejectCsrfToken = await getCsrfToken(homeUrl);
+        const rejectResponse = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: rejectCsrfToken,
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(rejectResponse.$, 'Failed to reject invitation');
+      });
+
+      const courseInstance = await selectCourseInstanceById('1');
+      const remainingInvitation = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: user.uid,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(remainingInvitation);
+      assert.equal(remainingInvitation.id, replacementInvitation.id);
+      assert.equal(remainingInvitation.status, 'invited');
+    } finally {
+      if (replacementInvitation !== null) {
+        await execute(sql.delete_enrollment_by_id, {
+          enrollment_id: replacementInvitation.id,
+        });
+      } else {
+        await execute(sql.delete_enrollment_by_id, {
+          enrollment_id: originalInvitation.id,
+        });
+      }
+    }
+  });
+
+  it('does not accept bound left, removed, or blocked enrollments as invitations', async () => {
+    for (const status of ['left', 'removed', 'blocked'] as const) {
+      const user = await getOrCreateUser({
+        uid: `non-actionable-${status}@example.com`,
+        name: `Non-actionable ${status}`,
+        uin: `non-actionable-${status}-uin`,
+        email: `non-actionable-${status}@example.com`,
+        institutionId: '1',
+      });
+      const enrollment = await createEnrollmentWithStatus({
+        userId: user.id,
+        courseInstanceId: '1',
+        status,
+      });
+
+      try {
+        await withUser(user, async () => {
+          const csrfToken = await getCsrfToken(homeUrl);
+          const response = await postHome(
+            new URLSearchParams({
+              __action: 'accept_invitation',
+              __csrf_token: csrfToken,
+              course_instance_id: '1',
+              enrollment_id: enrollment.id,
+            }),
+          );
+          assertAlert(response.$, 'Failed to accept invitation');
+        });
+
+        const courseInstance = await selectCourseInstanceById('1');
+        const finalEnrollment = await selectOptionalEnrollmentByUserId({
+          userId: user.id,
+          courseInstance,
+          requiredRole: ['System'],
+          authzData: dangerousFullSystemAuthz(),
+        });
+        assert.isNotNull(finalEnrollment);
+        assert.equal(finalEnrollment.status, status);
+      } finally {
+        await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollment.id });
+      }
+    }
+  });
+
+  it('preserves actionable conventional guest invitation acceptance', async () => {
+    const user = await getOrCreateUser({
+      uid: 'guest-invitation@example.com',
+      name: 'Guest Invitation User',
+      uin: 'guest-invitation-uin',
+      email: 'guest-invitation@example.com',
+      institutionId: '1',
+    });
+    const invitation = await createEnrollmentWithStatus({
+      userId: null,
+      courseInstanceId: '1',
+      isGuest: true,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        assert.equal(
+          page
+            .$(`input[name="enrollment_id"][value="${invitation.id}"]`)
+            .closest('form')
+            .find('input[name="__action"]')
+            .attr('value'),
+          'accept_invitation',
+        );
+
+        const csrfToken = await getCsrfToken(homeUrl);
+        const response = await fetchCheerio(homeUrl, {
+          method: 'POST',
+          body: new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: csrfToken,
+            course_instance_id: '1',
+            enrollment_id: invitation.id,
+          }),
+        });
+        assert.equal(response.status, 200);
+      });
+
+      const courseInstance = await selectCourseInstanceById('1');
+      const enrollment = await selectOptionalEnrollmentByUserId({
+        userId: user.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(enrollment);
+      assert.equal(enrollment.status, 'joined');
+      assert.isTrue(enrollment.is_guest);
+    } finally {
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
   });
 });

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -406,8 +406,7 @@ describe('Homepage enrollment actions', () => {
     });
 
     try {
-      // Create an invited enrollment
-      await createEnrollmentWithStatus({
+      const invitation = await createEnrollmentWithStatus({
         userId: null,
         courseInstanceId: '1',
         status: 'invited',
@@ -424,6 +423,25 @@ describe('Homepage enrollment actions', () => {
 
         const studentRows = studentCoursesTable.find('tr');
         assert.equal(studentRows.length, 0, 'No course rows should be visible');
+
+        const postResponse = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: invitation.id,
+          }),
+        );
+        assert.equal(postResponse.response.status, 403);
+
+        const finalInvitation = await selectOptionalEnrollmentByPendingUid({
+          pendingUid: user.uid,
+          courseInstance: await selectCourseInstanceById('1'),
+          requiredRole: ['System'],
+          authzData: dangerousFullSystemAuthz(),
+        });
+        assert.isNotNull(finalInvitation);
+        assert.equal(finalInvitation.status, 'invited');
       });
     } finally {
       await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
@@ -637,7 +655,7 @@ describe('Homepage enrollment actions', () => {
     const boundEnrollment = await createEnrollmentWithStatus({
       userId: user.id,
       courseInstanceId: '1',
-      status: 'joined',
+      status: 'left',
     });
     const rosterInvitation = await createEnrollmentWithStatus({
       userId: null,
@@ -668,16 +686,76 @@ describe('Homepage enrollment actions', () => {
 
     try {
       await withUser(user, async () => {
+        const enrollmentIds = [boundEnrollment.id, rosterInvitation.id];
+        const beforeEnrollments = await queryRows(
+          sql.select_enrollments_by_ids,
+          { enrollment_ids: enrollmentIds },
+          EnrollmentSchema,
+        );
+        const beforeAuditCount = await queryScalar(
+          sql.count_enrollment_audit_events,
+          { enrollment_ids: enrollmentIds },
+          z.number(),
+        );
+
         const response = await fetchCheerio(homeUrl);
         const studentRows = response.$(
           'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
         );
         assert.lengthOf(studentRows, 1);
+        assert.include(studentRows.text(), 'Roster invitation');
+        assert.lengthOf(studentRows.find('input[name="__action"][value="accept_invitation"]'), 0);
+        assert.lengthOf(studentRows.find('input[name="__action"][value="reject_invitation"]'), 0);
         assert.lengthOf(
           studentRows.find('button').filter((_, el) => response.$(el).text() === 'Remove'),
-          1,
+          0,
         );
-        assert.notInclude(studentRows.text(), 'Roster invitation');
+
+        assert.deepEqual(
+          await queryRows(
+            sql.select_enrollments_by_ids,
+            { enrollment_ids: enrollmentIds },
+            EnrollmentSchema,
+          ),
+          beforeEnrollments,
+        );
+        assert.equal(
+          await queryScalar(
+            sql.count_enrollment_audit_events,
+            { enrollment_ids: enrollmentIds },
+            z.number(),
+          ),
+          beforeAuditCount,
+        );
+
+        const openCourseLink = studentRows
+          .find('a')
+          .filter((_, el) => response.$(el).text().trim() === 'Open course');
+        assert.lengthOf(openCourseLink, 1);
+        const openCourseHref = openCourseLink.attr('href');
+        assert.isString(openCourseHref);
+
+        const courseResponse = await fetchCheerio(new URL(openCourseHref!, siteUrl));
+        assert.equal(courseResponse.status, 200);
+
+        const courseInstance = await selectCourseInstanceById('1');
+        const finalEnrollment = await selectOptionalEnrollmentByUserId({
+          userId: user.id,
+          courseInstance,
+          requiredRole: ['System'],
+          authzData: dangerousFullSystemAuthz(),
+        });
+        assert.isNotNull(finalEnrollment);
+        assert.equal(finalEnrollment.id, boundEnrollment.id);
+        assert.equal(finalEnrollment.status, 'joined');
+        assert.equal(
+          await queryScalar(
+            sql.select_publishing_extension_enrollment_id,
+            { publishing_extension_id: publishingExtension.id },
+            z.string(),
+          ),
+          boundEnrollment.id,
+        );
       });
     } finally {
       await execute(sql.update_course_instance_publishing, {
@@ -690,6 +768,83 @@ describe('Homepage enrollment actions', () => {
       });
       await execute(sql.delete_enrollment_by_id, { enrollment_id: rosterInvitation.id });
       await execute(sql.delete_enrollment_by_id, { enrollment_id: boundEnrollment.id });
+    }
+  });
+
+  it('accepts an extension-backed conventional invitation after the base interval', async () => {
+    const user = await getOrCreateUser({
+      uid: 'conventional-extension@example.com',
+      name: 'Conventional Extension User',
+      uin: 'conventional-extension-uin',
+      email: 'conventional-extension@example.com',
+      institutionId: '1',
+    });
+    const invitation = await createEnrollmentWithStatus({
+      userId: null,
+      courseInstanceId: '1',
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    const existingCourseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const publishingExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
+        course_instance_id: '1',
+        name: 'Homepage conventional invitation extension',
+        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: publishingExtension.id,
+      enrollment_id: invitation.id,
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: '1',
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        const acceptForm = page
+          .$(`input[name="enrollment_id"][value="${invitation.id}"]`)
+          .closest('form');
+        assert.equal(acceptForm.find('input[name="__action"]').attr('value'), 'accept_invitation');
+
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: invitation.id,
+          }),
+        );
+        assert.equal(response.response.status, 200);
+        assert.equal(response.response.url, homeUrl);
+
+        const finalEnrollment = await selectOptionalEnrollmentByUserId({
+          userId: user.id,
+          courseInstance: await selectCourseInstanceById('1'),
+          requiredRole: ['System'],
+          authzData: dangerousFullSystemAuthz(),
+        });
+        assert.isNotNull(finalEnrollment);
+        assert.equal(finalEnrollment.id, invitation.id);
+        assert.equal(finalEnrollment.status, 'joined');
+      });
+    } finally {
+      await execute(sql.update_course_instance_publishing, {
+        course_instance_id: '1',
+        publishing_start_date: existingCourseInstance.publishing_start_date,
+        publishing_end_date: existingCourseInstance.publishing_end_date,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: publishingExtension.id,
+      });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
     }
   });
 


### PR DESCRIPTION
# Description

Implements slice 6 of 6 for [PrairieLearnInc/planning#51](https://github.com/PrairieLearnInc/planning/issues/51).

Discovers pending-UIN invitations only when the authenticated user's institution matches the course institution, collapses the complete candidate set to one homepage entry per course instance, and computes the effective publishing extension across all matching candidates. A bound-left row plus pending roster invitation appears once as roster availability, not as joined access.

Renders roster availability separately from conventional invitation controls. Homepage GET remains read-only, roster entries expose only the ordinary course-entry path, and conventional Accept/Reject forms pin the exact rendered enrollment ID so stale, replacement, roster-only, left, removed, rejected, or blocked rows cannot become an authorization bypass. Legitimate conventional guest invitations retain their existing behavior.

Modern course authorization now recognizes a live extension across the canonical candidate set only for joined users or actionable conventional/institution-roster invitations. `has_student_access_with_enrollment` remains true only for joined users, so extension-backed invitations still pass through checked admission and reconciliation before course access.

Stack: 6 of 6. Depends on #15513.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance disclosure: Codex produced the majority of the implementation and tests under human-directed design, manager inspection, and independent adversarial review.

# Testing

Homepage integration coverage proves cross-institution UIN isolation, bound-left candidate grouping, no mutation on GET, distinct roster presentation, exact stale-form denial, conventional guest behavior, and old left/removed/rejected bypass prevention. An expired-base click-through case follows the rendered roster link through real middleware admission, verifies the bound survivor joins, and confirms the effective extension moves to that survivor; extension-backed conventional acceptance and unavailable-course denial are also covered.
