### PR TITLE
Use checked admission for student course entry

### DIFF
--- a/apps/prairielearn/src/components/EnrollmentPage.tsx
+++ b/apps/prairielearn/src/components/EnrollmentPage.tsx
@@ -1,14 +1,11 @@
+import type { EnrollmentIneligibilityReason } from '../lib/enrollment/eligibility.js';
 import type { UntypedResLocals } from '../lib/res-locals.types.js';
 
 import { PageLayout } from './PageLayout.js';
 
 interface EnrollmentPageProps {
+  reason: EnrollmentIneligibilityReason;
   resLocals: UntypedResLocals;
-  type:
-    | 'blocked'
-    | 'self-enrollment-disabled'
-    | 'self-enrollment-expired'
-    | 'institution-restriction';
 }
 
 function BlockedEnrollment() {
@@ -111,22 +108,22 @@ function InstitutionRestriction() {
   );
 }
 
-export function EnrollmentPage({ resLocals, type }: EnrollmentPageProps) {
+export function EnrollmentPage({ reason, resLocals }: EnrollmentPageProps) {
   const pageTitle =
-    type === 'blocked'
+    reason === 'blocked'
       ? 'Enrollment blocked'
-      : type === 'self-enrollment-expired'
+      : reason === 'self-enrollment-expired'
         ? 'Self-enrollment expired'
-        : type === 'institution-restriction'
+        : reason === 'institution-restriction'
           ? 'Institution restriction'
           : 'Self-enrollment not available';
 
   const content =
-    type === 'blocked' ? (
+    reason === 'blocked' ? (
       <BlockedEnrollment />
-    ) : type === 'self-enrollment-expired' ? (
+    ) : reason === 'self-enrollment-expired' ? (
       <SelfEnrollmentExpired />
-    ) : type === 'institution-restriction' ? (
+    ) : reason === 'institution-restriction' ? (
       <InstitutionRestriction />
     ) : (
       <SelfEnrollmentDisabled />

--- a/apps/prairielearn/src/ee/lib/lti13-course-instance-upgrade.ts
+++ b/apps/prairielearn/src/ee/lib/lti13-course-instance-upgrade.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+import { IdSchema } from '@prairielearn/zod';
+
+import { idsEqual } from '../../lib/id.js';
+
+// Give the student enough time to submit the upgrade form. Once the Stripe
+// checkout exists, the relaunch flag in its return URL no longer authorizes
+// anything.
+const LTI13_COURSE_INSTANCE_UPGRADE_TTL_MS = 30 * 60 * 1000;
+
+const Lti13CourseInstanceUpgradeAuthorizationSchema = z.object({
+  course_instance_id: IdSchema,
+  enrollment_id: IdSchema,
+  expires_at: z.iso.datetime(),
+  lti13_course_instance_id: IdSchema,
+  sub: z.string().min(1),
+  user_id: IdSchema,
+});
+
+export type Lti13CourseInstanceUpgradeAuthorization = z.infer<
+  typeof Lti13CourseInstanceUpgradeAuthorizationSchema
+>;
+
+type SessionData = Record<string, unknown>;
+
+export function setLti13CourseInstanceUpgradeAuthorization({
+  courseInstanceId,
+  enrollmentId,
+  lti13CourseInstanceId,
+  now,
+  session,
+  sub,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentId: string;
+  lti13CourseInstanceId: string;
+  now: Date;
+  session: SessionData;
+  sub: string;
+  userId: string;
+}) {
+  session.lti13_course_instance_upgrade = Lti13CourseInstanceUpgradeAuthorizationSchema.parse({
+    course_instance_id: courseInstanceId,
+    enrollment_id: enrollmentId,
+    expires_at: new Date(now.getTime() + LTI13_COURSE_INSTANCE_UPGRADE_TTL_MS).toISOString(),
+    lti13_course_instance_id: lti13CourseInstanceId,
+    sub,
+    user_id: userId,
+  });
+}
+
+export function getLti13CourseInstanceUpgradeAuthorization({
+  courseInstanceId,
+  now,
+  session,
+  userId,
+}: {
+  courseInstanceId: string;
+  now: Date;
+  session: SessionData;
+  userId: string;
+}): Lti13CourseInstanceUpgradeAuthorization | null {
+  const result = Lti13CourseInstanceUpgradeAuthorizationSchema.safeParse(
+    session.lti13_course_instance_upgrade,
+  );
+  if (!result.success || new Date(result.data.expires_at).getTime() <= now.getTime()) {
+    clearLti13CourseInstanceUpgradeAuthorization(session);
+    return null;
+  }
+  if (
+    !idsEqual(result.data.course_instance_id, courseInstanceId) ||
+    !idsEqual(result.data.user_id, userId)
+  ) {
+    return null;
+  }
+  return result.data;
+}
+
+export function clearLti13CourseInstanceUpgradeAuthorization(session: SessionData) {
+  delete session.lti13_course_instance_upgrade;
+}

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -279,6 +279,11 @@ export class Lti13Claim {
     return this.claims['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'];
   }
 
+  get sub() {
+    this.assertValid();
+    return this.claims.sub;
+  }
+
   get lineitems() {
     this.assertValid();
     return this.claims['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']?.lineitems;

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -280,6 +280,11 @@ export class Lti13Claim {
     return this.claims['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'];
   }
 
+  get sub() {
+    this.assertValid();
+    return this.claims.sub;
+  }
+
   get lineitems() {
     this.assertValid();
     return this.claims['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']?.lineitems;

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -11,9 +11,13 @@ import {
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
+import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { admitUserFromLti13CourseInstanceRequest } from '../../../models/course-instance-admission.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
+import { selectEnrollmentAdmissionDecision } from '../../../models/enrollment-identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../models/enrollment-reconciliation.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {
@@ -119,6 +123,13 @@ router.get(
     }
 
     const ltiClaim = new Lti13Claim(req);
+    if (
+      req.session.authn_lti13_instance_id === undefined ||
+      !idsEqual(req.session.authn_lti13_instance_id, req.params.lti13_instance_id)
+    ) {
+      ltiClaim.remove();
+      throw new HttpStatusError(403, 'Access denied');
+    }
     const courseName = prettyCourseName(ltiClaim);
     const role_instructor = ltiClaim.isRoleInstructor();
 
@@ -134,6 +145,8 @@ router.get(
     );
 
     if (lti13_course_instance) {
+      const courseInstanceId = lti13_course_instance.course_instance_id;
+
       // Update lti13_course_instance on instructor login
       // helpful as LMS updates or we add features
       if (role_instructor) {
@@ -150,17 +163,47 @@ router.get(
         });
 
         // TODO: Set course/instance staff permissions for LMS course staff here?
+
+        ltiClaim.remove();
+        res.redirect(`/pl/course_instance/${courseInstanceId}/instructor/`);
+        return;
       }
 
-      // LTI claims are not used after this page so remove them from the session
+      const lti13CourseInstanceId = lti13_course_instance.id;
+      const sub = ltiClaim.sub;
+      const userId = res.locals.authn_user.id;
+      const source = { type: 'lti13' as const, lti13CourseInstanceId, sub };
+
+      // Exact LTI authority is request-local. Consume the verified launch
+      // before selection, checked admission, or any resulting redirect/error.
       ltiClaim.remove();
 
-      // Redirect to linked course instance
-      res.redirect(
-        `/pl/course_instance/${lti13_course_instance.course_instance_id}/${
-          role_instructor ? 'instructor/' : ''
-        }`,
+      const decision = await selectEnrollmentAdmissionDecision(
+        {
+          courseInstanceId,
+          lti13Identity: { lti13CourseInstanceId, sub },
+          userId,
+        },
+        source,
       );
+      if (decision.allowed && decision.invitationCandidate !== null) {
+        try {
+          await admitUserFromLti13CourseInstanceRequest({
+            courseInstanceId,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            lti13CourseInstanceId,
+            reqDate: res.locals.req_date,
+            sub,
+            userId,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+        }
+      }
+
+      res.redirect(`/pl/course_instance/${courseInstanceId}/`);
       return;
     }
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -12,15 +12,13 @@ import {
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
 import { admitUserFromLti13Launch } from '../../../lib/enrollment/admission.js';
-import {
-  type EnrollmentAdmissionSource,
-  selectEnrollmentAdmissionDecision,
-} from '../../../lib/enrollment/identity.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
+import { setLti13CourseInstanceUpgradeAuthorization } from '../../lib/lti13-course-instance-upgrade.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {
@@ -175,41 +173,52 @@ router.get(
       const lti13CourseInstanceId = lti13_course_instance.id;
       const sub = ltiClaim.sub;
       const userId = res.locals.authn_user.id;
-      const source: EnrollmentAdmissionSource = {
-        type: 'invitation',
-        matchedBy: 'lti13',
-        lti13CourseInstanceId,
-        sub,
-      };
-
       // Remove the launch claims before admission. If admission redirects or
       // fails, the student must relaunch from the LMS.
       ltiClaim.remove();
 
-      const decision = await selectEnrollmentAdmissionDecision(
-        {
-          courseInstanceId,
-          lti13Identity: { lti13CourseInstanceId, sub },
-          userId,
+      const decision = await selectEnrollmentAdmissionDecision({
+        courseInstanceId,
+        source: {
+          type: 'invitation',
+          matchedBy: 'lti13',
+          lti13CourseInstanceId,
+          sub,
         },
-        source,
-      );
+        userId,
+      });
       if (decision.allowed && decision.invitationCandidate !== null) {
+        const invitationEnrollmentId = decision.invitationCandidate.enrollment.id;
         try {
           await admitUserFromLti13Launch({
             courseInstanceId,
-            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            expectedInvitationEnrollmentId: invitationEnrollmentId,
             ip: req.ip ?? null,
             isAdministrator: res.locals.is_administrator,
             lti13CourseInstanceId,
+            onPlanGrantsRequired: () => {
+              // Remember why this student was sent to the upgrade page. That
+              // page checks the invitation again, and enrollment still requires
+              // another launch from the LMS after payment.
+              setLti13CourseInstanceUpgradeAuthorization({
+                courseInstanceId,
+                enrollmentId: invitationEnrollmentId,
+                lti13CourseInstanceId,
+                now: res.locals.req_date,
+                session: req.session,
+                sub,
+                userId,
+              });
+            },
             reqDate: res.locals.req_date,
             sub,
             userId,
           });
         } catch (error) {
           if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
-          // The invitation may have changed after the read-only check. Continue
-          // to the course route, where entry is re-evaluated without LTI claims.
+          // The invitation changed after the first lookup. Continue to the
+          // course route, which will decide whether the student can enter
+          // without the LTI invitation.
         }
       }
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -11,13 +11,13 @@ import {
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
+import { admitUserFromLti13CourseInstanceRequest } from '../../../lib/enrollment/admission.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
-import { admitUserFromLti13CourseInstanceRequest } from '../../../models/course-instance-admission.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
-import { selectEnrollmentAdmissionDecision } from '../../../models/enrollment-identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../../models/enrollment-reconciliation.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -11,7 +11,7 @@ import {
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
-import { admitUserFromLti13CourseInstanceRequest } from '../../../lib/enrollment/admission.js';
+import { admitUserFromLti13Launch } from '../../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
@@ -172,7 +172,12 @@ router.get(
       const lti13CourseInstanceId = lti13_course_instance.id;
       const sub = ltiClaim.sub;
       const userId = res.locals.authn_user.id;
-      const source = { type: 'lti13' as const, lti13CourseInstanceId, sub };
+      const source = {
+        type: 'invitation' as const,
+        matchedBy: 'lti13' as const,
+        lti13CourseInstanceId,
+        sub,
+      };
 
       // Exact LTI authority is request-local. Consume the verified launch
       // before selection, checked admission, or any resulting redirect/error.
@@ -188,7 +193,7 @@ router.get(
       );
       if (decision.allowed && decision.invitationCandidate !== null) {
         try {
-          await admitUserFromLti13CourseInstanceRequest({
+          await admitUserFromLti13Launch({
             courseInstanceId,
             expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
             ip: req.ip ?? null,

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -134,7 +134,6 @@ router.get(
       throw new HttpStatusError(403, 'Access denied');
     }
     const courseName = prettyCourseName(ltiClaim);
-    const role_instructor = ltiClaim.isRoleInstructor();
 
     // Get lti13_course_instance info, if present
     const lti13_course_instance = await queryOptionalRow(
@@ -152,7 +151,7 @@ router.get(
 
       // Update lti13_course_instance on instructor login
       // helpful as LMS updates or we add features
-      if (role_instructor) {
+      if (ltiClaim.isRoleInstructor()) {
         await execute(sql.update_lti13_course_instance, {
           lti13_instance_id: req.params.lti13_instance_id,
           course_instance_id: lti13_course_instance.course_instance_id,
@@ -227,8 +226,21 @@ router.get(
     }
 
     // No course instance is linked to this LMS context.
-    // Students get a "come back later" message
-    if (!role_instructor) {
+    if (ltiClaim.isRoleInstructor()) {
+      // Instructors get a prompt for linking
+      res.send(
+        Lti13CourseNavigationInstructor({
+          resLocals: res.locals,
+          courseName,
+          courses: await selectCoursesWithEditAccess({
+            user_id: res.locals.authn_user.id,
+            is_administrator: res.locals.is_administrator,
+          }),
+          lti13_instance_id: req.params.lti13_instance_id,
+        }),
+      );
+    } else {
+      // Students get a "come back later" message
       res.send(
         Lti13CourseNavigationNotReady({
           resLocals: res.locals,
@@ -236,21 +248,7 @@ router.get(
           ltiRoles: ltiClaim.roles,
         }),
       );
-      return;
     }
-
-    // Instructors get a prompt for linking
-    res.send(
-      Lti13CourseNavigationInstructor({
-        resLocals: res.locals,
-        courseName,
-        courses: await selectCoursesWithEditAccess({
-          user_id: res.locals.authn_user.id,
-          is_administrator: res.locals.is_administrator,
-        }),
-        lti13_instance_id: req.params.lti13_instance_id,
-      }),
-    );
   }),
 );
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -126,6 +126,8 @@ router.get(
     }
 
     const ltiClaim = new Lti13Claim(req);
+    // LTI claims are stored in the browser session. Verify that this launch
+    // belongs to the LTI instance in the route before using them.
     if (
       req.session.authn_lti13_instance_id === undefined ||
       !idsEqual(req.session.authn_lti13_instance_id, req.params.lti13_instance_id)
@@ -165,8 +167,6 @@ router.get(
           resource_link_id: ltiClaim.resource_link_id,
         });
 
-        // TODO: Set course/instance staff permissions for LMS course staff here?
-
         ltiClaim.remove();
         res.redirect(`/pl/course_instance/${courseInstanceId}/instructor/`);
         return;
@@ -182,8 +182,8 @@ router.get(
         sub,
       };
 
-      // Exact LTI authority is request-local. Consume the verified launch
-      // before selection, checked admission, or any resulting redirect/error.
+      // Remove the launch claims before admission. If admission redirects or
+      // fails, the student must relaunch from the LMS.
       ltiClaim.remove();
 
       const decision = await selectEnrollmentAdmissionDecision(
@@ -208,6 +208,8 @@ router.get(
           });
         } catch (error) {
           if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          // The invitation may have changed after the read-only check. Continue
+          // to the course route, where entry is re-evaluated without LTI claims.
         }
       }
 
@@ -215,6 +217,7 @@ router.get(
       return;
     }
 
+    // No course instance is linked to this LMS context.
     // Students get a "come back later" message
     if (!role_instructor) {
       res.send(

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -12,7 +12,10 @@ import {
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
 import { admitUserFromLti13Launch } from '../../../lib/enrollment/admission.js';
-import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import {
+  type EnrollmentAdmissionSource,
+  selectEnrollmentAdmissionDecision,
+} from '../../../lib/enrollment/identity.js';
 import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
@@ -172,9 +175,9 @@ router.get(
       const lti13CourseInstanceId = lti13_course_instance.id;
       const sub = ltiClaim.sub;
       const userId = res.locals.authn_user.id;
-      const source = {
-        type: 'invitation' as const,
-        matchedBy: 'lti13' as const,
+      const source: EnrollmentAdmissionSource = {
+        type: 'invitation',
+        matchedBy: 'lti13',
         lti13CourseInstanceId,
         sub,
       };

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -196,9 +196,9 @@ router.get(
             isAdministrator: res.locals.is_administrator,
             lti13CourseInstanceId,
             onPlanGrantsRequired: () => {
-              // Remember why this student was sent to the upgrade page. That
-              // page checks the invitation again, and enrollment still requires
-              // another launch from the LMS after payment.
+              // Remember the invitation while the student completes the
+              // upgrade. The upgrade page checks it again before admitting the
+              // student.
               setLti13CourseInstanceUpgradeAuthorization({
                 courseInstanceId,
                 enrollmentId: invitationEnrollmentId,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -55,12 +55,7 @@ export function StudentCourseInstanceUpgrade({
         : html`
             ${PriceTable({ planNames: missingPlans, planPrices })}
 
-            <form
-              method="POST"
-              action="/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch
-                ? '?lti13_relaunch=1'
-                : ''}"
-            >
+            <form method="POST" action="/pl/course_instance/${courseInstance.id}/upgrade">
               <div class="form-check mb-3">
                 <input
                   type="checkbox"
@@ -77,6 +72,7 @@ export function StudentCourseInstanceUpgrade({
               </div>
 
               <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+              ${lti13Relaunch ? html`<input type="hidden" name="lti13_relaunch" value="1" />` : ''}
               ${missingPlans.map(
                 (plan) => html` <input type="hidden" name="unsafe_plan_names" value="${plan}" /> `,
               )}
@@ -139,7 +135,7 @@ export function CourseInstanceStudentUpdateSuccess({
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;
 }) {
-  if (lti13Relaunch) {
+  if (paid && lti13Relaunch) {
     return Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals });
   }
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -18,10 +18,9 @@ export function StudentCourseInstanceUpgrade({
   course: Course;
   courseInstance: CourseInstance;
   /**
-   * Whether this request is following the LTI-specific upgrade flow. When
-   * true, the query hint is preserved through payment and the student is
-   * directed back to the LMS for a fresh launch instead of continuing into the
-   * course.
+   * Whether the student reached this page from an LTI launch that matched a
+   * pending invitation. If so, send them back to their LMS after payment
+   * instead of directly into the course.
    */
   lti13Relaunch: boolean;
   missingPlans: PlanName[];

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -17,6 +17,12 @@ export function StudentCourseInstanceUpgrade({
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  /**
+   * Whether this request is following the LTI-specific upgrade flow. When
+   * true, the query hint is preserved through payment and the student is
+   * directed back to the LMS for a fresh launch instead of continuing into the
+   * course.
+   */
   lti13Relaunch: boolean;
   missingPlans: PlanName[];
   /**
@@ -125,6 +131,10 @@ export function CourseInstanceStudentUpdateSuccess({
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  /**
+   * Whether the completed upgrade should direct the student back to the LMS
+   * for a fresh LTI launch instead of continuing into the course.
+   */
   lti13Relaunch: boolean;
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -10,7 +10,7 @@ import { formatStripePrice } from '../../lib/billing/stripe.shared.js';
 export function StudentCourseInstanceUpgrade({
   course,
   courseInstance,
-  lti13Relaunch,
+  lti13AdmissionPending,
   missingPlans,
   planPrices,
   resLocals,
@@ -18,11 +18,11 @@ export function StudentCourseInstanceUpgrade({
   course: Course;
   courseInstance: CourseInstance;
   /**
-   * Whether the student reached this page from an LTI launch that matched a
-   * pending invitation. If so, send them back to their LMS after payment
-   * instead of directly into the course.
+   * Whether this upgrade started with an LTI invitation that is still pending.
+   * The hidden field lets the server look up the saved invitation again after
+   * the form submission and Stripe checkout.
    */
-  lti13Relaunch: boolean;
+  lti13AdmissionPending: boolean;
   missingPlans: PlanName[];
   /**
    * `null` here will indicate that we aren't configured with Stripe credentials
@@ -71,7 +71,9 @@ export function StudentCourseInstanceUpgrade({
               </div>
 
               <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              ${lti13Relaunch ? html`<input type="hidden" name="lti13_relaunch" value="1" />` : ''}
+              ${lti13AdmissionPending
+                ? html`<input type="hidden" name="lti13_relaunch" value="1" />`
+                : ''}
               ${missingPlans.map(
                 (plan) => html` <input type="hidden" name="unsafe_plan_names" value="${plan}" /> `,
               )}
@@ -120,21 +122,21 @@ export function Lti13CourseInstanceRelaunch({
 export function CourseInstanceStudentUpdateSuccess({
   course,
   courseInstance,
-  lti13Relaunch,
+  requireLti13Relaunch,
   paid,
   resLocals,
 }: {
   course: Course;
   courseInstance: CourseInstance;
   /**
-   * Whether the completed upgrade should direct the student back to the LMS
-   * for a fresh LTI launch instead of continuing into the course.
+   * Whether the saved LTI invitation could not be used after payment and the
+   * student must launch the course from the LMS again.
    */
-  lti13Relaunch: boolean;
+  requireLti13Relaunch: boolean;
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;
 }) {
-  if (paid && lti13Relaunch) {
+  if (paid && requireLti13Relaunch) {
     return Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals });
   }
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -10,12 +10,14 @@ import { formatStripePrice } from '../../lib/billing/stripe.shared.js';
 export function StudentCourseInstanceUpgrade({
   course,
   courseInstance,
+  lti13Relaunch,
   missingPlans,
   planPrices,
   resLocals,
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  lti13Relaunch: boolean;
   missingPlans: PlanName[];
   /**
    * `null` here will indicate that we aren't configured with Stripe credentials
@@ -47,7 +49,12 @@ export function StudentCourseInstanceUpgrade({
         : html`
             ${PriceTable({ planNames: missingPlans, planPrices })}
 
-            <form method="POST">
+            <form
+              method="POST"
+              action="/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch
+                ? '?lti13_relaunch=1'
+                : ''}"
+            >
               <div class="form-check mb-3">
                 <input
                   type="checkbox"
@@ -83,17 +90,49 @@ export function StudentCourseInstanceUpgrade({
   });
 }
 
+export function Lti13CourseInstanceRelaunch({
+  course,
+  courseInstance,
+  resLocals,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  resLocals: ResLocalsForPage<'course-instance'>;
+}) {
+  return PageLayout({
+    resLocals,
+    pageTitle: 'Return to your LMS',
+    navContext: {
+      type: 'student',
+      page: 'upgrade',
+    },
+    content: html`
+      <h1>Return to your LMS</h1>
+      <p>
+        ${course.short_name}: ${courseInstance.long_name} is ready. Return to your LMS and relaunch
+        this course to finish enrollment.
+      </p>
+    `,
+  });
+}
+
 export function CourseInstanceStudentUpdateSuccess({
   course,
   courseInstance,
+  lti13Relaunch,
   paid,
   resLocals,
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  lti13Relaunch: boolean;
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;
 }) {
+  if (lti13Relaunch) {
+    return Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals });
+  }
+
   return PageLayout({
     resLocals,
     pageTitle: 'Upgrade successful',

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -9,9 +9,9 @@ import {
   type AuthUser,
   getConfiguredUser,
   getOrCreateUser,
+  updateCourseInstanceSettings,
   withUser,
 } from '../../../tests/utils/auth.js';
-import { createEnrollment } from '../../../tests/utils/enrollment-identity.js';
 import {
   reconcilePlanGrantsForCourseInstance,
   reconcilePlanGrantsForCourseInstanceUser,
@@ -77,22 +77,18 @@ describe('studentCourseInstanceUpgrade', () => {
     });
   });
 
-  it('does not let an LTI relaunch hint bypass a blocked enrollment', async () => {
+  it('does not let an LTI relaunch hint bypass self-enrollment policy', async () => {
     await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
+    await updateCourseInstanceSettings('1', {
+      selfEnrollmentEnabled: false,
+      selfEnrollmentUseEnrollmentCode: false,
+      restrictToInstitution: false,
+    });
 
     await withUser(studentUser, async () => {
-      const user = await getConfiguredUser();
-      const courseInstance = await selectCourseInstanceById('1');
-      await createEnrollment({
-        courseInstance,
-        userId: user.id,
-        status: 'blocked',
-        firstJoinedAt: new Date('2024-01-01T00:00:00Z'),
-      });
-
       const res = await fetch(`${upgradeUrl}?lti13_relaunch=1`);
       assert.equal(res.status, 403);
-      assert.include(await res.text(), 'Enrollment blocked');
+      assert.include(await res.text(), 'Self-enrollment not available');
     });
   });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -17,6 +17,10 @@ import {
   reconcilePlanGrantsForCourseInstanceUser,
   updateRequiredPlansForCourseInstance,
 } from '../../lib/billing/plans.js';
+import {
+  insertStripeCheckoutSessionForUserInCourseInstance,
+  markStripeCheckoutSessionCompleted,
+} from '../../models/stripe-checkout-sessions.js';
 import { enableEnterpriseEdition } from '../../tests/ee-helpers.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
@@ -89,6 +93,37 @@ describe('studentCourseInstanceUpgrade', () => {
       const res = await fetch(`${upgradeUrl}?lti13_relaunch=1`);
       assert.equal(res.status, 403);
       assert.include(await res.text(), 'Self-enrollment not available');
+    });
+  });
+
+  it('does not ask a joined student to relaunch after a completed LTI upgrade', async () => {
+    await withUser(studentUser, async () => {
+      const user = await getConfiguredUser();
+      const courseInstance = await selectCourseInstanceById('1');
+      await ensureUncheckedEnrollment({
+        userId: user.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+        actionDetail: 'implicit_joined',
+      });
+
+      const stripeSessionId = 'completed-lti-upgrade';
+      await insertStripeCheckoutSessionForUserInCourseInstance({
+        agent_user_id: user.id,
+        stripe_object_id: stripeSessionId,
+        course_instance_id: courseInstance.id,
+        subject_user_id: user.id,
+        data: {},
+        plan_names: ['basic'],
+      });
+      await markStripeCheckoutSessionCompleted(stripeSessionId);
+
+      const res = await fetch(
+        `${upgradeUrl}/success?session_id=${stripeSessionId}&lti13_relaunch=1`,
+      );
+      assert.isOk(res.ok);
+      assert.include(await res.text(), 'You may now access the course.');
     });
   });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -11,6 +11,7 @@ import {
   getOrCreateUser,
   withUser,
 } from '../../../tests/utils/auth.js';
+import { createEnrollment } from '../../../tests/utils/enrollment-identity.js';
 import {
   reconcilePlanGrantsForCourseInstance,
   reconcilePlanGrantsForCourseInstanceUser,
@@ -73,6 +74,25 @@ describe('studentCourseInstanceUpgrade', () => {
       const res = await fetch(assessmentsUrl);
       assert.isOk(res.ok);
       assert.equal(res.url, upgradeUrl);
+    });
+  });
+
+  it('does not let an LTI relaunch hint bypass a blocked enrollment', async () => {
+    await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
+
+    await withUser(studentUser, async () => {
+      const user = await getConfiguredUser();
+      const courseInstance = await selectCourseInstanceById('1');
+      await createEnrollment({
+        courseInstance,
+        userId: user.id,
+        status: 'blocked',
+        firstJoinedAt: new Date('2024-01-01T00:00:00Z'),
+      });
+
+      const res = await fetch(`${upgradeUrl}?lti13_relaunch=1`);
+      assert.equal(res.status, 403);
+      assert.include(await res.text(), 'Enrollment blocked');
     });
   });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -17,7 +17,8 @@ import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment-eligibility.js';
-import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { idsEqual } from '../../../lib/id.js';
+import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import {
   type OrdinaryCourseInstanceAdmissionDecision,
@@ -45,6 +46,7 @@ import {
 
 import {
   CourseInstanceStudentUpdateSuccess,
+  Lti13CourseInstanceRelaunch,
   StudentCourseInstanceUpgrade,
 } from './studentCourseInstanceUpgrade.html.js';
 
@@ -52,12 +54,30 @@ const router = Router({ mergeParams: true });
 
 function getAdmissionIneligibilityReason(
   decision: OrdinaryCourseInstanceAdmissionDecision,
+  lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
   if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
     return null;
   }
+  if (lti13Relaunch && decision.reason !== 'blocked') return null;
   return decision.reason;
+}
+
+function canUseLti13RelaunchMarker(
+  marker: unknown,
+  resLocals: ResLocalsForPage<'course-instance'>,
+) {
+  // This marker only changes upgrade and payment routing. A fresh checked LTI
+  // admission is still required to enroll after the upgrade.
+  return (
+    marker === '1' &&
+    idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
+    resLocals.authz_data.authn_course_role === 'None' &&
+    resLocals.authz_data.authn_course_instance_role === 'None' &&
+    resLocals.authz_data.authn_has_student_access &&
+    !resLocals.is_administrator
+  );
 }
 
 router.get(
@@ -66,13 +86,14 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
+    const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
     const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
       course,
       courseInstance,
       user,
     });
-    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
       return;
@@ -83,7 +104,11 @@ router.get(
     // redirect them back to the assessments page.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
-      res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+      if (lti13Relaunch) {
+        res.send(Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals: res.locals }));
+      } else {
+        res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+      }
       return;
     }
 
@@ -104,6 +129,7 @@ router.get(
       StudentCourseInstanceUpgrade({
         course,
         courseInstance,
+        lti13Relaunch,
         missingPlans,
         planPrices,
         resLocals: res.locals,
@@ -130,13 +156,17 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
+      const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
       const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
         course,
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+      const ineligibilityReason = getAdmissionIneligibilityReason(
+        admissionDecision,
+        lti13Relaunch,
+      );
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
@@ -186,6 +216,7 @@ router.post(
 
       const host = getCanonicalHost(req);
       const urlBase = `${host}/pl/course_instance/${courseInstance.id}/upgrade`;
+      const lti13RelaunchQuery = lti13Relaunch ? '&lti13_relaunch=1' : '';
 
       const stripe = getStripeClient();
       const customerId = await getOrCreateStripeCustomerId(user.id, {
@@ -208,8 +239,8 @@ router.post(
         },
         line_items: lineItems,
         mode: 'payment',
-        success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: urlBase,
+        success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}${lti13RelaunchQuery}`,
+        cancel_url: `${urlBase}${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
         metadata,
         payment_intent_data: {
           metadata,
@@ -241,6 +272,7 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const authn_user = UserSchema.parse(res.locals.authn_user);
+    const lti13Relaunch = req.query.lti13_relaunch === '1';
 
     if (!req.query.session_id) throw new error.HttpStatusError(400, 'Missing session_id');
 
@@ -256,6 +288,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch,
           paid: true,
           resLocals: res.locals,
         }),
@@ -310,6 +343,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch,
           paid: true,
           resLocals: res.locals,
         }),
@@ -327,6 +361,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch: false,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -15,16 +15,16 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
+  type OrdinaryCourseInstanceAdmissionDecision,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../../lib/enrollment/admission.js';
+import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
-} from '../../../lib/enrollment-eligibility.js';
+} from '../../../lib/enrollment/eligibility.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import {
-  type OrdinaryCourseInstanceAdmissionDecision,
-  selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -4,10 +4,8 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
-import { run } from '@prairielearn/run';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
-import { hasRole } from '../../../lib/authz-data-lib.js';
 import { config } from '../../../lib/config.js';
 import {
   CourseInstanceSchema,
@@ -16,12 +14,15 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
-  checkEnrollmentEligibility,
+  type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment-eligibility.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import { selectOptionalEnrollmentByUid } from '../../../models/enrollment.js';
+import {
+  type OrdinaryCourseInstanceAdmissionDecision,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,
@@ -49,6 +50,16 @@ import {
 
 const router = Router({ mergeParams: true });
 
+function getAdmissionIneligibilityReason(
+  decision: OrdinaryCourseInstanceAdmissionDecision,
+): EnrollmentIneligibilityReason | null {
+  if (decision.allowed) return null;
+  if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
+    return null;
+  }
+  return decision.reason;
+}
+
 router.get(
   '/',
   typedAsyncHandler<'course-instance'>(async (req, res) => {
@@ -56,30 +67,14 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
 
-    // Check enrollment eligibility before showing the upgrade page.
-    // This prevents students from paying when they wouldn't be able to enroll
-    // (e.g., due to institution restrictions).
-    const existingEnrollment = await run(async () => {
-      if (!hasRole(res.locals.authz_data, ['Student'])) {
-        return null;
-      }
-      return await selectOptionalEnrollmentByUid({
-        uid: user.uid,
-        courseInstance,
-        requiredRole: ['Student'],
-        authzData: res.locals.authz_data,
-      });
-    });
-
-    const enrollmentInfo = checkEnrollmentEligibility({
-      user,
+    const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
       course,
       courseInstance,
-      existingEnrollment,
+      user,
     });
-
-    if (!enrollmentInfo.eligible) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: enrollmentInfo.reason }));
+    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+    if (ineligibilityReason !== null) {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
       return;
     }
 
@@ -136,28 +131,14 @@ router.post(
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
 
-      // Check enrollment eligibility before processing payment.
-      const existingEnrollment = await run(async () => {
-        if (!hasRole(res.locals.authz_data, ['Student'])) {
-          return null;
-        }
-        return await selectOptionalEnrollmentByUid({
-          uid: user.uid,
-          courseInstance,
-          requiredRole: ['Student'],
-          authzData: res.locals.authz_data,
-        });
-      });
-
-      const enrollmentInfo = checkEnrollmentEligibility({
-        user,
+      const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
         course,
         courseInstance,
-        existingEnrollment,
+        user,
       });
-
-      if (!enrollmentInfo.eligible) {
-        throw new error.HttpStatusError(403, getEligibilityErrorMessage(enrollmentInfo.reason));
+      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+      if (ineligibilityReason !== null) {
+        throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
 
       const body = UpgradeBodySchema.parse(req.body);

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -432,6 +432,22 @@ router.get(
       });
     };
 
+    const shouldRequireLti13Relaunch = async () => {
+      if (!lti13UpgradeRequested) return false;
+
+      // The Stripe success URL can be revisited after admission consumes the
+      // saved LTI authorization. Check the enrollment before asking the
+      // student to return to the LMS.
+      const decision = await selectEnrollmentAccessDecision({
+        course,
+        courseInstance,
+        user: authn_user,
+      });
+      if (!decision.allowed && decision.reason === 'already_joined') return false;
+
+      return true;
+    };
+
     if (localSession.completed_at) {
       if (await finishLti13Admission()) {
         res.redirect(`/pl/course_instance/${courseInstance.id}/`);
@@ -443,7 +459,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          requireLti13Relaunch: lti13UpgradeRequested,
+          requireLti13Relaunch: await shouldRequireLti13Relaunch(),
           paid: true,
           resLocals: res.locals,
         }),
@@ -493,7 +509,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          requireLti13Relaunch: lti13UpgradeRequested,
+          requireLti13Relaunch: await shouldRequireLti13Relaunch(),
           paid: true,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -53,6 +53,18 @@ import {
 
 const router = Router({ mergeParams: true });
 
+/**
+ * Returns the admission failure, if any, that should prevent a user from
+ * obtaining a required plan on this page. This is deliberately less strict
+ * than admission itself: joined users may need another plan, and an enrollment
+ * code is enforced when admission resumes rather than before the upgrade.
+ *
+ * The LTI relaunch flow also ignores ordinary self-enrollment restrictions.
+ * The query parameter that selects that flow is not enrollment authority, so
+ * this page only handles the upgrade and then sends the user back to the LMS.
+ * A fresh LTI launch must revalidate the exact invitation before admitting the
+ * user. A blocked enrollment is never allowed to proceed through this flow.
+ */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
   lti13Relaunch: boolean,
@@ -65,14 +77,21 @@ function getAdmissionIneligibilityReason(
   return decision.reason;
 }
 
-function canUseLti13RelaunchMarker(
-  marker: unknown,
+/**
+ * Returns whether this request should use the LTI-specific upgrade flow.
+ * `lti13_relaunch=1` is a routing hint appended when an exact LTI invitation is
+ * interrupted by a required plan upgrade. It carries no LTI claims and grants
+ * no enrollment authority; those claims were consumed before the redirect.
+ * We honor the hint only for a directly authenticated student, then require the
+ * student to relaunch from the LMS so admission can validate a fresh link and
+ * subject after the upgrade.
+ */
+function shouldUseLti13RelaunchFlow(
+  queryValue: unknown,
   resLocals: ResLocalsForPage<'course-instance'>,
 ) {
-  // This marker only changes upgrade and payment routing. A fresh checked LTI
-  // admission is still required to enroll after the upgrade.
   return (
-    marker === '1' &&
+    queryValue === '1' &&
     idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
     resLocals.authz_data.authn_course_role === 'None' &&
     resLocals.authz_data.authn_course_instance_role === 'None' &&
@@ -87,7 +106,7 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
+    const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
 
     const admissionDecision = await selectEnrollmentAccessDecision({
       course,
@@ -157,7 +176,7 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
+      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
 
       const admissionDecision = await selectEnrollmentAccessDecision({
         course,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../lib/db-types.js';
 import {
   type EnrollmentAccessDecision,
+  admitUserFromLti13Launch,
   selectEnrollmentAccessDecision,
 } from '../../../lib/enrollment/admission.js';
 import {
@@ -23,6 +24,7 @@ import {
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment/eligibility.js';
 import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
@@ -39,6 +41,7 @@ import {
   getStripeClient,
 } from '../../lib/billing/stripe.js';
 import {
+  type Lti13CourseInstanceUpgradeAuthorization,
   clearLti13CourseInstanceUpgradeAuthorization,
   getLti13CourseInstanceUpgradeAuthorization,
 } from '../../lib/lti13-course-instance-upgrade.js';
@@ -69,7 +72,7 @@ const router = Router({ mergeParams: true });
  */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
-  lti13Relaunch: boolean,
+  hasLti13Invitation: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
   switch (decision.reason) {
@@ -81,23 +84,22 @@ function getAdmissionIneligibilityReason(
     case 'institution-restriction':
     case 'self-enrollment-disabled':
     case 'self-enrollment-expired':
-      return lti13Relaunch ? null : decision.reason;
+      return hasLti13Invitation ? null : decision.reason;
     default:
       return assertNever(decision.reason);
   }
 }
 
 /**
- * `lti13_relaunch=1` only says which flow the browser is trying to continue.
- * The session must show that an LTI launch for this user and course was sent to
- * the upgrade page, and that invitation must still be pending for the same LTI
- * link and `sub`.
+ * `lti13_relaunch=1` tells us to look for an LTI invitation saved before the
+ * upgrade redirect. The session must contain an invitation for this user and
+ * course, and it must still be pending for the same LTI link and `sub`.
  */
-async function shouldUseLti13RelaunchFlow(
+async function selectLti13UpgradeAuthorization(
   queryValue: unknown,
   session: Record<string, unknown>,
   resLocals: ResLocalsForPage<'course-instance'>,
-) {
+): Promise<Lti13CourseInstanceUpgradeAuthorization | null> {
   if (
     queryValue !== '1' ||
     !idsEqual(resLocals.user.id, resLocals.authn_user.id) ||
@@ -106,7 +108,7 @@ async function shouldUseLti13RelaunchFlow(
     !resLocals.authz_data.authn_has_student_access ||
     resLocals.is_administrator
   ) {
-    return false;
+    return null;
   }
 
   const authorization = getLti13CourseInstanceUpgradeAuthorization({
@@ -115,7 +117,7 @@ async function shouldUseLti13RelaunchFlow(
     session,
     userId: resLocals.authn_user.id,
   });
-  if (authorization === null) return false;
+  if (authorization === null) return null;
 
   const decision = await selectEnrollmentAdmissionDecision({
     courseInstanceId: resLocals.course_instance.id,
@@ -133,8 +135,46 @@ async function shouldUseLti13RelaunchFlow(
     !idsEqual(decision.invitationCandidate.enrollment.id, authorization.enrollment_id)
   ) {
     clearLti13CourseInstanceUpgradeAuthorization(session);
+    return null;
+  }
+  return authorization;
+}
+
+async function finishLti13UpgradeAdmission({
+  authorization,
+  ip,
+  isAdministrator,
+  reqDate,
+  session,
+}: {
+  authorization: Lti13CourseInstanceUpgradeAuthorization;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  session: Record<string, unknown>;
+}): Promise<boolean> {
+  try {
+    await admitUserFromLti13Launch({
+      courseInstanceId: authorization.course_instance_id,
+      expectedInvitationEnrollmentId: authorization.enrollment_id,
+      ip,
+      isAdministrator,
+      lti13CourseInstanceId: authorization.lti13_course_instance_id,
+      reqDate,
+      sub: authorization.sub,
+      userId: authorization.user_id,
+    });
+  } catch (error) {
+    if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+
+    // The invitation can change while the student is at Stripe. A new LMS
+    // launch supplies current LTI data and either admits the student or shows
+    // the appropriate course access error.
+    clearLti13CourseInstanceUpgradeAuthorization(session);
     return false;
   }
+
+  clearLti13CourseInstanceUpgradeAuthorization(session);
   return true;
 }
 
@@ -144,7 +184,7 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+    const lti13UpgradeAuthorization = await selectLti13UpgradeAuthorization(
       req.query.lti13_relaunch,
       req.session,
       res.locals,
@@ -155,21 +195,37 @@ router.get(
       courseInstance,
       user,
     });
-    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
+    const ineligibilityReason = getAdmissionIneligibilityReason(
+      admissionDecision,
+      lti13UpgradeAuthorization !== null,
+    );
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ reason: ineligibilityReason, resLocals: res.locals }));
       return;
     }
 
-    // If no upgrade is needed, return normal requests to the assessments page.
-    // An interrupted LTI admission instead requires a fresh launch from the LMS.
+    // If the required plan was granted while this page was open, finish the
+    // admission without sending the student through the LMS again.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
-      if (lti13Relaunch) {
+      if (lti13UpgradeAuthorization !== null) {
+        const admitted = await finishLti13UpgradeAdmission({
+          authorization: lti13UpgradeAuthorization,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          session: req.session,
+        });
+        if (admitted) {
+          res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+          return;
+        }
+
         res.send(Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals: res.locals }));
-      } else {
-        res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+        return;
       }
+
+      res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
       return;
     }
 
@@ -190,7 +246,7 @@ router.get(
       StudentCourseInstanceUpgrade({
         course,
         courseInstance,
-        lti13Relaunch,
+        lti13AdmissionPending: lti13UpgradeAuthorization !== null,
         missingPlans,
         planPrices,
         resLocals: res.locals,
@@ -217,7 +273,7 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+      const lti13UpgradeAuthorization = await selectLti13UpgradeAuthorization(
         req.body.lti13_relaunch,
         req.session,
         res.locals,
@@ -229,7 +285,10 @@ router.post(
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
+      const ineligibilityReason = getAdmissionIneligibilityReason(
+        admissionDecision,
+        lti13UpgradeAuthorization !== null,
+      );
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
@@ -279,7 +338,7 @@ router.post(
 
       const host = getCanonicalHost(req);
       const urlBase = `${host}/pl/course_instance/${courseInstance.id}/upgrade`;
-      const lti13RelaunchQuery = lti13Relaunch ? '&lti13_relaunch=1' : '';
+      const lti13RelaunchQuery = lti13UpgradeAuthorization !== null ? '&lti13_relaunch=1' : '';
 
       const stripe = getStripeClient();
       const customerId = await getOrCreateStripeCustomerId(user.id, {
@@ -303,7 +362,7 @@ router.post(
         line_items: lineItems,
         mode: 'payment',
         success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}${lti13RelaunchQuery}`,
-        cancel_url: `${urlBase}${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
+        cancel_url: `${urlBase}${lti13UpgradeAuthorization !== null ? '?lti13_relaunch=1' : ''}`,
         metadata,
         payment_intent_data: {
           metadata,
@@ -335,7 +394,7 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const authn_user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = req.query.lti13_relaunch === '1';
+    const lti13UpgradeRequested = req.query.lti13_relaunch === '1';
 
     if (!req.query.session_id) throw new error.HttpStatusError(400, 'Missing session_id');
 
@@ -345,23 +404,6 @@ router.get(
     if (!localSession) {
       throw new Error(`Unknown Stripe session: ${stripeSessionId}`);
     }
-    if (localSession.completed_at) {
-      // We already processed this session; just show them the success page.
-      res.send(
-        CourseInstanceStudentUpdateSuccess({
-          course,
-          courseInstance,
-          lti13Relaunch,
-          paid: true,
-          resLocals: res.locals,
-        }),
-      );
-      return;
-    }
-
-    const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
-
     // Verify that the session is associated with the current course instance
     // and user. We shouldn't hit this during normal operations, but an attacker
     // could try to replay a session ID from a different course instance or user.
@@ -371,6 +413,45 @@ router.get(
     ) {
       throw new error.HttpStatusError(400, 'Invalid session');
     }
+
+    const finishLti13Admission = async () => {
+      const authorization = await selectLti13UpgradeAuthorization(
+        req.query.lti13_relaunch,
+        req.session,
+        res.locals,
+      );
+      if (authorization === null) return false;
+
+      return await finishLti13UpgradeAdmission({
+        authorization,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        session: req.session,
+      });
+    };
+
+    if (localSession.completed_at) {
+      if (await finishLti13Admission()) {
+        res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+        return;
+      }
+
+      // We already processed this session; just show them the success page.
+      res.send(
+        CourseInstanceStudentUpdateSuccess({
+          course,
+          courseInstance,
+          requireLti13Relaunch: lti13UpgradeRequested,
+          paid: true,
+          resLocals: res.locals,
+        }),
+      );
+      return;
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
 
     if (session.payment_status === 'paid') {
       if (!localSession.plan_grants_created) {
@@ -402,11 +483,16 @@ router.get(
         });
       }
 
+      if (await finishLti13Admission()) {
+        res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+        return;
+      }
+
       res.send(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch,
+          requireLti13Relaunch: lti13UpgradeRequested,
           paid: true,
           resLocals: res.locals,
         }),
@@ -424,7 +510,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch,
+          requireLti13Relaunch: false,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -15,8 +15,8 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
-  type OrdinaryCourseInstanceAdmissionDecision,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  type EnrollmentAccessDecision,
+  selectEnrollmentAccessDecision,
 } from '../../../lib/enrollment/admission.js';
 import {
   type EnrollmentIneligibilityReason,
@@ -54,7 +54,7 @@ import {
 const router = Router({ mergeParams: true });
 
 function getAdmissionIneligibilityReason(
-  decision: OrdinaryCourseInstanceAdmissionDecision,
+  decision: EnrollmentAccessDecision,
   lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
@@ -89,7 +89,7 @@ router.get(
     const user = UserSchema.parse(res.locals.authn_user);
     const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
-    const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const admissionDecision = await selectEnrollmentAccessDecision({
       course,
       courseInstance,
       user,
@@ -159,7 +159,7 @@ router.post(
       const user = UserSchema.parse(res.locals.authn_user);
       const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
-      const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      const admissionDecision = await selectEnrollmentAccessDecision({
         course,
         courseInstance,
         user,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -14,8 +14,8 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
-  type OrdinaryCourseInstanceAdmissionDecision,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  type EnrollmentAccessDecision,
+  selectEnrollmentAccessDecision,
 } from '../../../lib/enrollment/admission.js';
 import {
   type EnrollmentIneligibilityReason,
@@ -53,7 +53,7 @@ import {
 const router = Router({ mergeParams: true });
 
 function getAdmissionIneligibilityReason(
-  decision: OrdinaryCourseInstanceAdmissionDecision,
+  decision: EnrollmentAccessDecision,
   lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
@@ -88,7 +88,7 @@ router.get(
     const user = UserSchema.parse(res.locals.authn_user);
     const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
-    const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const admissionDecision = await selectEnrollmentAccessDecision({
       course,
       courseInstance,
       user,
@@ -158,7 +158,7 @@ router.post(
       const user = UserSchema.parse(res.locals.authn_user);
       const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
-      const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      const admissionDecision = await selectEnrollmentAccessDecision({
         course,
         courseInstance,
         user,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -14,16 +14,16 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
+  type OrdinaryCourseInstanceAdmissionDecision,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../../lib/enrollment/admission.js';
+import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
-} from '../../../lib/enrollment-eligibility.js';
+} from '../../../lib/enrollment/eligibility.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import {
-  type OrdinaryCourseInstanceAdmissionDecision,
-  selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -23,6 +23,7 @@ import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment/eligibility.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
@@ -38,6 +39,10 @@ import {
   getPricesForPlans,
   getStripeClient,
 } from '../../lib/billing/stripe.js';
+import {
+  clearLti13CourseInstanceUpgradeAuthorization,
+  getLti13CourseInstanceUpgradeAuthorization,
+} from '../../lib/lti13-course-instance-upgrade.js';
 import { ensurePlanGrant } from '../../models/plan-grants.js';
 import {
   getStripeCheckoutSessionByStripeObjectId,
@@ -55,16 +60,13 @@ import {
 const router = Router({ mergeParams: true });
 
 /**
- * Returns the admission failure, if any, that should prevent a user from
- * obtaining a required plan on this page. This is deliberately less strict
- * than admission itself: joined users may need another plan, and an enrollment
- * code is enforced when admission resumes rather than before the upgrade.
+ * Determines whether the student may buy a plan required by this course.
+ * Joined students may need another plan, and an enrollment code is checked
+ * when enrollment resumes rather than before payment.
  *
- * The LTI relaunch flow also ignores self-enrollment restrictions.
- * The query parameter that selects that flow is not enrollment authority, so
- * this page only handles the upgrade and then sends the user back to the LMS.
- * A fresh LTI launch must revalidate the exact invitation before admitting the
- * user. A blocked enrollment is never allowed to proceed through this flow.
+ * A student sent here from an LTI launch may also bypass self-enrollment
+ * restrictions. The session and pending invitation are checked before this
+ * function is called, and a blocked enrollment still takes precedence.
  */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
@@ -87,26 +89,54 @@ function getAdmissionIneligibilityReason(
 }
 
 /**
- * Returns whether this request should use the LTI-specific upgrade flow.
- * `lti13_relaunch=1` is a routing hint appended when an exact LTI invitation is
- * interrupted by a required plan upgrade. It carries no LTI claims and grants
- * no enrollment authority; those claims were consumed before the redirect.
- * We honor the hint only for a directly authenticated student, then require the
- * student to relaunch from the LMS so admission can validate a fresh link and
- * subject after the upgrade.
+ * `lti13_relaunch=1` only says which flow the browser is trying to continue.
+ * The session must show that an LTI launch for this user and course was sent to
+ * the upgrade page, and that invitation must still be pending for the same LTI
+ * link and `sub`.
  */
-function shouldUseLti13RelaunchFlow(
+async function shouldUseLti13RelaunchFlow(
   queryValue: unknown,
+  session: Record<string, unknown>,
   resLocals: ResLocalsForPage<'course-instance'>,
 ) {
-  return (
-    queryValue === '1' &&
-    idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
-    resLocals.authz_data.authn_course_role === 'None' &&
-    resLocals.authz_data.authn_course_instance_role === 'None' &&
-    resLocals.authz_data.authn_has_student_access &&
-    !resLocals.is_administrator
-  );
+  if (
+    queryValue !== '1' ||
+    !idsEqual(resLocals.user.id, resLocals.authn_user.id) ||
+    resLocals.authz_data.authn_course_role !== 'None' ||
+    resLocals.authz_data.authn_course_instance_role !== 'None' ||
+    !resLocals.authz_data.authn_has_student_access ||
+    resLocals.is_administrator
+  ) {
+    return false;
+  }
+
+  const authorization = getLti13CourseInstanceUpgradeAuthorization({
+    courseInstanceId: resLocals.course_instance.id,
+    now: resLocals.req_date,
+    session,
+    userId: resLocals.authn_user.id,
+  });
+  if (authorization === null) return false;
+
+  const decision = await selectEnrollmentAdmissionDecision({
+    courseInstanceId: resLocals.course_instance.id,
+    source: {
+      type: 'invitation',
+      matchedBy: 'lti13',
+      lti13CourseInstanceId: authorization.lti13_course_instance_id,
+      sub: authorization.sub,
+    },
+    userId: resLocals.authn_user.id,
+  });
+  if (
+    !decision.allowed ||
+    decision.invitationCandidate === null ||
+    !idsEqual(decision.invitationCandidate.enrollment.id, authorization.enrollment_id)
+  ) {
+    clearLti13CourseInstanceUpgradeAuthorization(session);
+    return false;
+  }
+  return true;
 }
 
 router.get(
@@ -115,7 +145,11 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
+    const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+      req.query.lti13_relaunch,
+      req.session,
+      res.locals,
+    );
 
     const admissionDecision = await selectEnrollmentAccessDecision({
       course,
@@ -184,7 +218,11 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.body.lti13_relaunch, res.locals);
+      const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+        req.body.lti13_relaunch,
+        req.session,
+        res.locals,
+      );
 
       // Recheck admission eligibility before creating the Stripe checkout session.
       const admissionDecision = await selectEnrollmentAccessDecision({

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
+import { assertNever } from '@prairielearn/utils';
 import { parseRequestBody } from '@prairielearn/zod';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
@@ -59,7 +60,7 @@ const router = Router({ mergeParams: true });
  * than admission itself: joined users may need another plan, and an enrollment
  * code is enforced when admission resumes rather than before the upgrade.
  *
- * The LTI relaunch flow also ignores ordinary self-enrollment restrictions.
+ * The LTI relaunch flow also ignores self-enrollment restrictions.
  * The query parameter that selects that flow is not enrollment authority, so
  * this page only handles the upgrade and then sends the user back to the LMS.
  * A fresh LTI launch must revalidate the exact invitation before admitting the
@@ -70,11 +71,19 @@ function getAdmissionIneligibilityReason(
   lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
-  if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
-    return null;
+  switch (decision.reason) {
+    case 'already_joined':
+    case 'enrollment_code_required':
+      return null;
+    case 'blocked':
+      return decision.reason;
+    case 'institution-restriction':
+    case 'self-enrollment-disabled':
+    case 'self-enrollment-expired':
+      return lti13Relaunch ? null : decision.reason;
+    default:
+      return assertNever(decision.reason);
   }
-  if (lti13Relaunch && decision.reason !== 'blocked') return null;
-  return decision.reason;
 }
 
 /**
@@ -115,13 +124,12 @@ router.get(
     });
     const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
     if (ineligibilityReason !== null) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
+      res.status(403).send(EnrollmentPage({ reason: ineligibilityReason, resLocals: res.locals }));
       return;
     }
 
-    // Check if the student is *actually* missing plan grants, or if they just
-    // came across this URL on accident. If they have all the necessary plan grants,
-    // redirect them back to the assessments page.
+    // If no upgrade is needed, return normal requests to the assessments page.
+    // An interrupted LTI admission instead requires a fresh launch from the LMS.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
       if (lti13Relaunch) {
@@ -176,8 +184,9 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
+      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.body.lti13_relaunch, res.locals);
 
+      // Recheck admission eligibility before creating the Stripe checkout session.
       const admissionDecision = await selectEnrollmentAccessDecision({
         course,
         courseInstance,
@@ -378,7 +387,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch: false,
+          lti13Relaunch,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -163,10 +163,7 @@ router.post(
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(
-        admissionDecision,
-        lti13Relaunch,
-      );
+      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -52,6 +52,18 @@ import {
 
 const router = Router({ mergeParams: true });
 
+/**
+ * Returns the admission failure, if any, that should prevent a user from
+ * obtaining a required plan on this page. This is deliberately less strict
+ * than admission itself: joined users may need another plan, and an enrollment
+ * code is enforced when admission resumes rather than before the upgrade.
+ *
+ * The LTI relaunch flow also ignores ordinary self-enrollment restrictions.
+ * The query parameter that selects that flow is not enrollment authority, so
+ * this page only handles the upgrade and then sends the user back to the LMS.
+ * A fresh LTI launch must revalidate the exact invitation before admitting the
+ * user. A blocked enrollment is never allowed to proceed through this flow.
+ */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
   lti13Relaunch: boolean,
@@ -64,14 +76,21 @@ function getAdmissionIneligibilityReason(
   return decision.reason;
 }
 
-function canUseLti13RelaunchMarker(
-  marker: unknown,
+/**
+ * Returns whether this request should use the LTI-specific upgrade flow.
+ * `lti13_relaunch=1` is a routing hint appended when an exact LTI invitation is
+ * interrupted by a required plan upgrade. It carries no LTI claims and grants
+ * no enrollment authority; those claims were consumed before the redirect.
+ * We honor the hint only for a directly authenticated student, then require the
+ * student to relaunch from the LMS so admission can validate a fresh link and
+ * subject after the upgrade.
+ */
+function shouldUseLti13RelaunchFlow(
+  queryValue: unknown,
   resLocals: ResLocalsForPage<'course-instance'>,
 ) {
-  // This marker only changes upgrade and payment routing. A fresh checked LTI
-  // admission is still required to enroll after the upgrade.
   return (
-    marker === '1' &&
+    queryValue === '1' &&
     idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
     resLocals.authz_data.authn_course_role === 'None' &&
     resLocals.authz_data.authn_course_instance_role === 'None' &&
@@ -86,7 +105,7 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
+    const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
 
     const admissionDecision = await selectEnrollmentAccessDecision({
       course,
@@ -156,7 +175,7 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
+      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
 
       const admissionDecision = await selectEnrollmentAccessDecision({
         course,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../lib/db-types.js';
 import {
   type EnrollmentAccessDecision,
+  admitUserFromLti13Launch,
   selectEnrollmentAccessDecision,
 } from '../../../lib/enrollment/admission.js';
 import {
@@ -24,6 +25,7 @@ import {
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment/eligibility.js';
 import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
@@ -40,6 +42,7 @@ import {
   getStripeClient,
 } from '../../lib/billing/stripe.js';
 import {
+  type Lti13CourseInstanceUpgradeAuthorization,
   clearLti13CourseInstanceUpgradeAuthorization,
   getLti13CourseInstanceUpgradeAuthorization,
 } from '../../lib/lti13-course-instance-upgrade.js';
@@ -70,7 +73,7 @@ const router = Router({ mergeParams: true });
  */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
-  lti13Relaunch: boolean,
+  hasLti13Invitation: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
   switch (decision.reason) {
@@ -82,23 +85,22 @@ function getAdmissionIneligibilityReason(
     case 'institution-restriction':
     case 'self-enrollment-disabled':
     case 'self-enrollment-expired':
-      return lti13Relaunch ? null : decision.reason;
+      return hasLti13Invitation ? null : decision.reason;
     default:
       return assertNever(decision.reason);
   }
 }
 
 /**
- * `lti13_relaunch=1` only says which flow the browser is trying to continue.
- * The session must show that an LTI launch for this user and course was sent to
- * the upgrade page, and that invitation must still be pending for the same LTI
- * link and `sub`.
+ * `lti13_relaunch=1` tells us to look for an LTI invitation saved before the
+ * upgrade redirect. The session must contain an invitation for this user and
+ * course, and it must still be pending for the same LTI link and `sub`.
  */
-async function shouldUseLti13RelaunchFlow(
+async function selectLti13UpgradeAuthorization(
   queryValue: unknown,
   session: Record<string, unknown>,
   resLocals: ResLocalsForPage<'course-instance'>,
-) {
+): Promise<Lti13CourseInstanceUpgradeAuthorization | null> {
   if (
     queryValue !== '1' ||
     !idsEqual(resLocals.user.id, resLocals.authn_user.id) ||
@@ -107,7 +109,7 @@ async function shouldUseLti13RelaunchFlow(
     !resLocals.authz_data.authn_has_student_access ||
     resLocals.is_administrator
   ) {
-    return false;
+    return null;
   }
 
   const authorization = getLti13CourseInstanceUpgradeAuthorization({
@@ -116,7 +118,7 @@ async function shouldUseLti13RelaunchFlow(
     session,
     userId: resLocals.authn_user.id,
   });
-  if (authorization === null) return false;
+  if (authorization === null) return null;
 
   const decision = await selectEnrollmentAdmissionDecision({
     courseInstanceId: resLocals.course_instance.id,
@@ -134,8 +136,46 @@ async function shouldUseLti13RelaunchFlow(
     !idsEqual(decision.invitationCandidate.enrollment.id, authorization.enrollment_id)
   ) {
     clearLti13CourseInstanceUpgradeAuthorization(session);
+    return null;
+  }
+  return authorization;
+}
+
+async function finishLti13UpgradeAdmission({
+  authorization,
+  ip,
+  isAdministrator,
+  reqDate,
+  session,
+}: {
+  authorization: Lti13CourseInstanceUpgradeAuthorization;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  session: Record<string, unknown>;
+}): Promise<boolean> {
+  try {
+    await admitUserFromLti13Launch({
+      courseInstanceId: authorization.course_instance_id,
+      expectedInvitationEnrollmentId: authorization.enrollment_id,
+      ip,
+      isAdministrator,
+      lti13CourseInstanceId: authorization.lti13_course_instance_id,
+      reqDate,
+      sub: authorization.sub,
+      userId: authorization.user_id,
+    });
+  } catch (error) {
+    if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+
+    // The invitation can change while the student is at Stripe. A new LMS
+    // launch supplies current LTI data and either admits the student or shows
+    // the appropriate course access error.
+    clearLti13CourseInstanceUpgradeAuthorization(session);
     return false;
   }
+
+  clearLti13CourseInstanceUpgradeAuthorization(session);
   return true;
 }
 
@@ -145,7 +185,7 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+    const lti13UpgradeAuthorization = await selectLti13UpgradeAuthorization(
       req.query.lti13_relaunch,
       req.session,
       res.locals,
@@ -156,21 +196,37 @@ router.get(
       courseInstance,
       user,
     });
-    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
+    const ineligibilityReason = getAdmissionIneligibilityReason(
+      admissionDecision,
+      lti13UpgradeAuthorization !== null,
+    );
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ reason: ineligibilityReason, resLocals: res.locals }));
       return;
     }
 
-    // If no upgrade is needed, return normal requests to the assessments page.
-    // An interrupted LTI admission instead requires a fresh launch from the LMS.
+    // If the required plan was granted while this page was open, finish the
+    // admission without sending the student through the LMS again.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
-      if (lti13Relaunch) {
+      if (lti13UpgradeAuthorization !== null) {
+        const admitted = await finishLti13UpgradeAdmission({
+          authorization: lti13UpgradeAuthorization,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          session: req.session,
+        });
+        if (admitted) {
+          res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+          return;
+        }
+
         res.send(Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals: res.locals }));
-      } else {
-        res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+        return;
       }
+
+      res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
       return;
     }
 
@@ -191,7 +247,7 @@ router.get(
       StudentCourseInstanceUpgrade({
         course,
         courseInstance,
-        lti13Relaunch,
+        lti13AdmissionPending: lti13UpgradeAuthorization !== null,
         missingPlans,
         planPrices,
         resLocals: res.locals,
@@ -218,7 +274,7 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+      const lti13UpgradeAuthorization = await selectLti13UpgradeAuthorization(
         req.body.lti13_relaunch,
         req.session,
         res.locals,
@@ -230,7 +286,10 @@ router.post(
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
+      const ineligibilityReason = getAdmissionIneligibilityReason(
+        admissionDecision,
+        lti13UpgradeAuthorization !== null,
+      );
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
@@ -280,7 +339,7 @@ router.post(
 
       const host = getCanonicalHost(req);
       const urlBase = `${host}/pl/course_instance/${courseInstance.id}/upgrade`;
-      const lti13RelaunchQuery = lti13Relaunch ? '&lti13_relaunch=1' : '';
+      const lti13RelaunchQuery = lti13UpgradeAuthorization !== null ? '&lti13_relaunch=1' : '';
 
       const stripe = getStripeClient();
       const customerId = await getOrCreateStripeCustomerId(user.id, {
@@ -304,7 +363,7 @@ router.post(
         line_items: lineItems,
         mode: 'payment',
         success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}${lti13RelaunchQuery}`,
-        cancel_url: `${urlBase}${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
+        cancel_url: `${urlBase}${lti13UpgradeAuthorization !== null ? '?lti13_relaunch=1' : ''}`,
         metadata,
         payment_intent_data: {
           metadata,
@@ -336,7 +395,7 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const authn_user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = req.query.lti13_relaunch === '1';
+    const lti13UpgradeRequested = req.query.lti13_relaunch === '1';
 
     if (!req.query.session_id) throw new error.HttpStatusError(400, 'Missing session_id');
 
@@ -346,23 +405,6 @@ router.get(
     if (!localSession) {
       throw new Error(`Unknown Stripe session: ${stripeSessionId}`);
     }
-    if (localSession.completed_at) {
-      // We already processed this session; just show them the success page.
-      res.send(
-        CourseInstanceStudentUpdateSuccess({
-          course,
-          courseInstance,
-          lti13Relaunch,
-          paid: true,
-          resLocals: res.locals,
-        }),
-      );
-      return;
-    }
-
-    const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
-
     // Verify that the session is associated with the current course instance
     // and user. We shouldn't hit this during normal operations, but an attacker
     // could try to replay a session ID from a different course instance or user.
@@ -372,6 +414,45 @@ router.get(
     ) {
       throw new error.HttpStatusError(400, 'Invalid session');
     }
+
+    const finishLti13Admission = async () => {
+      const authorization = await selectLti13UpgradeAuthorization(
+        req.query.lti13_relaunch,
+        req.session,
+        res.locals,
+      );
+      if (authorization === null) return false;
+
+      return await finishLti13UpgradeAdmission({
+        authorization,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        session: req.session,
+      });
+    };
+
+    if (localSession.completed_at) {
+      if (await finishLti13Admission()) {
+        res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+        return;
+      }
+
+      // We already processed this session; just show them the success page.
+      res.send(
+        CourseInstanceStudentUpdateSuccess({
+          course,
+          courseInstance,
+          requireLti13Relaunch: lti13UpgradeRequested,
+          paid: true,
+          resLocals: res.locals,
+        }),
+      );
+      return;
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
 
     if (session.payment_status === 'paid') {
       if (!localSession.plan_grants_created) {
@@ -403,11 +484,16 @@ router.get(
         });
       }
 
+      if (await finishLti13Admission()) {
+        res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+        return;
+      }
+
       res.send(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch,
+          requireLti13Relaunch: lti13UpgradeRequested,
           paid: true,
           resLocals: res.locals,
         }),
@@ -425,7 +511,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch,
+          requireLti13Relaunch: false,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -22,6 +22,7 @@ import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment/eligibility.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
@@ -37,6 +38,10 @@ import {
   getPricesForPlans,
   getStripeClient,
 } from '../../lib/billing/stripe.js';
+import {
+  clearLti13CourseInstanceUpgradeAuthorization,
+  getLti13CourseInstanceUpgradeAuthorization,
+} from '../../lib/lti13-course-instance-upgrade.js';
 import { ensurePlanGrant } from '../../models/plan-grants.js';
 import {
   getStripeCheckoutSessionByStripeObjectId,
@@ -54,16 +59,13 @@ import {
 const router = Router({ mergeParams: true });
 
 /**
- * Returns the admission failure, if any, that should prevent a user from
- * obtaining a required plan on this page. This is deliberately less strict
- * than admission itself: joined users may need another plan, and an enrollment
- * code is enforced when admission resumes rather than before the upgrade.
+ * Determines whether the student may buy a plan required by this course.
+ * Joined students may need another plan, and an enrollment code is checked
+ * when enrollment resumes rather than before payment.
  *
- * The LTI relaunch flow also ignores self-enrollment restrictions.
- * The query parameter that selects that flow is not enrollment authority, so
- * this page only handles the upgrade and then sends the user back to the LMS.
- * A fresh LTI launch must revalidate the exact invitation before admitting the
- * user. A blocked enrollment is never allowed to proceed through this flow.
+ * A student sent here from an LTI launch may also bypass self-enrollment
+ * restrictions. The session and pending invitation are checked before this
+ * function is called, and a blocked enrollment still takes precedence.
  */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
@@ -86,26 +88,54 @@ function getAdmissionIneligibilityReason(
 }
 
 /**
- * Returns whether this request should use the LTI-specific upgrade flow.
- * `lti13_relaunch=1` is a routing hint appended when an exact LTI invitation is
- * interrupted by a required plan upgrade. It carries no LTI claims and grants
- * no enrollment authority; those claims were consumed before the redirect.
- * We honor the hint only for a directly authenticated student, then require the
- * student to relaunch from the LMS so admission can validate a fresh link and
- * subject after the upgrade.
+ * `lti13_relaunch=1` only says which flow the browser is trying to continue.
+ * The session must show that an LTI launch for this user and course was sent to
+ * the upgrade page, and that invitation must still be pending for the same LTI
+ * link and `sub`.
  */
-function shouldUseLti13RelaunchFlow(
+async function shouldUseLti13RelaunchFlow(
   queryValue: unknown,
+  session: Record<string, unknown>,
   resLocals: ResLocalsForPage<'course-instance'>,
 ) {
-  return (
-    queryValue === '1' &&
-    idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
-    resLocals.authz_data.authn_course_role === 'None' &&
-    resLocals.authz_data.authn_course_instance_role === 'None' &&
-    resLocals.authz_data.authn_has_student_access &&
-    !resLocals.is_administrator
-  );
+  if (
+    queryValue !== '1' ||
+    !idsEqual(resLocals.user.id, resLocals.authn_user.id) ||
+    resLocals.authz_data.authn_course_role !== 'None' ||
+    resLocals.authz_data.authn_course_instance_role !== 'None' ||
+    !resLocals.authz_data.authn_has_student_access ||
+    resLocals.is_administrator
+  ) {
+    return false;
+  }
+
+  const authorization = getLti13CourseInstanceUpgradeAuthorization({
+    courseInstanceId: resLocals.course_instance.id,
+    now: resLocals.req_date,
+    session,
+    userId: resLocals.authn_user.id,
+  });
+  if (authorization === null) return false;
+
+  const decision = await selectEnrollmentAdmissionDecision({
+    courseInstanceId: resLocals.course_instance.id,
+    source: {
+      type: 'invitation',
+      matchedBy: 'lti13',
+      lti13CourseInstanceId: authorization.lti13_course_instance_id,
+      sub: authorization.sub,
+    },
+    userId: resLocals.authn_user.id,
+  });
+  if (
+    !decision.allowed ||
+    decision.invitationCandidate === null ||
+    !idsEqual(decision.invitationCandidate.enrollment.id, authorization.enrollment_id)
+  ) {
+    clearLti13CourseInstanceUpgradeAuthorization(session);
+    return false;
+  }
+  return true;
 }
 
 router.get(
@@ -114,7 +144,11 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
+    const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+      req.query.lti13_relaunch,
+      req.session,
+      res.locals,
+    );
 
     const admissionDecision = await selectEnrollmentAccessDecision({
       course,
@@ -183,7 +217,11 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.body.lti13_relaunch, res.locals);
+      const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+        req.body.lti13_relaunch,
+        req.session,
+        res.locals,
+      );
 
       // Recheck admission eligibility before creating the Stripe checkout session.
       const admissionDecision = await selectEnrollmentAccessDecision({

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
+import { assertNever } from '@prairielearn/utils';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
 import { config } from '../../../lib/config.js';
@@ -58,7 +59,7 @@ const router = Router({ mergeParams: true });
  * than admission itself: joined users may need another plan, and an enrollment
  * code is enforced when admission resumes rather than before the upgrade.
  *
- * The LTI relaunch flow also ignores ordinary self-enrollment restrictions.
+ * The LTI relaunch flow also ignores self-enrollment restrictions.
  * The query parameter that selects that flow is not enrollment authority, so
  * this page only handles the upgrade and then sends the user back to the LMS.
  * A fresh LTI launch must revalidate the exact invitation before admitting the
@@ -69,11 +70,19 @@ function getAdmissionIneligibilityReason(
   lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
-  if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
-    return null;
+  switch (decision.reason) {
+    case 'already_joined':
+    case 'enrollment_code_required':
+      return null;
+    case 'blocked':
+      return decision.reason;
+    case 'institution-restriction':
+    case 'self-enrollment-disabled':
+    case 'self-enrollment-expired':
+      return lti13Relaunch ? null : decision.reason;
+    default:
+      return assertNever(decision.reason);
   }
-  if (lti13Relaunch && decision.reason !== 'blocked') return null;
-  return decision.reason;
 }
 
 /**
@@ -114,13 +123,12 @@ router.get(
     });
     const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
     if (ineligibilityReason !== null) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
+      res.status(403).send(EnrollmentPage({ reason: ineligibilityReason, resLocals: res.locals }));
       return;
     }
 
-    // Check if the student is *actually* missing plan grants, or if they just
-    // came across this URL on accident. If they have all the necessary plan grants,
-    // redirect them back to the assessments page.
+    // If no upgrade is needed, return normal requests to the assessments page.
+    // An interrupted LTI admission instead requires a fresh launch from the LMS.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
       if (lti13Relaunch) {
@@ -175,8 +183,9 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
+      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.body.lti13_relaunch, res.locals);
 
+      // Recheck admission eligibility before creating the Stripe checkout session.
       const admissionDecision = await selectEnrollmentAccessDecision({
         course,
         courseInstance,
@@ -377,7 +386,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch: false,
+          lti13Relaunch,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -4,11 +4,9 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
-import { run } from '@prairielearn/run';
 import { parseRequestBody } from '@prairielearn/zod';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
-import { hasRole } from '../../../lib/authz-data-lib.js';
 import { config } from '../../../lib/config.js';
 import {
   CourseInstanceSchema,
@@ -17,12 +15,15 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
-  checkEnrollmentEligibility,
+  type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment-eligibility.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import { selectOptionalEnrollmentByUid } from '../../../models/enrollment.js';
+import {
+  type OrdinaryCourseInstanceAdmissionDecision,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,
@@ -50,6 +51,16 @@ import {
 
 const router = Router({ mergeParams: true });
 
+function getAdmissionIneligibilityReason(
+  decision: OrdinaryCourseInstanceAdmissionDecision,
+): EnrollmentIneligibilityReason | null {
+  if (decision.allowed) return null;
+  if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
+    return null;
+  }
+  return decision.reason;
+}
+
 router.get(
   '/',
   typedAsyncHandler<'course-instance'>(async (req, res) => {
@@ -57,30 +68,14 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
 
-    // Check enrollment eligibility before showing the upgrade page.
-    // This prevents students from paying when they wouldn't be able to enroll
-    // (e.g., due to institution restrictions).
-    const existingEnrollment = await run(async () => {
-      if (!hasRole(res.locals.authz_data, ['Student'])) {
-        return null;
-      }
-      return await selectOptionalEnrollmentByUid({
-        uid: user.uid,
-        courseInstance,
-        requiredRole: ['Student'],
-        authzData: res.locals.authz_data,
-      });
-    });
-
-    const enrollmentInfo = checkEnrollmentEligibility({
-      user,
+    const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
       course,
       courseInstance,
-      existingEnrollment,
+      user,
     });
-
-    if (!enrollmentInfo.eligible) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: enrollmentInfo.reason }));
+    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+    if (ineligibilityReason !== null) {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
       return;
     }
 
@@ -137,28 +132,14 @@ router.post(
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
 
-      // Check enrollment eligibility before processing payment.
-      const existingEnrollment = await run(async () => {
-        if (!hasRole(res.locals.authz_data, ['Student'])) {
-          return null;
-        }
-        return await selectOptionalEnrollmentByUid({
-          uid: user.uid,
-          courseInstance,
-          requiredRole: ['Student'],
-          authzData: res.locals.authz_data,
-        });
-      });
-
-      const enrollmentInfo = checkEnrollmentEligibility({
-        user,
+      const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
         course,
         courseInstance,
-        existingEnrollment,
+        user,
       });
-
-      if (!enrollmentInfo.eligible) {
-        throw new error.HttpStatusError(403, getEligibilityErrorMessage(enrollmentInfo.reason));
+      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+      if (ineligibilityReason !== null) {
+        throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
 
       const body = parseRequestBody(req, UpgradeBodySchema);

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -164,10 +164,7 @@ router.post(
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(
-        admissionDecision,
-        lti13Relaunch,
-      );
+      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -18,7 +18,8 @@ import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment-eligibility.js';
-import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { idsEqual } from '../../../lib/id.js';
+import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import {
   type OrdinaryCourseInstanceAdmissionDecision,
@@ -46,6 +47,7 @@ import {
 
 import {
   CourseInstanceStudentUpdateSuccess,
+  Lti13CourseInstanceRelaunch,
   StudentCourseInstanceUpgrade,
 } from './studentCourseInstanceUpgrade.html.js';
 
@@ -53,12 +55,30 @@ const router = Router({ mergeParams: true });
 
 function getAdmissionIneligibilityReason(
   decision: OrdinaryCourseInstanceAdmissionDecision,
+  lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
   if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
     return null;
   }
+  if (lti13Relaunch && decision.reason !== 'blocked') return null;
   return decision.reason;
+}
+
+function canUseLti13RelaunchMarker(
+  marker: unknown,
+  resLocals: ResLocalsForPage<'course-instance'>,
+) {
+  // This marker only changes upgrade and payment routing. A fresh checked LTI
+  // admission is still required to enroll after the upgrade.
+  return (
+    marker === '1' &&
+    idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
+    resLocals.authz_data.authn_course_role === 'None' &&
+    resLocals.authz_data.authn_course_instance_role === 'None' &&
+    resLocals.authz_data.authn_has_student_access &&
+    !resLocals.is_administrator
+  );
 }
 
 router.get(
@@ -67,13 +87,14 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
+    const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
     const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
       course,
       courseInstance,
       user,
     });
-    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
       return;
@@ -84,7 +105,11 @@ router.get(
     // redirect them back to the assessments page.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
-      res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+      if (lti13Relaunch) {
+        res.send(Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals: res.locals }));
+      } else {
+        res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+      }
       return;
     }
 
@@ -105,6 +130,7 @@ router.get(
       StudentCourseInstanceUpgrade({
         course,
         courseInstance,
+        lti13Relaunch,
         missingPlans,
         planPrices,
         resLocals: res.locals,
@@ -131,13 +157,17 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
+      const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
       const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
         course,
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+      const ineligibilityReason = getAdmissionIneligibilityReason(
+        admissionDecision,
+        lti13Relaunch,
+      );
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
@@ -187,6 +217,7 @@ router.post(
 
       const host = getCanonicalHost(req);
       const urlBase = `${host}/pl/course_instance/${courseInstance.id}/upgrade`;
+      const lti13RelaunchQuery = lti13Relaunch ? '&lti13_relaunch=1' : '';
 
       const stripe = getStripeClient();
       const customerId = await getOrCreateStripeCustomerId(user.id, {
@@ -209,8 +240,8 @@ router.post(
         },
         line_items: lineItems,
         mode: 'payment',
-        success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: urlBase,
+        success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}${lti13RelaunchQuery}`,
+        cancel_url: `${urlBase}${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
         metadata,
         payment_intent_data: {
           metadata,
@@ -242,6 +273,7 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const authn_user = UserSchema.parse(res.locals.authn_user);
+    const lti13Relaunch = req.query.lti13_relaunch === '1';
 
     if (!req.query.session_id) throw new error.HttpStatusError(400, 'Missing session_id');
 
@@ -257,6 +289,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch,
           paid: true,
           resLocals: res.locals,
         }),
@@ -311,6 +344,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch,
           paid: true,
           resLocals: res.locals,
         }),
@@ -328,6 +362,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch: false,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/lib/enrollment-eligibility.ts
+++ b/apps/prairielearn/src/lib/enrollment-eligibility.ts
@@ -2,7 +2,7 @@ import { assertNever } from '@prairielearn/utils';
 
 import type { Course, CourseInstance, Enrollment, User } from './db-types.js';
 
-type EnrollmentIneligibilityReason =
+export type EnrollmentIneligibilityReason =
   | 'blocked'
   | 'self-enrollment-disabled'
   | 'self-enrollment-expired'

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -145,12 +145,14 @@ async function validateEnterpriseAdmission({
   courseInstance,
   institution,
   lti13Relaunch,
+  onPlanGrantsRequired,
 }: {
   authzData: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['authzData'];
   course: Course;
   courseInstance: CourseInstance;
   institution: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['institution'];
   lti13Relaunch: boolean;
+  onPlanGrantsRequired?: () => void;
 }) {
   if (!isEnterprise()) return;
 
@@ -162,6 +164,7 @@ async function validateEnterpriseAdmission({
   });
   switch (status) {
     case PotentialEnrollmentStatus.PLAN_GRANTS_REQUIRED:
+      onPlanGrantsRequired?.();
       throw new HttpRedirect(
         `/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
       );
@@ -175,17 +178,16 @@ async function validateEnterpriseAdmission({
 }
 
 /**
- * Creates the policy callback that reconciliation invokes after reselecting
- * identity candidates under their enrollment locks and before mutating them.
- * It rebuilds the course context and checks student access, source-specific
- * admission policy, and enterprise requirements against that locked identity
- * classification.
+ * Reconciliation calls this after locking and re-reading the matching
+ * enrollments. It checks student access, enrollment policy, and plan
+ * requirements before any enrollment is changed.
  */
 function createAdmissionValidator({
   courseInstanceId,
   enrollmentCode,
   ip,
   isAdministrator,
+  onPlanGrantsRequired,
   reqDate,
   userId,
 }: {
@@ -193,6 +195,7 @@ function createAdmissionValidator({
   enrollmentCode?: string;
   ip: string | null;
   isAdministrator: boolean;
+  onPlanGrantsRequired?: () => void;
   reqDate: Date;
   userId: string;
 }) {
@@ -226,10 +229,9 @@ function createAdmissionValidator({
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    // Reconciliation has already matched an exact LTI link and subject against
-    // the locked invitation. Do not reinterpret that request-local authority as
-    // a UIN, UID, or self-enrollment source. Other sources must still pass the
-    // admission policy using the locked classification.
+    // The LTI path has already checked the invitation's link and `sub` while
+    // holding the enrollment locks. Other paths still need the usual UID, UIN,
+    // or self-enrollment checks below.
     if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
       const decision = getEnrollmentAccessDecision({
         classification,
@@ -249,7 +251,11 @@ function createAdmissionValidator({
       }
     }
 
-    // Invitation authority never bypasses plan grants or enrollment limits.
+    // We don't lock course settings or plan configuration. If either changes
+    // during this transaction, this admission may finish using the old values.
+    // Avoiding that would require coordinating every settings writer with this
+    // code. Enrollment identity and status are still protected by the locks.
+    // Invitations must still pass plan and enrollment-limit checks.
     await validateEnterpriseAdmission({
       authzData: makePageAuthzData({
         authzData,
@@ -259,6 +265,7 @@ function createAdmissionValidator({
       courseInstance,
       institution,
       lti13Relaunch: source.type === 'invitation' && source.matchedBy === 'lti13',
+      onPlanGrantsRequired,
     });
   };
 }
@@ -313,11 +320,48 @@ export async function admitUserForCourseInstanceAccess({
 }
 
 /**
- * Performs self-service admission from a fresh, verified LTI launch. The link
- * and subject are revalidated against locked candidates, while
- * `expectedInvitationEnrollmentId` prevents admission from silently falling
- * back to a different matching invitation. `userId` is both the enrollment
- * subject and audit actor.
+ * Accepts the selected pending UID invitation. The invitation ID is checked
+ * again after locking so a different invitation cannot take its place.
+ */
+export async function admitUserFromUidInvitation({
+  courseInstanceId,
+  expectedInvitationEnrollmentId,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  expectedInvitationEnrollmentId: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return await admitUserToCourseInstance({
+    actor: {
+      agentAuthnUserId: userId,
+      agentUserId: userId,
+    },
+    courseInstanceId,
+    expectedInvitationEnrollmentId,
+    source: { type: 'invitation', matchedBy: 'uid' },
+    userId,
+    validateAdmission: createAdmissionValidator({
+      courseInstanceId,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+/**
+ * Enrolls the current user from the pending invitation that matches the LTI
+ * launch. The invitation ID, linked course, and LMS user ID (`sub`) are checked
+ * again after locking. If any no longer match, admission fails instead of using
+ * another invitation.
  */
 export async function admitUserFromLti13Launch({
   courseInstanceId,
@@ -325,6 +369,7 @@ export async function admitUserFromLti13Launch({
   ip,
   isAdministrator,
   lti13CourseInstanceId,
+  onPlanGrantsRequired,
   reqDate,
   sub,
   userId,
@@ -334,6 +379,7 @@ export async function admitUserFromLti13Launch({
   ip: string | null;
   isAdministrator: boolean;
   lti13CourseInstanceId: string;
+  onPlanGrantsRequired?: () => void;
   reqDate: Date;
   sub: string;
   userId: string;
@@ -356,6 +402,7 @@ export async function admitUserFromLti13Launch({
       courseInstanceId,
       ip,
       isAdministrator,
+      onPlanGrantsRequired,
       reqDate,
       userId,
     }),

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -5,13 +5,15 @@ import {
   PotentialEnrollmentStatus,
   checkPotentialEnterpriseEnrollment,
 } from '../../ee/models/enrollment.js';
+import { setEnrollmentStatus } from '../../models/enrollment.js';
 import { selectUserById } from '../../models/user.js';
-import { hasRole, makePageAuthzData } from '../authz-data-lib.js';
+import { type AuthzData, hasRole, makePageAuthzData } from '../authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../authz-data.js';
 import type { Course, CourseInstance, User } from '../db-types.js';
 import { isEnterprise } from '../license.js';
 import { HttpRedirect } from '../redirect.js';
 
+import { runWithSharedEnrollmentBarrier } from './barrier.js';
 import {
   type EnrollmentIneligibilityReason,
   checkEnrollmentEligibility,
@@ -19,9 +21,11 @@ import {
 } from './eligibility.js';
 import {
   type EnrollmentAdmissionSource,
+  type EnrollmentIdentityCandidate,
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './identity.js';
+import { lockEnrollments } from './lock.js';
 import {
   EnrollmentAdmissionDeniedError,
   type SelectableEnrollmentAdmissionSource,
@@ -354,6 +358,62 @@ export async function admitUserFromUidInvitation({
       reqDate,
       userId,
     }),
+  });
+}
+
+function selectUidInvitationForRejection(
+  classification: EnrollmentIdentityClassification,
+): EnrollmentIdentityCandidate | null {
+  if (classification.boundCandidate !== null) return null;
+  return (
+    classification.candidates.find(
+      (candidate) =>
+        candidate.enrollment.user_id === null &&
+        (candidate.enrollment.status === 'invited' || candidate.enrollment.status === 'rejected') &&
+        candidate.matches.pendingUid &&
+        candidate.enrollment.pending_lti13_course_instance_id === null,
+    ) ?? null
+  );
+}
+
+/**
+ * Rejects a pending UID invitation. This uses the same UID rules as admission,
+ * but also treats an already rejected invitation as a successful no-op. The
+ * invitation is rechecked after locking so a changed or replacement invitation
+ * is left untouched.
+ */
+export async function rejectUserFromUidInvitation({
+  authzData,
+  courseInstanceId,
+  userId,
+}: {
+  authzData: AuthzData;
+  courseInstanceId: string;
+  userId: string;
+}): Promise<boolean> {
+  const context = { courseInstanceId, userId };
+
+  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
+    const initialClassification = await selectEnrollmentIdentityClassification(context);
+    const initialInvitation = selectUidInvitationForRejection(initialClassification);
+    if (initialInvitation === null) return false;
+
+    const enrollmentIds = initialClassification.candidates.map(
+      (candidate) => candidate.enrollment.id,
+    );
+    await lockEnrollments(enrollmentIds);
+    const classification = await selectEnrollmentIdentityClassification(context, enrollmentIds);
+    const invitation = selectUidInvitationForRejection(classification);
+    if (invitation?.enrollment.id !== initialInvitation.enrollment.id) return false;
+    if (invitation.enrollment.status === 'rejected') return true;
+
+    await setEnrollmentStatus({
+      enrollment: invitation.enrollment,
+      status: 'rejected',
+      authzData,
+      requiredRole: ['Student'],
+    });
+    return true;
   });
 }
 

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -4,25 +4,25 @@ import { assertNever } from '@prairielearn/utils';
 import {
   PotentialEnrollmentStatus,
   checkPotentialEnterpriseEnrollment,
-} from '../ee/models/enrollment.js';
-import { hasRole, makePageAuthzData } from '../lib/authz-data-lib.js';
-import { constructCourseOrInstanceContext } from '../lib/authz-data.js';
-import type { Course, CourseInstance, User } from '../lib/db-types.js';
+} from '../../ee/models/enrollment.js';
+import { selectUserById } from '../../models/user.js';
+import { hasRole, makePageAuthzData } from '../authz-data-lib.js';
+import { constructCourseOrInstanceContext } from '../authz-data.js';
+import type { Course, CourseInstance, User } from '../db-types.js';
+import { isEnterprise } from '../license.js';
+import { HttpRedirect } from '../redirect.js';
+
 import {
   type EnrollmentIneligibilityReason,
   checkEnrollmentEligibility,
   getEligibilityErrorMessage,
-} from '../lib/enrollment-eligibility.js';
-import { isEnterprise } from '../lib/license.js';
-import { HttpRedirect } from '../lib/redirect.js';
-
+} from './eligibility.js';
 import {
   type EnrollmentAdmissionSource,
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
-} from './enrollment-identity.js';
-import { admitUserToCourseInstance } from './enrollment-reconciliation.js';
-import { selectUserById } from './user.js';
+} from './identity.js';
+import { admitUserToCourseInstance } from './reconciliation.js';
 
 type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13' }>;
 

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -24,32 +24,31 @@ import {
 } from './identity.js';
 import { admitUserToCourseInstance } from './reconciliation.js';
 
-type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13' }>;
+type CourseInstanceAccessAdmissionSource = Exclude<
+  EnrollmentAdmissionSource,
+  { matchedBy: 'lti13' }
+>;
 
-export type OrdinaryCourseInstanceAdmissionDecision =
+export type EnrollmentAccessDecision =
   | {
       allowed: true;
-      source: OrdinaryAdmissionSource;
+      source: CourseInstanceAccessAdmissionSource;
     }
   | {
       allowed: false;
       reason: EnrollmentIneligibilityReason | 'already_joined' | 'enrollment_code_required';
     };
 
-export interface OrdinaryCourseInstanceAdmissionLocals {
-  ordinary_course_instance_admission_decision?: OrdinaryCourseInstanceAdmissionDecision;
-}
-
-function getOrdinaryAdmissionSource(
+function getEnrollmentAdmissionSource(
   classification: EnrollmentIdentityClassification,
-): OrdinaryAdmissionSource {
-  if (classification.actionableInstitutionRosterInvitation !== null) {
-    return { type: 'institution_uin' };
+): CourseInstanceAccessAdmissionSource {
+  if (classification.actionableInstitutionUinInvitation !== null) {
+    return { type: 'invitation', matchedBy: 'institution_uin' };
   }
-  if (classification.actionableConventionalInvitation !== null) {
-    return { type: 'pending_uid' };
+  if (classification.actionableUidInvitation !== null) {
+    return { type: 'invitation', matchedBy: 'uid' };
   }
-  return { type: 'ordinary' };
+  return { type: 'self_enrollment' };
 }
 
 function enrollmentCodeMatches(
@@ -59,7 +58,7 @@ function enrollmentCodeMatches(
   return enrollmentCode?.toUpperCase() === courseInstance.enrollment_code.toUpperCase();
 }
 
-function getOrdinaryCourseInstanceAdmissionDecision({
+function getEnrollmentAccessDecision({
   classification,
   course,
   courseInstance,
@@ -71,13 +70,13 @@ function getOrdinaryCourseInstanceAdmissionDecision({
   courseInstance: CourseInstance;
   enrollmentCode?: string;
   user: User;
-}): OrdinaryCourseInstanceAdmissionDecision {
+}): EnrollmentAccessDecision {
   const boundStatus = classification.boundCandidate?.enrollment.status;
   if (boundStatus === 'joined') return { allowed: false, reason: 'already_joined' };
   if (boundStatus === 'blocked') return { allowed: false, reason: 'blocked' };
 
-  const source = getOrdinaryAdmissionSource(classification);
-  if (source.type !== 'ordinary') {
+  const source = getEnrollmentAdmissionSource(classification);
+  if (source.type !== 'self_enrollment') {
     return { allowed: true, source };
   }
 
@@ -99,7 +98,7 @@ function getOrdinaryCourseInstanceAdmissionDecision({
   return { allowed: true, source };
 }
 
-export async function selectOrdinaryCourseInstanceAdmissionDecision({
+export async function selectEnrollmentAccessDecision({
   course,
   courseInstance,
   enrollmentCode,
@@ -109,12 +108,12 @@ export async function selectOrdinaryCourseInstanceAdmissionDecision({
   courseInstance: CourseInstance;
   enrollmentCode?: string;
   user: User;
-}): Promise<OrdinaryCourseInstanceAdmissionDecision> {
+}): Promise<EnrollmentAccessDecision> {
   const classification = await selectEnrollmentIdentityClassification({
     courseInstanceId: courseInstance.id,
     userId: user.id,
   });
-  return getOrdinaryCourseInstanceAdmissionDecision({
+  return getEnrollmentAccessDecision({
     classification,
     course,
     courseInstance,
@@ -202,8 +201,8 @@ function createAdmissionValidator({
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    if (source.type !== 'lti13') {
-      const decision = getOrdinaryCourseInstanceAdmissionDecision({
+    if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
+      const decision = getEnrollmentAccessDecision({
         classification,
         user,
         course,
@@ -219,9 +218,6 @@ function createAdmissionValidator({
         }
         throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
       }
-      if (decision.source.type !== source.type) {
-        throw new Error('Locked ordinary admission source changed during validation');
-      }
     }
 
     await validateEnterpriseAdmission({
@@ -232,14 +228,13 @@ function createAdmissionValidator({
       course,
       courseInstance,
       institution,
-      lti13Relaunch: source.type === 'lti13',
+      lti13Relaunch: source.type === 'invitation' && source.matchedBy === 'lti13',
     });
   };
 }
 
-export async function admitUserFromOrdinaryCourseInstanceRequest({
+export async function admitUserForCourseInstanceAccess({
   courseInstanceId,
-  decision,
   enrollmentCode,
   ip,
   isAdministrator,
@@ -247,7 +242,6 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
   userId,
 }: {
   courseInstanceId: string;
-  decision: Extract<OrdinaryCourseInstanceAdmissionDecision, { allowed: true }>;
   enrollmentCode?: string;
   ip: string | null;
   isAdministrator: boolean;
@@ -260,8 +254,7 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
       agentUserId: userId,
     },
     courseInstanceId,
-    selectSource: getOrdinaryAdmissionSource,
-    source: decision.source,
+    selectSource: getEnrollmentAdmissionSource,
     userId,
     validateAdmission: createAdmissionValidator({
       courseInstanceId,
@@ -274,7 +267,7 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
   });
 }
 
-export async function admitUserFromLti13CourseInstanceRequest({
+export async function admitUserFromLti13Launch({
   courseInstanceId,
   expectedInvitationEnrollmentId,
   ip,
@@ -294,7 +287,8 @@ export async function admitUserFromLti13CourseInstanceRequest({
   userId: string;
 }) {
   const source = {
-    type: 'lti13' as const,
+    type: 'invitation' as const,
+    matchedBy: 'lti13' as const,
     lti13CourseInstanceId,
     sub,
   };

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -23,6 +23,7 @@ import {
   selectEnrollmentIdentityClassification,
 } from './identity.js';
 import {
+  EnrollmentAdmissionDeniedError,
   type SelectableEnrollmentAdmissionSource,
   admitUserToCourseInstance,
 } from './reconciliation.js';
@@ -227,8 +228,8 @@ function createAdmissionValidator({
 
     // Reconciliation has already matched an exact LTI link and subject against
     // the locked invitation. Do not reinterpret that request-local authority as
-    // an ordinary UIN, UID, or self-enrollment source. Other sources must still
-    // pass the ordinary admission policy using the locked classification.
+    // a UIN, UID, or self-enrollment source. Other sources must still pass the
+    // admission policy using the locked classification.
     if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
       const decision = getEnrollmentAccessDecision({
         classification,
@@ -283,23 +284,32 @@ export async function admitUserForCourseInstanceAccess({
   reqDate: Date;
   userId: string;
 }) {
-  return await admitUserToCourseInstance({
-    actor: {
-      agentAuthnUserId: userId,
-      agentUserId: userId,
-    },
-    courseInstanceId,
-    selectSource: getEnrollmentAdmissionSource,
-    userId,
-    validateAdmission: createAdmissionValidator({
+  try {
+    return await admitUserToCourseInstance({
+      actor: {
+        agentAuthnUserId: userId,
+        agentUserId: userId,
+      },
       courseInstanceId,
-      enrollmentCode,
-      ip,
-      isAdministrator,
-      reqDate,
+      selectSource: getEnrollmentAdmissionSource,
       userId,
-    }),
-  });
+      validateAdmission: createAdmissionValidator({
+        courseInstanceId,
+        enrollmentCode,
+        ip,
+        isAdministrator,
+        reqDate,
+        userId,
+      }),
+    });
+  } catch (error) {
+    // The read-only preflight can become stale before admission locks and
+    // revalidates the enrollment candidates.
+    if (error instanceof EnrollmentAdmissionDeniedError && error.decision.reason === 'blocked') {
+      throw new HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+    }
+    throw error;
+  }
 }
 
 /**

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -22,17 +22,15 @@ import {
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './identity.js';
-import { admitUserToCourseInstance } from './reconciliation.js';
-
-type CourseInstanceAccessAdmissionSource = Exclude<
-  EnrollmentAdmissionSource,
-  { matchedBy: 'lti13' }
->;
+import {
+  type SelectableEnrollmentAdmissionSource,
+  admitUserToCourseInstance,
+} from './reconciliation.js';
 
 export type EnrollmentAccessDecision =
   | {
       allowed: true;
-      source: CourseInstanceAccessAdmissionSource;
+      source: SelectableEnrollmentAdmissionSource;
     }
   | {
       allowed: false;
@@ -41,7 +39,7 @@ export type EnrollmentAccessDecision =
 
 function getEnrollmentAdmissionSource(
   classification: EnrollmentIdentityClassification,
-): CourseInstanceAccessAdmissionSource {
+): SelectableEnrollmentAdmissionSource {
   if (classification.actionableInstitutionUinInvitation !== null) {
     return { type: 'invitation', matchedBy: 'institution_uin' };
   }
@@ -286,9 +284,9 @@ export async function admitUserFromLti13Launch({
   sub: string;
   userId: string;
 }) {
-  const source = {
-    type: 'invitation' as const,
-    matchedBy: 'lti13' as const,
+  const source: EnrollmentAdmissionSource = {
+    type: 'invitation',
+    matchedBy: 'lti13',
     lti13CourseInstanceId,
     sub,
   };

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -40,6 +40,9 @@ export type EnrollmentAccessDecision =
 function getEnrollmentAdmissionSource(
   classification: EnrollmentIdentityClassification,
 ): SelectableEnrollmentAdmissionSource {
+  // Prefer the institution-scoped identity when both invitation forms match.
+  // UIN is authoritative only within the course's institution, while UID is
+  // the fallback for invitations without that institution-scoped identity.
   if (classification.actionableInstitutionUinInvitation !== null) {
     return { type: 'invitation', matchedBy: 'institution_uin' };
   }
@@ -70,14 +73,22 @@ function getEnrollmentAccessDecision({
   user: User;
 }): EnrollmentAccessDecision {
   const boundStatus = classification.boundCandidate?.enrollment.status;
+  // An enrollment already bound to the user is authoritative: a pending
+  // invitation cannot override either existing access or a block.
   if (boundStatus === 'joined') return { allowed: false, reason: 'already_joined' };
   if (boundStatus === 'blocked') return { allowed: false, reason: 'blocked' };
 
   const source = getEnrollmentAdmissionSource(classification);
   if (source.type !== 'self_enrollment') {
+    // An actionable invitation supplies its own admission authority and is not
+    // subject to self-enrollment settings, expiration, institution
+    // restrictions, or codes.
     return { allowed: true, source };
   }
 
+  // Other bound states, such as left or removed, do not grant admission. Treat
+  // them as a fresh self-enrollment instead of allowing an old enrollment to
+  // bypass current self-enrollment policy.
   const eligibility = checkEnrollmentEligibility({
     user,
     course,
@@ -96,6 +107,13 @@ function getEnrollmentAccessDecision({
   return { allowed: true, source };
 }
 
+/**
+ * Computes a read-only admission preflight for routing and rendering. The
+ * result can become stale immediately and must not authorize a mutation;
+ * admission functions reselect identity candidates and rerun policy validation
+ * under enrollment locks. Exact LTI authority is request-local and must use
+ * {@link admitUserFromLti13Launch} instead.
+ */
 export async function selectEnrollmentAccessDecision({
   course,
   courseInstance,
@@ -155,6 +173,13 @@ async function validateEnterpriseAdmission({
   }
 }
 
+/**
+ * Creates the policy callback that reconciliation invokes after reselecting
+ * identity candidates under their enrollment locks and before mutating them.
+ * It rebuilds the course context and checks student access, source-specific
+ * admission policy, and enterprise requirements against that locked identity
+ * classification.
+ */
 function createAdmissionValidator({
   courseInstanceId,
   enrollmentCode,
@@ -188,17 +213,22 @@ function createAdmissionValidator({
         user,
       });
 
+    // Admission is self-service. `Student` requires student access and excludes
+    // course-instance staff roles; the course-role check also excludes users
+    // entering through course-level staff access.
     if (
       authzData === null ||
       courseInstance === null ||
       !hasRole(authzData, ['Student']) ||
-      authzData.course_role !== 'None' ||
-      authzData.course_instance_role !== 'None' ||
-      !authzData.has_student_access
+      authzData.course_role !== 'None'
     ) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
+    // Reconciliation has already matched an exact LTI link and subject against
+    // the locked invitation. Do not reinterpret that request-local authority as
+    // an ordinary UIN, UID, or self-enrollment source. Other sources must still
+    // pass the ordinary admission policy using the locked classification.
     if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
       const decision = getEnrollmentAccessDecision({
         classification,
@@ -218,6 +248,7 @@ function createAdmissionValidator({
       }
     }
 
+    // Invitation authority never bypasses plan grants or enrollment limits.
     await validateEnterpriseAdmission({
       authzData: makePageAuthzData({
         authzData,
@@ -231,6 +262,12 @@ function createAdmissionValidator({
   };
 }
 
+/**
+ * Performs self-service course entry for the authenticated user. `userId` is
+ * both the enrollment subject and audit actor; this is not an on-behalf-of-user
+ * API. The source is selected and policy is validated from the locked identity
+ * classification inside reconciliation.
+ */
 export async function admitUserForCourseInstanceAccess({
   courseInstanceId,
   enrollmentCode,
@@ -265,6 +302,13 @@ export async function admitUserForCourseInstanceAccess({
   });
 }
 
+/**
+ * Performs self-service admission from a fresh, verified LTI launch. The link
+ * and subject are revalidated against locked candidates, while
+ * `expectedInvitationEnrollmentId` prevents admission from silently falling
+ * back to a different matching invitation. `userId` is both the enrollment
+ * subject and audit actor.
+ */
 export async function admitUserFromLti13Launch({
   courseInstanceId,
   expectedInvitationEnrollmentId,
@@ -284,12 +328,6 @@ export async function admitUserFromLti13Launch({
   sub: string;
   userId: string;
 }) {
-  const source: EnrollmentAdmissionSource = {
-    type: 'invitation',
-    matchedBy: 'lti13',
-    lti13CourseInstanceId,
-    sub,
-  };
   return await admitUserToCourseInstance({
     actor: {
       agentAuthnUserId: userId,
@@ -297,7 +335,12 @@ export async function admitUserFromLti13Launch({
     },
     courseInstanceId,
     expectedInvitationEnrollmentId,
-    source,
+    source: {
+      type: 'invitation',
+      matchedBy: 'lti13',
+      lti13CourseInstanceId,
+      sub,
+    },
     userId,
     validateAdmission: createAdmissionValidator({
       courseInstanceId,

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -255,8 +255,10 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
   userId: string;
 }) {
   return await admitUserToCourseInstance({
-    agentAuthnUserId: userId,
-    agentUserId: userId,
+    actor: {
+      agentAuthnUserId: userId,
+      agentUserId: userId,
+    },
     courseInstanceId,
     selectSource: getOrdinaryAdmissionSource,
     source: decision.source,
@@ -297,8 +299,10 @@ export async function admitUserFromLti13CourseInstanceRequest({
     sub,
   };
   return await admitUserToCourseInstance({
-    agentAuthnUserId: userId,
-    agentUserId: userId,
+    actor: {
+      agentAuthnUserId: userId,
+      agentUserId: userId,
+    },
     courseInstanceId,
     expectedInvitationEnrollmentId,
     source,

--- a/apps/prairielearn/src/lib/enrollment/eligibility.test.ts
+++ b/apps/prairielearn/src/lib/enrollment/eligibility.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Course, CourseInstance, User } from './db-types.js';
-import { checkEnrollmentEligibility } from './enrollment-eligibility.js';
+import type { Course, CourseInstance, User } from '../db-types.js';
+
+import { checkEnrollmentEligibility } from './eligibility.js';
 
 describe('checkEnrollmentEligibility', () => {
   const baseParams = {

--- a/apps/prairielearn/src/lib/enrollment/eligibility.ts
+++ b/apps/prairielearn/src/lib/enrollment/eligibility.ts
@@ -1,6 +1,6 @@
 import { assertNever } from '@prairielearn/utils';
 
-import type { Course, CourseInstance, Enrollment, User } from './db-types.js';
+import type { Course, CourseInstance, Enrollment, User } from '../db-types.js';
 
 export type EnrollmentIneligibilityReason =
   | 'blocked'

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -194,7 +194,10 @@ export async function admitUserToCourseInstance(
      */
     expectedInvitationEnrollmentId?: string;
     userId: string;
-    validateAdmission: (context: { source: EnrollmentAdmissionSource }) => Promise<void>;
+    validateAdmission: (context: {
+      classification: EnrollmentIdentityClassification;
+      source: EnrollmentAdmissionSource;
+    }) => Promise<void>;
   } & EnrollmentAdmissionSourceSelection,
 ): Promise<Enrollment> {
   const { actor, userId, courseInstanceId, expectedInvitationEnrollmentId, validateAdmission } =
@@ -249,7 +252,7 @@ export async function admitUserToCourseInstance(
 
     // Check eligibility and enrollment limits only after re-reading the
     // matching invitation and bound enrollment while their locks are held.
-    await validateAdmission({ source: decision.source });
+    await validateAdmission({ classification, source: decision.source });
 
     const survivorCandidate = selectSurvivor(
       classification.candidates,

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,65 +1,59 @@
 import { EnrollmentPage } from '../components/EnrollmentPage.js';
 import {
-  type OrdinaryCourseInstanceAdmissionLocals,
-  admitUserFromOrdinaryCourseInstanceRequest,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  admitUserForCourseInstanceAccess,
+  selectEnrollmentAccessDecision,
 } from '../lib/enrollment/admission.js';
 import { idsEqual } from '../lib/id.js';
 import { typedAsyncHandler } from '../lib/res-locals.js';
 
-export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
-  async (req, res, next) => {
-    // If the user does not currently have access to the course, but could if
-    // they were enrolled, automatically enroll them. However, we will not
-    // attempt to enroll them if they are an instructor (that is, if they have
-    // a specific role in the course or course instance) or if they are
-    // impersonating another user.
+export default typedAsyncHandler<'course-instance'>(async (req, res, next) => {
+  // If the user does not currently have access to the course, but could if
+  // they were enrolled, automatically enroll them. However, we will not
+  // attempt to enroll them if they are an instructor (that is, if they have
+  // a specific role in the course or course instance) or if they are
+  // impersonating another user.
 
-    // TODO: check if self-enrollment requires a secret link.
+  // TODO: check if self-enrollment requires a secret link.
 
-    if (
-      idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
-      res.locals.authz_data.authn_course_role === 'None' &&
-      res.locals.authz_data.authn_course_instance_role === 'None' &&
-      res.locals.authz_data.authn_has_student_access &&
-      !res.locals.authz_data.authn_has_student_access_with_enrollment
-    ) {
-      const decision =
-        res.locals.ordinary_course_instance_admission_decision ??
-        (await selectOrdinaryCourseInstanceAdmissionDecision({
-          course: res.locals.course,
-          courseInstance: res.locals.course_instance,
-          user: res.locals.authn_user,
-        }));
+  if (
+    idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
+    res.locals.authz_data.authn_course_role === 'None' &&
+    res.locals.authz_data.authn_course_instance_role === 'None' &&
+    res.locals.authz_data.authn_has_student_access &&
+    !res.locals.authz_data.authn_has_student_access_with_enrollment
+  ) {
+    const decision = await selectEnrollmentAccessDecision({
+      course: res.locals.course,
+      courseInstance: res.locals.course_instance,
+      user: res.locals.authn_user,
+    });
 
-      if (decision.allowed) {
-        await admitUserFromOrdinaryCourseInstanceRequest({
-          courseInstanceId: res.locals.course_instance.id,
-          decision,
-          ip: req.ip ?? null,
-          isAdministrator: res.locals.is_administrator,
-          reqDate: res.locals.req_date,
-          userId: res.locals.authn_user.id,
-        });
+    if (decision.allowed) {
+      await admitUserForCourseInstanceAccess({
+        courseInstanceId: res.locals.course_instance.id,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        userId: res.locals.authn_user.id,
+      });
 
-        // This is the only part of the `authz_data` that would change as a
-        // result of this enrollment, so we can just update it directly.
-        res.locals.authz_data.has_student_access_with_enrollment = true;
-        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
-      } else if (decision.reason === 'already_joined') {
-        res.locals.authz_data.has_student_access_with_enrollment = true;
-        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
-      } else if (decision.reason === 'enrollment_code_required') {
-        res.redirect(
-          `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
-        );
-        return;
-      } else {
-        res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
-        return;
-      }
+      // This is the only part of the `authz_data` that would change as a
+      // result of this enrollment, so we can just update it directly.
+      res.locals.authz_data.has_student_access_with_enrollment = true;
+      res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+    } else if (decision.reason === 'already_joined') {
+      res.locals.authz_data.has_student_access_with_enrollment = true;
+      res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+    } else if (decision.reason === 'enrollment_code_required') {
+      res.redirect(
+        `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
+      );
+      return;
+    } else {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+      return;
     }
+  }
 
-    next();
-  },
-);
+  next();
+});

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,83 +1,65 @@
-import asyncHandler from 'express-async-handler';
-
-import { run } from '@prairielearn/run';
-
 import { EnrollmentPage } from '../components/EnrollmentPage.js';
-import { hasRole } from '../lib/authz-data-lib.js';
-import type { CourseInstance } from '../lib/db-types.js';
-import { checkEnrollmentEligibility } from '../lib/enrollment-eligibility.js';
 import { idsEqual } from '../lib/id.js';
-import { ensureEnrollment, selectOptionalEnrollmentByUid } from '../models/enrollment.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
+import {
+  type OrdinaryCourseInstanceAdmissionLocals,
+  admitUserFromOrdinaryCourseInstanceRequest,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../models/course-instance-admission.js';
 
-export default asyncHandler(async (req, res, next) => {
-  // If the user does not currently have access to the course, but could if
-  // they were enrolled, automatically enroll them. However, we will not
-  // attempt to enroll them if they are an instructor (that is, if they have
-  // a specific role in the course or course instance) or if they are
-  // impersonating another user.
+export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
+  async (req, res, next) => {
+    // If the user does not currently have access to the course, but could if
+    // they were enrolled, automatically enroll them. However, we will not
+    // attempt to enroll them if they are an instructor (that is, if they have
+    // a specific role in the course or course instance) or if they are
+    // impersonating another user.
 
-  // TODO: check if self-enrollment requires a secret link.
+    // TODO: check if self-enrollment requires a secret link.
 
-  const courseInstance: CourseInstance = res.locals.course_instance;
+    if (
+      idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
+      res.locals.authz_data.authn_course_role === 'None' &&
+      res.locals.authz_data.authn_course_instance_role === 'None' &&
+      res.locals.authz_data.authn_has_student_access &&
+      !res.locals.authz_data.authn_has_student_access_with_enrollment
+    ) {
+      const decision =
+        res.locals.ordinary_course_instance_admission_decision ??
+        (await selectOrdinaryCourseInstanceAdmissionDecision({
+          course: res.locals.course,
+          courseInstance: res.locals.course_instance,
+          user: res.locals.authn_user,
+        }));
 
-  // We select by user UID so that we can find invited/rejected enrollments as well
-  const existingEnrollment = await run(async () => {
-    // We only want to even try to lookup enrollment information if the user is a student.
-    if (!hasRole(res.locals.authz_data, ['Student'])) {
-      return null;
+      if (decision.allowed) {
+        await admitUserFromOrdinaryCourseInstanceRequest({
+          courseInstanceId: res.locals.course_instance.id,
+          decision,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          userId: res.locals.authn_user.id,
+        });
+
+        // This is the only part of the `authz_data` that would change as a
+        // result of this enrollment, so we can just update it directly.
+        res.locals.authz_data.has_student_access_with_enrollment = true;
+        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+      } else if (decision.reason === 'already_joined') {
+        res.locals.authz_data.has_student_access_with_enrollment = true;
+        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+      } else if (decision.reason === 'enrollment_code_required') {
+        res.redirect(
+          `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
+        );
+        return;
+      } else {
+        res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+        return;
+      }
     }
-    return await selectOptionalEnrollmentByUid({
-      uid: res.locals.authn_user.uid,
-      courseInstance,
-      requiredRole: ['Student'],
-      authzData: res.locals.authz_data,
-    });
-  });
 
-  const enrollmentEligibility = checkEnrollmentEligibility({
-    user: res.locals.authn_user,
-    course: res.locals.course,
-    courseInstance,
-    existingEnrollment,
-  });
-
-  // If the user is not enrolled, or is rejected/left/removed then they can enroll if self-enrollment is allowed.
-  const canSelfEnroll =
-    enrollmentEligibility.eligible &&
-    (existingEnrollment == null ||
-      ['rejected', 'left', 'removed'].includes(existingEnrollment.status));
-
-  // If the user is enrolled and is invited/joined, then they have access regardless of the self-enrollment status.
-  const canAccessCourseInstance =
-    existingEnrollment != null && ['invited', 'joined'].includes(existingEnrollment.status);
-
-  if (
-    idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
-    res.locals.authz_data.authn_course_role === 'None' &&
-    res.locals.authz_data.authn_course_instance_role === 'None' &&
-    res.locals.authz_data.authn_has_student_access &&
-    !res.locals.authz_data.authn_has_student_access_with_enrollment
-  ) {
-    if (canSelfEnroll || canAccessCourseInstance) {
-      await ensureEnrollment({
-        institution: res.locals.institution,
-        course: res.locals.course,
-        courseInstance,
-        authzData: res.locals.authz_data,
-        requiredRole: ['Student'],
-        actionDetail: 'implicit_joined',
-      });
-
-      // This is the only part of the `authz_data` that would change as a
-      // result of this enrollment, so we can just update it directly.
-      res.locals.authz_data.has_student_access_with_enrollment = true;
-    } else if (!enrollmentEligibility.eligible) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: enrollmentEligibility.reason }));
-      return;
-    }
-  }
-
-  next();
-});
+    next();
+  },
+);

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -50,7 +50,7 @@ export default typedAsyncHandler<'course-instance'>(async (req, res, next) => {
       );
       return;
     } else {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+      res.status(403).send(EnrollmentPage({ reason: decision.reason, resLocals: res.locals }));
       return;
     }
   }

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,11 +1,11 @@
 import { EnrollmentPage } from '../components/EnrollmentPage.js';
-import { idsEqual } from '../lib/id.js';
-import { typedAsyncHandler } from '../lib/res-locals.js';
 import {
   type OrdinaryCourseInstanceAdmissionLocals,
   admitUserFromOrdinaryCourseInstanceRequest,
   selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../models/course-instance-admission.js';
+} from '../lib/enrollment/admission.js';
+import { idsEqual } from '../lib/id.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
 
 export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
   async (req, res, next) => {

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,9 +1,9 @@
 import { extractPageContext } from '../lib/client/page-context.js';
-import { typedAsyncHandler } from '../lib/res-locals.js';
 import {
   type OrdinaryCourseInstanceAdmissionLocals,
   selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../models/course-instance-admission.js';
+} from '../lib/enrollment/admission.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
 
 export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
   async (req, res, next) => {

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,61 +1,60 @@
 import { extractPageContext } from '../lib/client/page-context.js';
-import {
-  type OrdinaryCourseInstanceAdmissionLocals,
-  selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../lib/enrollment/admission.js';
+import { selectEnrollmentAccessDecision } from '../lib/enrollment/admission.js';
 import { typedAsyncHandler } from '../lib/res-locals.js';
 
-export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
-  async (req, res, next) => {
-    // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
+export default typedAsyncHandler<'course-instance'>(async (req, res, next) => {
+  // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
 
-    // Check if the user needs an enrollment code to access the course instance.
-    const { course_instance: courseInstance } = extractPageContext(res.locals, {
-      pageType: 'courseInstance',
-      accessType: 'instructor',
-    });
+  // Check if the user needs an enrollment code to access the course instance.
+  const { course_instance: courseInstance } = extractPageContext(res.locals, {
+    pageType: 'courseInstance',
+    accessType: 'instructor',
+  });
 
-    // Skip if user already has student access with enrollment
-    if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
-      next();
-      return;
-    }
-
-    // Skip if user is an instructor or administrator
-    if (
-      res.locals.authz_data.authn_course_role !== 'None' ||
-      res.locals.authz_data.authn_course_instance_role !== 'None' ||
-      res.locals.is_administrator
-    ) {
-      next();
-      return;
-    }
-
-    // Check if user has student access (they should be able to enroll)
-    // This checks if access rules would allow them to enroll.
-    if (!res.locals.authz_data.authn_has_student_access) {
-      next();
-      return;
-    }
-
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
-      course: res.locals.course,
-      courseInstance,
-      user: res.locals.authn_user,
-    });
-    res.locals.ordinary_course_instance_admission_decision = decision;
-
-    if (decision.allowed || decision.reason !== 'enrollment_code_required') {
-      next();
-      return;
-    }
-
-    // User needs an enrollment code - redirect to the enrollment code page
-    // Preserve the current URL as a query parameter so they can return after enrollment
-    const currentUrl = req.originalUrl;
-    const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
-
-    res.redirect(redirectUrl);
+  // Skip if user already has student access with enrollment
+  if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
+    next();
     return;
-  },
-);
+  }
+
+  // Skip if user is an instructor or administrator
+  if (
+    res.locals.authz_data.authn_course_role !== 'None' ||
+    res.locals.authz_data.authn_course_instance_role !== 'None' ||
+    res.locals.is_administrator
+  ) {
+    next();
+    return;
+  }
+
+  // Check if user has student access (they should be able to enroll)
+  // This checks if access rules would allow them to enroll.
+  if (!res.locals.authz_data.authn_has_student_access) {
+    next();
+    return;
+  }
+
+  if (!courseInstance.self_enrollment_use_enrollment_code) {
+    next();
+    return;
+  }
+
+  const decision = await selectEnrollmentAccessDecision({
+    course: res.locals.course,
+    courseInstance,
+    user: res.locals.authn_user,
+  });
+
+  if (decision.allowed || decision.reason !== 'enrollment_code_required') {
+    next();
+    return;
+  }
+
+  // User needs an enrollment code - redirect to the enrollment code page
+  // Preserve the current URL as a query parameter so they can return after enrollment
+  const currentUrl = req.originalUrl;
+  const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
+
+  res.redirect(redirectUrl);
+  return;
+});

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,87 +1,61 @@
-import asyncHandler from 'express-async-handler';
-
 import { extractPageContext } from '../lib/client/page-context.js';
-import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
+import {
+  type OrdinaryCourseInstanceAdmissionLocals,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../models/course-instance-admission.js';
 
-export default asyncHandler(async (req, res, next) => {
-  // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
+export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
+  async (req, res, next) => {
+    // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
 
-  // Check if the user needs an enrollment code to access the course instance.
-  const { course_instance: courseInstance } = extractPageContext(res.locals, {
-    pageType: 'courseInstance',
-    accessType: 'instructor',
-  });
+    // Check if the user needs an enrollment code to access the course instance.
+    const { course_instance: courseInstance } = extractPageContext(res.locals, {
+      pageType: 'courseInstance',
+      accessType: 'instructor',
+    });
 
-  // Skip if user already has student access with enrollment
-  if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
-    next();
+    // Skip if user already has student access with enrollment
+    if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
+      next();
+      return;
+    }
+
+    // Skip if user is an instructor or administrator
+    if (
+      res.locals.authz_data.authn_course_role !== 'None' ||
+      res.locals.authz_data.authn_course_instance_role !== 'None' ||
+      res.locals.is_administrator
+    ) {
+      next();
+      return;
+    }
+
+    // Check if user has student access (they should be able to enroll)
+    // This checks if access rules would allow them to enroll.
+    if (!res.locals.authz_data.authn_has_student_access) {
+      next();
+      return;
+    }
+
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course: res.locals.course,
+      courseInstance,
+      user: res.locals.authn_user,
+    });
+    res.locals.ordinary_course_instance_admission_decision = decision;
+
+    if (decision.allowed || decision.reason !== 'enrollment_code_required') {
+      next();
+      return;
+    }
+
+    // User needs an enrollment code - redirect to the enrollment code page
+    // Preserve the current URL as a query parameter so they can return after enrollment
+    const currentUrl = req.originalUrl;
+    const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
+
+    res.redirect(redirectUrl);
     return;
-  }
-
-  // Skip if user is an instructor or administrator
-  if (
-    res.locals.authz_data.authn_course_role !== 'None' ||
-    res.locals.authz_data.authn_course_instance_role !== 'None' ||
-    res.locals.is_administrator
-  ) {
-    next();
-    return;
-  }
-
-  // Check if self-enrollment is enabled and requires an enrollment code
-  if (
-    !courseInstance.self_enrollment_enabled ||
-    !courseInstance.self_enrollment_use_enrollment_code
-  ) {
-    next();
-    return;
-  }
-
-  // Check if self-enrollment is still allowed (before the cutoff date)
-  const selfEnrollmentAllowed =
-    courseInstance.self_enrollment_enabled_before_date == null ||
-    new Date() < courseInstance.self_enrollment_enabled_before_date;
-
-  if (!selfEnrollmentAllowed) {
-    // TODO: Show nice error page
-    next();
-    return;
-  }
-
-  // Check if user has student access (they should be able to enroll)
-  // This checks if access rules would allow them to enroll.
-  if (!res.locals.authz_data.authn_has_student_access) {
-    next();
-    return;
-  }
-
-  // Check if user is already enrolled or blocked
-  const existingEnrollment = await selectOptionalEnrollmentByUserId({
-    userId: res.locals.authn_user.id,
-    requiredRole: ['Student'],
-    authzData: res.locals.authz_data,
-    courseInstance,
-  });
-
-  // If user is enrolled and joined/invited/rejected, let them through.
-  // Removed users need to re-enter the enrollment code.
-  if (existingEnrollment && ['joined', 'invited', 'rejected'].includes(existingEnrollment.status)) {
-    next();
-    return;
-  }
-
-  // If user is blocked, don't redirect them to enrollment code page
-  if (existingEnrollment?.status === 'blocked') {
-    // TODO: Show nice error page
-    next();
-    return;
-  }
-
-  // User needs an enrollment code - redirect to the enrollment code page
-  // Preserve the current URL as a query parameter so they can return after enrollment
-  const currentUrl = req.originalUrl;
-  const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
-
-  res.redirect(redirectUrl);
-  return;
-});
+  },
+);

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -29,7 +29,6 @@ type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13
 export type OrdinaryCourseInstanceAdmissionDecision =
   | {
       allowed: true;
-      expectedInvitationEnrollmentId?: string;
       source: OrdinaryAdmissionSource;
     }
   | {
@@ -79,18 +78,7 @@ function getOrdinaryCourseInstanceAdmissionDecision({
 
   const source = getOrdinaryAdmissionSource(classification);
   if (source.type !== 'ordinary') {
-    const invitationCandidate =
-      source.type === 'institution_uin'
-        ? classification.actionableInstitutionRosterInvitation
-        : classification.actionableConventionalInvitation;
-    if (invitationCandidate === null) {
-      throw new Error('Actionable admission source is missing its invitation');
-    }
-    return {
-      allowed: true,
-      expectedInvitationEnrollmentId: invitationCandidate.enrollment.id,
-      source,
-    };
+    return { allowed: true, source };
   }
 
   const eligibility = checkEnrollmentEligibility({
@@ -140,11 +128,13 @@ async function validateEnterpriseAdmission({
   course,
   courseInstance,
   institution,
+  lti13Relaunch,
 }: {
   authzData: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['authzData'];
   course: Course;
   courseInstance: CourseInstance;
   institution: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['institution'];
+  lti13Relaunch: boolean;
 }) {
   if (!isEnterprise()) return;
 
@@ -156,7 +146,9 @@ async function validateEnterpriseAdmission({
   });
   switch (status) {
     case PotentialEnrollmentStatus.PLAN_GRANTS_REQUIRED:
-      throw new HttpRedirect(`/pl/course_instance/${courseInstance.id}/upgrade`);
+      throw new HttpRedirect(
+        `/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
+      );
     case PotentialEnrollmentStatus.LIMIT_EXCEEDED:
       throw new HttpRedirect('/pl/enroll/limit_exceeded');
     case PotentialEnrollmentStatus.ALLOWED:
@@ -240,6 +232,7 @@ function createAdmissionValidator({
       course,
       courseInstance,
       institution,
+      lti13Relaunch: source.type === 'lti13',
     });
   };
 }
@@ -265,9 +258,6 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
     agentAuthnUserId: userId,
     agentUserId: userId,
     courseInstanceId,
-    ...(decision.expectedInvitationEnrollmentId === undefined
-      ? {}
-      : { expectedInvitationEnrollmentId: decision.expectedInvitationEnrollmentId }),
     selectSource: getOrdinaryAdmissionSource,
     source: decision.source,
     userId,

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -1,0 +1,324 @@
+import { HttpStatusError } from '@prairielearn/error';
+import { assertNever } from '@prairielearn/utils';
+
+import {
+  PotentialEnrollmentStatus,
+  checkPotentialEnterpriseEnrollment,
+} from '../ee/models/enrollment.js';
+import { hasRole, makePageAuthzData } from '../lib/authz-data-lib.js';
+import { constructCourseOrInstanceContext } from '../lib/authz-data.js';
+import type { Course, CourseInstance, User } from '../lib/db-types.js';
+import {
+  type EnrollmentIneligibilityReason,
+  checkEnrollmentEligibility,
+  getEligibilityErrorMessage,
+} from '../lib/enrollment-eligibility.js';
+import { isEnterprise } from '../lib/license.js';
+import { HttpRedirect } from '../lib/redirect.js';
+
+import {
+  type EnrollmentAdmissionSource,
+  type EnrollmentIdentityClassification,
+  selectEnrollmentIdentityClassification,
+} from './enrollment-identity.js';
+import { admitUserToCourseInstance } from './enrollment-reconciliation.js';
+import { selectUserById } from './user.js';
+
+type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13' }>;
+
+export type OrdinaryCourseInstanceAdmissionDecision =
+  | {
+      allowed: true;
+      expectedInvitationEnrollmentId?: string;
+      source: OrdinaryAdmissionSource;
+    }
+  | {
+      allowed: false;
+      reason: EnrollmentIneligibilityReason | 'already_joined' | 'enrollment_code_required';
+    };
+
+export interface OrdinaryCourseInstanceAdmissionLocals {
+  ordinary_course_instance_admission_decision?: OrdinaryCourseInstanceAdmissionDecision;
+}
+
+function getOrdinaryAdmissionSource(
+  classification: EnrollmentIdentityClassification,
+): OrdinaryAdmissionSource {
+  if (classification.actionableInstitutionRosterInvitation !== null) {
+    return { type: 'institution_uin' };
+  }
+  if (classification.actionableConventionalInvitation !== null) {
+    return { type: 'pending_uid' };
+  }
+  return { type: 'ordinary' };
+}
+
+function enrollmentCodeMatches(
+  courseInstance: CourseInstance,
+  enrollmentCode: string | undefined,
+): boolean {
+  return enrollmentCode?.toUpperCase() === courseInstance.enrollment_code.toUpperCase();
+}
+
+function getOrdinaryCourseInstanceAdmissionDecision({
+  classification,
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  classification: EnrollmentIdentityClassification;
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): OrdinaryCourseInstanceAdmissionDecision {
+  const boundStatus = classification.boundCandidate?.enrollment.status;
+  if (boundStatus === 'joined') return { allowed: false, reason: 'already_joined' };
+  if (boundStatus === 'blocked') return { allowed: false, reason: 'blocked' };
+
+  const source = getOrdinaryAdmissionSource(classification);
+  if (source.type !== 'ordinary') {
+    const invitationCandidate =
+      source.type === 'institution_uin'
+        ? classification.actionableInstitutionRosterInvitation
+        : classification.actionableConventionalInvitation;
+    if (invitationCandidate === null) {
+      throw new Error('Actionable admission source is missing its invitation');
+    }
+    return {
+      allowed: true,
+      expectedInvitationEnrollmentId: invitationCandidate.enrollment.id,
+      source,
+    };
+  }
+
+  const eligibility = checkEnrollmentEligibility({
+    user,
+    course,
+    courseInstance,
+    existingEnrollment: null,
+  });
+  if (!eligibility.eligible) return { allowed: false, reason: eligibility.reason };
+
+  if (
+    courseInstance.self_enrollment_use_enrollment_code &&
+    !enrollmentCodeMatches(courseInstance, enrollmentCode)
+  ) {
+    return { allowed: false, reason: 'enrollment_code_required' };
+  }
+
+  return { allowed: true, source };
+}
+
+export async function selectOrdinaryCourseInstanceAdmissionDecision({
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): Promise<OrdinaryCourseInstanceAdmissionDecision> {
+  const classification = await selectEnrollmentIdentityClassification({
+    courseInstanceId: courseInstance.id,
+    userId: user.id,
+  });
+  return getOrdinaryCourseInstanceAdmissionDecision({
+    classification,
+    course,
+    courseInstance,
+    enrollmentCode,
+    user,
+  });
+}
+
+async function validateEnterpriseAdmission({
+  authzData,
+  course,
+  courseInstance,
+  institution,
+}: {
+  authzData: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['authzData'];
+  course: Course;
+  courseInstance: CourseInstance;
+  institution: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['institution'];
+}) {
+  if (!isEnterprise()) return;
+
+  const status = await checkPotentialEnterpriseEnrollment({
+    authzData,
+    course,
+    courseInstance,
+    institution,
+  });
+  switch (status) {
+    case PotentialEnrollmentStatus.PLAN_GRANTS_REQUIRED:
+      throw new HttpRedirect(`/pl/course_instance/${courseInstance.id}/upgrade`);
+    case PotentialEnrollmentStatus.LIMIT_EXCEEDED:
+      throw new HttpRedirect('/pl/enroll/limit_exceeded');
+    case PotentialEnrollmentStatus.ALLOWED:
+      return;
+    default:
+      assertNever(status);
+  }
+}
+
+function createAdmissionValidator({
+  courseInstanceId,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return async ({
+    classification,
+    source,
+  }: {
+    classification: EnrollmentIdentityClassification;
+    source: EnrollmentAdmissionSource;
+  }) => {
+    const user = await selectUserById(userId);
+    const { authzData, course, courseInstance, institution } =
+      await constructCourseOrInstanceContext({
+        course_id: null,
+        course_instance_id: courseInstanceId,
+        ip,
+        is_administrator: isAdministrator,
+        req_date: reqDate,
+        user,
+      });
+
+    if (
+      authzData === null ||
+      courseInstance === null ||
+      !hasRole(authzData, ['Student']) ||
+      authzData.course_role !== 'None' ||
+      authzData.course_instance_role !== 'None' ||
+      !authzData.has_student_access
+    ) {
+      throw new HttpStatusError(403, 'Access denied');
+    }
+
+    if (source.type !== 'lti13') {
+      const decision = getOrdinaryCourseInstanceAdmissionDecision({
+        classification,
+        user,
+        course,
+        courseInstance,
+        enrollmentCode,
+      });
+      if (!decision.allowed) {
+        if (decision.reason === 'enrollment_code_required') {
+          throw new HttpRedirect(`/pl/course_instance/${courseInstance.id}/join`);
+        }
+        if (decision.reason === 'already_joined') {
+          throw new Error('Joined enrollment reached admission validation');
+        }
+        throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
+      }
+      if (decision.source.type !== source.type) {
+        throw new Error('Locked ordinary admission source changed during validation');
+      }
+    }
+
+    await validateEnterpriseAdmission({
+      authzData: makePageAuthzData({
+        authzData,
+        is_administrator: isAdministrator,
+      }),
+      course,
+      courseInstance,
+      institution,
+    });
+  };
+}
+
+export async function admitUserFromOrdinaryCourseInstanceRequest({
+  courseInstanceId,
+  decision,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  decision: Extract<OrdinaryCourseInstanceAdmissionDecision, { allowed: true }>;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return await admitUserToCourseInstance({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    ...(decision.expectedInvitationEnrollmentId === undefined
+      ? {}
+      : { expectedInvitationEnrollmentId: decision.expectedInvitationEnrollmentId }),
+    selectSource: getOrdinaryAdmissionSource,
+    source: decision.source,
+    userId,
+    validateAdmission: createAdmissionValidator({
+      courseInstanceId,
+      enrollmentCode,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+export async function admitUserFromLti13CourseInstanceRequest({
+  courseInstanceId,
+  expectedInvitationEnrollmentId,
+  ip,
+  isAdministrator,
+  lti13CourseInstanceId,
+  reqDate,
+  sub,
+  userId,
+}: {
+  courseInstanceId: string;
+  expectedInvitationEnrollmentId: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  lti13CourseInstanceId: string;
+  reqDate: Date;
+  sub: string;
+  userId: string;
+}) {
+  const source = {
+    type: 'lti13' as const,
+    lti13CourseInstanceId,
+    sub,
+  };
+  return await admitUserToCourseInstance({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    expectedInvitationEnrollmentId,
+    source,
+    userId,
+    validateAdmission: createAdmissionValidator({
+      courseInstanceId,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -222,8 +222,8 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Ensures that the user is enrolled in the given course instance. If the
- * enrollment already exists, this is a no-op.
+ * Legacy enrollment path for LTI 1.0 and test setup. Ordinary course-instance
+ * entry uses the checked reconciliation admission path instead.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required
@@ -231,7 +231,7 @@ export async function ensureUncheckedEnrollment({
  * instance enrollment limit to be exceeded.
  *
  */
-export async function ensureEnrollment({
+export async function ensureLegacyEnrollment({
   institution,
   course,
   courseInstance,

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -229,8 +229,9 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Legacy enrollment path for LTI 1.0 and test setup. Ordinary course-instance
- * entry uses the checked reconciliation admission path instead.
+ * Legacy enrollment path for LTI 1.0, homepage invitation acceptance, and test
+ * setup. Ordinary course-instance entry uses the checked reconciliation
+ * admission path instead.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -229,8 +229,8 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Ensures that the user is enrolled in the given course instance. If the
- * enrollment already exists, this is a no-op.
+ * Legacy enrollment path for LTI 1.0 and test setup. Ordinary course-instance
+ * entry uses the checked reconciliation admission path instead.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required
@@ -238,7 +238,7 @@ export async function ensureUncheckedEnrollment({
  * instance enrollment limit to be exceeded.
  *
  */
-export async function ensureEnrollment({
+export async function ensureLegacyEnrollment({
   institution,
   course,
   courseInstance,

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -222,9 +222,8 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Legacy enrollment path for LTI 1.0, homepage invitation acceptance, and test
- * setup. Ordinary course-instance entry uses the checked reconciliation
- * admission path instead.
+ * Ensures enrollment without reconciling multiple identity candidates. Callers
+ * must establish any required enrollment authority before using this path.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required
@@ -232,7 +231,7 @@ export async function ensureUncheckedEnrollment({
  * instance enrollment limit to be exceeded.
  *
  */
-export async function ensureLegacyEnrollment({
+export async function ensureEnrollmentWithoutReconciliation({
   institution,
   course,
   courseInstance,

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -222,8 +222,9 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Legacy enrollment path for LTI 1.0 and test setup. Ordinary course-instance
- * entry uses the checked reconciliation admission path instead.
+ * Legacy enrollment path for LTI 1.0, homepage invitation acceptance, and test
+ * setup. Ordinary course-instance entry uses the checked reconciliation
+ * admission path instead.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -229,9 +229,8 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Legacy enrollment path for LTI 1.0, homepage invitation acceptance, and test
- * setup. Ordinary course-instance entry uses the checked reconciliation
- * admission path instead.
+ * Ensures enrollment without reconciling multiple identity candidates. Callers
+ * must establish any required enrollment authority before using this path.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required
@@ -239,7 +238,7 @@ export async function ensureUncheckedEnrollment({
  * instance enrollment limit to be exceeded.
  *
  */
-export async function ensureLegacyEnrollment({
+export async function ensureEnrollmentWithoutReconciliation({
   institution,
   course,
   courseInstance,

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
@@ -17,7 +17,7 @@ import {
   LtiLinkSchema,
   SprocUsersIsInstructorInCourseInstanceSchema,
 } from '../../lib/db-types.js';
-import { ensureEnrollment } from '../../models/enrollment.js';
+import { ensureLegacyEnrollment } from '../../models/enrollment.js';
 
 const TIME_TOLERANCE_SEC = 3000;
 
@@ -153,7 +153,7 @@ router.post(
 
     if (!authzData.has_student_access_with_enrollment) {
       assert(courseInstance);
-      await ensureEnrollment({
+      await ensureLegacyEnrollment({
         institution,
         course,
         courseInstance,

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
@@ -131,8 +131,7 @@ router.post(
 
     // Persist the user's authentication data in the session. We do this before
     // checking authorization so that user information is available for any
-    // subsequent requests or redirects (e.g. if `ensureCheckedEnrollment`
-    // redirects to a payment page).
+    // subsequent requests or enrollment-related payment redirects.
     const { user } = await authnLib.loadUser(req, res, {
       user_id: userId,
       provider: 'LTI',

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
@@ -17,7 +17,7 @@ import {
   LtiLinkSchema,
   SprocUsersIsInstructorInCourseInstanceSchema,
 } from '../../lib/db-types.js';
-import { ensureLegacyEnrollment } from '../../models/enrollment.js';
+import { ensureEnrollmentWithoutReconciliation } from '../../models/enrollment.js';
 
 const TIME_TOLERANCE_SEC = 3000;
 
@@ -153,7 +153,7 @@ router.post(
 
     if (!authzData.has_student_access_with_enrollment) {
       assert(courseInstance);
-      await ensureLegacyEnrollment({
+      await ensureEnrollmentWithoutReconciliation({
         institution,
         course,
         courseInstance,

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -6,7 +6,7 @@ import { HttpStatusError } from '@prairielearn/error';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../lib/enrollment/admission.js';
+import { selectEnrollmentAccessDecision } from '../../../lib/enrollment/admission.js';
 import { getEligibilityErrorMessage } from '../../../lib/enrollment/eligibility.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
 
@@ -56,7 +56,7 @@ router.get(
       throw new HttpStatusError(404, 'Only students can look up course instances');
     }
 
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const decision = await selectEnrollmentAccessDecision({
       course,
       courseInstance,
       enrollmentCode: code,

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -7,8 +7,8 @@ import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import { getEligibilityErrorMessage } from '../../../lib/enrollment-eligibility.js';
-import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../models/course-instance-admission.js';
+import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../lib/enrollment/admission.js';
+import { getEligibilityErrorMessage } from '../../../lib/enrollment/eligibility.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
 
 const router = Router();

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -7,7 +7,7 @@ import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../lib/enrollment/admission.js';
+import { selectEnrollmentAccessDecision } from '../../../lib/enrollment/admission.js';
 import { getEligibilityErrorMessage } from '../../../lib/enrollment/eligibility.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
 
@@ -60,7 +60,7 @@ router.get(
       throw new HttpStatusError(404, 'Only students can look up course instances');
     }
 
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const decision = await selectEnrollmentAccessDecision({
       course,
       courseInstance,
       enrollmentCode: code,

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -6,8 +6,8 @@ import { HttpStatusError } from '@prairielearn/error';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import { getEligibilityErrorMessage } from '../../../lib/enrollment-eligibility.js';
-import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../models/course-instance-admission.js';
+import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../lib/enrollment/admission.js';
+import { getEligibilityErrorMessage } from '../../../lib/enrollment/eligibility.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
 
 const router = Router();

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -7,11 +7,9 @@ import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import type { User } from '../../../lib/db-types.js';
 import { getEligibilityErrorMessage } from '../../../lib/enrollment-eligibility.js';
+import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../models/course-instance-admission.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
-import { selectCourseById } from '../../../models/course.js';
-import { selectOptionalEnrollmentByUid } from '../../../models/enrollment.js';
 
 const router = Router();
 
@@ -46,7 +44,7 @@ router.get(
       throw new HttpStatusError(404, 'This enrollment code is for a different course');
     }
 
-    const { authzData, courseInstance } = await constructCourseOrInstanceContext({
+    const { authzData, course, courseInstance } = await constructCourseOrInstanceContext({
       user: res.locals.authn_user,
       course_id: null, // Inferred from course_instance_id
       course_instance_id: courseInstanceId,
@@ -62,56 +60,18 @@ router.get(
       throw new HttpStatusError(404, 'Only students can look up course instances');
     }
 
-    const authnUser: User = res.locals.authn_user;
-
-    const existingEnrollment = await selectOptionalEnrollmentByUid({
-      uid: res.locals.authn_user.uid,
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course,
       courseInstance,
-      requiredRole: ['Student'],
-      authzData,
+      enrollmentCode: code,
+      user: res.locals.authn_user,
     });
 
-    if (existingEnrollment) {
-      if (
-        !['invited', 'rejected', 'joined', 'left', 'removed'].includes(existingEnrollment.status)
-      ) {
-        throw new HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+    if (!decision.allowed && decision.reason !== 'already_joined') {
+      if (decision.reason === 'enrollment_code_required') {
+        throw new HttpStatusError(403, 'A valid enrollment code is required');
       }
-
-      // If the user was invited, joined, left, or removed, then they have access so we can return the course instance ID.
-      // This means that rejected users will fall through to the self-enrollment checks.
-      if (['invited', 'joined', 'left', 'removed'].includes(existingEnrollment.status)) {
-        res.json({
-          course_instance_id: courseInstance.id,
-        });
-        return;
-      }
-    }
-
-    // Check if self-enrollment is enabled for this course instance
-    if (!courseInstance.self_enrollment_enabled) {
-      throw new HttpStatusError(403, getEligibilityErrorMessage('self-enrollment-disabled'));
-    }
-
-    if (
-      courseInstance.self_enrollment_restrict_to_institution &&
-      // The default value for self-enrollment restriction is true.
-      // In the old system (before publishing was introduced), the default was false.
-      // So if publishing is not set up, we should ignore the restriction.
-      courseInstance.modern_publishing
-    ) {
-      // Lookup the course
-      const course = await selectCourseById(courseInstance.course_id);
-      if (course.institution_id !== authnUser.institution_id) {
-        throw new HttpStatusError(403, getEligibilityErrorMessage('institution-restriction'));
-      }
-    }
-
-    if (
-      courseInstance.self_enrollment_enabled_before_date &&
-      new Date() >= courseInstance.self_enrollment_enabled_before_date
-    ) {
-      throw new HttpStatusError(403, getEligibilityErrorMessage('self-enrollment-expired'));
+      throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
     }
 
     // Return the course instance ID

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -6,11 +6,9 @@ import { HttpStatusError } from '@prairielearn/error';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import type { User } from '../../../lib/db-types.js';
 import { getEligibilityErrorMessage } from '../../../lib/enrollment-eligibility.js';
+import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../models/course-instance-admission.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
-import { selectCourseById } from '../../../models/course.js';
-import { selectOptionalEnrollmentByUid } from '../../../models/enrollment.js';
 
 const router = Router();
 
@@ -42,7 +40,7 @@ router.get(
       throw new HttpStatusError(404, 'This enrollment code is for a different course');
     }
 
-    const { authzData, courseInstance } = await constructCourseOrInstanceContext({
+    const { authzData, course, courseInstance } = await constructCourseOrInstanceContext({
       user: res.locals.authn_user,
       course_id: null, // Inferred from course_instance_id
       course_instance_id: courseInstanceId,
@@ -58,56 +56,18 @@ router.get(
       throw new HttpStatusError(404, 'Only students can look up course instances');
     }
 
-    const authnUser: User = res.locals.authn_user;
-
-    const existingEnrollment = await selectOptionalEnrollmentByUid({
-      uid: res.locals.authn_user.uid,
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course,
       courseInstance,
-      requiredRole: ['Student'],
-      authzData,
+      enrollmentCode: code,
+      user: res.locals.authn_user,
     });
 
-    if (existingEnrollment) {
-      if (
-        !['invited', 'rejected', 'joined', 'left', 'removed'].includes(existingEnrollment.status)
-      ) {
-        throw new HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+    if (!decision.allowed && decision.reason !== 'already_joined') {
+      if (decision.reason === 'enrollment_code_required') {
+        throw new HttpStatusError(403, 'A valid enrollment code is required');
       }
-
-      // If the user was invited, joined, left, or removed, then they have access so we can return the course instance ID.
-      // This means that rejected users will fall through to the self-enrollment checks.
-      if (['invited', 'joined', 'left', 'removed'].includes(existingEnrollment.status)) {
-        res.json({
-          course_instance_id: courseInstance.id,
-        });
-        return;
-      }
-    }
-
-    // Check if self-enrollment is enabled for this course instance
-    if (!courseInstance.self_enrollment_enabled) {
-      throw new HttpStatusError(403, getEligibilityErrorMessage('self-enrollment-disabled'));
-    }
-
-    if (
-      courseInstance.self_enrollment_restrict_to_institution &&
-      // The default value for self-enrollment restriction is true.
-      // In the old system (before publishing was introduced), the default was false.
-      // So if publishing is not set up, we should ignore the restriction.
-      courseInstance.modern_publishing
-    ) {
-      // Lookup the course
-      const course = await selectCourseById(courseInstance.course_id);
-      if (course.institution_id !== authnUser.institution_id) {
-        throw new HttpStatusError(403, getEligibilityErrorMessage('institution-restriction'));
-      }
-    }
-
-    if (
-      courseInstance.self_enrollment_enabled_before_date &&
-      new Date() >= courseInstance.self_enrollment_enabled_before_date
-    ) {
-      throw new HttpStatusError(403, getEligibilityErrorMessage('self-enrollment-expired'));
+      throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
     }
 
     // Return the course instance ID

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -7,8 +7,8 @@ import { EnrollmentPage } from '../../components/EnrollmentPage.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import {
-  admitUserFromOrdinaryCourseInstanceRequest,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  admitUserForCourseInstanceAccess,
+  selectEnrollmentAccessDecision,
 } from '../../lib/enrollment/admission.js';
 import { idsEqual } from '../../lib/id.js';
 
@@ -49,7 +49,7 @@ router.get(
       return;
     }
 
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const decision = await selectEnrollmentAccessDecision({
       course: res.locals.course,
       courseInstance,
       enrollmentCode: code,
@@ -57,9 +57,8 @@ router.get(
     });
 
     if (decision.allowed) {
-      await admitUserFromOrdinaryCourseInstanceRequest({
+      await admitUserForCourseInstanceAccess({
         courseInstanceId: courseInstance.id,
-        decision,
         enrollmentCode: code,
         ip: req.ip ?? null,
         isAdministrator: res.locals.is_administrator,

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -6,11 +6,11 @@ import { Hydrate } from '@prairielearn/react/server';
 import { EnrollmentPage } from '../../components/EnrollmentPage.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
-import { idsEqual } from '../../lib/id.js';
 import {
   admitUserFromOrdinaryCourseInstanceRequest,
   selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../../models/course-instance-admission.js';
+} from '../../lib/enrollment/admission.js';
+import { idsEqual } from '../../lib/id.js';
 
 import { EnrollmentCodeRequired } from './enrollmentCodeRequired.html.js';
 

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -75,7 +75,7 @@ router.get(
       return;
     }
     if (decision.reason !== 'enrollment_code_required') {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+      res.status(403).send(EnrollmentPage({ reason: decision.reason, resLocals: res.locals }));
       return;
     }
 

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -2,14 +2,15 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Hydrate } from '@prairielearn/react/server';
-import { run } from '@prairielearn/run';
 
 import { EnrollmentPage } from '../../components/EnrollmentPage.js';
 import { PageLayout } from '../../components/PageLayout.js';
-import { hasRole } from '../../lib/authz-data-lib.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
-import { authzCourseOrInstance } from '../../middlewares/authzCourseOrInstance.js';
-import { ensureEnrollment, selectOptionalEnrollmentByUid } from '../../models/enrollment.js';
+import { idsEqual } from '../../lib/id.js';
+import {
+  admitUserFromOrdinaryCourseInstanceRequest,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../models/course-instance-admission.js';
 
 import { EnrollmentCodeRequired } from './enrollmentCodeRequired.html.js';
 
@@ -27,107 +28,55 @@ router.get(
       // We should be careful to not pass `courseInstance` to the hydrated page.
       accessType: 'instructor',
     });
-    const enrollmentCode = courseInstance.enrollment_code;
     const redirectUrl =
       typeof url === 'string' && url.startsWith('/') && !url.startsWith('//') ? url : null;
-    // Lookup if they have an existing enrollment
-    const existingEnrollment = await run(async () => {
-      // We don't want to 403 instructors
-      if (!hasRole(res.locals.authz_data, ['Student'])) return null;
-      return await selectOptionalEnrollmentByUid({
-        uid: res.locals.authn_user.uid,
-        courseInstance,
-        requiredRole: ['Student'],
-        authzData: res.locals.authz_data,
-      });
-    });
-
-    const needsToSelfEnroll =
-      existingEnrollment == null ||
-      !['joined', 'invited', 'left', 'removed'].includes(existingEnrollment.status);
-
-    const institutionRestrictionSatisfied =
-      res.locals.authn_user.institution_id === res.locals.course.institution_id ||
-      // The default value for self-enrollment restriction is true.
-      // In the old system (before publishing was introduced), the default was false.
-      // So if publishing is not set up, we should ignore the restriction.
-      !courseInstance.modern_publishing ||
-      !courseInstance.self_enrollment_restrict_to_institution;
-
-    const selfEnrollmentExpired =
-      courseInstance.self_enrollment_enabled_before_date != null &&
-      new Date() >= courseInstance.self_enrollment_enabled_before_date;
-
-    const selfEnrollmentEnabled = courseInstance.self_enrollment_enabled;
-
-    if (!selfEnrollmentEnabled && needsToSelfEnroll) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: 'self-enrollment-disabled' }));
-      return;
-    }
-
-    if (selfEnrollmentExpired && needsToSelfEnroll) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: 'self-enrollment-expired' }));
-      return;
-    }
-
-    if (!institutionRestrictionSatisfied && needsToSelfEnroll) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: 'institution-restriction' }));
-      return;
-    }
-
-    // Check if the user is enrolled, but is in a status where they cannot rejoin the course.
-    if (
-      existingEnrollment != null &&
-      !['joined', 'invited', 'rejected', 'left', 'removed'].includes(existingEnrollment.status)
-    ) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
-      return;
-    }
-
-    const userBypassesEnrollmentCodeRequirement =
-      existingEnrollment != null &&
-      ['joined', 'invited', 'left', 'removed'].includes(existingEnrollment.status);
-
-    if (
-      // No enrollment code required
-      !courseInstance.self_enrollment_use_enrollment_code ||
-      // Enrollment code is correct
-      code?.toUpperCase() === enrollmentCode.toUpperCase() ||
-      // Existing joined, invited, left, or removed enrollments can transition immediately.
-      // Rejected enrollments are treated as if they had no status.
-      userBypassesEnrollmentCodeRequirement
-    ) {
-      if (
-        code?.toUpperCase() === enrollmentCode.toUpperCase() ||
-        userBypassesEnrollmentCodeRequirement
-      ) {
-        // Authorize the user for the course instance
-        req.params.course_instance_id = courseInstance.id;
-        await authzCourseOrInstance(req, res);
-
-        // Enroll the user
-        await ensureEnrollment({
-          institution: res.locals.institution,
-          course: res.locals.course,
-          courseInstance: res.locals.course_instance,
-          authzData: res.locals.authz_data,
-          requiredRole: ['Student'],
-          actionDetail: 'implicit_joined',
-        });
-      }
-
-      // redirect to a different page, which will have proper authorization.
+    const redirectAfterJoin = () => {
       if (redirectUrl != null) {
         res.redirect(redirectUrl);
       } else {
         res.redirect(`/pl/course_instance/${courseInstance.id}/assessments`);
       }
+    };
+
+    if (
+      !idsEqual(res.locals.user.id, res.locals.authn_user.id) ||
+      res.locals.authz_data.authn_course_role !== 'None' ||
+      res.locals.authz_data.authn_course_instance_role !== 'None' ||
+      res.locals.is_administrator ||
+      !res.locals.authz_data.authn_has_student_access
+    ) {
+      redirectAfterJoin();
+      return;
+    }
+
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course: res.locals.course,
+      courseInstance,
+      enrollmentCode: code,
+      user: res.locals.authn_user,
+    });
+
+    if (decision.allowed) {
+      await admitUserFromOrdinaryCourseInstanceRequest({
+        courseInstanceId: courseInstance.id,
+        decision,
+        enrollmentCode: code,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        userId: res.locals.authn_user.id,
+      });
+
+      redirectAfterJoin();
+      return;
+    }
+
+    if (decision.reason === 'already_joined') {
+      redirectAfterJoin();
+      return;
+    }
+    if (decision.reason !== 'enrollment_code_required') {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
       return;
     }
 

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -198,7 +198,10 @@ WITH
       )
     WHERE
       e.user_id = $user_id
-      OR e.pending_uid = $pending_uid
+      OR (
+        e.pending_uid = $pending_uid
+        AND e.pending_lti13_course_instance_id IS NULL
+      )
   ),
   -- Legacy courses: use access rules for dates and initial filtering
   legacy_courses AS (

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -22,7 +22,7 @@ import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import {
-  ensureEnrollment,
+  ensureLegacyEnrollment,
   selectOptionalEnrollmentByUid,
   setEnrollmentStatus,
 } from '../../models/enrollment.js';
@@ -251,7 +251,7 @@ router.post(
           break;
         }
 
-        await ensureEnrollment({
+        await ensureLegacyEnrollment({
           institution,
           course,
           courseInstance,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -17,8 +17,12 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
-import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
+import {
+  admitUserFromUidInvitation,
+  rejectUserFromUidInvitation,
+} from '../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
@@ -246,35 +250,28 @@ router.post(
           break;
         }
 
-        await admitUserFromUidInvitation({
-          courseInstanceId: courseInstance.id,
-          expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
-          ip: req.ip ?? null,
-          isAdministrator: res.locals.is_administrator,
-          reqDate: res.locals.req_date,
-          userId: res.locals.authn_user.id,
-        });
+        try {
+          await admitUserFromUidInvitation({
+            courseInstanceId: courseInstance.id,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            reqDate: res.locals.req_date,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to accept invitation');
+        }
         break;
       }
       case 'reject_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
+        const rejected = await rejectUserFromUidInvitation({
           authzData,
+          courseInstanceId: courseInstance.id,
+          userId: res.locals.authn_user.id,
         });
-
-        if (!enrollment || !['invited', 'rejected'].includes(enrollment.status)) {
-          flash('error', 'Failed to reject invitation');
-          break;
-        }
-
-        await setEnrollmentStatus({
-          enrollment,
-          status: 'rejected',
-          authzData,
-          requiredRole: ['Student'],
-        });
+        if (!rejected) flash('error', 'Failed to reject invitation');
         break;
       }
       case 'unenroll': {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -22,7 +22,7 @@ import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import {
-  ensureLegacyEnrollment,
+  ensureEnrollmentWithoutReconciliation,
   selectOptionalEnrollmentByUid,
   setEnrollmentStatus,
 } from '../../models/enrollment.js';
@@ -251,7 +251,7 @@ router.post(
           break;
         }
 
-        await ensureLegacyEnrollment({
+        await ensureEnrollmentWithoutReconciliation({
           institution,
           course,
           courseInstance,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -23,7 +23,7 @@ import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import {
-  ensureLegacyEnrollment,
+  ensureEnrollmentWithoutReconciliation,
   selectOptionalEnrollmentByUid,
   setEnrollmentStatus,
 } from '../../models/enrollment.js';
@@ -253,7 +253,7 @@ router.post(
           break;
         }
 
-        await ensureLegacyEnrollment({
+        await ensureEnrollmentWithoutReconciliation({
           institution,
           course,
           courseInstance,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -19,7 +19,6 @@ import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
 import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
@@ -247,19 +246,14 @@ router.post(
           break;
         }
 
-        try {
-          await admitUserFromUidInvitation({
-            courseInstanceId: courseInstance.id,
-            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
-            ip: req.ip ?? null,
-            isAdministrator: res.locals.is_administrator,
-            reqDate: res.locals.req_date,
-            userId: res.locals.authn_user.id,
-          });
-        } catch (error) {
-          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
-          flash('error', 'Failed to accept invitation');
-        }
+        await admitUserFromUidInvitation({
+          courseInstanceId: courseInstance.id,
+          expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          userId: res.locals.authn_user.id,
+        });
         break;
       }
       case 'reject_invitation': {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -18,7 +18,6 @@ import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
 import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
@@ -245,19 +244,14 @@ router.post(
           break;
         }
 
-        try {
-          await admitUserFromUidInvitation({
-            courseInstanceId: courseInstance.id,
-            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
-            ip: req.ip ?? null,
-            isAdministrator: res.locals.is_administrator,
-            reqDate: res.locals.req_date,
-            userId: res.locals.authn_user.id,
-          });
-        } catch (error) {
-          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
-          flash('error', 'Failed to accept invitation');
-        }
+        await admitUserFromUidInvitation({
+          courseInstanceId: courseInstance.id,
+          expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          userId: res.locals.authn_user.id,
+        });
         break;
       }
       case 'reject_invitation': {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -16,16 +16,15 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
+import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
+import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
-import {
-  ensureEnrollmentWithoutReconciliation,
-  selectOptionalEnrollmentByUid,
-  setEnrollmentStatus,
-} from '../../models/enrollment.js';
+import { selectOptionalEnrollmentByUid, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
@@ -198,15 +197,14 @@ router.post(
       return;
     }
 
-    const { authzData, courseInstance, institution, course } =
-      await constructCourseOrInstanceContext({
-        user: res.locals.authn_user,
-        course_id: null,
-        course_instance_id: body.course_instance_id,
-        ip: req.ip ?? null,
-        req_date: res.locals.req_date,
-        is_administrator: res.locals.is_administrator,
-      });
+    const { authzData, courseInstance } = await constructCourseOrInstanceContext({
+      user: res.locals.authn_user,
+      course_id: null,
+      course_instance_id: body.course_instance_id,
+      ip: req.ip ?? null,
+      req_date: res.locals.req_date,
+      is_administrator: res.locals.is_administrator,
+    });
 
     if (authzData === null || courseInstance === null) {
       throw new HttpStatusError(403, 'Access denied');
@@ -237,28 +235,29 @@ router.post(
 
     switch (body.__action) {
       case 'accept_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
-          authzData,
+        const decision = await selectEnrollmentAdmissionDecision({
+          courseInstanceId: courseInstance.id,
+          source: { type: 'invitation', matchedBy: 'uid' },
+          userId: res.locals.authn_user.id,
         });
-        if (
-          !enrollment ||
-          !['left', 'removed', 'rejected', 'invited', 'joined'].includes(enrollment.status)
-        ) {
+        if (!decision.allowed || decision.invitationCandidate === null) {
           flash('error', 'Failed to accept invitation');
           break;
         }
 
-        await ensureEnrollmentWithoutReconciliation({
-          institution,
-          course,
-          courseInstance,
-          authzData,
-          requiredRole: ['Student'],
-          actionDetail: 'invitation_accepted',
-        });
+        try {
+          await admitUserFromUidInvitation({
+            courseInstanceId: courseInstance.id,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            reqDate: res.locals.req_date,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to accept invitation');
+        }
         break;
       }
       case 'reject_invitation': {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -23,7 +23,7 @@ import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import {
-  ensureEnrollment,
+  ensureLegacyEnrollment,
   selectOptionalEnrollmentByUid,
   setEnrollmentStatus,
 } from '../../models/enrollment.js';
@@ -253,7 +253,7 @@ router.post(
           break;
         }
 
-        await ensureEnrollment({
+        await ensureLegacyEnrollment({
           institution,
           course,
           courseInstance,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -17,16 +17,15 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
+import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
+import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
-import {
-  ensureEnrollmentWithoutReconciliation,
-  selectOptionalEnrollmentByUid,
-  setEnrollmentStatus,
-} from '../../models/enrollment.js';
+import { selectOptionalEnrollmentByUid, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
@@ -200,15 +199,14 @@ router.post(
       return;
     }
 
-    const { authzData, courseInstance, institution, course } =
-      await constructCourseOrInstanceContext({
-        user: res.locals.authn_user,
-        course_id: null,
-        course_instance_id: body.course_instance_id,
-        ip: req.ip ?? null,
-        req_date: res.locals.req_date,
-        is_administrator: res.locals.is_administrator,
-      });
+    const { authzData, courseInstance } = await constructCourseOrInstanceContext({
+      user: res.locals.authn_user,
+      course_id: null,
+      course_instance_id: body.course_instance_id,
+      ip: req.ip ?? null,
+      req_date: res.locals.req_date,
+      is_administrator: res.locals.is_administrator,
+    });
 
     if (authzData === null || courseInstance === null) {
       throw new HttpStatusError(403, 'Access denied');
@@ -239,28 +237,29 @@ router.post(
 
     switch (body.__action) {
       case 'accept_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
-          authzData,
+        const decision = await selectEnrollmentAdmissionDecision({
+          courseInstanceId: courseInstance.id,
+          source: { type: 'invitation', matchedBy: 'uid' },
+          userId: res.locals.authn_user.id,
         });
-        if (
-          !enrollment ||
-          !['left', 'removed', 'rejected', 'invited', 'joined'].includes(enrollment.status)
-        ) {
+        if (!decision.allowed || decision.invitationCandidate === null) {
           flash('error', 'Failed to accept invitation');
           break;
         }
 
-        await ensureEnrollmentWithoutReconciliation({
-          institution,
-          course,
-          courseInstance,
-          authzData,
-          requiredRole: ['Student'],
-          actionDetail: 'invitation_accepted',
-        });
+        try {
+          await admitUserFromUidInvitation({
+            courseInstanceId: courseInstance.id,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            reqDate: res.locals.req_date,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to accept invitation');
+        }
         break;
       }
       case 'reject_invitation': {

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -23,6 +23,7 @@ import {
   updateCourseInstanceSettings,
   withUser,
 } from './utils/auth.js';
+import { createEnrollment } from './utils/enrollment-identity.js';
 import { enrollUser, unenrollUser } from './utils/enrollments.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
@@ -330,23 +331,24 @@ describe('Self-enrollment settings transitions', () => {
       email: 'uin-invitation@example.com',
       institutionId: '1',
     });
-    const invitation = await queryRow(
-      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
-       VALUES ('1', 'invited', $pending_uin)
-       RETURNING *`,
-      { pending_uin: uinUser.uin },
-      EnrollmentSchema,
-    );
+    const invitation = await createEnrollment({
+      courseInstance,
+      pendingUin: uinUser.uin,
+      status: 'invited',
+    });
 
     await withUser(uinUser, async () => {
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
 
-      const enrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const enrollment = await selectOptionalEnrollmentByUserId({
+        userId: uinUser.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(enrollment);
+      assert.equal(enrollment.id, invitation.id);
       assert.equal(enrollment.status, 'joined');
       assert.equal(enrollment.user_id, uinUser.id);
       assert.isNull(enrollment.pending_uin);

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, assert, beforeAll, describe, it, test } from 'vitest';
+import { afterAll, assert, beforeAll, describe, expect, it, test } from 'vitest';
 
 import { execute, queryOptionalRow, queryRow } from '@prairielearn/postgres';
 
@@ -7,6 +7,7 @@ import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { getSelfEnrollmentLinkUrl } from '../lib/client/url.js';
 import { config } from '../lib/config.js';
 import { type CourseInstance, EnrollmentSchema } from '../lib/db-types.js';
+import { admitUserForCourseInstanceAccess } from '../lib/enrollment/admission.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -23,7 +24,7 @@ import {
   updateCourseInstanceSettings,
   withUser,
 } from './utils/auth.js';
-import { createEnrollment } from './utils/enrollment-identity.js';
+import { createEnrollment, selectEnrollments } from './utils/enrollment-identity.js';
 import { enrollUser, unenrollUser } from './utils/enrollments.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
@@ -316,44 +317,74 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
-  it('admits an institution UIN invitation without self-enrollment or a code', async () => {
-    await deleteEnrollmentsInCourseInstance('1');
-    await updateCourseInstanceSettings('1', {
-      selfEnrollmentEnabled: false,
-      selfEnrollmentUseEnrollmentCode: true,
-      restrictToInstitution: false,
-    });
-
-    const uinUser = await getOrCreateUser({
-      uid: 'uin-invitation@example.com',
-      name: 'UIN Invitation Student',
-      uin: 'invitation-uin',
-      email: 'uin-invitation@example.com',
-      institutionId: '1',
-    });
-    const invitation = await createEnrollment({
-      courseInstance,
-      pendingUin: uinUser.uin,
-      status: 'invited',
-    });
-
-    await withUser(uinUser, async () => {
-      const response = await fetch(assessmentsUrl);
-      assert.equal(response.status, 200);
-
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: uinUser.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
+  it.each([
+    {
+      name: 'without a bound enrollment',
+      prefix: 'uin-invitation',
+      boundStatus: null,
+      expectedHttpStatus: 200,
+      expectedPersistedStatuses: ['joined'],
+    },
+    {
+      name: 'paired with a left enrollment',
+      prefix: 'left-with-invitation',
+      boundStatus: 'left' as const,
+      expectedHttpStatus: 200,
+      expectedPersistedStatuses: ['joined'],
+    },
+    {
+      name: 'paired with a removed enrollment',
+      prefix: 'removed-with-invitation',
+      boundStatus: 'removed' as const,
+      expectedHttpStatus: 403,
+      expectedPersistedStatuses: ['removed', 'invited'],
+    },
+  ])(
+    'handles an institution UIN invitation $name',
+    async ({ prefix, boundStatus, expectedHttpStatus, expectedPersistedStatuses }) => {
+      await deleteEnrollmentsInCourseInstance('1');
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
       });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.id, invitation.id);
-      assert.equal(enrollment.status, 'joined');
-      assert.equal(enrollment.user_id, uinUser.id);
-      assert.isNull(enrollment.pending_uin);
-    });
-  });
+
+      const user = await getOrCreateUser({
+        uid: `${prefix}@example.com`,
+        name: prefix,
+        uin: prefix,
+        email: `${prefix}@example.com`,
+        institutionId: '1',
+      });
+      const enrollmentIds: string[] = [];
+      if (boundStatus !== null) {
+        const boundEnrollment = await createEnrollment({
+          courseInstance,
+          userId: user.id,
+          status: boundStatus,
+          firstJoinedAt: new Date('2024-01-01T00:00:00Z'),
+        });
+        enrollmentIds.push(boundEnrollment.id);
+      }
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingUin: user.uin,
+        status: 'invited',
+      });
+      enrollmentIds.push(invitation.id);
+
+      await withUser(user, async () => {
+        const response = await fetch(assessmentsUrl);
+        assert.equal(response.status, expectedHttpStatus);
+      });
+
+      const persistedEnrollments = await selectEnrollments(enrollmentIds);
+      assert.deepEqual(
+        persistedEnrollments.map((enrollment) => enrollment.status),
+        expectedPersistedStatuses,
+      );
+    },
+  );
 
   it('does not allow rejected user to self-enroll via the assessments endpoint when self-enrollment is disabled', async () => {
     await deleteEnrollmentsInCourseInstance('1');
@@ -494,6 +525,19 @@ describe('Self-enrollment settings transitions', () => {
       });
       assert.isNotNull(finalEnrollment);
       assert.equal(finalEnrollment.status, 'blocked');
+    });
+
+    await expect(
+      admitUserForCourseInstanceAccess({
+        courseInstanceId: courseInstance.id,
+        ip: null,
+        isAdministrator: false,
+        reqDate: new Date(),
+        userId: blockedUser.id,
+      }),
+    ).rejects.toMatchObject({
+      message: 'You are blocked from accessing this course',
+      status: 403,
     });
   });
 

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -315,6 +315,94 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
+  it('admits an institution-roster invitation without self-enrollment or a code', async () => {
+    await deleteEnrollmentsInCourseInstance('1');
+    await updateCourseInstanceSettings('1', {
+      selfEnrollmentEnabled: false,
+      selfEnrollmentUseEnrollmentCode: true,
+      restrictToInstitution: false,
+    });
+
+    const rosterUser = await getOrCreateUser({
+      uid: 'roster@example.com',
+      name: 'Roster Student',
+      uin: 'roster-uin',
+      email: 'roster@example.com',
+      institutionId: '1',
+    });
+    const invitation = await queryRow(
+      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
+       VALUES ('1', 'invited', $pending_uin)
+       RETURNING *`,
+      { pending_uin: rosterUser.uin },
+      EnrollmentSchema,
+    );
+
+    await withUser(rosterUser, async () => {
+      const response = await fetch(assessmentsUrl);
+      assert.equal(response.status, 200);
+
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      assert.equal(enrollment.status, 'joined');
+      assert.equal(enrollment.user_id, rosterUser.id);
+      assert.isNull(enrollment.pending_uin);
+    });
+  });
+
+  it('applies normal self-enrollment policy when a removed user also has a roster row', async () => {
+    await deleteEnrollmentsInCourseInstance('1');
+    await updateCourseInstanceSettings('1', {
+      selfEnrollmentEnabled: false,
+      selfEnrollmentUseEnrollmentCode: true,
+      restrictToInstitution: false,
+    });
+
+    const removedUser = await getOrCreateUser({
+      uid: 'removed-roster@example.com',
+      name: 'Removed Roster Student',
+      uin: 'removed-roster-uin',
+      email: 'removed-roster@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await queryRow(
+      `INSERT INTO enrollments (course_instance_id, first_joined_at, status, user_id)
+       VALUES ('1', now(), 'removed', $user_id)
+       RETURNING *`,
+      { user_id: removedUser.id },
+      EnrollmentSchema,
+    );
+    const invitation = await queryRow(
+      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
+       VALUES ('1', 'invited', $pending_uin)
+       RETURNING *`,
+      { pending_uin: removedUser.uin },
+      EnrollmentSchema,
+    );
+
+    await withUser(removedUser, async () => {
+      const response = await fetch(assessmentsUrl);
+      assert.equal(response.status, 403);
+
+      const persistedBoundEnrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: boundEnrollment.id },
+        EnrollmentSchema,
+      );
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      assert.equal(persistedBoundEnrollment.status, 'removed');
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
+    });
+  });
+
   it('does not allow rejected user to self-enroll via the assessments endpoint when self-enrollment is disabled', async () => {
     await deleteEnrollmentsInCourseInstance('1');
     await updateCourseInstanceSettings('1', {

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -315,7 +315,7 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
-  it('admits an institution-roster invitation without self-enrollment or a code', async () => {
+  it('admits an institution UIN invitation without self-enrollment or a code', async () => {
     await deleteEnrollmentsInCourseInstance('1');
     await updateCourseInstanceSettings('1', {
       selfEnrollmentEnabled: false,
@@ -323,22 +323,22 @@ describe('Self-enrollment settings transitions', () => {
       restrictToInstitution: false,
     });
 
-    const rosterUser = await getOrCreateUser({
-      uid: 'roster@example.com',
-      name: 'Roster Student',
-      uin: 'roster-uin',
-      email: 'roster@example.com',
+    const uinUser = await getOrCreateUser({
+      uid: 'uin-invitation@example.com',
+      name: 'UIN Invitation Student',
+      uin: 'invitation-uin',
+      email: 'uin-invitation@example.com',
       institutionId: '1',
     });
     const invitation = await queryRow(
       `INSERT INTO enrollments (course_instance_id, status, pending_uin)
        VALUES ('1', 'invited', $pending_uin)
        RETURNING *`,
-      { pending_uin: rosterUser.uin },
+      { pending_uin: uinUser.uin },
       EnrollmentSchema,
     );
 
-    await withUser(rosterUser, async () => {
+    await withUser(uinUser, async () => {
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
 
@@ -348,7 +348,7 @@ describe('Self-enrollment settings transitions', () => {
         EnrollmentSchema,
       );
       assert.equal(enrollment.status, 'joined');
-      assert.equal(enrollment.user_id, rosterUser.id);
+      assert.equal(enrollment.user_id, uinUser.id);
       assert.isNull(enrollment.pending_uin);
     });
   });

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -353,56 +353,6 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
-  it('applies normal self-enrollment policy when a removed user also has a roster row', async () => {
-    await deleteEnrollmentsInCourseInstance('1');
-    await updateCourseInstanceSettings('1', {
-      selfEnrollmentEnabled: false,
-      selfEnrollmentUseEnrollmentCode: true,
-      restrictToInstitution: false,
-    });
-
-    const removedUser = await getOrCreateUser({
-      uid: 'removed-roster@example.com',
-      name: 'Removed Roster Student',
-      uin: 'removed-roster-uin',
-      email: 'removed-roster@example.com',
-      institutionId: '1',
-    });
-    const boundEnrollment = await queryRow(
-      `INSERT INTO enrollments (course_instance_id, first_joined_at, status, user_id)
-       VALUES ('1', now(), 'removed', $user_id)
-       RETURNING *`,
-      { user_id: removedUser.id },
-      EnrollmentSchema,
-    );
-    const invitation = await queryRow(
-      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
-       VALUES ('1', 'invited', $pending_uin)
-       RETURNING *`,
-      { pending_uin: removedUser.uin },
-      EnrollmentSchema,
-    );
-
-    await withUser(removedUser, async () => {
-      const response = await fetch(assessmentsUrl);
-      assert.equal(response.status, 403);
-
-      const persistedBoundEnrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: boundEnrollment.id },
-        EnrollmentSchema,
-      );
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
-      assert.equal(persistedBoundEnrollment.status, 'removed');
-      assert.equal(persistedInvitation.status, 'invited');
-      assert.isNull(persistedInvitation.user_id);
-    });
-  });
-
   it('does not allow rejected user to self-enroll via the assessments endpoint when self-enrollment is disabled', async () => {
     await deleteEnrollmentsInCourseInstance('1');
     await updateCourseInstanceSettings('1', {

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -30,6 +30,11 @@ WHERE
   course_instance_id = $course_instance_id
   AND pending_uid = $pending_uid;
 
+-- BLOCK delete_lti13_course_instance
+DELETE FROM lti13_course_instances
+WHERE
+  id = $lti13_course_instance_id;
+
 -- BLOCK update_course_instance_publishing
 UPDATE course_instances
 SET

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -18,6 +18,11 @@ import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
 import { getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
+import {
+  createEnrollment,
+  createLti13CourseInstance,
+  selectEnrollments,
+} from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
@@ -206,6 +211,54 @@ describe('Homepage enrollment actions', () => {
       course_instance_id: '1',
       pending_uid: user.uid,
     });
+  });
+
+  it('does not show or reject an LTI invitation that only matches by UID', async () => {
+    const user = await getOrCreateUser({
+      uid: 'lti-uid-only@example.com',
+      name: 'UID-only LTI user',
+      uin: 'different-uin',
+      email: 'lti-uid-only@example.com',
+      institutionId: '1',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
+    const invitation = await createEnrollment({
+      courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: 'rightful-student-sub',
+      pendingUid: user.uid,
+      pendingUin: 'rightful-student-uin',
+    });
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        assert.lengthOf(
+          page.$(`form:has(input[name="course_instance_id"][value="${courseInstance.id}"])`),
+          0,
+        );
+
+        const response = await fetchCheerio(homeUrl, {
+          method: 'POST',
+          body: new URLSearchParams({
+            __action: 'reject_invitation',
+            course_instance_id: courseInstance.id,
+            __csrf_token: await getCsrfToken(homeUrl),
+          }),
+        });
+        assert.equal(response.status, 200);
+        assertAlert(response.$, 'Failed to reject invitation');
+      });
+
+      const enrollments = await selectEnrollments([invitation.id]);
+      assert.lengthOf(enrollments, 1);
+      assert.equal(enrollments[0].status, 'invited');
+    } finally {
+      await execute(sql.delete_lti13_course_instance, {
+        lti13_course_instance_id: lti13CourseInstance.id,
+      });
+    }
   });
 
   it('shows error when rejecting after accepting invitation', async () => {

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -239,7 +239,7 @@ describe('Homepage enrollment actions', () => {
           0,
         );
 
-        const response = await fetchCheerio(homeUrl, {
+        const response = await fetchCookie(fetch)(homeUrl, {
           method: 'POST',
           body: new URLSearchParams({
             __action: 'reject_invitation',
@@ -248,7 +248,8 @@ describe('Homepage enrollment actions', () => {
           }),
         });
         assert.equal(response.status, 200);
-        assertAlert(response.$, 'Failed to reject invitation');
+        const cheerio = await import('cheerio');
+        assertAlert(cheerio.load(await response.text()), 'Failed to reject invitation');
       });
 
       const enrollments = await selectEnrollments([invitation.id]);

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -43,7 +43,9 @@ async function createEnrollmentWithStatus({
       course_instance_id: courseInstanceId,
       status,
       pending_uid: pendingUid,
-      first_joined_at: status === 'joined' ? new Date() : null,
+      first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
+        ? new Date()
+        : null,
     },
     EnrollmentSchema,
   );
@@ -279,78 +281,71 @@ describe('Homepage enrollment actions', () => {
     });
   });
 
-  it('allows accepting invitation after rejecting it', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited4@example.com',
-      name: 'Invited User 4',
-      uin: 'invited4',
-      email: 'invited4@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First reject the invitation
-      const rejectResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
+  it.each(['left', 'removed', 'rejected'] as const)(
+    'does not treat a %s enrollment as an invitation',
+    async (status) => {
+      const user = await getOrCreateUser({
+        uid: `non-actionable-${status}@example.com`,
+        name: `Non-actionable ${status} user`,
+        uin: `non-actionable-${status}`,
+        email: `non-actionable-${status}@example.com`,
+        institutionId: '1',
       });
-      assert.equal(rejectResponse.status, 200);
-      assert.equal(rejectResponse.url, homeUrl);
-
-      // Verify enrollment is rejected
-      const courseInstance = await selectCourseInstanceById('1');
-      const rejectedEnrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
+      const isPending = status === 'rejected';
+      await createEnrollmentWithStatus({
+        userId: isPending ? null : user.id,
+        courseInstanceId: '1',
+        status,
+        pendingUid: isPending ? user.uid : null,
       });
-      assert.isNotNull(rejectedEnrollment);
-      assert.equal(rejectedEnrollment.status, 'rejected');
 
-      // Now accept the invitation (should succeed)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const acceptResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(acceptResponse.status, 200);
-      assert.equal(acceptResponse.url, homeUrl);
+      try {
+        await withUser(user, async () => {
+          const fetchWithCookies = fetchCookie(fetch);
+          const response = await fetchWithCookies(homeUrl, {
+            method: 'POST',
+            body: new URLSearchParams({
+              __action: 'accept_invitation',
+              course_instance_id: '1',
+              __csrf_token: await getCsrfToken(homeUrl),
+            }),
+          });
+          assert.equal(response.status, 200);
+          const $ = (await import('cheerio')).load(await response.text());
+          assertAlert($, 'Failed to accept invitation');
 
-      // Verify enrollment is now joined
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
+          const courseInstance = await selectCourseInstanceById('1');
+          const enrollment = isPending
+            ? await selectOptionalEnrollmentByPendingUid({
+                pendingUid: user.uid,
+                courseInstance,
+                requiredRole: ['System'],
+                authzData: dangerousFullSystemAuthz(),
+              })
+            : await selectOptionalEnrollmentByUserId({
+                userId: user.id,
+                courseInstance,
+                requiredRole: ['System'],
+                authzData: dangerousFullSystemAuthz(),
+              });
+          assert.isNotNull(enrollment);
+          assert.equal(enrollment.status, status);
+        });
+      } finally {
+        if (isPending) {
+          await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
+            course_instance_id: '1',
+            pending_uid: user.uid,
+          });
+        } else {
+          await execute(sql.delete_enrollment_by_course_instance_and_user, {
+            course_instance_id: '1',
+            user_id: user.id,
+          });
+        }
+      }
+    },
+  );
 
   it('does not show invited course that is not published', async () => {
     const user = await getOrCreateUser({

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
@@ -248,7 +249,6 @@ describe('Homepage enrollment actions', () => {
           }),
         });
         assert.equal(response.status, 200);
-        const cheerio = await import('cheerio');
         assertAlert(cheerio.load(await response.text()), 'Failed to reject invitation');
       });
 
@@ -311,7 +311,6 @@ describe('Homepage enrollment actions', () => {
 
       // Get the HTML to check for flash message
       const rejectResponseText = await rejectResponse.text();
-      const cheerio = await import('cheerio');
       const $ = cheerio.load(rejectResponseText);
 
       // Verify error message is shown
@@ -365,7 +364,7 @@ describe('Homepage enrollment actions', () => {
             }),
           });
           assert.equal(response.status, 200);
-          const $ = (await import('cheerio')).load(await response.text());
+          const $ = cheerio.load(await response.text());
           assertAlert($, 'Failed to accept invitation');
 
           const courseInstance = await selectCourseInstanceById('1');

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -16,9 +16,12 @@ import {
   updateRequiredPlansForCourseInstance,
 } from '../ee/lib/billing/plans.js';
 import { Lti13CombinedInstanceSchema, inspectRoster } from '../ee/lib/lti13.js';
+import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import { EnrollmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
+import { type CourseInstance, Lti13CourseInstanceSchema } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
+import { selectCourseInstanceById } from '../models/course-instances.js';
+import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
 import { selectOptionalUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
@@ -33,10 +36,13 @@ import {
   makeLoginExecutor,
   withServer,
 } from './lti13TestHelpers.js';
+import { updateCourseInstanceSettings } from './utils/auth.js';
+import { createEnrollment, selectEnrollments } from './utils/enrollment-identity.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
+  let courseInstance: CourseInstance;
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
 
@@ -52,36 +58,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
   }
 
-  async function insertLti13Invitation({
-    lti13CourseInstanceId,
-    pendingUin,
-    sub,
-  }: {
-    lti13CourseInstanceId: string;
-    pendingUin: string;
-    sub: string;
-  }) {
-    return await queryRow(
-      `INSERT INTO enrollments (
-         course_instance_id,
-         pending_lti13_course_instance_id,
-         pending_lti13_sub,
-         pending_uin,
-         status
-       )
-       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
-       RETURNING *`,
-      {
-        lti13_course_instance_id: lti13CourseInstanceId,
-        pending_uin: pendingUin,
-        sub,
-      },
-      EnrollmentSchema,
-    );
-  }
-
-  async function selectLatestSessionData(userId: string) {
-    return await queryScalar(
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await queryScalar(
       `SELECT data
        FROM user_sessions
        WHERE user_id = $user_id
@@ -90,10 +68,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       { user_id: userId },
       z.record(z.string(), z.unknown()),
     );
-  }
-
-  async function assertLtiLaunchConsumed(userId: string) {
-    const sessionData = await selectLatestSessionData(userId);
     assert.notProperty(sessionData, 'lti13_claims');
     assert.notProperty(sessionData, 'authn_lti13_instance_id');
   }
@@ -101,6 +75,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   beforeAll(async () => {
     config.isEnterprise = true;
     await helperServer.before()();
+    courseInstance = await selectCourseInstanceById('1');
 
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$'");
 
@@ -419,30 +394,28 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
     afterEach(async () => {
       await updateRequiredPlansForCourseInstance('1', [], '1');
-      await execute(
-        `UPDATE course_instances
-         SET
-           enrollment_limit = NULL,
-           self_enrollment_enabled = TRUE,
-           self_enrollment_use_enrollment_code = FALSE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: true,
+        selfEnrollmentUseEnrollmentCode: false,
+        restrictToInstitution: false,
+      });
+      await execute("UPDATE course_instances SET enrollment_limit = NULL WHERE id = '1'");
     });
 
     test('admits only the exact link and sub from the fresh launch', async () => {
-      await execute(
-        `UPDATE course_instances
-         SET
-           self_enrollment_enabled = FALSE,
-           self_enrollment_use_enrollment_code = TRUE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
+      });
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
       const sub = 'exact-invitation-admission-sub';
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: sub,
         pendingUin: 'exact-invitation-unmatched-uin',
-        sub,
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -467,11 +440,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
       const user = await selectOptionalUserByUid('exact-invitation-admission@example.com');
       assert.ok(user);
-      const enrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [enrollment] = await selectEnrollments([invitation.id]);
       assert.equal(enrollment.status, 'joined');
       assert.equal(enrollment.user_id, user.id);
       await assertLtiLaunchConsumed(user.id);
@@ -479,10 +448,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
     test('rejects a wrong sub and falls back to self-enrollment', async () => {
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: 'expected-invitation-sub',
         pendingUin: 'wrong-sub-unmatched-uin',
-        sub: 'expected-invitation-sub',
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -507,40 +478,35 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
       assert.ok(user);
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const selfEnrollment = await queryRow(
-        `SELECT *
-         FROM enrollments
-         WHERE course_instance_id = '1'
-         AND user_id = $user_id`,
-        { user_id: user.id },
-        EnrollmentSchema,
-      );
+      const selfEnrollment = await selectOptionalEnrollmentByUserId({
+        userId: user.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(selfEnrollment);
       assert.equal(selfEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
     test('requires a fresh launch after an exact admission plan upgrade', async () => {
       await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
-      await execute(
-        `UPDATE course_instances
-         SET
-           self_enrollment_enabled = FALSE,
-           self_enrollment_use_enrollment_code = TRUE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
+      });
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
       const sub = 'upgrade-exact-invitation-sub';
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: sub,
         pendingUin: 'upgrade-exact-invitation-unmatched-uin',
-        sub,
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -565,11 +531,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const $ = cheerio.load(await response.text());
       assert.include($('body').text(), 'Upgrade required');
 
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
       const user = await selectOptionalUserByUid('upgrade-exact-invitation@example.com');

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,11 +6,15 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, test } from 'vitest';
 import { z } from 'zod';
 
 import { execute, queryOptionalRow, queryRow, queryScalar } from '@prairielearn/postgres';
 
+import {
+  reconcilePlanGrantsForCourseInstanceUser,
+  updateRequiredPlansForCourseInstance,
+} from '../ee/lib/billing/plans.js';
 import { Lti13CombinedInstanceSchema, inspectRoster } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
 import { EnrollmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
@@ -414,6 +418,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     });
 
     afterEach(async () => {
+      await updateRequiredPlansForCourseInstance('1', [], '1');
       await execute(
         `UPDATE course_instances
          SET
@@ -458,7 +463,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
       const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
@@ -468,16 +472,9 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(enrollment).toMatchObject({
-        pending_lti13_course_instance_id: null,
-        pending_lti13_sub: null,
-        pending_uin: null,
-        status: 'joined',
-        user_id: user.id,
-      });
+      assert.equal(enrollment.status, 'joined');
+      assert.equal(enrollment.user_id, user.id);
       await assertLtiLaunchConsumed(user.id);
-      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
-      assert.equal(consumedLaunchResponse.status, 403);
     });
 
     test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
@@ -506,7 +503,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
@@ -516,12 +512,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: 'expected-roster-sub',
-        status: 'invited',
-        user_id: null,
-      });
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
       const ordinaryEnrollment = await queryRow(
         `SELECT *
          FROM enrollments
@@ -530,34 +522,33 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { user_id: user.id },
         EnrollmentSchema,
       );
-      assert.notEqual(ordinaryEnrollment.id, invitation.id);
       assert.equal(ordinaryEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('consumes the launch before an exact admission limit redirect', async () => {
+    test('requires a fresh launch after an exact admission plan upgrade', async () => {
+      await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
       await execute(
         `UPDATE course_instances
          SET
-           enrollment_limit = 0,
            self_enrollment_enabled = FALSE,
            self_enrollment_use_enrollment_code = TRUE
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'limited-exact-roster-sub';
+      const sub = 'upgrade-exact-roster-sub';
       const invitation = await insertLtiRosterInvitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'limited-exact-roster-unmatched-uin',
+        pendingUin: 'upgrade-exact-roster-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Limited Exact Roster',
-          email: 'limited-exact-roster@example.com',
-          uin: 'limited-exact-roster-user-uin',
+          name: 'Upgrade Exact Roster',
+          email: 'upgrade-exact-roster@example.com',
+          uin: 'upgrade-exact-roster-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -570,25 +561,31 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
-      assert.include(response.url, '/pl/enroll/limit_exceeded');
+      assert.include(response.url, '/pl/course_instance/1/upgrade?lti13_relaunch=1');
+      const $ = cheerio.load(await response.text());
+      assert.include($('body').text(), 'Upgrade required');
 
       const persistedInvitation = await queryRow(
         'SELECT * FROM enrollments WHERE id = $enrollment_id',
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: sub,
-        status: 'invited',
-        user_id: null,
-      });
-      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
+      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
-      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
-      assert.equal(consumedLaunchResponse.status, 403);
+
+      await reconcilePlanGrantsForCourseInstanceUser(
+        { institution_id: '1', course_instance_id: '1', user_id: user.id },
+        [{ plan: 'basic', grantType: 'stripe' }],
+        '1',
+      );
+      const relaunchResponse = await fetchWithCookies(
+        `${siteUrl}/pl/course_instance/1/upgrade?lti13_relaunch=1`,
+      );
+      assert.equal(relaunchResponse.status, 200);
+      assert.include(await relaunchResponse.text(), 'Return to your LMS');
     });
   });
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -71,7 +71,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
   }
 
-  async function insertLtiRosterInvitation({
+  async function insertLti13Invitation({
     lti13CourseInstanceId,
     pendingUin,
     sub,
@@ -397,7 +397,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.notInclude(res.url, '/instructor/');
   });
 
-  describe('LTI 1.3 roster admission', () => {
+  describe('LTI 1.3 invitation admission', () => {
     beforeAll(async () => {
       const linkedCourseInstance = await queryOptionalRow(
         `SELECT *
@@ -439,19 +439,19 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'exact-roster-admission-sub';
-      const invitation = await insertLtiRosterInvitation({
+      const sub = 'exact-invitation-admission-sub';
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'exact-roster-unmatched-uin',
+        pendingUin: 'exact-invitation-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Exact Roster Admission',
-          email: 'exact-roster-admission@example.com',
-          uin: 'exact-roster-user-uin',
+          name: 'Exact Invitation Admission',
+          email: 'exact-invitation-admission@example.com',
+          uin: 'exact-invitation-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -466,7 +466,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const response = await executor.login();
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
-      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      const user = await selectOptionalUserByUid('exact-invitation-admission@example.com');
       assert.ok(user);
       const enrollment = await queryRow(
         'SELECT * FROM enrollments WHERE id = $enrollment_id',
@@ -478,12 +478,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
+    test('rejects a wrong sub and falls back to self-enrollment', async () => {
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const invitation = await insertLtiRosterInvitation({
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
         pendingUin: 'wrong-sub-unmatched-uin',
-        sub: 'expected-roster-sub',
+        sub: 'expected-invitation-sub',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -492,7 +492,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
           name: 'Wrong Sub Student',
           email: 'wrong-sub-student@example.com',
           uin: 'wrong-sub-user-uin',
-          sub: 'actual-roster-sub',
+          sub: 'actual-invitation-sub',
         },
         fetchWithCookies,
         oidcProviderPort,
@@ -515,7 +515,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       );
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const ordinaryEnrollment = await queryRow(
+      const selfEnrollment = await queryRow(
         `SELECT *
          FROM enrollments
          WHERE course_instance_id = '1'
@@ -523,7 +523,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { user_id: user.id },
         EnrollmentSchema,
       );
-      assert.equal(ordinaryEnrollment.status, 'joined');
+      assert.equal(selfEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
@@ -537,19 +537,19 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'upgrade-exact-roster-sub';
-      const invitation = await insertLtiRosterInvitation({
+      const sub = 'upgrade-exact-invitation-sub';
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'upgrade-exact-roster-unmatched-uin',
+        pendingUin: 'upgrade-exact-invitation-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Upgrade Exact Roster',
-          email: 'upgrade-exact-roster@example.com',
-          uin: 'upgrade-exact-roster-user-uin',
+          name: 'Upgrade Exact Invitation',
+          email: 'upgrade-exact-invitation@example.com',
+          uin: 'upgrade-exact-invitation-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -573,7 +573,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       );
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
+      const user = await selectOptionalUserByUid('upgrade-exact-invitation@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,7 +6,8 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, assert, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { z } from 'zod';
 
 import {
   execute,
@@ -25,7 +26,11 @@ import {
   updateLti13Scores,
 } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
-import { Lti13AssessmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
+import {
+  EnrollmentSchema,
+  Lti13AssessmentSchema,
+  Lti13CourseInstanceSchema,
+} from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectOptionalUserByUid, selectOrInsertUserByUid } from '../models/user.js';
@@ -49,6 +54,64 @@ const siteUrl = 'http://localhost:' + config.serverPort;
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
+
+  async function selectLinkedLtiCourseInstance() {
+    return await queryRow(
+      `SELECT *
+       FROM lti13_course_instances
+       WHERE lti13_instance_id = '1'
+       AND deployment_id = $deployment_id
+       AND context_id = $context_id`,
+      { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+      Lti13CourseInstanceSchema,
+    );
+  }
+
+  async function insertLtiRosterInvitation({
+    lti13CourseInstanceId,
+    pendingUin,
+    sub,
+  }: {
+    lti13CourseInstanceId: string;
+    pendingUin: string;
+    sub: string;
+  }) {
+    return await queryRow(
+      `INSERT INTO enrollments (
+         course_instance_id,
+         pending_lti13_course_instance_id,
+         pending_lti13_sub,
+         pending_uin,
+         status
+       )
+       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
+       RETURNING *`,
+      {
+        lti13_course_instance_id: lti13CourseInstanceId,
+        pending_uin: pendingUin,
+        sub,
+      },
+      EnrollmentSchema,
+    );
+  }
+
+  async function selectLatestSessionData(userId: string) {
+    return await queryScalar(
+      `SELECT data
+       FROM user_sessions
+       WHERE user_id = $user_id
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      { user_id: userId },
+      z.record(z.string(), z.unknown()),
+    );
+  }
+
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await selectLatestSessionData(userId);
+    assert.notProperty(sessionData, 'lti13_claims');
+    assert.notProperty(sessionData, 'authn_lti13_instance_id');
+  }
 
   beforeAll(async () => {
     config.isEnterprise = true;
@@ -328,6 +391,206 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.equal(res.status, 200);
     assert.include(res.url, '/pl/course_instance/1/');
     assert.notInclude(res.url, '/instructor/');
+  });
+
+  describe('LTI 1.3 roster admission', () => {
+    beforeAll(async () => {
+      const linkedCourseInstance = await queryOptionalRow(
+        `SELECT *
+         FROM lti13_course_instances
+         WHERE lti13_instance_id = '1'
+         AND deployment_id = $deployment_id
+         AND context_id = $context_id`,
+        { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+        Lti13CourseInstanceSchema,
+      );
+      if (linkedCourseInstance === null) {
+        await linkLtiContext({
+          lti13InstanceId: '1',
+          deploymentId: LTI_DEPLOYMENT_ID,
+          contextId: LTI_CONTEXT_ID,
+          courseInstanceId: '1',
+        });
+      }
+    });
+
+    afterEach(async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = NULL,
+           self_enrollment_enabled = TRUE,
+           self_enrollment_use_enrollment_code = FALSE
+         WHERE id = '1'`,
+      );
+    });
+
+    test('admits only the exact link and sub from the fresh launch', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'exact-roster-admission-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Exact Roster Admission',
+          email: 'exact-roster-admission@example.com',
+          uin: 'exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      assert.ok(user);
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(enrollment).toMatchObject({
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
+      });
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchResponse.status, 403);
+    });
+
+    test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'wrong-sub-unmatched-uin',
+        sub: 'expected-roster-sub',
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Wrong Sub Student',
+          email: 'wrong-sub-student@example.com',
+          uin: 'wrong-sub-user-uin',
+          sub: 'actual-roster-sub',
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
+      assert.ok(user);
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: 'expected-roster-sub',
+        status: 'invited',
+        user_id: null,
+      });
+      const ordinaryEnrollment = await queryRow(
+        `SELECT *
+         FROM enrollments
+         WHERE course_instance_id = '1'
+         AND user_id = $user_id`,
+        { user_id: user.id },
+        EnrollmentSchema,
+      );
+      assert.notEqual(ordinaryEnrollment.id, invitation.id);
+      assert.equal(ordinaryEnrollment.status, 'joined');
+      await assertLtiLaunchConsumed(user.id);
+    });
+
+    test('consumes the launch before an exact admission limit redirect', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = 0,
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'limited-exact-roster-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'limited-exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Limited Exact Roster',
+          email: 'limited-exact-roster@example.com',
+          uin: 'limited-exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/enroll/limit_exceeded');
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: sub,
+        status: 'invited',
+        user_id: null,
+      });
+      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchResponse.status, 403);
+    });
   });
 
   describe('LTI 1.3 linking authorization', () => {

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -492,7 +492,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('requires a fresh launch after an exact admission plan upgrade', async () => {
+    test('finishes LTI invitation admission after the required plan is granted', async () => {
       await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
       await updateCourseInstanceSettings('1', {
         selfEnrollmentEnabled: false,
@@ -543,11 +543,14 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         [{ plan: 'basic', grantType: 'stripe' }],
         '1',
       );
-      const relaunchResponse = await fetchWithCookies(
+      const admissionResponse = await fetchWithCookies(
         `${siteUrl}/pl/course_instance/1/upgrade?lti13_relaunch=1`,
       );
-      assert.equal(relaunchResponse.status, 200);
-      assert.include(await relaunchResponse.text(), 'Return to your LMS');
+      assert.include(admissionResponse.url, '/pl/course_instance/1/assessments');
+
+      const [admittedEnrollment] = await selectEnrollments([invitation.id]);
+      assert.equal(admittedEnrollment.status, 'joined');
+      assert.equal(admittedEnrollment.user_id, user.id);
     });
   });
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -52,7 +52,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
   }
 
-  async function insertLtiRosterInvitation({
+  async function insertLti13Invitation({
     lti13CourseInstanceId,
     pendingUin,
     sub,
@@ -396,7 +396,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.notInclude(res.url, '/instructor/');
   });
 
-  describe('LTI 1.3 roster admission', () => {
+  describe('LTI 1.3 invitation admission', () => {
     beforeAll(async () => {
       const linkedCourseInstance = await queryOptionalRow(
         `SELECT *
@@ -438,19 +438,19 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'exact-roster-admission-sub';
-      const invitation = await insertLtiRosterInvitation({
+      const sub = 'exact-invitation-admission-sub';
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'exact-roster-unmatched-uin',
+        pendingUin: 'exact-invitation-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Exact Roster Admission',
-          email: 'exact-roster-admission@example.com',
-          uin: 'exact-roster-user-uin',
+          name: 'Exact Invitation Admission',
+          email: 'exact-invitation-admission@example.com',
+          uin: 'exact-invitation-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -465,7 +465,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const response = await executor.login();
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
-      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      const user = await selectOptionalUserByUid('exact-invitation-admission@example.com');
       assert.ok(user);
       const enrollment = await queryRow(
         'SELECT * FROM enrollments WHERE id = $enrollment_id',
@@ -477,12 +477,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
+    test('rejects a wrong sub and falls back to self-enrollment', async () => {
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const invitation = await insertLtiRosterInvitation({
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
         pendingUin: 'wrong-sub-unmatched-uin',
-        sub: 'expected-roster-sub',
+        sub: 'expected-invitation-sub',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -491,7 +491,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
           name: 'Wrong Sub Student',
           email: 'wrong-sub-student@example.com',
           uin: 'wrong-sub-user-uin',
-          sub: 'actual-roster-sub',
+          sub: 'actual-invitation-sub',
         },
         fetchWithCookies,
         oidcProviderPort,
@@ -514,7 +514,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       );
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const ordinaryEnrollment = await queryRow(
+      const selfEnrollment = await queryRow(
         `SELECT *
          FROM enrollments
          WHERE course_instance_id = '1'
@@ -522,7 +522,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { user_id: user.id },
         EnrollmentSchema,
       );
-      assert.equal(ordinaryEnrollment.status, 'joined');
+      assert.equal(selfEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
@@ -536,19 +536,19 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'upgrade-exact-roster-sub';
-      const invitation = await insertLtiRosterInvitation({
+      const sub = 'upgrade-exact-invitation-sub';
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'upgrade-exact-roster-unmatched-uin',
+        pendingUin: 'upgrade-exact-invitation-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Upgrade Exact Roster',
-          email: 'upgrade-exact-roster@example.com',
-          uin: 'upgrade-exact-roster-user-uin',
+          name: 'Upgrade Exact Invitation',
+          email: 'upgrade-exact-invitation@example.com',
+          uin: 'upgrade-exact-invitation-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -572,7 +572,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       );
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
+      const user = await selectOptionalUserByUid('upgrade-exact-invitation@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, test } from 'vitest';
 import { z } from 'zod';
 
 import {
@@ -18,6 +18,10 @@ import {
 } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
+import {
+  reconcilePlanGrantsForCourseInstanceUser,
+  updateRequiredPlansForCourseInstance,
+} from '../ee/lib/billing/plans.js';
 import {
   type Lti13CombinedInstance,
   Lti13CombinedInstanceSchema,
@@ -415,6 +419,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     });
 
     afterEach(async () => {
+      await updateRequiredPlansForCourseInstance('1', [], '1');
       await execute(
         `UPDATE course_instances
          SET
@@ -459,7 +464,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
       const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
@@ -469,16 +473,9 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(enrollment).toMatchObject({
-        pending_lti13_course_instance_id: null,
-        pending_lti13_sub: null,
-        pending_uin: null,
-        status: 'joined',
-        user_id: user.id,
-      });
+      assert.equal(enrollment.status, 'joined');
+      assert.equal(enrollment.user_id, user.id);
       await assertLtiLaunchConsumed(user.id);
-      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
-      assert.equal(consumedLaunchResponse.status, 403);
     });
 
     test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
@@ -507,7 +504,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
@@ -517,12 +513,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: 'expected-roster-sub',
-        status: 'invited',
-        user_id: null,
-      });
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
       const ordinaryEnrollment = await queryRow(
         `SELECT *
          FROM enrollments
@@ -531,34 +523,33 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { user_id: user.id },
         EnrollmentSchema,
       );
-      assert.notEqual(ordinaryEnrollment.id, invitation.id);
       assert.equal(ordinaryEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('consumes the launch before an exact admission limit redirect', async () => {
+    test('requires a fresh launch after an exact admission plan upgrade', async () => {
+      await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
       await execute(
         `UPDATE course_instances
          SET
-           enrollment_limit = 0,
            self_enrollment_enabled = FALSE,
            self_enrollment_use_enrollment_code = TRUE
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'limited-exact-roster-sub';
+      const sub = 'upgrade-exact-roster-sub';
       const invitation = await insertLtiRosterInvitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'limited-exact-roster-unmatched-uin',
+        pendingUin: 'upgrade-exact-roster-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Limited Exact Roster',
-          email: 'limited-exact-roster@example.com',
-          uin: 'limited-exact-roster-user-uin',
+          name: 'Upgrade Exact Roster',
+          email: 'upgrade-exact-roster@example.com',
+          uin: 'upgrade-exact-roster-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -571,25 +562,31 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
-      assert.include(response.url, '/pl/enroll/limit_exceeded');
+      assert.include(response.url, '/pl/course_instance/1/upgrade?lti13_relaunch=1');
+      const $ = cheerio.load(await response.text());
+      assert.include($('body').text(), 'Upgrade required');
 
       const persistedInvitation = await queryRow(
         'SELECT * FROM enrollments WHERE id = $enrollment_id',
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: sub,
-        status: 'invited',
-        user_id: null,
-      });
-      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
+      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
-      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
-      assert.equal(consumedLaunchResponse.status, 403);
+
+      await reconcilePlanGrantsForCourseInstanceUser(
+        { institution_id: '1', course_instance_id: '1', user_id: user.id },
+        [{ plan: 'basic', grantType: 'stripe' }],
+        '1',
+      );
+      const relaunchResponse = await fetchWithCookies(
+        `${siteUrl}/pl/course_instance/1/upgrade?lti13_relaunch=1`,
+      );
+      assert.equal(relaunchResponse.status, 200);
+      assert.include(await relaunchResponse.text(), 'Return to your LMS');
     });
   });
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, afterEach, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
 import { z } from 'zod';
 
 import {

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,13 +6,14 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { z } from 'zod';
 
-import { execute, queryOptionalRow, queryRow } from '@prairielearn/postgres';
+import { execute, queryOptionalRow, queryRow, queryScalar } from '@prairielearn/postgres';
 
 import { Lti13CombinedInstanceSchema, inspectRoster } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
-import { Lti13CourseInstanceSchema } from '../lib/db-types.js';
+import { EnrollmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
 import { selectOptionalUserByUid } from '../models/user.js';
 
@@ -34,6 +35,64 @@ const siteUrl = 'http://localhost:' + config.serverPort;
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
+
+  async function selectLinkedLtiCourseInstance() {
+    return await queryRow(
+      `SELECT *
+       FROM lti13_course_instances
+       WHERE lti13_instance_id = '1'
+       AND deployment_id = $deployment_id
+       AND context_id = $context_id`,
+      { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+      Lti13CourseInstanceSchema,
+    );
+  }
+
+  async function insertLtiRosterInvitation({
+    lti13CourseInstanceId,
+    pendingUin,
+    sub,
+  }: {
+    lti13CourseInstanceId: string;
+    pendingUin: string;
+    sub: string;
+  }) {
+    return await queryRow(
+      `INSERT INTO enrollments (
+         course_instance_id,
+         pending_lti13_course_instance_id,
+         pending_lti13_sub,
+         pending_uin,
+         status
+       )
+       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
+       RETURNING *`,
+      {
+        lti13_course_instance_id: lti13CourseInstanceId,
+        pending_uin: pendingUin,
+        sub,
+      },
+      EnrollmentSchema,
+    );
+  }
+
+  async function selectLatestSessionData(userId: string) {
+    return await queryScalar(
+      `SELECT data
+       FROM user_sessions
+       WHERE user_id = $user_id
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      { user_id: userId },
+      z.record(z.string(), z.unknown()),
+    );
+  }
+
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await selectLatestSessionData(userId);
+    assert.notProperty(sessionData, 'lti13_claims');
+    assert.notProperty(sessionData, 'authn_lti13_instance_id');
+  }
 
   beforeAll(async () => {
     config.isEnterprise = true;
@@ -331,6 +390,206 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.equal(res.status, 200);
     assert.include(res.url, '/pl/course_instance/1/');
     assert.notInclude(res.url, '/instructor/');
+  });
+
+  describe('LTI 1.3 roster admission', () => {
+    beforeAll(async () => {
+      const linkedCourseInstance = await queryOptionalRow(
+        `SELECT *
+         FROM lti13_course_instances
+         WHERE lti13_instance_id = '1'
+         AND deployment_id = $deployment_id
+         AND context_id = $context_id`,
+        { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+        Lti13CourseInstanceSchema,
+      );
+      if (linkedCourseInstance === null) {
+        await linkLtiContext({
+          lti13InstanceId: '1',
+          deploymentId: LTI_DEPLOYMENT_ID,
+          contextId: LTI_CONTEXT_ID,
+          courseInstanceId: '1',
+        });
+      }
+    });
+
+    afterEach(async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = NULL,
+           self_enrollment_enabled = TRUE,
+           self_enrollment_use_enrollment_code = FALSE
+         WHERE id = '1'`,
+      );
+    });
+
+    test('admits only the exact link and sub from the fresh launch', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'exact-roster-admission-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Exact Roster Admission',
+          email: 'exact-roster-admission@example.com',
+          uin: 'exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      assert.ok(user);
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(enrollment).toMatchObject({
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
+      });
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchResponse.status, 403);
+    });
+
+    test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'wrong-sub-unmatched-uin',
+        sub: 'expected-roster-sub',
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Wrong Sub Student',
+          email: 'wrong-sub-student@example.com',
+          uin: 'wrong-sub-user-uin',
+          sub: 'actual-roster-sub',
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
+      assert.ok(user);
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: 'expected-roster-sub',
+        status: 'invited',
+        user_id: null,
+      });
+      const ordinaryEnrollment = await queryRow(
+        `SELECT *
+         FROM enrollments
+         WHERE course_instance_id = '1'
+         AND user_id = $user_id`,
+        { user_id: user.id },
+        EnrollmentSchema,
+      );
+      assert.notEqual(ordinaryEnrollment.id, invitation.id);
+      assert.equal(ordinaryEnrollment.status, 'joined');
+      await assertLtiLaunchConsumed(user.id);
+    });
+
+    test('consumes the launch before an exact admission limit redirect', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = 0,
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'limited-exact-roster-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'limited-exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Limited Exact Roster',
+          email: 'limited-exact-roster@example.com',
+          uin: 'limited-exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/enroll/limit_exceeded');
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: sub,
+        status: 'invited',
+        user_id: null,
+      });
+      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchResponse.status, 403);
+    });
   });
 
   describe('LTI 1.3 linking authorization', () => {

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -29,14 +29,16 @@ import {
   queryAndLinkLineitem,
   updateLti13Scores,
 } from '../ee/lib/lti13.js';
+import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
 import {
-  EnrollmentSchema,
+  type CourseInstance,
   Lti13AssessmentSchema,
   Lti13CourseInstanceSchema,
 } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
+import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
 import { selectOptionalUserByUid, selectOrInsertUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
@@ -52,10 +54,13 @@ import {
   makeLoginExecutor,
   withServer,
 } from './lti13TestHelpers.js';
+import { updateCourseInstanceSettings } from './utils/auth.js';
+import { createEnrollment, selectEnrollments } from './utils/enrollment-identity.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
+  let courseInstance: CourseInstance;
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
 
@@ -71,36 +76,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
   }
 
-  async function insertLti13Invitation({
-    lti13CourseInstanceId,
-    pendingUin,
-    sub,
-  }: {
-    lti13CourseInstanceId: string;
-    pendingUin: string;
-    sub: string;
-  }) {
-    return await queryRow(
-      `INSERT INTO enrollments (
-         course_instance_id,
-         pending_lti13_course_instance_id,
-         pending_lti13_sub,
-         pending_uin,
-         status
-       )
-       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
-       RETURNING *`,
-      {
-        lti13_course_instance_id: lti13CourseInstanceId,
-        pending_uin: pendingUin,
-        sub,
-      },
-      EnrollmentSchema,
-    );
-  }
-
-  async function selectLatestSessionData(userId: string) {
-    return await queryScalar(
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await queryScalar(
       `SELECT data
        FROM user_sessions
        WHERE user_id = $user_id
@@ -109,10 +86,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       { user_id: userId },
       z.record(z.string(), z.unknown()),
     );
-  }
-
-  async function assertLtiLaunchConsumed(userId: string) {
-    const sessionData = await selectLatestSessionData(userId);
     assert.notProperty(sessionData, 'lti13_claims');
     assert.notProperty(sessionData, 'authn_lti13_instance_id');
   }
@@ -120,6 +93,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   beforeAll(async () => {
     config.isEnterprise = true;
     await helperServer.before()();
+    courseInstance = await selectCourseInstanceById('1');
 
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$'");
 
@@ -420,30 +394,28 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
     afterEach(async () => {
       await updateRequiredPlansForCourseInstance('1', [], '1');
-      await execute(
-        `UPDATE course_instances
-         SET
-           enrollment_limit = NULL,
-           self_enrollment_enabled = TRUE,
-           self_enrollment_use_enrollment_code = FALSE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: true,
+        selfEnrollmentUseEnrollmentCode: false,
+        restrictToInstitution: false,
+      });
+      await execute("UPDATE course_instances SET enrollment_limit = NULL WHERE id = '1'");
     });
 
     test('admits only the exact link and sub from the fresh launch', async () => {
-      await execute(
-        `UPDATE course_instances
-         SET
-           self_enrollment_enabled = FALSE,
-           self_enrollment_use_enrollment_code = TRUE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
+      });
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
       const sub = 'exact-invitation-admission-sub';
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: sub,
         pendingUin: 'exact-invitation-unmatched-uin',
-        sub,
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -468,11 +440,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
       const user = await selectOptionalUserByUid('exact-invitation-admission@example.com');
       assert.ok(user);
-      const enrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [enrollment] = await selectEnrollments([invitation.id]);
       assert.equal(enrollment.status, 'joined');
       assert.equal(enrollment.user_id, user.id);
       await assertLtiLaunchConsumed(user.id);
@@ -480,10 +448,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
     test('rejects a wrong sub and falls back to self-enrollment', async () => {
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: 'expected-invitation-sub',
         pendingUin: 'wrong-sub-unmatched-uin',
-        sub: 'expected-invitation-sub',
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -508,40 +478,35 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
       assert.ok(user);
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const selfEnrollment = await queryRow(
-        `SELECT *
-         FROM enrollments
-         WHERE course_instance_id = '1'
-         AND user_id = $user_id`,
-        { user_id: user.id },
-        EnrollmentSchema,
-      );
+      const selfEnrollment = await selectOptionalEnrollmentByUserId({
+        userId: user.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(selfEnrollment);
       assert.equal(selfEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
     test('requires a fresh launch after an exact admission plan upgrade', async () => {
       await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
-      await execute(
-        `UPDATE course_instances
-         SET
-           self_enrollment_enabled = FALSE,
-           self_enrollment_use_enrollment_code = TRUE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
+      });
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
       const sub = 'upgrade-exact-invitation-sub';
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: sub,
         pendingUin: 'upgrade-exact-invitation-unmatched-uin',
-        sub,
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -566,11 +531,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const $ = cheerio.load(await response.text());
       assert.include($('body').text(), 'Upgrade required');
 
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
       const user = await selectOptionalUserByUid('upgrade-exact-invitation@example.com');

--- a/apps/prairielearn/src/tests/utils/enrollments.ts
+++ b/apps/prairielearn/src/tests/utils/enrollments.ts
@@ -7,7 +7,7 @@ import '../helperServer.js';
 import { type PotentialEnrollmentStatus } from '../../ee/models/enrollment.js';
 import { constructCourseOrInstanceContext } from '../../lib/authz-data.js';
 import { config } from '../../lib/config.js';
-import { ensureEnrollment } from '../../models/enrollment.js';
+import { ensureLegacyEnrollment } from '../../models/enrollment.js';
 
 import { type AuthUser, getOrCreateUser, withUser } from './auth.js';
 import { getCsrfToken } from './csrf.js';
@@ -40,7 +40,7 @@ export async function enrollUser(
 
   const { authzData, course, institution, courseInstance } = context;
 
-  return ensureEnrollment({
+  return ensureLegacyEnrollment({
     institution,
     course,
     courseInstance,

--- a/apps/prairielearn/src/tests/utils/enrollments.ts
+++ b/apps/prairielearn/src/tests/utils/enrollments.ts
@@ -7,7 +7,7 @@ import '../helperServer.js';
 import { type PotentialEnrollmentStatus } from '../../ee/models/enrollment.js';
 import { constructCourseOrInstanceContext } from '../../lib/authz-data.js';
 import { config } from '../../lib/config.js';
-import { ensureLegacyEnrollment } from '../../models/enrollment.js';
+import { ensureEnrollmentWithoutReconciliation } from '../../models/enrollment.js';
 
 import { type AuthUser, getOrCreateUser, withUser } from './auth.js';
 import { getCsrfToken } from './csrf.js';
@@ -40,7 +40,7 @@ export async function enrollUser(
 
   const { authzData, course, institution, courseInstance } = context;
 
-  return ensureLegacyEnrollment({
+  return ensureEnrollmentWithoutReconciliation({
     institution,
     course,
     courseInstance,


### PR DESCRIPTION
# Description

Implements the fourth of five review slices for [PrairieLearnInc/planning#51](https://github.com/PrairieLearnInc/planning/issues/51), consolidating checked course-instance access admission and LTI invitation admission into one review unit.

Routes enrollment-code decisions, auto-enrollment, the join page, and the final mutation through one shared access decision. A pending UID invitation or an institution-scoped pending UIN invitation may bypass self-enrollment settings, expiration, institution restrictions, and enrollment codes; course access, staff-role exclusion, enterprise plan grants, enrollment limits, blocked status, and guest restrictions are still checked inside the locked transaction. Bound `left` and `removed` enrollments do not provide invitation access on their own and follow the current self-enrollment policy.

Adds LTI 1.3 invitation admission to course navigation. Student launches copy the matching link, `sub`, invitation ID, user ID, and course instance into local variables, remove the raw launch claims before any redirect or error path, and admit only the pending invitation with that same link and `sub`. A wrong `sub` or a matching `sub` on another link falls back to the normal course-entry policy, and instructor launches are unchanged.

When a required plan interrupts LTI admission, the verified invitation details are saved in the student's session for 30 minutes before redirecting to the upgrade page. After the plan is granted, PrairieLearn rechecks the same invitation and normally finishes enrollment without another LMS launch. If the session expires or the invitation changes while the student is upgrading, the page asks the student to launch the course from the LMS again so fresh LTI data can be checked.

Also hardens the existing homepage UID-invitation action in this slice so the first four PRs can be deployed safely without the homepage changes above them. The POST must first find a currently actionable UID invitation and then passes its ID to the locked admission function; an invalid initial request gets the existing flash message, while an unexpected failure after that point reaches the normal error handler and Sentry.

Stack: 4 of 5. Depends on #15511. Next: #15519.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance disclosure: Codex produced the majority of the implementation and tests under human-directed design, manager inspection, and independent adversarial review.

# Testing

Focused model and route coverage exercises enrollment-code and self-enrollment decisions, UID and institution-scoped UIN invitations, enterprise eligibility and limits, LTI link-and-`sub` isolation, launch-claim removal, plan-upgrade continuation, spoofed upgrade hints, invitation loss, blocked status, and direct homepage posts for non-invitation enrollment states.
