### PR TITLE
Show institution-provided course access on the homepage

### DIFF
--- a/.agents/skills/express-request-validation/SKILL.md
+++ b/.agents/skills/express-request-validation/SKILL.md
@@ -7,6 +7,7 @@ description: Conventions for validating PrairieLearn Express request parameters,
 
 - Define request schemas at module scope unless they genuinely depend on request-time values. Prefer a static structural schema followed by a semantic check over constructing a schema per request.
 - Parse every request source a handler consumes before database queries or other work. After parsing, use only the parsed values; do not read the corresponding `req.params`, `req.query`, or `req.body` values again.
+- Use `IdSchema` from `@prairielearn/zod` for PrairieLearn database IDs in params, query strings, and bodies. Do not validate them as arbitrary strings or numbers. External-system identifiers that are not PrairieLearn database IDs should use schemas appropriate to those systems.
 - Treat parsed request objects as boundary data, not as parameter bags. Pass explicit fields to database queries, model functions, and other downstream APIs instead of passing `params`, `query`, or `body` wholesale; this keeps each callsite's contract visible and avoids unused-parameter failures when request schemas grow.
 - Use `parseRequest` when validating multiple sources together. Use `parseRequestParams`, `parseRequestQuery`, or `parseRequestBody` when validating only one source.
 - Express cannot verify that a params schema matches the router path. Check the parent mount path as well as the local route and ensure every `ParamsSchema` key matches an actual `:parameter`.

--- a/apps/prairielearn/src/components/EnrollmentPage.tsx
+++ b/apps/prairielearn/src/components/EnrollmentPage.tsx
@@ -1,14 +1,11 @@
+import type { EnrollmentIneligibilityReason } from '../lib/enrollment/eligibility.js';
 import type { UntypedResLocals } from '../lib/res-locals.types.js';
 
 import { PageLayout } from './PageLayout.js';
 
 interface EnrollmentPageProps {
+  reason: EnrollmentIneligibilityReason;
   resLocals: UntypedResLocals;
-  type:
-    | 'blocked'
-    | 'self-enrollment-disabled'
-    | 'self-enrollment-expired'
-    | 'institution-restriction';
 }
 
 function BlockedEnrollment() {
@@ -111,22 +108,22 @@ function InstitutionRestriction() {
   );
 }
 
-export function EnrollmentPage({ resLocals, type }: EnrollmentPageProps) {
+export function EnrollmentPage({ reason, resLocals }: EnrollmentPageProps) {
   const pageTitle =
-    type === 'blocked'
+    reason === 'blocked'
       ? 'Enrollment blocked'
-      : type === 'self-enrollment-expired'
+      : reason === 'self-enrollment-expired'
         ? 'Self-enrollment expired'
-        : type === 'institution-restriction'
+        : reason === 'institution-restriction'
           ? 'Institution restriction'
           : 'Self-enrollment not available';
 
   const content =
-    type === 'blocked' ? (
+    reason === 'blocked' ? (
       <BlockedEnrollment />
-    ) : type === 'self-enrollment-expired' ? (
+    ) : reason === 'self-enrollment-expired' ? (
       <SelfEnrollmentExpired />
-    ) : type === 'institution-restriction' ? (
+    ) : reason === 'institution-restriction' ? (
       <InstitutionRestriction />
     ) : (
       <SelfEnrollmentDisabled />

--- a/apps/prairielearn/src/ee/lib/lti13-course-instance-upgrade.ts
+++ b/apps/prairielearn/src/ee/lib/lti13-course-instance-upgrade.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod';
+
+import { IdSchema } from '@prairielearn/zod';
+
+import { idsEqual } from '../../lib/id.js';
+
+// Give the student enough time to submit the upgrade form. Once the Stripe
+// checkout exists, the relaunch flag in its return URL no longer authorizes
+// anything.
+const LTI13_COURSE_INSTANCE_UPGRADE_TTL_MS = 30 * 60 * 1000;
+
+const Lti13CourseInstanceUpgradeAuthorizationSchema = z.object({
+  course_instance_id: IdSchema,
+  enrollment_id: IdSchema,
+  expires_at: z.iso.datetime(),
+  lti13_course_instance_id: IdSchema,
+  sub: z.string().min(1),
+  user_id: IdSchema,
+});
+
+export type Lti13CourseInstanceUpgradeAuthorization = z.infer<
+  typeof Lti13CourseInstanceUpgradeAuthorizationSchema
+>;
+
+type SessionData = Record<string, unknown>;
+
+export function setLti13CourseInstanceUpgradeAuthorization({
+  courseInstanceId,
+  enrollmentId,
+  lti13CourseInstanceId,
+  now,
+  session,
+  sub,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentId: string;
+  lti13CourseInstanceId: string;
+  now: Date;
+  session: SessionData;
+  sub: string;
+  userId: string;
+}) {
+  session.lti13_course_instance_upgrade = Lti13CourseInstanceUpgradeAuthorizationSchema.parse({
+    course_instance_id: courseInstanceId,
+    enrollment_id: enrollmentId,
+    expires_at: new Date(now.getTime() + LTI13_COURSE_INSTANCE_UPGRADE_TTL_MS).toISOString(),
+    lti13_course_instance_id: lti13CourseInstanceId,
+    sub,
+    user_id: userId,
+  });
+}
+
+export function getLti13CourseInstanceUpgradeAuthorization({
+  courseInstanceId,
+  now,
+  session,
+  userId,
+}: {
+  courseInstanceId: string;
+  now: Date;
+  session: SessionData;
+  userId: string;
+}): Lti13CourseInstanceUpgradeAuthorization | null {
+  const result = Lti13CourseInstanceUpgradeAuthorizationSchema.safeParse(
+    session.lti13_course_instance_upgrade,
+  );
+  if (!result.success || new Date(result.data.expires_at).getTime() <= now.getTime()) {
+    clearLti13CourseInstanceUpgradeAuthorization(session);
+    return null;
+  }
+  if (
+    !idsEqual(result.data.course_instance_id, courseInstanceId) ||
+    !idsEqual(result.data.user_id, userId)
+  ) {
+    return null;
+  }
+  return result.data;
+}
+
+export function clearLti13CourseInstanceUpgradeAuthorization(session: SessionData) {
+  delete session.lti13_course_instance_upgrade;
+}

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -280,6 +280,11 @@ export class Lti13Claim {
     return this.claims['https://purl.imsglobal.org/spec/lti/claim/target_link_uri'];
   }
 
+  get sub() {
+    this.assertValid();
+    return this.claims.sub;
+  }
+
   get lineitems() {
     this.assertValid();
     return this.claims['https://purl.imsglobal.org/spec/lti-ags/claim/endpoint']?.lineitems;

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -11,9 +11,13 @@ import {
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
+import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { admitUserFromLti13CourseInstanceRequest } from '../../../models/course-instance-admission.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
+import { selectEnrollmentAdmissionDecision } from '../../../models/enrollment-identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../models/enrollment-reconciliation.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {
@@ -119,6 +123,13 @@ router.get(
     }
 
     const ltiClaim = new Lti13Claim(req);
+    if (
+      req.session.authn_lti13_instance_id === undefined ||
+      !idsEqual(req.session.authn_lti13_instance_id, req.params.lti13_instance_id)
+    ) {
+      ltiClaim.remove();
+      throw new HttpStatusError(403, 'Access denied');
+    }
     const courseName = prettyCourseName(ltiClaim);
     const role_instructor = ltiClaim.isRoleInstructor();
 
@@ -134,6 +145,8 @@ router.get(
     );
 
     if (lti13_course_instance) {
+      const courseInstanceId = lti13_course_instance.course_instance_id;
+
       // Update lti13_course_instance on instructor login
       // helpful as LMS updates or we add features
       if (role_instructor) {
@@ -150,17 +163,47 @@ router.get(
         });
 
         // TODO: Set course/instance staff permissions for LMS course staff here?
+
+        ltiClaim.remove();
+        res.redirect(`/pl/course_instance/${courseInstanceId}/instructor/`);
+        return;
       }
 
-      // LTI claims are not used after this page so remove them from the session
+      const lti13CourseInstanceId = lti13_course_instance.id;
+      const sub = ltiClaim.sub;
+      const userId = res.locals.authn_user.id;
+      const source = { type: 'lti13' as const, lti13CourseInstanceId, sub };
+
+      // Exact LTI authority is request-local. Consume the verified launch
+      // before selection, checked admission, or any resulting redirect/error.
       ltiClaim.remove();
 
-      // Redirect to linked course instance
-      res.redirect(
-        `/pl/course_instance/${lti13_course_instance.course_instance_id}/${
-          role_instructor ? 'instructor/' : ''
-        }`,
+      const decision = await selectEnrollmentAdmissionDecision(
+        {
+          courseInstanceId,
+          lti13Identity: { lti13CourseInstanceId, sub },
+          userId,
+        },
+        source,
       );
+      if (decision.allowed && decision.invitationCandidate !== null) {
+        try {
+          await admitUserFromLti13CourseInstanceRequest({
+            courseInstanceId,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            lti13CourseInstanceId,
+            reqDate: res.locals.req_date,
+            sub,
+            userId,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+        }
+      }
+
+      res.redirect(`/pl/course_instance/${courseInstanceId}/`);
       return;
     }
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -12,15 +12,13 @@ import {
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
 import { admitUserFromLti13Launch } from '../../../lib/enrollment/admission.js';
-import {
-  type EnrollmentAdmissionSource,
-  selectEnrollmentAdmissionDecision,
-} from '../../../lib/enrollment/identity.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
+import { setLti13CourseInstanceUpgradeAuthorization } from '../../lib/lti13-course-instance-upgrade.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {
@@ -175,41 +173,52 @@ router.get(
       const lti13CourseInstanceId = lti13_course_instance.id;
       const sub = ltiClaim.sub;
       const userId = res.locals.authn_user.id;
-      const source: EnrollmentAdmissionSource = {
-        type: 'invitation',
-        matchedBy: 'lti13',
-        lti13CourseInstanceId,
-        sub,
-      };
-
       // Remove the launch claims before admission. If admission redirects or
       // fails, the student must relaunch from the LMS.
       ltiClaim.remove();
 
-      const decision = await selectEnrollmentAdmissionDecision(
-        {
-          courseInstanceId,
-          lti13Identity: { lti13CourseInstanceId, sub },
-          userId,
+      const decision = await selectEnrollmentAdmissionDecision({
+        courseInstanceId,
+        source: {
+          type: 'invitation',
+          matchedBy: 'lti13',
+          lti13CourseInstanceId,
+          sub,
         },
-        source,
-      );
+        userId,
+      });
       if (decision.allowed && decision.invitationCandidate !== null) {
+        const invitationEnrollmentId = decision.invitationCandidate.enrollment.id;
         try {
           await admitUserFromLti13Launch({
             courseInstanceId,
-            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            expectedInvitationEnrollmentId: invitationEnrollmentId,
             ip: req.ip ?? null,
             isAdministrator: res.locals.is_administrator,
             lti13CourseInstanceId,
+            onPlanGrantsRequired: () => {
+              // Remember why this student was sent to the upgrade page. That
+              // page checks the invitation again, and enrollment still requires
+              // another launch from the LMS after payment.
+              setLti13CourseInstanceUpgradeAuthorization({
+                courseInstanceId,
+                enrollmentId: invitationEnrollmentId,
+                lti13CourseInstanceId,
+                now: res.locals.req_date,
+                session: req.session,
+                sub,
+                userId,
+              });
+            },
             reqDate: res.locals.req_date,
             sub,
             userId,
           });
         } catch (error) {
           if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
-          // The invitation may have changed after the read-only check. Continue
-          // to the course route, where entry is re-evaluated without LTI claims.
+          // The invitation changed after the first lookup. Continue to the
+          // course route, which will decide whether the student can enter
+          // without the LTI invitation.
         }
       }
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -11,13 +11,13 @@ import {
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
+import { admitUserFromLti13CourseInstanceRequest } from '../../../lib/enrollment/admission.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
-import { admitUserFromLti13CourseInstanceRequest } from '../../../models/course-instance-admission.js';
 import { selectCourseInstancesWithStaffAccess } from '../../../models/course-instances.js';
 import { selectCoursesWithEditAccess } from '../../../models/course.js';
-import { selectEnrollmentAdmissionDecision } from '../../../models/enrollment-identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../../models/enrollment-reconciliation.js';
 import { Lti13Claim } from '../../lib/lti13.js';
 
 import {

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -11,7 +11,7 @@ import {
   CourseInstanceSchema,
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
-import { admitUserFromLti13CourseInstanceRequest } from '../../../lib/enrollment/admission.js';
+import { admitUserFromLti13Launch } from '../../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
@@ -172,7 +172,12 @@ router.get(
       const lti13CourseInstanceId = lti13_course_instance.id;
       const sub = ltiClaim.sub;
       const userId = res.locals.authn_user.id;
-      const source = { type: 'lti13' as const, lti13CourseInstanceId, sub };
+      const source = {
+        type: 'invitation' as const,
+        matchedBy: 'lti13' as const,
+        lti13CourseInstanceId,
+        sub,
+      };
 
       // Exact LTI authority is request-local. Consume the verified launch
       // before selection, checked admission, or any resulting redirect/error.
@@ -188,7 +193,7 @@ router.get(
       );
       if (decision.allowed && decision.invitationCandidate !== null) {
         try {
-          await admitUserFromLti13CourseInstanceRequest({
+          await admitUserFromLti13Launch({
             courseInstanceId,
             expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
             ip: req.ip ?? null,

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -134,7 +134,6 @@ router.get(
       throw new HttpStatusError(403, 'Access denied');
     }
     const courseName = prettyCourseName(ltiClaim);
-    const role_instructor = ltiClaim.isRoleInstructor();
 
     // Get lti13_course_instance info, if present
     const lti13_course_instance = await queryOptionalRow(
@@ -152,7 +151,7 @@ router.get(
 
       // Update lti13_course_instance on instructor login
       // helpful as LMS updates or we add features
-      if (role_instructor) {
+      if (ltiClaim.isRoleInstructor()) {
         await execute(sql.update_lti13_course_instance, {
           lti13_instance_id: req.params.lti13_instance_id,
           course_instance_id: lti13_course_instance.course_instance_id,
@@ -227,8 +226,21 @@ router.get(
     }
 
     // No course instance is linked to this LMS context.
-    // Students get a "come back later" message
-    if (!role_instructor) {
+    if (ltiClaim.isRoleInstructor()) {
+      // Instructors get a prompt for linking
+      res.send(
+        Lti13CourseNavigationInstructor({
+          resLocals: res.locals,
+          courseName,
+          courses: await selectCoursesWithEditAccess({
+            user_id: res.locals.authn_user.id,
+            is_administrator: res.locals.is_administrator,
+          }),
+          lti13_instance_id: req.params.lti13_instance_id,
+        }),
+      );
+    } else {
+      // Students get a "come back later" message
       res.send(
         Lti13CourseNavigationNotReady({
           resLocals: res.locals,
@@ -236,21 +248,7 @@ router.get(
           ltiRoles: ltiClaim.roles,
         }),
       );
-      return;
     }
-
-    // Instructors get a prompt for linking
-    res.send(
-      Lti13CourseNavigationInstructor({
-        resLocals: res.locals,
-        courseName,
-        courses: await selectCoursesWithEditAccess({
-          user_id: res.locals.authn_user.id,
-          is_administrator: res.locals.is_administrator,
-        }),
-        lti13_instance_id: req.params.lti13_instance_id,
-      }),
-    );
   }),
 );
 

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -126,6 +126,8 @@ router.get(
     }
 
     const ltiClaim = new Lti13Claim(req);
+    // LTI claims are stored in the browser session. Verify that this launch
+    // belongs to the LTI instance in the route before using them.
     if (
       req.session.authn_lti13_instance_id === undefined ||
       !idsEqual(req.session.authn_lti13_instance_id, req.params.lti13_instance_id)
@@ -165,8 +167,6 @@ router.get(
           resource_link_id: ltiClaim.resource_link_id,
         });
 
-        // TODO: Set course/instance staff permissions for LMS course staff here?
-
         ltiClaim.remove();
         res.redirect(`/pl/course_instance/${courseInstanceId}/instructor/`);
         return;
@@ -182,8 +182,8 @@ router.get(
         sub,
       };
 
-      // Exact LTI authority is request-local. Consume the verified launch
-      // before selection, checked admission, or any resulting redirect/error.
+      // Remove the launch claims before admission. If admission redirects or
+      // fails, the student must relaunch from the LMS.
       ltiClaim.remove();
 
       const decision = await selectEnrollmentAdmissionDecision(
@@ -208,6 +208,8 @@ router.get(
           });
         } catch (error) {
           if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          // The invitation may have changed after the read-only check. Continue
+          // to the course route, where entry is re-evaluated without LTI claims.
         }
       }
 
@@ -215,6 +217,7 @@ router.get(
       return;
     }
 
+    // No course instance is linked to this LMS context.
     // Students get a "come back later" message
     if (!role_instructor) {
       res.send(

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -12,7 +12,10 @@ import {
   Lti13CourseInstanceSchema,
 } from '../../../lib/db-types.js';
 import { admitUserFromLti13Launch } from '../../../lib/enrollment/admission.js';
-import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import {
+  type EnrollmentAdmissionSource,
+  selectEnrollmentAdmissionDecision,
+} from '../../../lib/enrollment/identity.js';
 import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
@@ -172,9 +175,9 @@ router.get(
       const lti13CourseInstanceId = lti13_course_instance.id;
       const sub = ltiClaim.sub;
       const userId = res.locals.authn_user.id;
-      const source = {
-        type: 'invitation' as const,
-        matchedBy: 'lti13' as const,
+      const source: EnrollmentAdmissionSource = {
+        type: 'invitation',
+        matchedBy: 'lti13',
         lti13CourseInstanceId,
         sub,
       };

--- a/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
+++ b/apps/prairielearn/src/ee/pages/lti13CourseNavigation/lti13CourseNavigation.ts
@@ -196,9 +196,9 @@ router.get(
             isAdministrator: res.locals.is_administrator,
             lti13CourseInstanceId,
             onPlanGrantsRequired: () => {
-              // Remember why this student was sent to the upgrade page. That
-              // page checks the invitation again, and enrollment still requires
-              // another launch from the LMS after payment.
+              // Remember the invitation while the student completes the
+              // upgrade. The upgrade page checks it again before admitting the
+              // student.
               setLti13CourseInstanceUpgradeAuthorization({
                 courseInstanceId,
                 enrollmentId: invitationEnrollmentId,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -55,12 +55,7 @@ export function StudentCourseInstanceUpgrade({
         : html`
             ${PriceTable({ planNames: missingPlans, planPrices })}
 
-            <form
-              method="POST"
-              action="/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch
-                ? '?lti13_relaunch=1'
-                : ''}"
-            >
+            <form method="POST" action="/pl/course_instance/${courseInstance.id}/upgrade">
               <div class="form-check mb-3">
                 <input
                   type="checkbox"
@@ -77,6 +72,7 @@ export function StudentCourseInstanceUpgrade({
               </div>
 
               <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
+              ${lti13Relaunch ? html`<input type="hidden" name="lti13_relaunch" value="1" />` : ''}
               ${missingPlans.map(
                 (plan) => html` <input type="hidden" name="unsafe_plan_names" value="${plan}" /> `,
               )}
@@ -139,7 +135,7 @@ export function CourseInstanceStudentUpdateSuccess({
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;
 }) {
-  if (lti13Relaunch) {
+  if (paid && lti13Relaunch) {
     return Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals });
   }
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -18,10 +18,9 @@ export function StudentCourseInstanceUpgrade({
   course: Course;
   courseInstance: CourseInstance;
   /**
-   * Whether this request is following the LTI-specific upgrade flow. When
-   * true, the query hint is preserved through payment and the student is
-   * directed back to the LMS for a fresh launch instead of continuing into the
-   * course.
+   * Whether the student reached this page from an LTI launch that matched a
+   * pending invitation. If so, send them back to their LMS after payment
+   * instead of directly into the course.
    */
   lti13Relaunch: boolean;
   missingPlans: PlanName[];

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -17,6 +17,12 @@ export function StudentCourseInstanceUpgrade({
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  /**
+   * Whether this request is following the LTI-specific upgrade flow. When
+   * true, the query hint is preserved through payment and the student is
+   * directed back to the LMS for a fresh launch instead of continuing into the
+   * course.
+   */
   lti13Relaunch: boolean;
   missingPlans: PlanName[];
   /**
@@ -125,6 +131,10 @@ export function CourseInstanceStudentUpdateSuccess({
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  /**
+   * Whether the completed upgrade should direct the student back to the LMS
+   * for a fresh LTI launch instead of continuing into the course.
+   */
   lti13Relaunch: boolean;
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -10,7 +10,7 @@ import { formatStripePrice } from '../../lib/billing/stripe.shared.js';
 export function StudentCourseInstanceUpgrade({
   course,
   courseInstance,
-  lti13Relaunch,
+  lti13AdmissionPending,
   missingPlans,
   planPrices,
   resLocals,
@@ -18,11 +18,11 @@ export function StudentCourseInstanceUpgrade({
   course: Course;
   courseInstance: CourseInstance;
   /**
-   * Whether the student reached this page from an LTI launch that matched a
-   * pending invitation. If so, send them back to their LMS after payment
-   * instead of directly into the course.
+   * Whether this upgrade started with an LTI invitation that is still pending.
+   * The hidden field lets the server look up the saved invitation again after
+   * the form submission and Stripe checkout.
    */
-  lti13Relaunch: boolean;
+  lti13AdmissionPending: boolean;
   missingPlans: PlanName[];
   /**
    * `null` here will indicate that we aren't configured with Stripe credentials
@@ -71,7 +71,9 @@ export function StudentCourseInstanceUpgrade({
               </div>
 
               <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-              ${lti13Relaunch ? html`<input type="hidden" name="lti13_relaunch" value="1" />` : ''}
+              ${lti13AdmissionPending
+                ? html`<input type="hidden" name="lti13_relaunch" value="1" />`
+                : ''}
               ${missingPlans.map(
                 (plan) => html` <input type="hidden" name="unsafe_plan_names" value="${plan}" /> `,
               )}
@@ -120,21 +122,21 @@ export function Lti13CourseInstanceRelaunch({
 export function CourseInstanceStudentUpdateSuccess({
   course,
   courseInstance,
-  lti13Relaunch,
+  requireLti13Relaunch,
   paid,
   resLocals,
 }: {
   course: Course;
   courseInstance: CourseInstance;
   /**
-   * Whether the completed upgrade should direct the student back to the LMS
-   * for a fresh LTI launch instead of continuing into the course.
+   * Whether the saved LTI invitation could not be used after payment and the
+   * student must launch the course from the LMS again.
    */
-  lti13Relaunch: boolean;
+  requireLti13Relaunch: boolean;
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;
 }) {
-  if (paid && lti13Relaunch) {
+  if (paid && requireLti13Relaunch) {
     return Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals });
   }
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.html.ts
@@ -10,12 +10,14 @@ import { formatStripePrice } from '../../lib/billing/stripe.shared.js';
 export function StudentCourseInstanceUpgrade({
   course,
   courseInstance,
+  lti13Relaunch,
   missingPlans,
   planPrices,
   resLocals,
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  lti13Relaunch: boolean;
   missingPlans: PlanName[];
   /**
    * `null` here will indicate that we aren't configured with Stripe credentials
@@ -47,7 +49,12 @@ export function StudentCourseInstanceUpgrade({
         : html`
             ${PriceTable({ planNames: missingPlans, planPrices })}
 
-            <form method="POST">
+            <form
+              method="POST"
+              action="/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch
+                ? '?lti13_relaunch=1'
+                : ''}"
+            >
               <div class="form-check mb-3">
                 <input
                   type="checkbox"
@@ -83,17 +90,49 @@ export function StudentCourseInstanceUpgrade({
   });
 }
 
+export function Lti13CourseInstanceRelaunch({
+  course,
+  courseInstance,
+  resLocals,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  resLocals: ResLocalsForPage<'course-instance'>;
+}) {
+  return PageLayout({
+    resLocals,
+    pageTitle: 'Return to your LMS',
+    navContext: {
+      type: 'student',
+      page: 'upgrade',
+    },
+    content: html`
+      <h1>Return to your LMS</h1>
+      <p>
+        ${course.short_name}: ${courseInstance.long_name} is ready. Return to your LMS and relaunch
+        this course to finish enrollment.
+      </p>
+    `,
+  });
+}
+
 export function CourseInstanceStudentUpdateSuccess({
   course,
   courseInstance,
+  lti13Relaunch,
   paid,
   resLocals,
 }: {
   course: Course;
   courseInstance: CourseInstance;
+  lti13Relaunch: boolean;
   paid: boolean;
   resLocals: ResLocalsForPage<'course-instance'>;
 }) {
+  if (lti13Relaunch) {
+    return Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals });
+  }
+
   return PageLayout({
     resLocals,
     pageTitle: 'Upgrade successful',

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -9,9 +9,9 @@ import {
   type AuthUser,
   getConfiguredUser,
   getOrCreateUser,
+  updateCourseInstanceSettings,
   withUser,
 } from '../../../tests/utils/auth.js';
-import { createEnrollment } from '../../../tests/utils/enrollment-identity.js';
 import {
   reconcilePlanGrantsForCourseInstance,
   reconcilePlanGrantsForCourseInstanceUser,
@@ -77,22 +77,18 @@ describe('studentCourseInstanceUpgrade', () => {
     });
   });
 
-  it('does not let an LTI relaunch hint bypass a blocked enrollment', async () => {
+  it('does not let an LTI relaunch hint bypass self-enrollment policy', async () => {
     await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
+    await updateCourseInstanceSettings('1', {
+      selfEnrollmentEnabled: false,
+      selfEnrollmentUseEnrollmentCode: false,
+      restrictToInstitution: false,
+    });
 
     await withUser(studentUser, async () => {
-      const user = await getConfiguredUser();
-      const courseInstance = await selectCourseInstanceById('1');
-      await createEnrollment({
-        courseInstance,
-        userId: user.id,
-        status: 'blocked',
-        firstJoinedAt: new Date('2024-01-01T00:00:00Z'),
-      });
-
       const res = await fetch(`${upgradeUrl}?lti13_relaunch=1`);
       assert.equal(res.status, 403);
-      assert.include(await res.text(), 'Enrollment blocked');
+      assert.include(await res.text(), 'Self-enrollment not available');
     });
   });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -17,6 +17,10 @@ import {
   reconcilePlanGrantsForCourseInstanceUser,
   updateRequiredPlansForCourseInstance,
 } from '../../lib/billing/plans.js';
+import {
+  insertStripeCheckoutSessionForUserInCourseInstance,
+  markStripeCheckoutSessionCompleted,
+} from '../../models/stripe-checkout-sessions.js';
 import { enableEnterpriseEdition } from '../../tests/ee-helpers.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
@@ -89,6 +93,37 @@ describe('studentCourseInstanceUpgrade', () => {
       const res = await fetch(`${upgradeUrl}?lti13_relaunch=1`);
       assert.equal(res.status, 403);
       assert.include(await res.text(), 'Self-enrollment not available');
+    });
+  });
+
+  it('does not ask a joined student to relaunch after a completed LTI upgrade', async () => {
+    await withUser(studentUser, async () => {
+      const user = await getConfiguredUser();
+      const courseInstance = await selectCourseInstanceById('1');
+      await ensureUncheckedEnrollment({
+        userId: user.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+        actionDetail: 'implicit_joined',
+      });
+
+      const stripeSessionId = 'completed-lti-upgrade';
+      await insertStripeCheckoutSessionForUserInCourseInstance({
+        agent_user_id: user.id,
+        stripe_object_id: stripeSessionId,
+        course_instance_id: courseInstance.id,
+        subject_user_id: user.id,
+        data: {},
+        plan_names: ['basic'],
+      });
+      await markStripeCheckoutSessionCompleted(stripeSessionId);
+
+      const res = await fetch(
+        `${upgradeUrl}/success?session_id=${stripeSessionId}&lti13_relaunch=1`,
+      );
+      assert.isOk(res.ok);
+      assert.include(await res.text(), 'You may now access the course.');
     });
   });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.test.ts
@@ -11,6 +11,7 @@ import {
   getOrCreateUser,
   withUser,
 } from '../../../tests/utils/auth.js';
+import { createEnrollment } from '../../../tests/utils/enrollment-identity.js';
 import {
   reconcilePlanGrantsForCourseInstance,
   reconcilePlanGrantsForCourseInstanceUser,
@@ -73,6 +74,25 @@ describe('studentCourseInstanceUpgrade', () => {
       const res = await fetch(assessmentsUrl);
       assert.isOk(res.ok);
       assert.equal(res.url, upgradeUrl);
+    });
+  });
+
+  it('does not let an LTI relaunch hint bypass a blocked enrollment', async () => {
+    await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
+
+    await withUser(studentUser, async () => {
+      const user = await getConfiguredUser();
+      const courseInstance = await selectCourseInstanceById('1');
+      await createEnrollment({
+        courseInstance,
+        userId: user.id,
+        status: 'blocked',
+        firstJoinedAt: new Date('2024-01-01T00:00:00Z'),
+      });
+
+      const res = await fetch(`${upgradeUrl}?lti13_relaunch=1`);
+      assert.equal(res.status, 403);
+      assert.include(await res.text(), 'Enrollment blocked');
     });
   });
 

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -15,16 +15,16 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
+  type OrdinaryCourseInstanceAdmissionDecision,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../../lib/enrollment/admission.js';
+import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
-} from '../../../lib/enrollment-eligibility.js';
+} from '../../../lib/enrollment/eligibility.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import {
-  type OrdinaryCourseInstanceAdmissionDecision,
-  selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -432,6 +432,22 @@ router.get(
       });
     };
 
+    const shouldRequireLti13Relaunch = async () => {
+      if (!lti13UpgradeRequested) return false;
+
+      // The Stripe success URL can be revisited after admission consumes the
+      // saved LTI authorization. Check the enrollment before asking the
+      // student to return to the LMS.
+      const decision = await selectEnrollmentAccessDecision({
+        course,
+        courseInstance,
+        user: authn_user,
+      });
+      if (!decision.allowed && decision.reason === 'already_joined') return false;
+
+      return true;
+    };
+
     if (localSession.completed_at) {
       if (await finishLti13Admission()) {
         res.redirect(`/pl/course_instance/${courseInstance.id}/`);
@@ -443,7 +459,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          requireLti13Relaunch: lti13UpgradeRequested,
+          requireLti13Relaunch: await shouldRequireLti13Relaunch(),
           paid: true,
           resLocals: res.locals,
         }),
@@ -493,7 +509,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          requireLti13Relaunch: lti13UpgradeRequested,
+          requireLti13Relaunch: await shouldRequireLti13Relaunch(),
           paid: true,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -53,6 +53,18 @@ import {
 
 const router = Router({ mergeParams: true });
 
+/**
+ * Returns the admission failure, if any, that should prevent a user from
+ * obtaining a required plan on this page. This is deliberately less strict
+ * than admission itself: joined users may need another plan, and an enrollment
+ * code is enforced when admission resumes rather than before the upgrade.
+ *
+ * The LTI relaunch flow also ignores ordinary self-enrollment restrictions.
+ * The query parameter that selects that flow is not enrollment authority, so
+ * this page only handles the upgrade and then sends the user back to the LMS.
+ * A fresh LTI launch must revalidate the exact invitation before admitting the
+ * user. A blocked enrollment is never allowed to proceed through this flow.
+ */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
   lti13Relaunch: boolean,
@@ -65,14 +77,21 @@ function getAdmissionIneligibilityReason(
   return decision.reason;
 }
 
-function canUseLti13RelaunchMarker(
-  marker: unknown,
+/**
+ * Returns whether this request should use the LTI-specific upgrade flow.
+ * `lti13_relaunch=1` is a routing hint appended when an exact LTI invitation is
+ * interrupted by a required plan upgrade. It carries no LTI claims and grants
+ * no enrollment authority; those claims were consumed before the redirect.
+ * We honor the hint only for a directly authenticated student, then require the
+ * student to relaunch from the LMS so admission can validate a fresh link and
+ * subject after the upgrade.
+ */
+function shouldUseLti13RelaunchFlow(
+  queryValue: unknown,
   resLocals: ResLocalsForPage<'course-instance'>,
 ) {
-  // This marker only changes upgrade and payment routing. A fresh checked LTI
-  // admission is still required to enroll after the upgrade.
   return (
-    marker === '1' &&
+    queryValue === '1' &&
     idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
     resLocals.authz_data.authn_course_role === 'None' &&
     resLocals.authz_data.authn_course_instance_role === 'None' &&
@@ -87,7 +106,7 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
+    const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
 
     const admissionDecision = await selectEnrollmentAccessDecision({
       course,
@@ -157,7 +176,7 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
+      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
 
       const admissionDecision = await selectEnrollmentAccessDecision({
         course,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -15,8 +15,8 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
-  type OrdinaryCourseInstanceAdmissionDecision,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  type EnrollmentAccessDecision,
+  selectEnrollmentAccessDecision,
 } from '../../../lib/enrollment/admission.js';
 import {
   type EnrollmentIneligibilityReason,
@@ -54,7 +54,7 @@ import {
 const router = Router({ mergeParams: true });
 
 function getAdmissionIneligibilityReason(
-  decision: OrdinaryCourseInstanceAdmissionDecision,
+  decision: EnrollmentAccessDecision,
   lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
@@ -89,7 +89,7 @@ router.get(
     const user = UserSchema.parse(res.locals.authn_user);
     const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
-    const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const admissionDecision = await selectEnrollmentAccessDecision({
       course,
       courseInstance,
       user,
@@ -159,7 +159,7 @@ router.post(
       const user = UserSchema.parse(res.locals.authn_user);
       const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
-      const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      const admissionDecision = await selectEnrollmentAccessDecision({
         course,
         courseInstance,
         user,

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -23,6 +23,7 @@ import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment/eligibility.js';
+import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
@@ -38,6 +39,10 @@ import {
   getPricesForPlans,
   getStripeClient,
 } from '../../lib/billing/stripe.js';
+import {
+  clearLti13CourseInstanceUpgradeAuthorization,
+  getLti13CourseInstanceUpgradeAuthorization,
+} from '../../lib/lti13-course-instance-upgrade.js';
 import { ensurePlanGrant } from '../../models/plan-grants.js';
 import {
   getStripeCheckoutSessionByStripeObjectId,
@@ -55,16 +60,13 @@ import {
 const router = Router({ mergeParams: true });
 
 /**
- * Returns the admission failure, if any, that should prevent a user from
- * obtaining a required plan on this page. This is deliberately less strict
- * than admission itself: joined users may need another plan, and an enrollment
- * code is enforced when admission resumes rather than before the upgrade.
+ * Determines whether the student may buy a plan required by this course.
+ * Joined students may need another plan, and an enrollment code is checked
+ * when enrollment resumes rather than before payment.
  *
- * The LTI relaunch flow also ignores self-enrollment restrictions.
- * The query parameter that selects that flow is not enrollment authority, so
- * this page only handles the upgrade and then sends the user back to the LMS.
- * A fresh LTI launch must revalidate the exact invitation before admitting the
- * user. A blocked enrollment is never allowed to proceed through this flow.
+ * A student sent here from an LTI launch may also bypass self-enrollment
+ * restrictions. The session and pending invitation are checked before this
+ * function is called, and a blocked enrollment still takes precedence.
  */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
@@ -87,26 +89,54 @@ function getAdmissionIneligibilityReason(
 }
 
 /**
- * Returns whether this request should use the LTI-specific upgrade flow.
- * `lti13_relaunch=1` is a routing hint appended when an exact LTI invitation is
- * interrupted by a required plan upgrade. It carries no LTI claims and grants
- * no enrollment authority; those claims were consumed before the redirect.
- * We honor the hint only for a directly authenticated student, then require the
- * student to relaunch from the LMS so admission can validate a fresh link and
- * subject after the upgrade.
+ * `lti13_relaunch=1` only says which flow the browser is trying to continue.
+ * The session must show that an LTI launch for this user and course was sent to
+ * the upgrade page, and that invitation must still be pending for the same LTI
+ * link and `sub`.
  */
-function shouldUseLti13RelaunchFlow(
+async function shouldUseLti13RelaunchFlow(
   queryValue: unknown,
+  session: Record<string, unknown>,
   resLocals: ResLocalsForPage<'course-instance'>,
 ) {
-  return (
-    queryValue === '1' &&
-    idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
-    resLocals.authz_data.authn_course_role === 'None' &&
-    resLocals.authz_data.authn_course_instance_role === 'None' &&
-    resLocals.authz_data.authn_has_student_access &&
-    !resLocals.is_administrator
-  );
+  if (
+    queryValue !== '1' ||
+    !idsEqual(resLocals.user.id, resLocals.authn_user.id) ||
+    resLocals.authz_data.authn_course_role !== 'None' ||
+    resLocals.authz_data.authn_course_instance_role !== 'None' ||
+    !resLocals.authz_data.authn_has_student_access ||
+    resLocals.is_administrator
+  ) {
+    return false;
+  }
+
+  const authorization = getLti13CourseInstanceUpgradeAuthorization({
+    courseInstanceId: resLocals.course_instance.id,
+    now: resLocals.req_date,
+    session,
+    userId: resLocals.authn_user.id,
+  });
+  if (authorization === null) return false;
+
+  const decision = await selectEnrollmentAdmissionDecision({
+    courseInstanceId: resLocals.course_instance.id,
+    source: {
+      type: 'invitation',
+      matchedBy: 'lti13',
+      lti13CourseInstanceId: authorization.lti13_course_instance_id,
+      sub: authorization.sub,
+    },
+    userId: resLocals.authn_user.id,
+  });
+  if (
+    !decision.allowed ||
+    decision.invitationCandidate === null ||
+    !idsEqual(decision.invitationCandidate.enrollment.id, authorization.enrollment_id)
+  ) {
+    clearLti13CourseInstanceUpgradeAuthorization(session);
+    return false;
+  }
+  return true;
 }
 
 router.get(
@@ -115,7 +145,11 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
+    const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+      req.query.lti13_relaunch,
+      req.session,
+      res.locals,
+    );
 
     const admissionDecision = await selectEnrollmentAccessDecision({
       course,
@@ -184,7 +218,11 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.body.lti13_relaunch, res.locals);
+      const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+        req.body.lti13_relaunch,
+        req.session,
+        res.locals,
+      );
 
       // Recheck admission eligibility before creating the Stripe checkout session.
       const admissionDecision = await selectEnrollmentAccessDecision({

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
+import { assertNever } from '@prairielearn/utils';
 import { parseRequestBody } from '@prairielearn/zod';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
@@ -59,7 +60,7 @@ const router = Router({ mergeParams: true });
  * than admission itself: joined users may need another plan, and an enrollment
  * code is enforced when admission resumes rather than before the upgrade.
  *
- * The LTI relaunch flow also ignores ordinary self-enrollment restrictions.
+ * The LTI relaunch flow also ignores self-enrollment restrictions.
  * The query parameter that selects that flow is not enrollment authority, so
  * this page only handles the upgrade and then sends the user back to the LMS.
  * A fresh LTI launch must revalidate the exact invitation before admitting the
@@ -70,11 +71,19 @@ function getAdmissionIneligibilityReason(
   lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
-  if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
-    return null;
+  switch (decision.reason) {
+    case 'already_joined':
+    case 'enrollment_code_required':
+      return null;
+    case 'blocked':
+      return decision.reason;
+    case 'institution-restriction':
+    case 'self-enrollment-disabled':
+    case 'self-enrollment-expired':
+      return lti13Relaunch ? null : decision.reason;
+    default:
+      return assertNever(decision.reason);
   }
-  if (lti13Relaunch && decision.reason !== 'blocked') return null;
-  return decision.reason;
 }
 
 /**
@@ -115,13 +124,12 @@ router.get(
     });
     const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
     if (ineligibilityReason !== null) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
+      res.status(403).send(EnrollmentPage({ reason: ineligibilityReason, resLocals: res.locals }));
       return;
     }
 
-    // Check if the student is *actually* missing plan grants, or if they just
-    // came across this URL on accident. If they have all the necessary plan grants,
-    // redirect them back to the assessments page.
+    // If no upgrade is needed, return normal requests to the assessments page.
+    // An interrupted LTI admission instead requires a fresh launch from the LMS.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
       if (lti13Relaunch) {
@@ -176,8 +184,9 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.query.lti13_relaunch, res.locals);
+      const lti13Relaunch = shouldUseLti13RelaunchFlow(req.body.lti13_relaunch, res.locals);
 
+      // Recheck admission eligibility before creating the Stripe checkout session.
       const admissionDecision = await selectEnrollmentAccessDecision({
         course,
         courseInstance,
@@ -378,7 +387,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch: false,
+          lti13Relaunch,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../lib/db-types.js';
 import {
   type EnrollmentAccessDecision,
+  admitUserFromLti13Launch,
   selectEnrollmentAccessDecision,
 } from '../../../lib/enrollment/admission.js';
 import {
@@ -24,6 +25,7 @@ import {
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment/eligibility.js';
 import { selectEnrollmentAdmissionDecision } from '../../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../../lib/id.js';
 import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
@@ -40,6 +42,7 @@ import {
   getStripeClient,
 } from '../../lib/billing/stripe.js';
 import {
+  type Lti13CourseInstanceUpgradeAuthorization,
   clearLti13CourseInstanceUpgradeAuthorization,
   getLti13CourseInstanceUpgradeAuthorization,
 } from '../../lib/lti13-course-instance-upgrade.js';
@@ -70,7 +73,7 @@ const router = Router({ mergeParams: true });
  */
 function getAdmissionIneligibilityReason(
   decision: EnrollmentAccessDecision,
-  lti13Relaunch: boolean,
+  hasLti13Invitation: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
   switch (decision.reason) {
@@ -82,23 +85,22 @@ function getAdmissionIneligibilityReason(
     case 'institution-restriction':
     case 'self-enrollment-disabled':
     case 'self-enrollment-expired':
-      return lti13Relaunch ? null : decision.reason;
+      return hasLti13Invitation ? null : decision.reason;
     default:
       return assertNever(decision.reason);
   }
 }
 
 /**
- * `lti13_relaunch=1` only says which flow the browser is trying to continue.
- * The session must show that an LTI launch for this user and course was sent to
- * the upgrade page, and that invitation must still be pending for the same LTI
- * link and `sub`.
+ * `lti13_relaunch=1` tells us to look for an LTI invitation saved before the
+ * upgrade redirect. The session must contain an invitation for this user and
+ * course, and it must still be pending for the same LTI link and `sub`.
  */
-async function shouldUseLti13RelaunchFlow(
+async function selectLti13UpgradeAuthorization(
   queryValue: unknown,
   session: Record<string, unknown>,
   resLocals: ResLocalsForPage<'course-instance'>,
-) {
+): Promise<Lti13CourseInstanceUpgradeAuthorization | null> {
   if (
     queryValue !== '1' ||
     !idsEqual(resLocals.user.id, resLocals.authn_user.id) ||
@@ -107,7 +109,7 @@ async function shouldUseLti13RelaunchFlow(
     !resLocals.authz_data.authn_has_student_access ||
     resLocals.is_administrator
   ) {
-    return false;
+    return null;
   }
 
   const authorization = getLti13CourseInstanceUpgradeAuthorization({
@@ -116,7 +118,7 @@ async function shouldUseLti13RelaunchFlow(
     session,
     userId: resLocals.authn_user.id,
   });
-  if (authorization === null) return false;
+  if (authorization === null) return null;
 
   const decision = await selectEnrollmentAdmissionDecision({
     courseInstanceId: resLocals.course_instance.id,
@@ -134,8 +136,46 @@ async function shouldUseLti13RelaunchFlow(
     !idsEqual(decision.invitationCandidate.enrollment.id, authorization.enrollment_id)
   ) {
     clearLti13CourseInstanceUpgradeAuthorization(session);
+    return null;
+  }
+  return authorization;
+}
+
+async function finishLti13UpgradeAdmission({
+  authorization,
+  ip,
+  isAdministrator,
+  reqDate,
+  session,
+}: {
+  authorization: Lti13CourseInstanceUpgradeAuthorization;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  session: Record<string, unknown>;
+}): Promise<boolean> {
+  try {
+    await admitUserFromLti13Launch({
+      courseInstanceId: authorization.course_instance_id,
+      expectedInvitationEnrollmentId: authorization.enrollment_id,
+      ip,
+      isAdministrator,
+      lti13CourseInstanceId: authorization.lti13_course_instance_id,
+      reqDate,
+      sub: authorization.sub,
+      userId: authorization.user_id,
+    });
+  } catch (error) {
+    if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+
+    // The invitation can change while the student is at Stripe. A new LMS
+    // launch supplies current LTI data and either admits the student or shows
+    // the appropriate course access error.
+    clearLti13CourseInstanceUpgradeAuthorization(session);
     return false;
   }
+
+  clearLti13CourseInstanceUpgradeAuthorization(session);
   return true;
 }
 
@@ -145,7 +185,7 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+    const lti13UpgradeAuthorization = await selectLti13UpgradeAuthorization(
       req.query.lti13_relaunch,
       req.session,
       res.locals,
@@ -156,21 +196,37 @@ router.get(
       courseInstance,
       user,
     });
-    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
+    const ineligibilityReason = getAdmissionIneligibilityReason(
+      admissionDecision,
+      lti13UpgradeAuthorization !== null,
+    );
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ reason: ineligibilityReason, resLocals: res.locals }));
       return;
     }
 
-    // If no upgrade is needed, return normal requests to the assessments page.
-    // An interrupted LTI admission instead requires a fresh launch from the LMS.
+    // If the required plan was granted while this page was open, finish the
+    // admission without sending the student through the LMS again.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
-      if (lti13Relaunch) {
+      if (lti13UpgradeAuthorization !== null) {
+        const admitted = await finishLti13UpgradeAdmission({
+          authorization: lti13UpgradeAuthorization,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          session: req.session,
+        });
+        if (admitted) {
+          res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+          return;
+        }
+
         res.send(Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals: res.locals }));
-      } else {
-        res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+        return;
       }
+
+      res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
       return;
     }
 
@@ -191,7 +247,7 @@ router.get(
       StudentCourseInstanceUpgrade({
         course,
         courseInstance,
-        lti13Relaunch,
+        lti13AdmissionPending: lti13UpgradeAuthorization !== null,
         missingPlans,
         planPrices,
         resLocals: res.locals,
@@ -218,7 +274,7 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
-      const lti13Relaunch = await shouldUseLti13RelaunchFlow(
+      const lti13UpgradeAuthorization = await selectLti13UpgradeAuthorization(
         req.body.lti13_relaunch,
         req.session,
         res.locals,
@@ -230,7 +286,10 @@ router.post(
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
+      const ineligibilityReason = getAdmissionIneligibilityReason(
+        admissionDecision,
+        lti13UpgradeAuthorization !== null,
+      );
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
@@ -280,7 +339,7 @@ router.post(
 
       const host = getCanonicalHost(req);
       const urlBase = `${host}/pl/course_instance/${courseInstance.id}/upgrade`;
-      const lti13RelaunchQuery = lti13Relaunch ? '&lti13_relaunch=1' : '';
+      const lti13RelaunchQuery = lti13UpgradeAuthorization !== null ? '&lti13_relaunch=1' : '';
 
       const stripe = getStripeClient();
       const customerId = await getOrCreateStripeCustomerId(user.id, {
@@ -304,7 +363,7 @@ router.post(
         line_items: lineItems,
         mode: 'payment',
         success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}${lti13RelaunchQuery}`,
-        cancel_url: `${urlBase}${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
+        cancel_url: `${urlBase}${lti13UpgradeAuthorization !== null ? '?lti13_relaunch=1' : ''}`,
         metadata,
         payment_intent_data: {
           metadata,
@@ -336,7 +395,7 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const authn_user = UserSchema.parse(res.locals.authn_user);
-    const lti13Relaunch = req.query.lti13_relaunch === '1';
+    const lti13UpgradeRequested = req.query.lti13_relaunch === '1';
 
     if (!req.query.session_id) throw new error.HttpStatusError(400, 'Missing session_id');
 
@@ -346,23 +405,6 @@ router.get(
     if (!localSession) {
       throw new Error(`Unknown Stripe session: ${stripeSessionId}`);
     }
-    if (localSession.completed_at) {
-      // We already processed this session; just show them the success page.
-      res.send(
-        CourseInstanceStudentUpdateSuccess({
-          course,
-          courseInstance,
-          lti13Relaunch,
-          paid: true,
-          resLocals: res.locals,
-        }),
-      );
-      return;
-    }
-
-    const stripe = getStripeClient();
-    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
-
     // Verify that the session is associated with the current course instance
     // and user. We shouldn't hit this during normal operations, but an attacker
     // could try to replay a session ID from a different course instance or user.
@@ -372,6 +414,45 @@ router.get(
     ) {
       throw new error.HttpStatusError(400, 'Invalid session');
     }
+
+    const finishLti13Admission = async () => {
+      const authorization = await selectLti13UpgradeAuthorization(
+        req.query.lti13_relaunch,
+        req.session,
+        res.locals,
+      );
+      if (authorization === null) return false;
+
+      return await finishLti13UpgradeAdmission({
+        authorization,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        session: req.session,
+      });
+    };
+
+    if (localSession.completed_at) {
+      if (await finishLti13Admission()) {
+        res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+        return;
+      }
+
+      // We already processed this session; just show them the success page.
+      res.send(
+        CourseInstanceStudentUpdateSuccess({
+          course,
+          courseInstance,
+          requireLti13Relaunch: lti13UpgradeRequested,
+          paid: true,
+          resLocals: res.locals,
+        }),
+      );
+      return;
+    }
+
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.retrieve(stripeSessionId);
 
     if (session.payment_status === 'paid') {
       if (!localSession.plan_grants_created) {
@@ -403,11 +484,16 @@ router.get(
         });
       }
 
+      if (await finishLti13Admission()) {
+        res.redirect(`/pl/course_instance/${courseInstance.id}/`);
+        return;
+      }
+
       res.send(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch,
+          requireLti13Relaunch: lti13UpgradeRequested,
           paid: true,
           resLocals: res.locals,
         }),
@@ -425,7 +511,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
-          lti13Relaunch,
+          requireLti13Relaunch: false,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -4,11 +4,9 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
-import { run } from '@prairielearn/run';
 import { parseRequestBody } from '@prairielearn/zod';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
-import { hasRole } from '../../../lib/authz-data-lib.js';
 import { config } from '../../../lib/config.js';
 import {
   CourseInstanceSchema,
@@ -17,12 +15,15 @@ import {
   UserSchema,
 } from '../../../lib/db-types.js';
 import {
-  checkEnrollmentEligibility,
+  type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment-eligibility.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
-import { selectOptionalEnrollmentByUid } from '../../../models/enrollment.js';
+import {
+  type OrdinaryCourseInstanceAdmissionDecision,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../../models/course-instance-admission.js';
 import { checkPlanGrantsForLocals } from '../../lib/billing/plan-grants.js';
 import {
   getMissingPlanGrants,
@@ -50,6 +51,16 @@ import {
 
 const router = Router({ mergeParams: true });
 
+function getAdmissionIneligibilityReason(
+  decision: OrdinaryCourseInstanceAdmissionDecision,
+): EnrollmentIneligibilityReason | null {
+  if (decision.allowed) return null;
+  if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
+    return null;
+  }
+  return decision.reason;
+}
+
 router.get(
   '/',
   typedAsyncHandler<'course-instance'>(async (req, res) => {
@@ -57,30 +68,14 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
 
-    // Check enrollment eligibility before showing the upgrade page.
-    // This prevents students from paying when they wouldn't be able to enroll
-    // (e.g., due to institution restrictions).
-    const existingEnrollment = await run(async () => {
-      if (!hasRole(res.locals.authz_data, ['Student'])) {
-        return null;
-      }
-      return await selectOptionalEnrollmentByUid({
-        uid: user.uid,
-        courseInstance,
-        requiredRole: ['Student'],
-        authzData: res.locals.authz_data,
-      });
-    });
-
-    const enrollmentInfo = checkEnrollmentEligibility({
-      user,
+    const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
       course,
       courseInstance,
-      existingEnrollment,
+      user,
     });
-
-    if (!enrollmentInfo.eligible) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: enrollmentInfo.reason }));
+    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+    if (ineligibilityReason !== null) {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
       return;
     }
 
@@ -137,28 +132,14 @@ router.post(
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
 
-      // Check enrollment eligibility before processing payment.
-      const existingEnrollment = await run(async () => {
-        if (!hasRole(res.locals.authz_data, ['Student'])) {
-          return null;
-        }
-        return await selectOptionalEnrollmentByUid({
-          uid: user.uid,
-          courseInstance,
-          requiredRole: ['Student'],
-          authzData: res.locals.authz_data,
-        });
-      });
-
-      const enrollmentInfo = checkEnrollmentEligibility({
-        user,
+      const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
         course,
         courseInstance,
-        existingEnrollment,
+        user,
       });
-
-      if (!enrollmentInfo.eligible) {
-        throw new error.HttpStatusError(403, getEligibilityErrorMessage(enrollmentInfo.reason));
+      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+      if (ineligibilityReason !== null) {
+        throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
 
       const body = parseRequestBody(req, UpgradeBodySchema);

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -164,10 +164,7 @@ router.post(
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(
-        admissionDecision,
-        lti13Relaunch,
-      );
+      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -18,7 +18,8 @@ import {
   type EnrollmentIneligibilityReason,
   getEligibilityErrorMessage,
 } from '../../../lib/enrollment-eligibility.js';
-import { typedAsyncHandler } from '../../../lib/res-locals.js';
+import { idsEqual } from '../../../lib/id.js';
+import { type ResLocalsForPage, typedAsyncHandler } from '../../../lib/res-locals.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import {
   type OrdinaryCourseInstanceAdmissionDecision,
@@ -46,6 +47,7 @@ import {
 
 import {
   CourseInstanceStudentUpdateSuccess,
+  Lti13CourseInstanceRelaunch,
   StudentCourseInstanceUpgrade,
 } from './studentCourseInstanceUpgrade.html.js';
 
@@ -53,12 +55,30 @@ const router = Router({ mergeParams: true });
 
 function getAdmissionIneligibilityReason(
   decision: OrdinaryCourseInstanceAdmissionDecision,
+  lti13Relaunch: boolean,
 ): EnrollmentIneligibilityReason | null {
   if (decision.allowed) return null;
   if (decision.reason === 'already_joined' || decision.reason === 'enrollment_code_required') {
     return null;
   }
+  if (lti13Relaunch && decision.reason !== 'blocked') return null;
   return decision.reason;
+}
+
+function canUseLti13RelaunchMarker(
+  marker: unknown,
+  resLocals: ResLocalsForPage<'course-instance'>,
+) {
+  // This marker only changes upgrade and payment routing. A fresh checked LTI
+  // admission is still required to enroll after the upgrade.
+  return (
+    marker === '1' &&
+    idsEqual(resLocals.user.id, resLocals.authn_user.id) &&
+    resLocals.authz_data.authn_course_role === 'None' &&
+    resLocals.authz_data.authn_course_instance_role === 'None' &&
+    resLocals.authz_data.authn_has_student_access &&
+    !resLocals.is_administrator
+  );
 }
 
 router.get(
@@ -67,13 +87,14 @@ router.get(
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const course = CourseSchema.parse(res.locals.course);
     const user = UserSchema.parse(res.locals.authn_user);
+    const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
     const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
       course,
       courseInstance,
       user,
     });
-    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+    const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision, lti13Relaunch);
     if (ineligibilityReason !== null) {
       res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: ineligibilityReason }));
       return;
@@ -84,7 +105,11 @@ router.get(
     // redirect them back to the assessments page.
     const hasPlanGrants = await checkPlanGrantsForLocals(res.locals);
     if (hasPlanGrants) {
-      res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+      if (lti13Relaunch) {
+        res.send(Lti13CourseInstanceRelaunch({ course, courseInstance, resLocals: res.locals }));
+      } else {
+        res.redirect(`/pl/course_instance/${res.locals.course_instance.id}/assessments`);
+      }
       return;
     }
 
@@ -105,6 +130,7 @@ router.get(
       StudentCourseInstanceUpgrade({
         course,
         courseInstance,
+        lti13Relaunch,
         missingPlans,
         planPrices,
         resLocals: res.locals,
@@ -131,13 +157,17 @@ router.post(
       const course = CourseSchema.parse(res.locals.course);
       const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
       const user = UserSchema.parse(res.locals.authn_user);
+      const lti13Relaunch = canUseLti13RelaunchMarker(req.query.lti13_relaunch, res.locals);
 
       const admissionDecision = await selectOrdinaryCourseInstanceAdmissionDecision({
         course,
         courseInstance,
         user,
       });
-      const ineligibilityReason = getAdmissionIneligibilityReason(admissionDecision);
+      const ineligibilityReason = getAdmissionIneligibilityReason(
+        admissionDecision,
+        lti13Relaunch,
+      );
       if (ineligibilityReason !== null) {
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(ineligibilityReason));
       }
@@ -187,6 +217,7 @@ router.post(
 
       const host = getCanonicalHost(req);
       const urlBase = `${host}/pl/course_instance/${courseInstance.id}/upgrade`;
+      const lti13RelaunchQuery = lti13Relaunch ? '&lti13_relaunch=1' : '';
 
       const stripe = getStripeClient();
       const customerId = await getOrCreateStripeCustomerId(user.id, {
@@ -209,8 +240,8 @@ router.post(
         },
         line_items: lineItems,
         mode: 'payment',
-        success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}`,
-        cancel_url: urlBase,
+        success_url: `${urlBase}/success?session_id={CHECKOUT_SESSION_ID}${lti13RelaunchQuery}`,
+        cancel_url: `${urlBase}${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
         metadata,
         payment_intent_data: {
           metadata,
@@ -242,6 +273,7 @@ router.get(
     const course = CourseSchema.parse(res.locals.course);
     const courseInstance = CourseInstanceSchema.parse(res.locals.course_instance);
     const authn_user = UserSchema.parse(res.locals.authn_user);
+    const lti13Relaunch = req.query.lti13_relaunch === '1';
 
     if (!req.query.session_id) throw new error.HttpStatusError(400, 'Missing session_id');
 
@@ -257,6 +289,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch,
           paid: true,
           resLocals: res.locals,
         }),
@@ -311,6 +344,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch,
           paid: true,
           resLocals: res.locals,
         }),
@@ -328,6 +362,7 @@ router.get(
         CourseInstanceStudentUpdateSuccess({
           course,
           courseInstance,
+          lti13Relaunch: false,
           paid: false,
           resLocals: res.locals,
         }),

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -387,7 +387,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
-    it('uses every matching candidate for institution UIN invitation access', async () => {
+    it('uses publishing extensions from both the left enrollment and its UIN invitation', async () => {
       const courseInstance = createMockCourseInstance();
       const boundCandidate = createCandidate(
         createMockEnrollment({ id: 'bound', status: 'left' }),

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -220,8 +220,8 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
     classification: Partial<EnrollmentIdentityClassification> = {},
   ): EnrollmentIdentityClassification {
     const resolved = {
-      actionableConventionalInvitation: null,
-      actionableInstitutionRosterInvitation: null,
+      actionableInstitutionUinInvitation: null,
+      actionableUidInvitation: null,
       boundCandidate: null,
       candidates: [],
       ...classification,
@@ -387,15 +387,15 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
-    it('uses every matching candidate for roster invitation access', async () => {
+    it('uses every matching candidate for institution UIN invitation access', async () => {
       const courseInstance = createMockCourseInstance();
       const boundCandidate = createCandidate(
         createMockEnrollment({ id: 'bound', status: 'left' }),
         { boundUser: true },
       );
-      const rosterCandidate = createCandidate(
+      const uinInvitationCandidate = createCandidate(
         createMockEnrollment({
-          id: 'roster',
+          id: 'uin-invitation',
           user_id: null,
           status: 'invited',
           pending_uin: 'uin',
@@ -403,9 +403,9 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         { institutionUin: true },
       );
       mockClassification({
-        actionableInstitutionRosterInvitation: rosterCandidate,
+        actionableInstitutionUinInvitation: uinInvitationCandidate,
         boundCandidate,
-        candidates: [boundCandidate, rosterCandidate],
+        candidates: [boundCandidate, uinInvitationCandidate],
       });
       const extensionSelector = vi
         .spyOn(publishingExtensionsModel, 'selectLatestPublishingExtensionByEnrollmentIds')
@@ -422,7 +422,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         has_student_access_with_enrollment: false,
       });
       assert.deepEqual(extensionSelector.mock.calls, [
-        [{ courseInstance, enrollmentIds: ['bound', 'roster'] }],
+        [{ courseInstance, enrollmentIds: ['bound', 'uin-invitation'] }],
       ]);
     });
 

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -426,23 +426,39 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       ]);
     });
 
-    it('allows access when the request date is before the latest extension end date', async () => {
+    it("does not use a pending invitation's extension after the user has joined", async () => {
       const courseInstance = createMockCourseInstance({
         publishing_start_date: new Date('2025-01-01T00:00:00Z'),
         publishing_end_date: new Date('2025-12-31T23:59:59Z'),
       });
       const reqDate = new Date('2026-02-15T12:00:00Z');
-      const enrollment = createMockEnrollment();
-      const extension = createMockPublishingExtension({
+      const boundCandidate = createCandidate(createMockEnrollment({ id: 'bound' }), {
+        boundUser: true,
+      });
+      const pendingCandidate = createCandidate(
+        createMockEnrollment({
+          id: 'pending',
+          pending_uin: 'uin',
+          status: 'invited',
+          user_id: null,
+        }),
+        { institutionUin: true },
+      );
+      const pendingExtension = createMockPublishingExtension({
         id: 'extension',
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
-      mockBoundEnrollment(enrollment);
+      mockClassification({
+        boundCandidate,
+        candidates: [boundCandidate, pendingCandidate],
+      });
       vi.spyOn(
         publishingExtensionsModel,
         'selectLatestPublishingExtensionByEnrollmentIds',
-      ).mockResolvedValue(extension);
+      ).mockImplementation(({ enrollmentIds }) =>
+        Promise.resolve(enrollmentIds.includes('pending') ? pendingExtension : null),
+      );
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -450,9 +466,8 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         reqDate,
       );
 
-      // Request date is 2026-02-15 12:00:00, latest extension is 2026-02-28 23:59:59
-      assert.isTrue(result.has_student_access);
-      assert.isTrue(result.has_student_access_with_enrollment);
+      assert.isFalse(result.has_student_access);
+      assert.isFalse(result.has_student_access_with_enrollment);
     });
 
     it('forbids access when request date is after all extensions', async () => {

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -5,7 +5,11 @@ import { afterAll, assert, beforeAll, beforeEach, describe, it, vi } from 'vites
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 
 import * as publishingExtensionsModel from '../models/course-instance-publishing-extensions.js';
-import * as enrollmentModel from '../models/enrollment.js';
+import {
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+} from '../models/enrollment-identity.js';
+import * as enrollmentIdentityModel from '../models/enrollment-identity.js';
 import * as helperDb from '../tests/helperDb.js';
 
 import {
@@ -196,6 +200,45 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
     };
   }
 
+  function createCandidate(
+    enrollment: Enrollment,
+    matches: Partial<EnrollmentIdentityCandidate['matches']> = {},
+  ): EnrollmentIdentityCandidate {
+    return {
+      enrollment,
+      matches: {
+        boundUser: false,
+        institutionUin: false,
+        lti13: false,
+        pendingUid: false,
+        ...matches,
+      },
+    };
+  }
+
+  function mockClassification(
+    classification: Partial<EnrollmentIdentityClassification> = {},
+  ): EnrollmentIdentityClassification {
+    const resolved = {
+      actionableConventionalInvitation: null,
+      actionableInstitutionRosterInvitation: null,
+      boundCandidate: null,
+      candidates: [],
+      ...classification,
+    };
+    vi.spyOn(
+      enrollmentIdentityModel,
+      'selectEnrollmentIdentityClassification',
+    ).mockResolvedValue(resolved);
+    return resolved;
+  }
+
+  function mockBoundEnrollment(enrollment: Enrollment | null) {
+    if (enrollment === null) return mockClassification();
+    const candidate = createCandidate(enrollment, { boundUser: true });
+    return mockClassification({ boundCandidate: candidate, candidates: [candidate] });
+  }
+
   describe('no publishing dates', () => {
     it('forbids access when publishing_start_date is null', async () => {
       const courseInstance = createMockCourseInstance({
@@ -204,7 +247,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2025-06-01T12:00:00Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -225,7 +268,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2024-12-31T23:59:59Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -245,7 +288,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2024-12-31T23:59:59Z');
       const enrollment = createMockEnrollment();
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -266,7 +309,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2025-06-01T12:00:00Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -286,7 +329,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2025-06-01T12:00:00Z');
       const enrollment = createMockEnrollment();
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -307,7 +350,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2026-01-01T00:00:00Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -327,10 +370,10 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2026-01-01T00:00:00Z');
       const enrollment = createMockEnrollment();
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
@@ -345,6 +388,48 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
+    it('uses every matching candidate for roster invitation access', async () => {
+      const courseInstance = createMockCourseInstance();
+      const boundCandidate = createCandidate(
+        createMockEnrollment({ id: 'bound', status: 'left' }),
+        { boundUser: true },
+      );
+      const rosterCandidate = createCandidate(
+        createMockEnrollment({
+          id: 'roster',
+          user_id: null,
+          status: 'invited',
+          pending_uin: 'uin',
+        }),
+        { institutionUin: true },
+      );
+      mockClassification({
+        actionableInstitutionRosterInvitation: rosterCandidate,
+        boundCandidate,
+        candidates: [boundCandidate, rosterCandidate],
+      });
+      const extensionSelector = vi
+        .spyOn(
+          publishingExtensionsModel,
+          'selectLatestPublishingExtensionByEnrollmentIds',
+        )
+        .mockResolvedValue(createMockPublishingExtension());
+
+      const result = await calculateModernCourseInstanceStudentAccess(
+        courseInstance,
+        'test-user-id',
+        new Date('2026-01-15T12:00:00Z'),
+      );
+
+      assert.deepEqual(result, {
+        has_student_access: true,
+        has_student_access_with_enrollment: false,
+      });
+      assert.deepEqual(extensionSelector.mock.calls, [
+        [{ courseInstance, enrollmentIds: ['bound', 'roster'] }],
+      ]);
+    });
+
     it('allows access when the request date is before the latest extension end date', async () => {
       const courseInstance = createMockCourseInstance({
         publishing_start_date: new Date('2025-01-01T00:00:00Z'),
@@ -357,10 +442,10 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(extension);
 
       const result = await calculateModernCourseInstanceStudentAccess(
@@ -386,10 +471,10 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(extension);
 
       const result = await calculateModernCourseInstanceStudentAccess(

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -5,11 +5,6 @@ import { afterAll, assert, beforeAll, beforeEach, describe, it, vi } from 'vites
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 
 import * as publishingExtensionsModel from '../models/course-instance-publishing-extensions.js';
-import {
-  type EnrollmentIdentityCandidate,
-  type EnrollmentIdentityClassification,
-} from '../models/enrollment-identity.js';
-import * as enrollmentIdentityModel from '../models/enrollment-identity.js';
 import * as helperDb from '../tests/helperDb.js';
 
 import {
@@ -17,6 +12,11 @@ import {
   checkCourseInstanceLegacyAccess,
 } from './authz-data.js';
 import type { CourseInstance, CourseInstancePublishingExtension, Enrollment } from './db-types.js';
+import * as enrollmentIdentityModel from './enrollment/identity.js';
+import {
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+} from './enrollment/identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -226,10 +226,9 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       candidates: [],
       ...classification,
     };
-    vi.spyOn(
-      enrollmentIdentityModel,
-      'selectEnrollmentIdentityClassification',
-    ).mockResolvedValue(resolved);
+    vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+      resolved,
+    );
     return resolved;
   }
 
@@ -409,10 +408,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         candidates: [boundCandidate, rosterCandidate],
       });
       const extensionSelector = vi
-        .spyOn(
-          publishingExtensionsModel,
-          'selectLatestPublishingExtensionByEnrollmentIds',
-        )
+        .spyOn(publishingExtensionsModel, 'selectLatestPublishingExtensionByEnrollmentIds')
         .mockResolvedValue(createMockPublishingExtension());
 
       const result = await calculateModernCourseInstanceStudentAccess(

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -107,7 +107,11 @@ export async function calculateModernCourseInstanceStudentAccess(
     courseInstanceId: courseInstance.id,
     userId,
   });
-  const isJoined = classification.boundCandidate?.enrollment.status === 'joined';
+  const joinedEnrollment =
+    classification.boundCandidate?.enrollment.status === 'joined'
+      ? classification.boundCandidate.enrollment
+      : null;
+  const isJoined = joinedEnrollment !== null;
 
   // Not published at all.
   if (courseInstance.publishing_start_date == null) {
@@ -130,8 +134,9 @@ export async function calculateModernCourseInstanceStudentAccess(
     };
   }
 
-  // A publishing extension may be assigned to the joined enrollment or to any
-  // row that will be merged when a pending UID or UIN invitation is accepted.
+  // Before admission, any matching row may carry the extension that will be
+  // preserved when those rows are merged. Once the user has joined, pending
+  // rows are not merged automatically and must not extend the joined row's access.
   const hasActionableInvitation =
     classification.actionableUidInvitation !== null ||
     classification.actionableInstitutionUinInvitation !== null;
@@ -141,7 +146,10 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollmentIds({
     courseInstance,
-    enrollmentIds: classification.candidates.map((candidate) => candidate.enrollment.id),
+    enrollmentIds:
+      joinedEnrollment === null
+        ? classification.candidates.map((candidate) => candidate.enrollment.id)
+        : [joinedEnrollment.id],
   });
 
   // Check if we have access via extension.

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -130,8 +130,8 @@ export async function calculateModernCourseInstanceStudentAccess(
     };
   }
 
-  // Joined students and actionable invitations can have an extension on any
-  // enrollment candidate that would participate in admission reconciliation.
+  // A publishing extension may be assigned to the joined enrollment or to any
+  // row that will be merged when a pending UID or UIN invitation is accepted.
   const hasActionableInvitation =
     classification.actionableUidInvitation !== null ||
     classification.actionableInstitutionUinInvitation !== null;

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -7,15 +7,14 @@ import { run } from '@prairielearn/run';
 import { withBrand } from '@prairielearn/utils';
 import { IdSchema } from '@prairielearn/zod';
 
-import { selectLatestPublishingExtensionByEnrollment } from '../models/course-instance-publishing-extensions.js';
-import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
+import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
+import { selectEnrollmentIdentityClassification } from '../models/enrollment-identity.js';
 
 import {
   type ConstructedCourseOrInstanceContext,
   type PlainAuthzData,
   calculateCourseInstanceRolePermissions,
   calculateCourseRolePermissions,
-  dangerousFullSystemAuthz,
 } from './authz-data-lib.js';
 import {
   type CourseInstance,
@@ -104,14 +103,11 @@ export async function calculateModernCourseInstanceStudentAccess(
   // modern publishing configs.
   assert(courseInstance.modern_publishing);
 
-  // We can't trust the authzData to have the correct permissioning,
-  // so we need to use system auth to get the enrollment.
-  const enrollment = await selectOptionalEnrollmentByUserId({
+  const classification = await selectEnrollmentIdentityClassification({
+    courseInstanceId: courseInstance.id,
     userId,
-    requiredRole: ['System'],
-    authzData: dangerousFullSystemAuthz(),
-    courseInstance,
   });
+  const isJoined = classification.boundCandidate?.enrollment.status === 'joined';
 
   // Not published at all.
   if (courseInstance.publishing_start_date == null) {
@@ -130,18 +126,22 @@ export async function calculateModernCourseInstanceStudentAccess(
   if (reqDate < courseInstance.publishing_end_date) {
     return {
       has_student_access: true,
-      has_student_access_with_enrollment: enrollment?.status === 'joined',
+      has_student_access_with_enrollment: isJoined,
     };
   }
 
-  // We are after the end date. We might have access if we have an extension.
-  // Only enrolled students can have extensions.
-  if (enrollment?.status !== 'joined') {
+  // Joined students and actionable invitations can have an extension on any
+  // enrollment candidate that would participate in admission reconciliation.
+  const hasActionableInvitation =
+    classification.actionableConventionalInvitation !== null ||
+    classification.actionableInstitutionRosterInvitation !== null;
+  if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }
 
-  const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollment({
-    enrollment,
+  const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollmentIds({
+    courseInstance,
+    enrollmentIds: classification.candidates.map((candidate) => candidate.enrollment.id),
   });
 
   // Check if we have access via extension.
@@ -150,7 +150,7 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   return {
     has_student_access: hasAccessViaExtension,
-    has_student_access_with_enrollment: hasAccessViaExtension,
+    has_student_access_with_enrollment: hasAccessViaExtension && isJoined,
   };
 }
 

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -8,7 +8,7 @@ import { withBrand } from '@prairielearn/utils';
 import { IdSchema } from '@prairielearn/zod';
 
 import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
-import { selectEnrollmentIdentityClassification } from '../models/enrollment-identity.js';
+
 
 import {
   type ConstructedCourseOrInstanceContext,
@@ -27,6 +27,7 @@ import {
   InstitutionSchema,
   type User,
 } from './db-types.js';
+import { selectEnrollmentIdentityClassification } from './enrollment/identity.js';
 import { ipToMode } from './exam-mode.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -26,7 +26,11 @@ import {
   InstitutionSchema,
   type User,
 } from './db-types.js';
-import { selectEnrollmentIdentityClassification } from './enrollment/identity.js';
+import {
+  type EnrollmentIdentityContext,
+  getEnrollmentAdmissionDecision,
+  selectEnrollmentIdentityClassification,
+} from './enrollment/identity.js';
 import { ipToMode } from './exam-mode.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
@@ -93,11 +97,13 @@ export async function checkCourseInstanceLegacyAccess({
  * @param courseInstance - The course instance to check access for.
  * @param userId - The ID of the user to check access for.
  * @param reqDate - The date of the request.
+ * @param lti13Identity - Exact link and `sub` from a verified LTI launch, used to find a pending enrollment's publishing extension.
  */
 export async function calculateModernCourseInstanceStudentAccess(
   courseInstance: CourseInstance,
   userId: string,
   reqDate: Date,
+  lti13Identity?: NonNullable<EnrollmentIdentityContext['lti13Identity']>,
 ) {
   // This function should only be called for course instances that are using
   // modern publishing configs.
@@ -105,6 +111,7 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   const classification = await selectEnrollmentIdentityClassification({
     courseInstanceId: courseInstance.id,
+    lti13Identity,
     userId,
   });
   const joinedEnrollment =
@@ -139,7 +146,14 @@ export async function calculateModernCourseInstanceStudentAccess(
   // rows are not merged automatically and must not extend the joined row's access.
   const hasActionableInvitation =
     classification.actionableUidInvitation !== null ||
-    classification.actionableInstitutionUinInvitation !== null;
+    classification.actionableInstitutionUinInvitation !== null ||
+    (lti13Identity !== undefined &&
+      getEnrollmentAdmissionDecision(classification, {
+        type: 'invitation',
+        matchedBy: 'lti13',
+        lti13CourseInstanceId: lti13Identity.lti13CourseInstanceId,
+        sub: lti13Identity.sub,
+      }).allowed);
   if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }
@@ -163,33 +177,34 @@ export async function calculateModernCourseInstanceStudentAccess(
 }
 
 /**
- * Builds the authorization data for a user on a page. The optional parameters are used for effective user overrides,
- * most scenarios should not need to change these parameters.
- *
- * @param params
- * @param params.user - The authenticated user.
- * @param params.course_id - The ID of the course. Inferred from the course instance if null.
- * @param params.course_instance_id - The ID of the course instance.
- * @param params.ip - The IP address of the request.
- * @param params.req_date - The date of the request.
- * @param params.is_administrator - Whether the user is an administrator.
- * @param params.overrides - The overrides to apply to the authorization data.
+ * Builds the authorization data for a user on a page. Most callers should not
+ * need the LTI identity or effective-user overrides.
  */
 export async function constructCourseOrInstanceContext({
   user,
   course_id,
   course_instance_id,
+  lti13Identity,
   ip,
   req_date,
   is_administrator,
   overrides = {},
 }: {
+  /** The authenticated user. */
   user: User;
+  /** The course ID, or `null` to infer it from the course instance. */
   course_id: string | null;
+  /** The course instance ID. */
   course_instance_id: string | null;
+  /** Exact link and `sub` from a verified LTI launch, used when checking publishing extensions. */
+  lti13Identity?: NonNullable<EnrollmentIdentityContext['lti13Identity']>;
+  /** The request IP address. */
   ip: string | null;
+  /** The request date. */
   req_date: Date;
+  /** Whether the authenticated user is an administrator. */
   is_administrator: boolean;
+  /** Effective-user and course-context overrides. */
   overrides?: CourseOrInstanceOverrides;
 }): Promise<ConstructedCourseOrInstanceContext> {
   const resolvedOverrides = {
@@ -273,6 +288,7 @@ export async function constructCourseOrInstanceContext({
                 rawAuthzData.course_instance,
                 user.id,
                 req_date,
+                lti13Identity,
               );
             }
             const courseInstanceIdsWithAccess = await checkCourseInstanceLegacyAccess({

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -9,7 +9,6 @@ import { IdSchema } from '@prairielearn/zod';
 
 import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
 
-
 import {
   type ConstructedCourseOrInstanceContext,
   type PlainAuthzData,
@@ -134,8 +133,8 @@ export async function calculateModernCourseInstanceStudentAccess(
   // Joined students and actionable invitations can have an extension on any
   // enrollment candidate that would participate in admission reconciliation.
   const hasActionableInvitation =
-    classification.actionableConventionalInvitation !== null ||
-    classification.actionableInstitutionRosterInvitation !== null;
+    classification.actionableUidInvitation !== null ||
+    classification.actionableInstitutionUinInvitation !== null;
   if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }

--- a/apps/prairielearn/src/lib/enrollment-eligibility.ts
+++ b/apps/prairielearn/src/lib/enrollment-eligibility.ts
@@ -2,7 +2,7 @@ import { assertNever } from '@prairielearn/utils';
 
 import type { Course, CourseInstance, Enrollment, User } from './db-types.js';
 
-type EnrollmentIneligibilityReason =
+export type EnrollmentIneligibilityReason =
   | 'blocked'
   | 'self-enrollment-disabled'
   | 'self-enrollment-expired'

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -5,15 +5,13 @@ import {
   PotentialEnrollmentStatus,
   checkPotentialEnterpriseEnrollment,
 } from '../../ee/models/enrollment.js';
-import { setEnrollmentStatus } from '../../models/enrollment.js';
 import { selectUserById } from '../../models/user.js';
-import { type AuthzData, hasRole, makePageAuthzData } from '../authz-data-lib.js';
+import { hasRole, makePageAuthzData } from '../authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../authz-data.js';
 import type { Course, CourseInstance, User } from '../db-types.js';
 import { isEnterprise } from '../license.js';
 import { HttpRedirect } from '../redirect.js';
 
-import { runWithSharedEnrollmentBarrier } from './barrier.js';
 import {
   type EnrollmentIneligibilityReason,
   checkEnrollmentEligibility,
@@ -21,11 +19,9 @@ import {
 } from './eligibility.js';
 import {
   type EnrollmentAdmissionSource,
-  type EnrollmentIdentityCandidate,
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './identity.js';
-import { lockEnrollments } from './lock.js';
 import {
   EnrollmentAdmissionDeniedError,
   type SelectableEnrollmentAdmissionSource,
@@ -358,62 +354,6 @@ export async function admitUserFromUidInvitation({
       reqDate,
       userId,
     }),
-  });
-}
-
-function selectUidInvitationForRejection(
-  classification: EnrollmentIdentityClassification,
-): EnrollmentIdentityCandidate | null {
-  if (classification.boundCandidate !== null) return null;
-  return (
-    classification.candidates.find(
-      (candidate) =>
-        candidate.enrollment.user_id === null &&
-        (candidate.enrollment.status === 'invited' || candidate.enrollment.status === 'rejected') &&
-        candidate.matches.pendingUid &&
-        candidate.enrollment.pending_lti13_course_instance_id === null,
-    ) ?? null
-  );
-}
-
-/**
- * Rejects a pending UID invitation. This uses the same UID rules as admission,
- * but also treats an already rejected invitation as a successful no-op. The
- * invitation is rechecked after locking so a changed or replacement invitation
- * is left untouched.
- */
-export async function rejectUserFromUidInvitation({
-  authzData,
-  courseInstanceId,
-  userId,
-}: {
-  authzData: AuthzData;
-  courseInstanceId: string;
-  userId: string;
-}): Promise<boolean> {
-  const context = { courseInstanceId, userId };
-
-  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
-    const initialClassification = await selectEnrollmentIdentityClassification(context);
-    const initialInvitation = selectUidInvitationForRejection(initialClassification);
-    if (initialInvitation === null) return false;
-
-    const enrollmentIds = initialClassification.candidates.map(
-      (candidate) => candidate.enrollment.id,
-    );
-    await lockEnrollments(enrollmentIds);
-    const classification = await selectEnrollmentIdentityClassification(context, enrollmentIds);
-    const invitation = selectUidInvitationForRejection(classification);
-    if (invitation?.enrollment.id !== initialInvitation.enrollment.id) return false;
-    if (invitation.enrollment.status === 'rejected') return true;
-
-    await setEnrollmentStatus({
-      enrollment: invitation.enrollment,
-      status: 'rejected',
-      authzData,
-      requiredRole: ['Student'],
-    });
-    return true;
   });
 }
 

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -145,12 +145,14 @@ async function validateEnterpriseAdmission({
   courseInstance,
   institution,
   lti13Relaunch,
+  onPlanGrantsRequired,
 }: {
   authzData: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['authzData'];
   course: Course;
   courseInstance: CourseInstance;
   institution: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['institution'];
   lti13Relaunch: boolean;
+  onPlanGrantsRequired?: () => void;
 }) {
   if (!isEnterprise()) return;
 
@@ -162,6 +164,7 @@ async function validateEnterpriseAdmission({
   });
   switch (status) {
     case PotentialEnrollmentStatus.PLAN_GRANTS_REQUIRED:
+      onPlanGrantsRequired?.();
       throw new HttpRedirect(
         `/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
       );
@@ -175,17 +178,16 @@ async function validateEnterpriseAdmission({
 }
 
 /**
- * Creates the policy callback that reconciliation invokes after reselecting
- * identity candidates under their enrollment locks and before mutating them.
- * It rebuilds the course context and checks student access, source-specific
- * admission policy, and enterprise requirements against that locked identity
- * classification.
+ * Reconciliation calls this after locking and re-reading the matching
+ * enrollments. It checks student access, enrollment policy, and plan
+ * requirements before any enrollment is changed.
  */
 function createAdmissionValidator({
   courseInstanceId,
   enrollmentCode,
   ip,
   isAdministrator,
+  onPlanGrantsRequired,
   reqDate,
   userId,
 }: {
@@ -193,6 +195,7 @@ function createAdmissionValidator({
   enrollmentCode?: string;
   ip: string | null;
   isAdministrator: boolean;
+  onPlanGrantsRequired?: () => void;
   reqDate: Date;
   userId: string;
 }) {
@@ -226,10 +229,9 @@ function createAdmissionValidator({
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    // Reconciliation has already matched an exact LTI link and subject against
-    // the locked invitation. Do not reinterpret that request-local authority as
-    // a UIN, UID, or self-enrollment source. Other sources must still pass the
-    // admission policy using the locked classification.
+    // The LTI path has already checked the invitation's link and `sub` while
+    // holding the enrollment locks. Other paths still need the usual UID, UIN,
+    // or self-enrollment checks below.
     if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
       const decision = getEnrollmentAccessDecision({
         classification,
@@ -249,7 +251,11 @@ function createAdmissionValidator({
       }
     }
 
-    // Invitation authority never bypasses plan grants or enrollment limits.
+    // We don't lock course settings or plan configuration. If either changes
+    // during this transaction, this admission may finish using the old values.
+    // Avoiding that would require coordinating every settings writer with this
+    // code. Enrollment identity and status are still protected by the locks.
+    // Invitations must still pass plan and enrollment-limit checks.
     await validateEnterpriseAdmission({
       authzData: makePageAuthzData({
         authzData,
@@ -259,6 +265,7 @@ function createAdmissionValidator({
       courseInstance,
       institution,
       lti13Relaunch: source.type === 'invitation' && source.matchedBy === 'lti13',
+      onPlanGrantsRequired,
     });
   };
 }
@@ -313,11 +320,48 @@ export async function admitUserForCourseInstanceAccess({
 }
 
 /**
- * Performs self-service admission from a fresh, verified LTI launch. The link
- * and subject are revalidated against locked candidates, while
- * `expectedInvitationEnrollmentId` prevents admission from silently falling
- * back to a different matching invitation. `userId` is both the enrollment
- * subject and audit actor.
+ * Accepts the selected pending UID invitation. The invitation ID is checked
+ * again after locking so a different invitation cannot take its place.
+ */
+export async function admitUserFromUidInvitation({
+  courseInstanceId,
+  expectedInvitationEnrollmentId,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  expectedInvitationEnrollmentId: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return await admitUserToCourseInstance({
+    actor: {
+      agentAuthnUserId: userId,
+      agentUserId: userId,
+    },
+    courseInstanceId,
+    expectedInvitationEnrollmentId,
+    source: { type: 'invitation', matchedBy: 'uid' },
+    userId,
+    validateAdmission: createAdmissionValidator({
+      courseInstanceId,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+/**
+ * Enrolls the current user from the pending invitation that matches the LTI
+ * launch. The invitation ID, linked course, and LMS user ID (`sub`) are checked
+ * again after locking. If any no longer match, admission fails instead of using
+ * another invitation.
  */
 export async function admitUserFromLti13Launch({
   courseInstanceId,
@@ -325,6 +369,7 @@ export async function admitUserFromLti13Launch({
   ip,
   isAdministrator,
   lti13CourseInstanceId,
+  onPlanGrantsRequired,
   reqDate,
   sub,
   userId,
@@ -334,6 +379,7 @@ export async function admitUserFromLti13Launch({
   ip: string | null;
   isAdministrator: boolean;
   lti13CourseInstanceId: string;
+  onPlanGrantsRequired?: () => void;
   reqDate: Date;
   sub: string;
   userId: string;
@@ -356,6 +402,7 @@ export async function admitUserFromLti13Launch({
       courseInstanceId,
       ip,
       isAdministrator,
+      onPlanGrantsRequired,
       reqDate,
       userId,
     }),

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -5,13 +5,15 @@ import {
   PotentialEnrollmentStatus,
   checkPotentialEnterpriseEnrollment,
 } from '../../ee/models/enrollment.js';
+import { setEnrollmentStatus } from '../../models/enrollment.js';
 import { selectUserById } from '../../models/user.js';
-import { hasRole, makePageAuthzData } from '../authz-data-lib.js';
+import { type AuthzData, hasRole, makePageAuthzData } from '../authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../authz-data.js';
 import type { Course, CourseInstance, User } from '../db-types.js';
 import { isEnterprise } from '../license.js';
 import { HttpRedirect } from '../redirect.js';
 
+import { runWithSharedEnrollmentBarrier } from './barrier.js';
 import {
   type EnrollmentIneligibilityReason,
   checkEnrollmentEligibility,
@@ -19,9 +21,11 @@ import {
 } from './eligibility.js';
 import {
   type EnrollmentAdmissionSource,
+  type EnrollmentIdentityCandidate,
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './identity.js';
+import { lockEnrollments } from './lock.js';
 import {
   EnrollmentAdmissionDeniedError,
   type SelectableEnrollmentAdmissionSource,
@@ -354,6 +358,62 @@ export async function admitUserFromUidInvitation({
       reqDate,
       userId,
     }),
+  });
+}
+
+function selectUidInvitationForRejection(
+  classification: EnrollmentIdentityClassification,
+): EnrollmentIdentityCandidate | null {
+  if (classification.boundCandidate !== null) return null;
+  return (
+    classification.candidates.find(
+      (candidate) =>
+        candidate.enrollment.user_id === null &&
+        (candidate.enrollment.status === 'invited' || candidate.enrollment.status === 'rejected') &&
+        candidate.matches.pendingUid &&
+        candidate.enrollment.pending_lti13_course_instance_id === null,
+    ) ?? null
+  );
+}
+
+/**
+ * Rejects a pending UID invitation. This uses the same UID rules as admission,
+ * but also treats an already rejected invitation as a successful no-op. The
+ * invitation is rechecked after locking so a changed or replacement invitation
+ * is left untouched.
+ */
+export async function rejectUserFromUidInvitation({
+  authzData,
+  courseInstanceId,
+  userId,
+}: {
+  authzData: AuthzData;
+  courseInstanceId: string;
+  userId: string;
+}): Promise<boolean> {
+  const context = { courseInstanceId, userId };
+
+  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
+    const initialClassification = await selectEnrollmentIdentityClassification(context);
+    const initialInvitation = selectUidInvitationForRejection(initialClassification);
+    if (initialInvitation === null) return false;
+
+    const enrollmentIds = initialClassification.candidates.map(
+      (candidate) => candidate.enrollment.id,
+    );
+    await lockEnrollments(enrollmentIds);
+    const classification = await selectEnrollmentIdentityClassification(context, enrollmentIds);
+    const invitation = selectUidInvitationForRejection(classification);
+    if (invitation?.enrollment.id !== initialInvitation.enrollment.id) return false;
+    if (invitation.enrollment.status === 'rejected') return true;
+
+    await setEnrollmentStatus({
+      enrollment: invitation.enrollment,
+      status: 'rejected',
+      authzData,
+      requiredRole: ['Student'],
+    });
+    return true;
   });
 }
 

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -4,25 +4,25 @@ import { assertNever } from '@prairielearn/utils';
 import {
   PotentialEnrollmentStatus,
   checkPotentialEnterpriseEnrollment,
-} from '../ee/models/enrollment.js';
-import { hasRole, makePageAuthzData } from '../lib/authz-data-lib.js';
-import { constructCourseOrInstanceContext } from '../lib/authz-data.js';
-import type { Course, CourseInstance, User } from '../lib/db-types.js';
+} from '../../ee/models/enrollment.js';
+import { selectUserById } from '../../models/user.js';
+import { hasRole, makePageAuthzData } from '../authz-data-lib.js';
+import { constructCourseOrInstanceContext } from '../authz-data.js';
+import type { Course, CourseInstance, User } from '../db-types.js';
+import { isEnterprise } from '../license.js';
+import { HttpRedirect } from '../redirect.js';
+
 import {
   type EnrollmentIneligibilityReason,
   checkEnrollmentEligibility,
   getEligibilityErrorMessage,
-} from '../lib/enrollment-eligibility.js';
-import { isEnterprise } from '../lib/license.js';
-import { HttpRedirect } from '../lib/redirect.js';
-
+} from './eligibility.js';
 import {
   type EnrollmentAdmissionSource,
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
-} from './enrollment-identity.js';
-import { admitUserToCourseInstance } from './enrollment-reconciliation.js';
-import { selectUserById } from './user.js';
+} from './identity.js';
+import { admitUserToCourseInstance } from './reconciliation.js';
 
 type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13' }>;
 

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -24,32 +24,31 @@ import {
 } from './identity.js';
 import { admitUserToCourseInstance } from './reconciliation.js';
 
-type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13' }>;
+type CourseInstanceAccessAdmissionSource = Exclude<
+  EnrollmentAdmissionSource,
+  { matchedBy: 'lti13' }
+>;
 
-export type OrdinaryCourseInstanceAdmissionDecision =
+export type EnrollmentAccessDecision =
   | {
       allowed: true;
-      source: OrdinaryAdmissionSource;
+      source: CourseInstanceAccessAdmissionSource;
     }
   | {
       allowed: false;
       reason: EnrollmentIneligibilityReason | 'already_joined' | 'enrollment_code_required';
     };
 
-export interface OrdinaryCourseInstanceAdmissionLocals {
-  ordinary_course_instance_admission_decision?: OrdinaryCourseInstanceAdmissionDecision;
-}
-
-function getOrdinaryAdmissionSource(
+function getEnrollmentAdmissionSource(
   classification: EnrollmentIdentityClassification,
-): OrdinaryAdmissionSource {
-  if (classification.actionableInstitutionRosterInvitation !== null) {
-    return { type: 'institution_uin' };
+): CourseInstanceAccessAdmissionSource {
+  if (classification.actionableInstitutionUinInvitation !== null) {
+    return { type: 'invitation', matchedBy: 'institution_uin' };
   }
-  if (classification.actionableConventionalInvitation !== null) {
-    return { type: 'pending_uid' };
+  if (classification.actionableUidInvitation !== null) {
+    return { type: 'invitation', matchedBy: 'uid' };
   }
-  return { type: 'ordinary' };
+  return { type: 'self_enrollment' };
 }
 
 function enrollmentCodeMatches(
@@ -59,7 +58,7 @@ function enrollmentCodeMatches(
   return enrollmentCode?.toUpperCase() === courseInstance.enrollment_code.toUpperCase();
 }
 
-function getOrdinaryCourseInstanceAdmissionDecision({
+function getEnrollmentAccessDecision({
   classification,
   course,
   courseInstance,
@@ -71,13 +70,13 @@ function getOrdinaryCourseInstanceAdmissionDecision({
   courseInstance: CourseInstance;
   enrollmentCode?: string;
   user: User;
-}): OrdinaryCourseInstanceAdmissionDecision {
+}): EnrollmentAccessDecision {
   const boundStatus = classification.boundCandidate?.enrollment.status;
   if (boundStatus === 'joined') return { allowed: false, reason: 'already_joined' };
   if (boundStatus === 'blocked') return { allowed: false, reason: 'blocked' };
 
-  const source = getOrdinaryAdmissionSource(classification);
-  if (source.type !== 'ordinary') {
+  const source = getEnrollmentAdmissionSource(classification);
+  if (source.type !== 'self_enrollment') {
     return { allowed: true, source };
   }
 
@@ -99,7 +98,7 @@ function getOrdinaryCourseInstanceAdmissionDecision({
   return { allowed: true, source };
 }
 
-export async function selectOrdinaryCourseInstanceAdmissionDecision({
+export async function selectEnrollmentAccessDecision({
   course,
   courseInstance,
   enrollmentCode,
@@ -109,12 +108,12 @@ export async function selectOrdinaryCourseInstanceAdmissionDecision({
   courseInstance: CourseInstance;
   enrollmentCode?: string;
   user: User;
-}): Promise<OrdinaryCourseInstanceAdmissionDecision> {
+}): Promise<EnrollmentAccessDecision> {
   const classification = await selectEnrollmentIdentityClassification({
     courseInstanceId: courseInstance.id,
     userId: user.id,
   });
-  return getOrdinaryCourseInstanceAdmissionDecision({
+  return getEnrollmentAccessDecision({
     classification,
     course,
     courseInstance,
@@ -202,8 +201,8 @@ function createAdmissionValidator({
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    if (source.type !== 'lti13') {
-      const decision = getOrdinaryCourseInstanceAdmissionDecision({
+    if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
+      const decision = getEnrollmentAccessDecision({
         classification,
         user,
         course,
@@ -219,9 +218,6 @@ function createAdmissionValidator({
         }
         throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
       }
-      if (decision.source.type !== source.type) {
-        throw new Error('Locked ordinary admission source changed during validation');
-      }
     }
 
     await validateEnterpriseAdmission({
@@ -232,14 +228,13 @@ function createAdmissionValidator({
       course,
       courseInstance,
       institution,
-      lti13Relaunch: source.type === 'lti13',
+      lti13Relaunch: source.type === 'invitation' && source.matchedBy === 'lti13',
     });
   };
 }
 
-export async function admitUserFromOrdinaryCourseInstanceRequest({
+export async function admitUserForCourseInstanceAccess({
   courseInstanceId,
-  decision,
   enrollmentCode,
   ip,
   isAdministrator,
@@ -247,7 +242,6 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
   userId,
 }: {
   courseInstanceId: string;
-  decision: Extract<OrdinaryCourseInstanceAdmissionDecision, { allowed: true }>;
   enrollmentCode?: string;
   ip: string | null;
   isAdministrator: boolean;
@@ -260,8 +254,7 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
       agentUserId: userId,
     },
     courseInstanceId,
-    selectSource: getOrdinaryAdmissionSource,
-    source: decision.source,
+    selectSource: getEnrollmentAdmissionSource,
     userId,
     validateAdmission: createAdmissionValidator({
       courseInstanceId,
@@ -274,7 +267,7 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
   });
 }
 
-export async function admitUserFromLti13CourseInstanceRequest({
+export async function admitUserFromLti13Launch({
   courseInstanceId,
   expectedInvitationEnrollmentId,
   ip,
@@ -294,7 +287,8 @@ export async function admitUserFromLti13CourseInstanceRequest({
   userId: string;
 }) {
   const source = {
-    type: 'lti13' as const,
+    type: 'invitation' as const,
+    matchedBy: 'lti13' as const,
     lti13CourseInstanceId,
     sub,
   };

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -23,6 +23,7 @@ import {
   selectEnrollmentIdentityClassification,
 } from './identity.js';
 import {
+  EnrollmentAdmissionDeniedError,
   type SelectableEnrollmentAdmissionSource,
   admitUserToCourseInstance,
 } from './reconciliation.js';
@@ -227,8 +228,8 @@ function createAdmissionValidator({
 
     // Reconciliation has already matched an exact LTI link and subject against
     // the locked invitation. Do not reinterpret that request-local authority as
-    // an ordinary UIN, UID, or self-enrollment source. Other sources must still
-    // pass the ordinary admission policy using the locked classification.
+    // a UIN, UID, or self-enrollment source. Other sources must still pass the
+    // admission policy using the locked classification.
     if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
       const decision = getEnrollmentAccessDecision({
         classification,
@@ -283,23 +284,32 @@ export async function admitUserForCourseInstanceAccess({
   reqDate: Date;
   userId: string;
 }) {
-  return await admitUserToCourseInstance({
-    actor: {
-      agentAuthnUserId: userId,
-      agentUserId: userId,
-    },
-    courseInstanceId,
-    selectSource: getEnrollmentAdmissionSource,
-    userId,
-    validateAdmission: createAdmissionValidator({
+  try {
+    return await admitUserToCourseInstance({
+      actor: {
+        agentAuthnUserId: userId,
+        agentUserId: userId,
+      },
       courseInstanceId,
-      enrollmentCode,
-      ip,
-      isAdministrator,
-      reqDate,
+      selectSource: getEnrollmentAdmissionSource,
       userId,
-    }),
-  });
+      validateAdmission: createAdmissionValidator({
+        courseInstanceId,
+        enrollmentCode,
+        ip,
+        isAdministrator,
+        reqDate,
+        userId,
+      }),
+    });
+  } catch (error) {
+    // The read-only preflight can become stale before admission locks and
+    // revalidates the enrollment candidates.
+    if (error instanceof EnrollmentAdmissionDeniedError && error.decision.reason === 'blocked') {
+      throw new HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+    }
+    throw error;
+  }
 }
 
 /**

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -22,17 +22,15 @@ import {
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './identity.js';
-import { admitUserToCourseInstance } from './reconciliation.js';
-
-type CourseInstanceAccessAdmissionSource = Exclude<
-  EnrollmentAdmissionSource,
-  { matchedBy: 'lti13' }
->;
+import {
+  type SelectableEnrollmentAdmissionSource,
+  admitUserToCourseInstance,
+} from './reconciliation.js';
 
 export type EnrollmentAccessDecision =
   | {
       allowed: true;
-      source: CourseInstanceAccessAdmissionSource;
+      source: SelectableEnrollmentAdmissionSource;
     }
   | {
       allowed: false;
@@ -41,7 +39,7 @@ export type EnrollmentAccessDecision =
 
 function getEnrollmentAdmissionSource(
   classification: EnrollmentIdentityClassification,
-): CourseInstanceAccessAdmissionSource {
+): SelectableEnrollmentAdmissionSource {
   if (classification.actionableInstitutionUinInvitation !== null) {
     return { type: 'invitation', matchedBy: 'institution_uin' };
   }
@@ -286,9 +284,9 @@ export async function admitUserFromLti13Launch({
   sub: string;
   userId: string;
 }) {
-  const source = {
-    type: 'invitation' as const,
-    matchedBy: 'lti13' as const,
+  const source: EnrollmentAdmissionSource = {
+    type: 'invitation',
+    matchedBy: 'lti13',
     lti13CourseInstanceId,
     sub,
   };

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -40,6 +40,9 @@ export type EnrollmentAccessDecision =
 function getEnrollmentAdmissionSource(
   classification: EnrollmentIdentityClassification,
 ): SelectableEnrollmentAdmissionSource {
+  // Prefer the institution-scoped identity when both invitation forms match.
+  // UIN is authoritative only within the course's institution, while UID is
+  // the fallback for invitations without that institution-scoped identity.
   if (classification.actionableInstitutionUinInvitation !== null) {
     return { type: 'invitation', matchedBy: 'institution_uin' };
   }
@@ -70,14 +73,22 @@ function getEnrollmentAccessDecision({
   user: User;
 }): EnrollmentAccessDecision {
   const boundStatus = classification.boundCandidate?.enrollment.status;
+  // An enrollment already bound to the user is authoritative: a pending
+  // invitation cannot override either existing access or a block.
   if (boundStatus === 'joined') return { allowed: false, reason: 'already_joined' };
   if (boundStatus === 'blocked') return { allowed: false, reason: 'blocked' };
 
   const source = getEnrollmentAdmissionSource(classification);
   if (source.type !== 'self_enrollment') {
+    // An actionable invitation supplies its own admission authority and is not
+    // subject to self-enrollment settings, expiration, institution
+    // restrictions, or codes.
     return { allowed: true, source };
   }
 
+  // Other bound states, such as left or removed, do not grant admission. Treat
+  // them as a fresh self-enrollment instead of allowing an old enrollment to
+  // bypass current self-enrollment policy.
   const eligibility = checkEnrollmentEligibility({
     user,
     course,
@@ -96,6 +107,13 @@ function getEnrollmentAccessDecision({
   return { allowed: true, source };
 }
 
+/**
+ * Computes a read-only admission preflight for routing and rendering. The
+ * result can become stale immediately and must not authorize a mutation;
+ * admission functions reselect identity candidates and rerun policy validation
+ * under enrollment locks. Exact LTI authority is request-local and must use
+ * {@link admitUserFromLti13Launch} instead.
+ */
 export async function selectEnrollmentAccessDecision({
   course,
   courseInstance,
@@ -155,6 +173,13 @@ async function validateEnterpriseAdmission({
   }
 }
 
+/**
+ * Creates the policy callback that reconciliation invokes after reselecting
+ * identity candidates under their enrollment locks and before mutating them.
+ * It rebuilds the course context and checks student access, source-specific
+ * admission policy, and enterprise requirements against that locked identity
+ * classification.
+ */
 function createAdmissionValidator({
   courseInstanceId,
   enrollmentCode,
@@ -188,17 +213,22 @@ function createAdmissionValidator({
         user,
       });
 
+    // Admission is self-service. `Student` requires student access and excludes
+    // course-instance staff roles; the course-role check also excludes users
+    // entering through course-level staff access.
     if (
       authzData === null ||
       courseInstance === null ||
       !hasRole(authzData, ['Student']) ||
-      authzData.course_role !== 'None' ||
-      authzData.course_instance_role !== 'None' ||
-      !authzData.has_student_access
+      authzData.course_role !== 'None'
     ) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
+    // Reconciliation has already matched an exact LTI link and subject against
+    // the locked invitation. Do not reinterpret that request-local authority as
+    // an ordinary UIN, UID, or self-enrollment source. Other sources must still
+    // pass the ordinary admission policy using the locked classification.
     if (!(source.type === 'invitation' && source.matchedBy === 'lti13')) {
       const decision = getEnrollmentAccessDecision({
         classification,
@@ -218,6 +248,7 @@ function createAdmissionValidator({
       }
     }
 
+    // Invitation authority never bypasses plan grants or enrollment limits.
     await validateEnterpriseAdmission({
       authzData: makePageAuthzData({
         authzData,
@@ -231,6 +262,12 @@ function createAdmissionValidator({
   };
 }
 
+/**
+ * Performs self-service course entry for the authenticated user. `userId` is
+ * both the enrollment subject and audit actor; this is not an on-behalf-of-user
+ * API. The source is selected and policy is validated from the locked identity
+ * classification inside reconciliation.
+ */
 export async function admitUserForCourseInstanceAccess({
   courseInstanceId,
   enrollmentCode,
@@ -265,6 +302,13 @@ export async function admitUserForCourseInstanceAccess({
   });
 }
 
+/**
+ * Performs self-service admission from a fresh, verified LTI launch. The link
+ * and subject are revalidated against locked candidates, while
+ * `expectedInvitationEnrollmentId` prevents admission from silently falling
+ * back to a different matching invitation. `userId` is both the enrollment
+ * subject and audit actor.
+ */
 export async function admitUserFromLti13Launch({
   courseInstanceId,
   expectedInvitationEnrollmentId,
@@ -284,12 +328,6 @@ export async function admitUserFromLti13Launch({
   sub: string;
   userId: string;
 }) {
-  const source: EnrollmentAdmissionSource = {
-    type: 'invitation',
-    matchedBy: 'lti13',
-    lti13CourseInstanceId,
-    sub,
-  };
   return await admitUserToCourseInstance({
     actor: {
       agentAuthnUserId: userId,
@@ -297,7 +335,12 @@ export async function admitUserFromLti13Launch({
     },
     courseInstanceId,
     expectedInvitationEnrollmentId,
-    source,
+    source: {
+      type: 'invitation',
+      matchedBy: 'lti13',
+      lti13CourseInstanceId,
+      sub,
+    },
     userId,
     validateAdmission: createAdmissionValidator({
       courseInstanceId,

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -211,6 +211,8 @@ function createAdmissionValidator({
       await constructCourseOrInstanceContext({
         course_id: null,
         course_instance_id: courseInstanceId,
+        lti13Identity:
+          source.type === 'invitation' && source.matchedBy === 'lti13' ? source : undefined,
         ip,
         is_administrator: isAdministrator,
         req_date: reqDate,

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -255,8 +255,10 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
   userId: string;
 }) {
   return await admitUserToCourseInstance({
-    agentAuthnUserId: userId,
-    agentUserId: userId,
+    actor: {
+      agentAuthnUserId: userId,
+      agentUserId: userId,
+    },
     courseInstanceId,
     selectSource: getOrdinaryAdmissionSource,
     source: decision.source,
@@ -297,8 +299,10 @@ export async function admitUserFromLti13CourseInstanceRequest({
     sub,
   };
   return await admitUserToCourseInstance({
-    agentAuthnUserId: userId,
-    agentUserId: userId,
+    actor: {
+      agentAuthnUserId: userId,
+      agentUserId: userId,
+    },
     courseInstanceId,
     expectedInvitationEnrollmentId,
     source,

--- a/apps/prairielearn/src/lib/enrollment/eligibility.test.ts
+++ b/apps/prairielearn/src/lib/enrollment/eligibility.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { Course, CourseInstance, User } from './db-types.js';
-import { checkEnrollmentEligibility } from './enrollment-eligibility.js';
+import type { Course, CourseInstance, User } from '../db-types.js';
+
+import { checkEnrollmentEligibility } from './eligibility.js';
 
 describe('checkEnrollmentEligibility', () => {
   const baseParams = {

--- a/apps/prairielearn/src/lib/enrollment/eligibility.ts
+++ b/apps/prairielearn/src/lib/enrollment/eligibility.ts
@@ -1,6 +1,6 @@
 import { assertNever } from '@prairielearn/utils';
 
-import type { Course, CourseInstance, Enrollment, User } from './db-types.js';
+import type { Course, CourseInstance, Enrollment, User } from '../db-types.js';
 
 export type EnrollmentIneligibilityReason =
   | 'blocked'

--- a/apps/prairielearn/src/lib/enrollment/identity.ts
+++ b/apps/prairielearn/src/lib/enrollment/identity.ts
@@ -120,7 +120,7 @@ function allowsUinOrLtiInvitation(
   return boundCandidate.enrollment.status === 'left';
 }
 
-function classifyEnrollmentIdentityCandidates(
+export function classifyEnrollmentIdentityCandidates(
   candidates: readonly EnrollmentIdentityCandidate[],
 ): EnrollmentIdentityClassification {
   const boundCandidates = candidates.filter((candidate) => candidate.matches.boundUser);

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.sql
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.sql
@@ -135,7 +135,7 @@ VALUES
 RETURNING
   *;
 
--- BLOCK reject_uid_invitation
+-- BLOCK reject_invitation
 UPDATE enrollments
 SET
   status = 'rejected'

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.sql
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.sql
@@ -135,6 +135,16 @@ VALUES
 RETURNING
   *;
 
+-- BLOCK reject_conventional_invitation
+UPDATE enrollments
+SET
+  status = 'rejected'
+WHERE
+  id = $enrollment_id
+  AND status = 'invited'
+RETURNING
+  *;
+
 -- BLOCK delete_loser_enrollments
 DELETE FROM enrollments
 WHERE

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.sql
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.sql
@@ -135,7 +135,7 @@ VALUES
 RETURNING
   *;
 
--- BLOCK reject_conventional_invitation
+-- BLOCK reject_uid_invitation
 UPDATE enrollments
 SET
   status = 'rejected'

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -342,11 +342,8 @@ export async function admitUserToCourseInstance(
   });
 }
 
-/**
- * Rejects only the exact actionable UID-matched invitation selected by the
- * caller. UIN and LTI identity matches cannot authorize this mutation.
- */
-export async function rejectUidInvitation({
+async function rejectInvitation({
+  source,
   agentAuthnUserId,
   agentUserId,
   courseInstanceId,
@@ -355,9 +352,12 @@ export async function rejectUidInvitation({
 }: EnrollmentAuditActor & {
   courseInstanceId: string;
   enrollmentId: string;
+  source: Extract<
+    EnrollmentAdmissionSource,
+    { type: 'invitation'; matchedBy: 'institution_uin' | 'uid' }
+  >;
   userId: string;
 }): Promise<Enrollment> {
-  const source: EnrollmentAdmissionSource = { type: 'invitation', matchedBy: 'uid' };
   const context = { courseInstanceId, userId };
 
   return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
@@ -383,7 +383,7 @@ export async function rejectUidInvitation({
 
     const oldEnrollment = decision.invitationCandidate.enrollment;
     const enrollment = await queryRow(
-      sql.reject_uid_invitation,
+      sql.reject_invitation,
       { enrollment_id: oldEnrollment.id },
       EnrollmentSchema,
     );
@@ -398,5 +398,40 @@ export async function rejectUidInvitation({
       agentUserId,
     });
     return enrollment;
+  });
+}
+
+/**
+ * Rejects only the exact actionable UID-matched invitation selected by the
+ * caller. UIN and LTI identity matches cannot authorize this mutation.
+ */
+export async function rejectUidInvitation(
+  options: EnrollmentAuditActor & {
+    courseInstanceId: string;
+    enrollmentId: string;
+    userId: string;
+  },
+): Promise<Enrollment> {
+  return await rejectInvitation({
+    ...options,
+    source: { type: 'invitation', matchedBy: 'uid' },
+  });
+}
+
+/**
+ * Hides institution-provided course access without binding the user or changing
+ * a paired left enrollment. A later roster sync may make the course available
+ * again by reinviting the exact same identity.
+ */
+export async function rejectInstitutionUinInvitation(
+  options: EnrollmentAuditActor & {
+    courseInstanceId: string;
+    enrollmentId: string;
+    userId: string;
+  },
+): Promise<Enrollment> {
+  return await rejectInvitation({
+    ...options,
+    source: { type: 'invitation', matchedBy: 'institution_uin' },
   });
 }

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -237,7 +237,7 @@ export async function admitUserToCourseInstance(
       if (
         decision.reason === 'already_joined' &&
         classification.boundCandidate !== null &&
-        selectedSource.type !== 'pending_uid'
+        !(selectedSource.type === 'invitation' && selectedSource.matchedBy === 'uid')
       ) {
         return classification.boundCandidate.enrollment;
       }
@@ -343,10 +343,10 @@ export async function admitUserToCourseInstance(
 }
 
 /**
- * Rejects only the exact actionable conventional invitation selected by the
- * caller. Roster identity cannot authorize this mutation.
+ * Rejects only the exact actionable UID-matched invitation selected by the
+ * caller. UIN and LTI identity matches cannot authorize this mutation.
  */
-export async function rejectConventionalEnrollmentInvitation({
+export async function rejectUidInvitation({
   agentAuthnUserId,
   agentUserId,
   courseInstanceId,
@@ -357,7 +357,7 @@ export async function rejectConventionalEnrollmentInvitation({
   enrollmentId: string;
   userId: string;
 }): Promise<Enrollment> {
-  const source = { type: 'pending_uid' as const };
+  const source: EnrollmentAdmissionSource = { type: 'invitation', matchedBy: 'uid' };
   const context = { courseInstanceId, userId };
 
   return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
@@ -383,7 +383,7 @@ export async function rejectConventionalEnrollmentInvitation({
 
     const oldEnrollment = decision.invitationCandidate.enrollment;
     const enrollment = await queryRow(
-      sql.reject_conventional_invitation,
+      sql.reject_uid_invitation,
       { enrollment_id: oldEnrollment.id },
       EnrollmentSchema,
     );

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -402,8 +402,8 @@ async function rejectInvitation({
 }
 
 /**
- * Rejects only the exact actionable UID-matched invitation selected by the
- * caller. UIN and LTI identity matches cannot authorize this mutation.
+ * Rejects the pending UID invitation with the ID selected by the caller. A UIN
+ * or LTI match on the same row is not enough to reject it through this method.
  */
 export async function rejectUidInvitation(
   options: EnrollmentAuditActor & {
@@ -419,9 +419,9 @@ export async function rejectUidInvitation(
 }
 
 /**
- * Hides institution-provided course access without binding the user or changing
- * a paired left enrollment. A later roster sync may make the course available
- * again by reinviting the exact same identity.
+ * Hides a pending UIN invitation without binding the user or changing a paired
+ * `left` enrollment. A later import may set the invitation back to `invited`,
+ * making the course appear on the homepage again.
  */
 export async function rejectInstitutionUinInvitation(
   options: EnrollmentAuditActor & {

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -194,7 +194,10 @@ export async function admitUserToCourseInstance(
      */
     expectedInvitationEnrollmentId?: string;
     userId: string;
-    validateAdmission: (context: { source: EnrollmentAdmissionSource }) => Promise<void>;
+    validateAdmission: (context: {
+      classification: EnrollmentIdentityClassification;
+      source: EnrollmentAdmissionSource;
+    }) => Promise<void>;
   } & EnrollmentAdmissionSourceSelection,
 ): Promise<Enrollment> {
   const { actor, userId, courseInstanceId, expectedInvitationEnrollmentId, validateAdmission } =
@@ -249,7 +252,7 @@ export async function admitUserToCourseInstance(
 
     // Check eligibility and enrollment limits only after re-reading the
     // matching invitation and bound enrollment while their locks are held.
-    await validateAdmission({ source: decision.source });
+    await validateAdmission({ classification, source: decision.source });
 
     const survivorCandidate = selectSurvivor(
       classification.candidates,

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -237,7 +237,7 @@ export async function admitUserToCourseInstance(
       if (
         decision.reason === 'already_joined' &&
         classification.boundCandidate !== null &&
-        (selectedSource.type !== 'pending_uid' || expectedInvitationEnrollmentId === undefined)
+        selectedSource.type !== 'pending_uid'
       ) {
         return classification.boundCandidate.enrollment;
       }

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -372,10 +372,7 @@ export async function rejectConventionalEnrollmentInvitation({
     );
     const decision = getEnrollmentAdmissionDecision(classification, source);
 
-    if (
-      !decision.allowed ||
-      decision.invitationCandidate?.enrollment.id !== enrollmentId
-    ) {
+    if (!decision.allowed || decision.invitationCandidate?.enrollment.id !== enrollmentId) {
       throw new EnrollmentAdmissionDeniedError(
         decision.allowed
           ? {

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -237,7 +237,7 @@ export async function admitUserToCourseInstance(
       if (
         decision.reason === 'already_joined' &&
         classification.boundCandidate !== null &&
-        selectedSource.type !== 'pending_uid'
+        (selectedSource.type !== 'pending_uid' || expectedInvitationEnrollmentId === undefined)
       ) {
         return classification.boundCandidate.enrollment;
       }

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -234,7 +234,11 @@ export async function admitUserToCourseInstance(
     const decision = getEnrollmentAdmissionDecision(classification, selectedSource);
 
     if (!decision.allowed) {
-      if (decision.reason === 'already_joined' && classification.boundCandidate !== null) {
+      if (
+        decision.reason === 'already_joined' &&
+        classification.boundCandidate !== null &&
+        selectedSource.type !== 'pending_uid'
+      ) {
         return classification.boundCandidate.enrollment;
       }
       throw new EnrollmentAdmissionDeniedError(decision);
@@ -333,6 +337,71 @@ export async function admitUserToCourseInstance(
       oldSurvivor: survivorCandidate.enrollment,
       newSurvivor: enrollment,
       deletedEnrollments,
+    });
+    return enrollment;
+  });
+}
+
+/**
+ * Rejects only the exact actionable conventional invitation selected by the
+ * caller. Roster identity cannot authorize this mutation.
+ */
+export async function rejectConventionalEnrollmentInvitation({
+  agentAuthnUserId,
+  agentUserId,
+  courseInstanceId,
+  enrollmentId,
+  userId,
+}: EnrollmentAuditActor & {
+  courseInstanceId: string;
+  enrollmentId: string;
+  userId: string;
+}): Promise<Enrollment> {
+  const source = { type: 'pending_uid' as const };
+  const context = { courseInstanceId, userId };
+
+  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
+    const initialClassification = await selectEnrollmentIdentityClassification(context);
+    const enrollmentIds = initialClassification.candidates.map(
+      (candidate) => candidate.enrollment.id,
+    );
+    await lockEnrollments(enrollmentIds);
+    const classification = await selectEnrollmentIdentityClassificationForRevalidation(
+      context,
+      enrollmentIds,
+    );
+    const decision = getEnrollmentAdmissionDecision(classification, source);
+
+    if (
+      !decision.allowed ||
+      decision.invitationCandidate?.enrollment.id !== enrollmentId
+    ) {
+      throw new EnrollmentAdmissionDeniedError(
+        decision.allowed
+          ? {
+              allowed: false,
+              reason: 'no_matching_invitation',
+              source,
+            }
+          : decision,
+      );
+    }
+
+    const oldEnrollment = decision.invitationCandidate.enrollment;
+    const enrollment = await queryRow(
+      sql.reject_conventional_invitation,
+      { enrollment_id: oldEnrollment.id },
+      EnrollmentSchema,
+    );
+    await insertAuditEvent({
+      tableName: 'enrollments',
+      action: 'update',
+      actionDetail: 'invitation_rejected',
+      rowId: enrollment.id,
+      oldRow: oldEnrollment,
+      newRow: enrollment,
+      agentAuthnUserId,
+      agentUserId,
     });
     return enrollment;
   });

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -366,10 +366,7 @@ export async function rejectConventionalEnrollmentInvitation({
       (candidate) => candidate.enrollment.id,
     );
     await lockEnrollments(enrollmentIds);
-    const classification = await selectEnrollmentIdentityClassificationForRevalidation(
-      context,
-      enrollmentIds,
-    );
+    const classification = await selectEnrollmentIdentityClassification(context, enrollmentIds);
     const decision = getEnrollmentAdmissionDecision(classification, source);
 
     if (!decision.allowed || decision.invitationCandidate?.enrollment.id !== enrollmentId) {

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,65 +1,59 @@
 import { EnrollmentPage } from '../components/EnrollmentPage.js';
 import {
-  type OrdinaryCourseInstanceAdmissionLocals,
-  admitUserFromOrdinaryCourseInstanceRequest,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  admitUserForCourseInstanceAccess,
+  selectEnrollmentAccessDecision,
 } from '../lib/enrollment/admission.js';
 import { idsEqual } from '../lib/id.js';
 import { typedAsyncHandler } from '../lib/res-locals.js';
 
-export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
-  async (req, res, next) => {
-    // If the user does not currently have access to the course, but could if
-    // they were enrolled, automatically enroll them. However, we will not
-    // attempt to enroll them if they are an instructor (that is, if they have
-    // a specific role in the course or course instance) or if they are
-    // impersonating another user.
+export default typedAsyncHandler<'course-instance'>(async (req, res, next) => {
+  // If the user does not currently have access to the course, but could if
+  // they were enrolled, automatically enroll them. However, we will not
+  // attempt to enroll them if they are an instructor (that is, if they have
+  // a specific role in the course or course instance) or if they are
+  // impersonating another user.
 
-    // TODO: check if self-enrollment requires a secret link.
+  // TODO: check if self-enrollment requires a secret link.
 
-    if (
-      idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
-      res.locals.authz_data.authn_course_role === 'None' &&
-      res.locals.authz_data.authn_course_instance_role === 'None' &&
-      res.locals.authz_data.authn_has_student_access &&
-      !res.locals.authz_data.authn_has_student_access_with_enrollment
-    ) {
-      const decision =
-        res.locals.ordinary_course_instance_admission_decision ??
-        (await selectOrdinaryCourseInstanceAdmissionDecision({
-          course: res.locals.course,
-          courseInstance: res.locals.course_instance,
-          user: res.locals.authn_user,
-        }));
+  if (
+    idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
+    res.locals.authz_data.authn_course_role === 'None' &&
+    res.locals.authz_data.authn_course_instance_role === 'None' &&
+    res.locals.authz_data.authn_has_student_access &&
+    !res.locals.authz_data.authn_has_student_access_with_enrollment
+  ) {
+    const decision = await selectEnrollmentAccessDecision({
+      course: res.locals.course,
+      courseInstance: res.locals.course_instance,
+      user: res.locals.authn_user,
+    });
 
-      if (decision.allowed) {
-        await admitUserFromOrdinaryCourseInstanceRequest({
-          courseInstanceId: res.locals.course_instance.id,
-          decision,
-          ip: req.ip ?? null,
-          isAdministrator: res.locals.is_administrator,
-          reqDate: res.locals.req_date,
-          userId: res.locals.authn_user.id,
-        });
+    if (decision.allowed) {
+      await admitUserForCourseInstanceAccess({
+        courseInstanceId: res.locals.course_instance.id,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        userId: res.locals.authn_user.id,
+      });
 
-        // This is the only part of the `authz_data` that would change as a
-        // result of this enrollment, so we can just update it directly.
-        res.locals.authz_data.has_student_access_with_enrollment = true;
-        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
-      } else if (decision.reason === 'already_joined') {
-        res.locals.authz_data.has_student_access_with_enrollment = true;
-        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
-      } else if (decision.reason === 'enrollment_code_required') {
-        res.redirect(
-          `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
-        );
-        return;
-      } else {
-        res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
-        return;
-      }
+      // This is the only part of the `authz_data` that would change as a
+      // result of this enrollment, so we can just update it directly.
+      res.locals.authz_data.has_student_access_with_enrollment = true;
+      res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+    } else if (decision.reason === 'already_joined') {
+      res.locals.authz_data.has_student_access_with_enrollment = true;
+      res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+    } else if (decision.reason === 'enrollment_code_required') {
+      res.redirect(
+        `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
+      );
+      return;
+    } else {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+      return;
     }
+  }
 
-    next();
-  },
-);
+  next();
+});

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,83 +1,65 @@
-import asyncHandler from 'express-async-handler';
-
-import { run } from '@prairielearn/run';
-
 import { EnrollmentPage } from '../components/EnrollmentPage.js';
-import { hasRole } from '../lib/authz-data-lib.js';
-import type { CourseInstance } from '../lib/db-types.js';
-import { checkEnrollmentEligibility } from '../lib/enrollment-eligibility.js';
 import { idsEqual } from '../lib/id.js';
-import { ensureEnrollment, selectOptionalEnrollmentByUid } from '../models/enrollment.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
+import {
+  type OrdinaryCourseInstanceAdmissionLocals,
+  admitUserFromOrdinaryCourseInstanceRequest,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../models/course-instance-admission.js';
 
-export default asyncHandler(async (req, res, next) => {
-  // If the user does not currently have access to the course, but could if
-  // they were enrolled, automatically enroll them. However, we will not
-  // attempt to enroll them if they are an instructor (that is, if they have
-  // a specific role in the course or course instance) or if they are
-  // impersonating another user.
+export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
+  async (req, res, next) => {
+    // If the user does not currently have access to the course, but could if
+    // they were enrolled, automatically enroll them. However, we will not
+    // attempt to enroll them if they are an instructor (that is, if they have
+    // a specific role in the course or course instance) or if they are
+    // impersonating another user.
 
-  // TODO: check if self-enrollment requires a secret link.
+    // TODO: check if self-enrollment requires a secret link.
 
-  const courseInstance: CourseInstance = res.locals.course_instance;
+    if (
+      idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
+      res.locals.authz_data.authn_course_role === 'None' &&
+      res.locals.authz_data.authn_course_instance_role === 'None' &&
+      res.locals.authz_data.authn_has_student_access &&
+      !res.locals.authz_data.authn_has_student_access_with_enrollment
+    ) {
+      const decision =
+        res.locals.ordinary_course_instance_admission_decision ??
+        (await selectOrdinaryCourseInstanceAdmissionDecision({
+          course: res.locals.course,
+          courseInstance: res.locals.course_instance,
+          user: res.locals.authn_user,
+        }));
 
-  // We select by user UID so that we can find invited/rejected enrollments as well
-  const existingEnrollment = await run(async () => {
-    // We only want to even try to lookup enrollment information if the user is a student.
-    if (!hasRole(res.locals.authz_data, ['Student'])) {
-      return null;
+      if (decision.allowed) {
+        await admitUserFromOrdinaryCourseInstanceRequest({
+          courseInstanceId: res.locals.course_instance.id,
+          decision,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          userId: res.locals.authn_user.id,
+        });
+
+        // This is the only part of the `authz_data` that would change as a
+        // result of this enrollment, so we can just update it directly.
+        res.locals.authz_data.has_student_access_with_enrollment = true;
+        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+      } else if (decision.reason === 'already_joined') {
+        res.locals.authz_data.has_student_access_with_enrollment = true;
+        res.locals.authz_data.authn_has_student_access_with_enrollment = true;
+      } else if (decision.reason === 'enrollment_code_required') {
+        res.redirect(
+          `/pl/course_instance/${res.locals.course_instance.id}/join?url=${encodeURIComponent(req.originalUrl)}`,
+        );
+        return;
+      } else {
+        res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+        return;
+      }
     }
-    return await selectOptionalEnrollmentByUid({
-      uid: res.locals.authn_user.uid,
-      courseInstance,
-      requiredRole: ['Student'],
-      authzData: res.locals.authz_data,
-    });
-  });
 
-  const enrollmentEligibility = checkEnrollmentEligibility({
-    user: res.locals.authn_user,
-    course: res.locals.course,
-    courseInstance,
-    existingEnrollment,
-  });
-
-  // If the user is not enrolled, or is rejected/left/removed then they can enroll if self-enrollment is allowed.
-  const canSelfEnroll =
-    enrollmentEligibility.eligible &&
-    (existingEnrollment == null ||
-      ['rejected', 'left', 'removed'].includes(existingEnrollment.status));
-
-  // If the user is enrolled and is invited/joined, then they have access regardless of the self-enrollment status.
-  const canAccessCourseInstance =
-    existingEnrollment != null && ['invited', 'joined'].includes(existingEnrollment.status);
-
-  if (
-    idsEqual(res.locals.user.id, res.locals.authn_user.id) &&
-    res.locals.authz_data.authn_course_role === 'None' &&
-    res.locals.authz_data.authn_course_instance_role === 'None' &&
-    res.locals.authz_data.authn_has_student_access &&
-    !res.locals.authz_data.authn_has_student_access_with_enrollment
-  ) {
-    if (canSelfEnroll || canAccessCourseInstance) {
-      await ensureEnrollment({
-        institution: res.locals.institution,
-        course: res.locals.course,
-        courseInstance,
-        authzData: res.locals.authz_data,
-        requiredRole: ['Student'],
-        actionDetail: 'implicit_joined',
-      });
-
-      // This is the only part of the `authz_data` that would change as a
-      // result of this enrollment, so we can just update it directly.
-      res.locals.authz_data.has_student_access_with_enrollment = true;
-    } else if (!enrollmentEligibility.eligible) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: enrollmentEligibility.reason }));
-      return;
-    }
-  }
-
-  next();
-});
+    next();
+  },
+);

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -50,7 +50,7 @@ export default typedAsyncHandler<'course-instance'>(async (req, res, next) => {
       );
       return;
     } else {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+      res.status(403).send(EnrollmentPage({ reason: decision.reason, resLocals: res.locals }));
       return;
     }
   }

--- a/apps/prairielearn/src/middlewares/autoEnroll.ts
+++ b/apps/prairielearn/src/middlewares/autoEnroll.ts
@@ -1,11 +1,11 @@
 import { EnrollmentPage } from '../components/EnrollmentPage.js';
-import { idsEqual } from '../lib/id.js';
-import { typedAsyncHandler } from '../lib/res-locals.js';
 import {
   type OrdinaryCourseInstanceAdmissionLocals,
   admitUserFromOrdinaryCourseInstanceRequest,
   selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../models/course-instance-admission.js';
+} from '../lib/enrollment/admission.js';
+import { idsEqual } from '../lib/id.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
 
 export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
   async (req, res, next) => {

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,9 +1,9 @@
 import { extractPageContext } from '../lib/client/page-context.js';
-import { typedAsyncHandler } from '../lib/res-locals.js';
 import {
   type OrdinaryCourseInstanceAdmissionLocals,
   selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../models/course-instance-admission.js';
+} from '../lib/enrollment/admission.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
 
 export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
   async (req, res, next) => {

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,61 +1,60 @@
 import { extractPageContext } from '../lib/client/page-context.js';
-import {
-  type OrdinaryCourseInstanceAdmissionLocals,
-  selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../lib/enrollment/admission.js';
+import { selectEnrollmentAccessDecision } from '../lib/enrollment/admission.js';
 import { typedAsyncHandler } from '../lib/res-locals.js';
 
-export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
-  async (req, res, next) => {
-    // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
+export default typedAsyncHandler<'course-instance'>(async (req, res, next) => {
+  // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
 
-    // Check if the user needs an enrollment code to access the course instance.
-    const { course_instance: courseInstance } = extractPageContext(res.locals, {
-      pageType: 'courseInstance',
-      accessType: 'instructor',
-    });
+  // Check if the user needs an enrollment code to access the course instance.
+  const { course_instance: courseInstance } = extractPageContext(res.locals, {
+    pageType: 'courseInstance',
+    accessType: 'instructor',
+  });
 
-    // Skip if user already has student access with enrollment
-    if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
-      next();
-      return;
-    }
-
-    // Skip if user is an instructor or administrator
-    if (
-      res.locals.authz_data.authn_course_role !== 'None' ||
-      res.locals.authz_data.authn_course_instance_role !== 'None' ||
-      res.locals.is_administrator
-    ) {
-      next();
-      return;
-    }
-
-    // Check if user has student access (they should be able to enroll)
-    // This checks if access rules would allow them to enroll.
-    if (!res.locals.authz_data.authn_has_student_access) {
-      next();
-      return;
-    }
-
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
-      course: res.locals.course,
-      courseInstance,
-      user: res.locals.authn_user,
-    });
-    res.locals.ordinary_course_instance_admission_decision = decision;
-
-    if (decision.allowed || decision.reason !== 'enrollment_code_required') {
-      next();
-      return;
-    }
-
-    // User needs an enrollment code - redirect to the enrollment code page
-    // Preserve the current URL as a query parameter so they can return after enrollment
-    const currentUrl = req.originalUrl;
-    const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
-
-    res.redirect(redirectUrl);
+  // Skip if user already has student access with enrollment
+  if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
+    next();
     return;
-  },
-);
+  }
+
+  // Skip if user is an instructor or administrator
+  if (
+    res.locals.authz_data.authn_course_role !== 'None' ||
+    res.locals.authz_data.authn_course_instance_role !== 'None' ||
+    res.locals.is_administrator
+  ) {
+    next();
+    return;
+  }
+
+  // Check if user has student access (they should be able to enroll)
+  // This checks if access rules would allow them to enroll.
+  if (!res.locals.authz_data.authn_has_student_access) {
+    next();
+    return;
+  }
+
+  if (!courseInstance.self_enrollment_use_enrollment_code) {
+    next();
+    return;
+  }
+
+  const decision = await selectEnrollmentAccessDecision({
+    course: res.locals.course,
+    courseInstance,
+    user: res.locals.authn_user,
+  });
+
+  if (decision.allowed || decision.reason !== 'enrollment_code_required') {
+    next();
+    return;
+  }
+
+  // User needs an enrollment code - redirect to the enrollment code page
+  // Preserve the current URL as a query parameter so they can return after enrollment
+  const currentUrl = req.originalUrl;
+  const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
+
+  res.redirect(redirectUrl);
+  return;
+});

--- a/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
+++ b/apps/prairielearn/src/middlewares/requireEnrollmentCode.ts
@@ -1,87 +1,61 @@
-import asyncHandler from 'express-async-handler';
-
 import { extractPageContext } from '../lib/client/page-context.js';
-import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
+import { typedAsyncHandler } from '../lib/res-locals.js';
+import {
+  type OrdinaryCourseInstanceAdmissionLocals,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../models/course-instance-admission.js';
 
-export default asyncHandler(async (req, res, next) => {
-  // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
+export default typedAsyncHandler<'course-instance', OrdinaryCourseInstanceAdmissionLocals>(
+  async (req, res, next) => {
+    // The user will already be denied access if they are impersonating another user that is not enrolled in the course instance.
 
-  // Check if the user needs an enrollment code to access the course instance.
-  const { course_instance: courseInstance } = extractPageContext(res.locals, {
-    pageType: 'courseInstance',
-    accessType: 'instructor',
-  });
+    // Check if the user needs an enrollment code to access the course instance.
+    const { course_instance: courseInstance } = extractPageContext(res.locals, {
+      pageType: 'courseInstance',
+      accessType: 'instructor',
+    });
 
-  // Skip if user already has student access with enrollment
-  if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
-    next();
+    // Skip if user already has student access with enrollment
+    if (res.locals.authz_data.authn_has_student_access_with_enrollment) {
+      next();
+      return;
+    }
+
+    // Skip if user is an instructor or administrator
+    if (
+      res.locals.authz_data.authn_course_role !== 'None' ||
+      res.locals.authz_data.authn_course_instance_role !== 'None' ||
+      res.locals.is_administrator
+    ) {
+      next();
+      return;
+    }
+
+    // Check if user has student access (they should be able to enroll)
+    // This checks if access rules would allow them to enroll.
+    if (!res.locals.authz_data.authn_has_student_access) {
+      next();
+      return;
+    }
+
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course: res.locals.course,
+      courseInstance,
+      user: res.locals.authn_user,
+    });
+    res.locals.ordinary_course_instance_admission_decision = decision;
+
+    if (decision.allowed || decision.reason !== 'enrollment_code_required') {
+      next();
+      return;
+    }
+
+    // User needs an enrollment code - redirect to the enrollment code page
+    // Preserve the current URL as a query parameter so they can return after enrollment
+    const currentUrl = req.originalUrl;
+    const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
+
+    res.redirect(redirectUrl);
     return;
-  }
-
-  // Skip if user is an instructor or administrator
-  if (
-    res.locals.authz_data.authn_course_role !== 'None' ||
-    res.locals.authz_data.authn_course_instance_role !== 'None' ||
-    res.locals.is_administrator
-  ) {
-    next();
-    return;
-  }
-
-  // Check if self-enrollment is enabled and requires an enrollment code
-  if (
-    !courseInstance.self_enrollment_enabled ||
-    !courseInstance.self_enrollment_use_enrollment_code
-  ) {
-    next();
-    return;
-  }
-
-  // Check if self-enrollment is still allowed (before the cutoff date)
-  const selfEnrollmentAllowed =
-    courseInstance.self_enrollment_enabled_before_date == null ||
-    new Date() < courseInstance.self_enrollment_enabled_before_date;
-
-  if (!selfEnrollmentAllowed) {
-    // TODO: Show nice error page
-    next();
-    return;
-  }
-
-  // Check if user has student access (they should be able to enroll)
-  // This checks if access rules would allow them to enroll.
-  if (!res.locals.authz_data.authn_has_student_access) {
-    next();
-    return;
-  }
-
-  // Check if user is already enrolled or blocked
-  const existingEnrollment = await selectOptionalEnrollmentByUserId({
-    userId: res.locals.authn_user.id,
-    requiredRole: ['Student'],
-    authzData: res.locals.authz_data,
-    courseInstance,
-  });
-
-  // If user is enrolled and joined/invited/rejected, let them through.
-  // Removed users need to re-enter the enrollment code.
-  if (existingEnrollment && ['joined', 'invited', 'rejected'].includes(existingEnrollment.status)) {
-    next();
-    return;
-  }
-
-  // If user is blocked, don't redirect them to enrollment code page
-  if (existingEnrollment?.status === 'blocked') {
-    // TODO: Show nice error page
-    next();
-    return;
-  }
-
-  // User needs an enrollment code - redirect to the enrollment code page
-  // Preserve the current URL as a query parameter so they can return after enrollment
-  const currentUrl = req.originalUrl;
-  const redirectUrl = `/pl/course_instance/${courseInstance.id}/join?url=${encodeURIComponent(currentUrl)}`;
-
-  res.redirect(redirectUrl);
-  return;
-});
+  },
+);

--- a/apps/prairielearn/src/migrations/20260820185253_enrollments__pending_uin__replacement_unique_index.sql
+++ b/apps/prairielearn/src/migrations/20260820185253_enrollments__pending_uin__replacement_unique_index.sql
@@ -1,0 +1,5 @@
+-- prairielearn:migrations NO TRANSACTION
+-- Build the replacement before the constraint swap so writes remain protected throughout the deploy.
+-- Intentionally omit IF NOT EXISTS so a failed concurrent build's invalid index is not silently accepted.
+-- squawk-ignore prefer-robust-stmts
+CREATE UNIQUE INDEX CONCURRENTLY enrollments_pending_uin_course_instance_id_idx ON enrollments (pending_uin, course_instance_id);

--- a/apps/prairielearn/src/migrations/20260820185254_enrollments__pending_uin__replace_unique_constraint.sql
+++ b/apps/prairielearn/src/migrations/20260820185254_enrollments__pending_uin__replace_unique_constraint.sql
@@ -1,0 +1,5 @@
+-- The replacement index was built concurrently, so this swap does not rebuild or scan it.
+ALTER TABLE enrollments
+DROP CONSTRAINT enrollments_course_instance_id_pending_uin_key,
+-- squawk-ignore constraint-missing-not-valid, disallowed-unique-constraint
+ADD CONSTRAINT enrollments_pending_uin_course_instance_id_key UNIQUE USING INDEX enrollments_pending_uin_course_instance_id_idx;

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -29,7 +29,6 @@ type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13
 export type OrdinaryCourseInstanceAdmissionDecision =
   | {
       allowed: true;
-      expectedInvitationEnrollmentId?: string;
       source: OrdinaryAdmissionSource;
     }
   | {
@@ -79,18 +78,7 @@ function getOrdinaryCourseInstanceAdmissionDecision({
 
   const source = getOrdinaryAdmissionSource(classification);
   if (source.type !== 'ordinary') {
-    const invitationCandidate =
-      source.type === 'institution_uin'
-        ? classification.actionableInstitutionRosterInvitation
-        : classification.actionableConventionalInvitation;
-    if (invitationCandidate === null) {
-      throw new Error('Actionable admission source is missing its invitation');
-    }
-    return {
-      allowed: true,
-      expectedInvitationEnrollmentId: invitationCandidate.enrollment.id,
-      source,
-    };
+    return { allowed: true, source };
   }
 
   const eligibility = checkEnrollmentEligibility({
@@ -140,11 +128,13 @@ async function validateEnterpriseAdmission({
   course,
   courseInstance,
   institution,
+  lti13Relaunch,
 }: {
   authzData: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['authzData'];
   course: Course;
   courseInstance: CourseInstance;
   institution: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['institution'];
+  lti13Relaunch: boolean;
 }) {
   if (!isEnterprise()) return;
 
@@ -156,7 +146,9 @@ async function validateEnterpriseAdmission({
   });
   switch (status) {
     case PotentialEnrollmentStatus.PLAN_GRANTS_REQUIRED:
-      throw new HttpRedirect(`/pl/course_instance/${courseInstance.id}/upgrade`);
+      throw new HttpRedirect(
+        `/pl/course_instance/${courseInstance.id}/upgrade${lti13Relaunch ? '?lti13_relaunch=1' : ''}`,
+      );
     case PotentialEnrollmentStatus.LIMIT_EXCEEDED:
       throw new HttpRedirect('/pl/enroll/limit_exceeded');
     case PotentialEnrollmentStatus.ALLOWED:
@@ -240,6 +232,7 @@ function createAdmissionValidator({
       course,
       courseInstance,
       institution,
+      lti13Relaunch: source.type === 'lti13',
     });
   };
 }
@@ -265,9 +258,6 @@ export async function admitUserFromOrdinaryCourseInstanceRequest({
     agentAuthnUserId: userId,
     agentUserId: userId,
     courseInstanceId,
-    ...(decision.expectedInvitationEnrollmentId === undefined
-      ? {}
-      : { expectedInvitationEnrollmentId: decision.expectedInvitationEnrollmentId }),
     selectSource: getOrdinaryAdmissionSource,
     source: decision.source,
     userId,

--- a/apps/prairielearn/src/models/course-instance-admission.ts
+++ b/apps/prairielearn/src/models/course-instance-admission.ts
@@ -1,0 +1,324 @@
+import { HttpStatusError } from '@prairielearn/error';
+import { assertNever } from '@prairielearn/utils';
+
+import {
+  PotentialEnrollmentStatus,
+  checkPotentialEnterpriseEnrollment,
+} from '../ee/models/enrollment.js';
+import { hasRole, makePageAuthzData } from '../lib/authz-data-lib.js';
+import { constructCourseOrInstanceContext } from '../lib/authz-data.js';
+import type { Course, CourseInstance, User } from '../lib/db-types.js';
+import {
+  type EnrollmentIneligibilityReason,
+  checkEnrollmentEligibility,
+  getEligibilityErrorMessage,
+} from '../lib/enrollment-eligibility.js';
+import { isEnterprise } from '../lib/license.js';
+import { HttpRedirect } from '../lib/redirect.js';
+
+import {
+  type EnrollmentAdmissionSource,
+  type EnrollmentIdentityClassification,
+  selectEnrollmentIdentityClassification,
+} from './enrollment-identity.js';
+import { admitUserToCourseInstance } from './enrollment-reconciliation.js';
+import { selectUserById } from './user.js';
+
+type OrdinaryAdmissionSource = Exclude<EnrollmentAdmissionSource, { type: 'lti13' }>;
+
+export type OrdinaryCourseInstanceAdmissionDecision =
+  | {
+      allowed: true;
+      expectedInvitationEnrollmentId?: string;
+      source: OrdinaryAdmissionSource;
+    }
+  | {
+      allowed: false;
+      reason: EnrollmentIneligibilityReason | 'already_joined' | 'enrollment_code_required';
+    };
+
+export interface OrdinaryCourseInstanceAdmissionLocals {
+  ordinary_course_instance_admission_decision?: OrdinaryCourseInstanceAdmissionDecision;
+}
+
+function getOrdinaryAdmissionSource(
+  classification: EnrollmentIdentityClassification,
+): OrdinaryAdmissionSource {
+  if (classification.actionableInstitutionRosterInvitation !== null) {
+    return { type: 'institution_uin' };
+  }
+  if (classification.actionableConventionalInvitation !== null) {
+    return { type: 'pending_uid' };
+  }
+  return { type: 'ordinary' };
+}
+
+function enrollmentCodeMatches(
+  courseInstance: CourseInstance,
+  enrollmentCode: string | undefined,
+): boolean {
+  return enrollmentCode?.toUpperCase() === courseInstance.enrollment_code.toUpperCase();
+}
+
+function getOrdinaryCourseInstanceAdmissionDecision({
+  classification,
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  classification: EnrollmentIdentityClassification;
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): OrdinaryCourseInstanceAdmissionDecision {
+  const boundStatus = classification.boundCandidate?.enrollment.status;
+  if (boundStatus === 'joined') return { allowed: false, reason: 'already_joined' };
+  if (boundStatus === 'blocked') return { allowed: false, reason: 'blocked' };
+
+  const source = getOrdinaryAdmissionSource(classification);
+  if (source.type !== 'ordinary') {
+    const invitationCandidate =
+      source.type === 'institution_uin'
+        ? classification.actionableInstitutionRosterInvitation
+        : classification.actionableConventionalInvitation;
+    if (invitationCandidate === null) {
+      throw new Error('Actionable admission source is missing its invitation');
+    }
+    return {
+      allowed: true,
+      expectedInvitationEnrollmentId: invitationCandidate.enrollment.id,
+      source,
+    };
+  }
+
+  const eligibility = checkEnrollmentEligibility({
+    user,
+    course,
+    courseInstance,
+    existingEnrollment: null,
+  });
+  if (!eligibility.eligible) return { allowed: false, reason: eligibility.reason };
+
+  if (
+    courseInstance.self_enrollment_use_enrollment_code &&
+    !enrollmentCodeMatches(courseInstance, enrollmentCode)
+  ) {
+    return { allowed: false, reason: 'enrollment_code_required' };
+  }
+
+  return { allowed: true, source };
+}
+
+export async function selectOrdinaryCourseInstanceAdmissionDecision({
+  course,
+  courseInstance,
+  enrollmentCode,
+  user,
+}: {
+  course: Course;
+  courseInstance: CourseInstance;
+  enrollmentCode?: string;
+  user: User;
+}): Promise<OrdinaryCourseInstanceAdmissionDecision> {
+  const classification = await selectEnrollmentIdentityClassification({
+    courseInstanceId: courseInstance.id,
+    userId: user.id,
+  });
+  return getOrdinaryCourseInstanceAdmissionDecision({
+    classification,
+    course,
+    courseInstance,
+    enrollmentCode,
+    user,
+  });
+}
+
+async function validateEnterpriseAdmission({
+  authzData,
+  course,
+  courseInstance,
+  institution,
+}: {
+  authzData: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['authzData'];
+  course: Course;
+  courseInstance: CourseInstance;
+  institution: Parameters<typeof checkPotentialEnterpriseEnrollment>[0]['institution'];
+}) {
+  if (!isEnterprise()) return;
+
+  const status = await checkPotentialEnterpriseEnrollment({
+    authzData,
+    course,
+    courseInstance,
+    institution,
+  });
+  switch (status) {
+    case PotentialEnrollmentStatus.PLAN_GRANTS_REQUIRED:
+      throw new HttpRedirect(`/pl/course_instance/${courseInstance.id}/upgrade`);
+    case PotentialEnrollmentStatus.LIMIT_EXCEEDED:
+      throw new HttpRedirect('/pl/enroll/limit_exceeded');
+    case PotentialEnrollmentStatus.ALLOWED:
+      return;
+    default:
+      assertNever(status);
+  }
+}
+
+function createAdmissionValidator({
+  courseInstanceId,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return async ({
+    classification,
+    source,
+  }: {
+    classification: EnrollmentIdentityClassification;
+    source: EnrollmentAdmissionSource;
+  }) => {
+    const user = await selectUserById(userId);
+    const { authzData, course, courseInstance, institution } =
+      await constructCourseOrInstanceContext({
+        course_id: null,
+        course_instance_id: courseInstanceId,
+        ip,
+        is_administrator: isAdministrator,
+        req_date: reqDate,
+        user,
+      });
+
+    if (
+      authzData === null ||
+      courseInstance === null ||
+      !hasRole(authzData, ['Student']) ||
+      authzData.course_role !== 'None' ||
+      authzData.course_instance_role !== 'None' ||
+      !authzData.has_student_access
+    ) {
+      throw new HttpStatusError(403, 'Access denied');
+    }
+
+    if (source.type !== 'lti13') {
+      const decision = getOrdinaryCourseInstanceAdmissionDecision({
+        classification,
+        user,
+        course,
+        courseInstance,
+        enrollmentCode,
+      });
+      if (!decision.allowed) {
+        if (decision.reason === 'enrollment_code_required') {
+          throw new HttpRedirect(`/pl/course_instance/${courseInstance.id}/join`);
+        }
+        if (decision.reason === 'already_joined') {
+          throw new Error('Joined enrollment reached admission validation');
+        }
+        throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
+      }
+      if (decision.source.type !== source.type) {
+        throw new Error('Locked ordinary admission source changed during validation');
+      }
+    }
+
+    await validateEnterpriseAdmission({
+      authzData: makePageAuthzData({
+        authzData,
+        is_administrator: isAdministrator,
+      }),
+      course,
+      courseInstance,
+      institution,
+    });
+  };
+}
+
+export async function admitUserFromOrdinaryCourseInstanceRequest({
+  courseInstanceId,
+  decision,
+  enrollmentCode,
+  ip,
+  isAdministrator,
+  reqDate,
+  userId,
+}: {
+  courseInstanceId: string;
+  decision: Extract<OrdinaryCourseInstanceAdmissionDecision, { allowed: true }>;
+  enrollmentCode?: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  reqDate: Date;
+  userId: string;
+}) {
+  return await admitUserToCourseInstance({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    ...(decision.expectedInvitationEnrollmentId === undefined
+      ? {}
+      : { expectedInvitationEnrollmentId: decision.expectedInvitationEnrollmentId }),
+    selectSource: getOrdinaryAdmissionSource,
+    source: decision.source,
+    userId,
+    validateAdmission: createAdmissionValidator({
+      courseInstanceId,
+      enrollmentCode,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}
+
+export async function admitUserFromLti13CourseInstanceRequest({
+  courseInstanceId,
+  expectedInvitationEnrollmentId,
+  ip,
+  isAdministrator,
+  lti13CourseInstanceId,
+  reqDate,
+  sub,
+  userId,
+}: {
+  courseInstanceId: string;
+  expectedInvitationEnrollmentId: string;
+  ip: string | null;
+  isAdministrator: boolean;
+  lti13CourseInstanceId: string;
+  reqDate: Date;
+  sub: string;
+  userId: string;
+}) {
+  const source = {
+    type: 'lti13' as const,
+    lti13CourseInstanceId,
+    sub,
+  };
+  return await admitUserToCourseInstance({
+    agentAuthnUserId: userId,
+    agentUserId: userId,
+    courseInstanceId,
+    expectedInvitationEnrollmentId,
+    source,
+    userId,
+    validateAdmission: createAdmissionValidator({
+      courseInstanceId,
+      ip,
+      isAdministrator,
+      reqDate,
+      userId,
+    }),
+  });
+}

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.sql
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.sql
@@ -13,6 +13,23 @@ ORDER BY
 LIMIT
   1;
 
+-- BLOCK select_latest_publishing_extension_by_enrollment_ids
+SELECT
+  ci_extensions.*
+FROM
+  course_instance_publishing_extensions AS ci_extensions
+  JOIN course_instance_publishing_extension_enrollments AS ci_enrollment_extensions ON (
+    ci_enrollment_extensions.course_instance_publishing_extension_id = ci_extensions.id
+  )
+WHERE
+  ci_extensions.course_instance_id = $course_instance_id
+  AND ci_enrollment_extensions.enrollment_id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  ci_extensions.end_date DESC,
+  ci_extensions.id DESC
+LIMIT
+  1;
+
 -- BLOCK select_publishing_extension_by_id
 SELECT
   *

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
@@ -73,6 +73,29 @@ export async function selectLatestPublishingExtensionByEnrollment({
 }
 
 /**
+ * Finds the latest publishing extension across enrollment identity candidates
+ * for a course instance.
+ */
+export async function selectLatestPublishingExtensionByEnrollmentIds({
+  courseInstance,
+  enrollmentIds,
+}: {
+  courseInstance: CourseInstance;
+  enrollmentIds: readonly string[];
+}) {
+  if (enrollmentIds.length === 0) return null;
+
+  return await queryOptionalRow(
+    sql.select_latest_publishing_extension_by_enrollment_ids,
+    {
+      course_instance_id: courseInstance.id,
+      enrollment_ids: [...enrollmentIds],
+    },
+    CourseInstancePublishingExtensionSchema,
+  );
+}
+
+/**
  * Finds a publishing extension by name within a course instance.
  */
 export async function selectPublishingExtensionByName({

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
@@ -73,8 +73,8 @@ export async function selectLatestPublishingExtensionByEnrollment({
 }
 
 /**
- * Finds the latest publishing extension across enrollment identity candidates
- * for a course instance.
+ * Finds the latest publishing extension assigned to any of the supplied
+ * enrollments in this course instance.
  */
 export async function selectLatestPublishingExtensionByEnrollmentIds({
   courseInstance,

--- a/apps/prairielearn/src/models/enrollment.test.ts
+++ b/apps/prairielearn/src/models/enrollment.test.ts
@@ -598,7 +598,7 @@ describe('DB validation of enrollment', () => {
       },
       // pending_uin is unique within a course instance
       {
-        constraint: 'enrollments_course_instance_id_pending_uin_key',
+        constraint: 'enrollments_pending_uin_course_instance_id_key',
         user_id: null,
         status: 'invited',
         created_at: '2025-01-01',

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -229,8 +229,9 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Legacy enrollment path for LTI 1.0 and test setup. Ordinary course-instance
- * entry uses the checked reconciliation admission path instead.
+ * Legacy enrollment path for LTI 1.0, homepage invitation acceptance, and test
+ * setup. Ordinary course-instance entry uses the checked reconciliation
+ * admission path instead.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -229,8 +229,8 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Ensures that the user is enrolled in the given course instance. If the
- * enrollment already exists, this is a no-op.
+ * Legacy enrollment path for LTI 1.0 and test setup. Ordinary course-instance
+ * entry uses the checked reconciliation admission path instead.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required
@@ -238,7 +238,7 @@ export async function ensureUncheckedEnrollment({
  * instance enrollment limit to be exceeded.
  *
  */
-export async function ensureEnrollment({
+export async function ensureLegacyEnrollment({
   institution,
   course,
   courseInstance,

--- a/apps/prairielearn/src/models/enrollment.ts
+++ b/apps/prairielearn/src/models/enrollment.ts
@@ -229,9 +229,8 @@ export async function ensureUncheckedEnrollment({
 }
 
 /**
- * Legacy enrollment path for LTI 1.0, homepage invitation acceptance, and test
- * setup. Ordinary course-instance entry uses the checked reconciliation
- * admission path instead.
+ * Ensures enrollment without reconciling multiple identity candidates. Callers
+ * must establish any required enrollment authority before using this path.
  *
  * For enterprise installations, this will also check if the user is eligible
  * for an enrollment. They are considered eligible if they have all required
@@ -239,7 +238,7 @@ export async function ensureUncheckedEnrollment({
  * instance enrollment limit to be exceeded.
  *
  */
-export async function ensureLegacyEnrollment({
+export async function ensureEnrollmentWithoutReconciliation({
   institution,
   course,
   courseInstance,

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
@@ -17,7 +17,7 @@ import {
   LtiLinkSchema,
   SprocUsersIsInstructorInCourseInstanceSchema,
 } from '../../lib/db-types.js';
-import { ensureEnrollment } from '../../models/enrollment.js';
+import { ensureLegacyEnrollment } from '../../models/enrollment.js';
 
 const TIME_TOLERANCE_SEC = 3000;
 
@@ -153,7 +153,7 @@ router.post(
 
     if (!authzData.has_student_access_with_enrollment) {
       assert(courseInstance);
-      await ensureEnrollment({
+      await ensureLegacyEnrollment({
         institution,
         course,
         courseInstance,

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
@@ -131,8 +131,7 @@ router.post(
 
     // Persist the user's authentication data in the session. We do this before
     // checking authorization so that user information is available for any
-    // subsequent requests or redirects (e.g. if `ensureCheckedEnrollment`
-    // redirects to a payment page).
+    // subsequent requests or enrollment-related payment redirects.
     const { user } = await authnLib.loadUser(req, res, {
       user_id: userId,
       provider: 'LTI',

--- a/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
+++ b/apps/prairielearn/src/pages/authCallbackLti/authCallbackLti.ts
@@ -17,7 +17,7 @@ import {
   LtiLinkSchema,
   SprocUsersIsInstructorInCourseInstanceSchema,
 } from '../../lib/db-types.js';
-import { ensureLegacyEnrollment } from '../../models/enrollment.js';
+import { ensureEnrollmentWithoutReconciliation } from '../../models/enrollment.js';
 
 const TIME_TOLERANCE_SEC = 3000;
 
@@ -153,7 +153,7 @@ router.post(
 
     if (!authzData.has_student_access_with_enrollment) {
       assert(courseInstance);
-      await ensureLegacyEnrollment({
+      await ensureEnrollmentWithoutReconciliation({
         institution,
         course,
         courseInstance,

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -7,8 +7,8 @@ import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import { getEligibilityErrorMessage } from '../../../lib/enrollment-eligibility.js';
-import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../models/course-instance-admission.js';
+import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../lib/enrollment/admission.js';
+import { getEligibilityErrorMessage } from '../../../lib/enrollment/eligibility.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
 
 const router = Router();

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -7,7 +7,7 @@ import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../lib/enrollment/admission.js';
+import { selectEnrollmentAccessDecision } from '../../../lib/enrollment/admission.js';
 import { getEligibilityErrorMessage } from '../../../lib/enrollment/eligibility.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
 
@@ -60,7 +60,7 @@ router.get(
       throw new HttpStatusError(404, 'Only students can look up course instances');
     }
 
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const decision = await selectEnrollmentAccessDecision({
       course,
       courseInstance,
       enrollmentCode: code,

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -7,11 +7,9 @@ import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
-import type { User } from '../../../lib/db-types.js';
 import { getEligibilityErrorMessage } from '../../../lib/enrollment-eligibility.js';
+import { selectOrdinaryCourseInstanceAdmissionDecision } from '../../../models/course-instance-admission.js';
 import { selectOptionalCourseInstanceIdByEnrollmentCode } from '../../../models/course-instances.js';
-import { selectCourseById } from '../../../models/course.js';
-import { selectOptionalEnrollmentByUid } from '../../../models/enrollment.js';
 
 const router = Router();
 
@@ -46,7 +44,7 @@ router.get(
       throw new HttpStatusError(404, 'This enrollment code is for a different course');
     }
 
-    const { authzData, courseInstance } = await constructCourseOrInstanceContext({
+    const { authzData, course, courseInstance } = await constructCourseOrInstanceContext({
       user: res.locals.authn_user,
       course_id: null, // Inferred from course_instance_id
       course_instance_id: courseInstanceId,
@@ -62,56 +60,18 @@ router.get(
       throw new HttpStatusError(404, 'Only students can look up course instances');
     }
 
-    const authnUser: User = res.locals.authn_user;
-
-    const existingEnrollment = await selectOptionalEnrollmentByUid({
-      uid: res.locals.authn_user.uid,
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course,
       courseInstance,
-      requiredRole: ['Student'],
-      authzData,
+      enrollmentCode: code,
+      user: res.locals.authn_user,
     });
 
-    if (existingEnrollment) {
-      if (
-        !['invited', 'rejected', 'joined', 'left', 'removed'].includes(existingEnrollment.status)
-      ) {
-        throw new HttpStatusError(403, getEligibilityErrorMessage('blocked'));
+    if (!decision.allowed && decision.reason !== 'already_joined') {
+      if (decision.reason === 'enrollment_code_required') {
+        throw new HttpStatusError(403, 'A valid enrollment code is required');
       }
-
-      // If the user was invited, joined, left, or removed, then they have access so we can return the course instance ID.
-      // This means that rejected users will fall through to the self-enrollment checks.
-      if (['invited', 'joined', 'left', 'removed'].includes(existingEnrollment.status)) {
-        res.json({
-          course_instance_id: courseInstance.id,
-        });
-        return;
-      }
-    }
-
-    // Check if self-enrollment is enabled for this course instance
-    if (!courseInstance.self_enrollment_enabled) {
-      throw new HttpStatusError(403, getEligibilityErrorMessage('self-enrollment-disabled'));
-    }
-
-    if (
-      courseInstance.self_enrollment_restrict_to_institution &&
-      // The default value for self-enrollment restriction is true.
-      // In the old system (before publishing was introduced), the default was false.
-      // So if publishing is not set up, we should ignore the restriction.
-      courseInstance.modern_publishing
-    ) {
-      // Lookup the course
-      const course = await selectCourseById(courseInstance.course_id);
-      if (course.institution_id !== authnUser.institution_id) {
-        throw new HttpStatusError(403, getEligibilityErrorMessage('institution-restriction'));
-      }
-    }
-
-    if (
-      courseInstance.self_enrollment_enabled_before_date &&
-      new Date() >= courseInstance.self_enrollment_enabled_before_date
-    ) {
-      throw new HttpStatusError(403, getEligibilityErrorMessage('self-enrollment-expired'));
+      throw new HttpStatusError(403, getEligibilityErrorMessage(decision.reason));
     }
 
     // Return the course instance ID

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -7,8 +7,8 @@ import { EnrollmentPage } from '../../components/EnrollmentPage.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import {
-  admitUserFromOrdinaryCourseInstanceRequest,
-  selectOrdinaryCourseInstanceAdmissionDecision,
+  admitUserForCourseInstanceAccess,
+  selectEnrollmentAccessDecision,
 } from '../../lib/enrollment/admission.js';
 import { idsEqual } from '../../lib/id.js';
 
@@ -49,7 +49,7 @@ router.get(
       return;
     }
 
-    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+    const decision = await selectEnrollmentAccessDecision({
       course: res.locals.course,
       courseInstance,
       enrollmentCode: code,
@@ -57,9 +57,8 @@ router.get(
     });
 
     if (decision.allowed) {
-      await admitUserFromOrdinaryCourseInstanceRequest({
+      await admitUserForCourseInstanceAccess({
         courseInstanceId: courseInstance.id,
-        decision,
         enrollmentCode: code,
         ip: req.ip ?? null,
         isAdministrator: res.locals.is_administrator,

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -6,11 +6,11 @@ import { Hydrate } from '@prairielearn/react/server';
 import { EnrollmentPage } from '../../components/EnrollmentPage.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
-import { idsEqual } from '../../lib/id.js';
 import {
   admitUserFromOrdinaryCourseInstanceRequest,
   selectOrdinaryCourseInstanceAdmissionDecision,
-} from '../../models/course-instance-admission.js';
+} from '../../lib/enrollment/admission.js';
+import { idsEqual } from '../../lib/id.js';
 
 import { EnrollmentCodeRequired } from './enrollmentCodeRequired.html.js';
 

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -75,7 +75,7 @@ router.get(
       return;
     }
     if (decision.reason !== 'enrollment_code_required') {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
+      res.status(403).send(EnrollmentPage({ reason: decision.reason, resLocals: res.locals }));
       return;
     }
 

--- a/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
+++ b/apps/prairielearn/src/pages/enrollmentCodeRequired/enrollmentCodeRequired.tsx
@@ -2,14 +2,15 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { Hydrate } from '@prairielearn/react/server';
-import { run } from '@prairielearn/run';
 
 import { EnrollmentPage } from '../../components/EnrollmentPage.js';
 import { PageLayout } from '../../components/PageLayout.js';
-import { hasRole } from '../../lib/authz-data-lib.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
-import { authzCourseOrInstance } from '../../middlewares/authzCourseOrInstance.js';
-import { ensureEnrollment, selectOptionalEnrollmentByUid } from '../../models/enrollment.js';
+import { idsEqual } from '../../lib/id.js';
+import {
+  admitUserFromOrdinaryCourseInstanceRequest,
+  selectOrdinaryCourseInstanceAdmissionDecision,
+} from '../../models/course-instance-admission.js';
 
 import { EnrollmentCodeRequired } from './enrollmentCodeRequired.html.js';
 
@@ -27,107 +28,55 @@ router.get(
       // We should be careful to not pass `courseInstance` to the hydrated page.
       accessType: 'instructor',
     });
-    const enrollmentCode = courseInstance.enrollment_code;
     const redirectUrl =
       typeof url === 'string' && url.startsWith('/') && !url.startsWith('//') ? url : null;
-    // Lookup if they have an existing enrollment
-    const existingEnrollment = await run(async () => {
-      // We don't want to 403 instructors
-      if (!hasRole(res.locals.authz_data, ['Student'])) return null;
-      return await selectOptionalEnrollmentByUid({
-        uid: res.locals.authn_user.uid,
-        courseInstance,
-        requiredRole: ['Student'],
-        authzData: res.locals.authz_data,
-      });
-    });
-
-    const needsToSelfEnroll =
-      existingEnrollment == null ||
-      !['joined', 'invited', 'left', 'removed'].includes(existingEnrollment.status);
-
-    const institutionRestrictionSatisfied =
-      res.locals.authn_user.institution_id === res.locals.course.institution_id ||
-      // The default value for self-enrollment restriction is true.
-      // In the old system (before publishing was introduced), the default was false.
-      // So if publishing is not set up, we should ignore the restriction.
-      !courseInstance.modern_publishing ||
-      !courseInstance.self_enrollment_restrict_to_institution;
-
-    const selfEnrollmentExpired =
-      courseInstance.self_enrollment_enabled_before_date != null &&
-      new Date() >= courseInstance.self_enrollment_enabled_before_date;
-
-    const selfEnrollmentEnabled = courseInstance.self_enrollment_enabled;
-
-    if (!selfEnrollmentEnabled && needsToSelfEnroll) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: 'self-enrollment-disabled' }));
-      return;
-    }
-
-    if (selfEnrollmentExpired && needsToSelfEnroll) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: 'self-enrollment-expired' }));
-      return;
-    }
-
-    if (!institutionRestrictionSatisfied && needsToSelfEnroll) {
-      res
-        .status(403)
-        .send(EnrollmentPage({ resLocals: res.locals, type: 'institution-restriction' }));
-      return;
-    }
-
-    // Check if the user is enrolled, but is in a status where they cannot rejoin the course.
-    if (
-      existingEnrollment != null &&
-      !['joined', 'invited', 'rejected', 'left', 'removed'].includes(existingEnrollment.status)
-    ) {
-      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: 'blocked' }));
-      return;
-    }
-
-    const userBypassesEnrollmentCodeRequirement =
-      existingEnrollment != null &&
-      ['joined', 'invited', 'left', 'removed'].includes(existingEnrollment.status);
-
-    if (
-      // No enrollment code required
-      !courseInstance.self_enrollment_use_enrollment_code ||
-      // Enrollment code is correct
-      code?.toUpperCase() === enrollmentCode.toUpperCase() ||
-      // Existing joined, invited, left, or removed enrollments can transition immediately.
-      // Rejected enrollments are treated as if they had no status.
-      userBypassesEnrollmentCodeRequirement
-    ) {
-      if (
-        code?.toUpperCase() === enrollmentCode.toUpperCase() ||
-        userBypassesEnrollmentCodeRequirement
-      ) {
-        // Authorize the user for the course instance
-        req.params.course_instance_id = courseInstance.id;
-        await authzCourseOrInstance(req, res);
-
-        // Enroll the user
-        await ensureEnrollment({
-          institution: res.locals.institution,
-          course: res.locals.course,
-          courseInstance: res.locals.course_instance,
-          authzData: res.locals.authz_data,
-          requiredRole: ['Student'],
-          actionDetail: 'implicit_joined',
-        });
-      }
-
-      // redirect to a different page, which will have proper authorization.
+    const redirectAfterJoin = () => {
       if (redirectUrl != null) {
         res.redirect(redirectUrl);
       } else {
         res.redirect(`/pl/course_instance/${courseInstance.id}/assessments`);
       }
+    };
+
+    if (
+      !idsEqual(res.locals.user.id, res.locals.authn_user.id) ||
+      res.locals.authz_data.authn_course_role !== 'None' ||
+      res.locals.authz_data.authn_course_instance_role !== 'None' ||
+      res.locals.is_administrator ||
+      !res.locals.authz_data.authn_has_student_access
+    ) {
+      redirectAfterJoin();
+      return;
+    }
+
+    const decision = await selectOrdinaryCourseInstanceAdmissionDecision({
+      course: res.locals.course,
+      courseInstance,
+      enrollmentCode: code,
+      user: res.locals.authn_user,
+    });
+
+    if (decision.allowed) {
+      await admitUserFromOrdinaryCourseInstanceRequest({
+        courseInstanceId: courseInstance.id,
+        decision,
+        enrollmentCode: code,
+        ip: req.ip ?? null,
+        isAdministrator: res.locals.is_administrator,
+        reqDate: res.locals.req_date,
+        userId: res.locals.authn_user.id,
+      });
+
+      redirectAfterJoin();
+      return;
+    }
+
+    if (decision.reason === 'already_joined') {
+      redirectAfterJoin();
+      return;
+    }
+    if (decision.reason !== 'enrollment_code_required') {
+      res.status(403).send(EnrollmentPage({ resLocals: res.locals, type: decision.reason }));
       return;
     }
 

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -21,15 +21,20 @@ export function StudentCoursesCard({
   setShowJoinModal: (value: boolean) => void;
 }) {
   const heading = hasInstructorCourses ? 'Courses with student access' : 'Courses';
-  const [rejectingCourseId, setRejectingCourseId] = useState<string | null>(null);
+  const [rejectingInvitation, setRejectingInvitation] = useState<{
+    courseInstanceId: string;
+    enrollmentId: string;
+  } | null>(null);
   const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
 
-  const invited: StudentHomePageCourse[] = studentCourses.filter(
-    (ci) => ci.enrollment.status === 'invited',
+  const conventionalInvitations = studentCourses.filter(
+    (course): course is StudentHomePageCourse & { access_type: 'conventional_invitation' } =>
+      course.access_type === 'conventional_invitation',
   );
-  const joined: StudentHomePageCourse[] = studentCourses.filter(
-    (ci) => ci.enrollment.status === 'joined',
+  const rosterAvailable = studentCourses.filter(
+    (course) => course.access_type === 'roster_available',
   );
+  const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
   return (
     <div className="card mb-4">
@@ -69,7 +74,7 @@ export function StudentCoursesCard({
         <div className="table-responsive">
           <table className="table table-sm table-hover table-striped" aria-label={heading}>
             <tbody>
-              {invited.map((entry: StudentHomePageCourse) => (
+              {conventionalInvitations.map((entry) => (
                 <tr key={`invite-${entry.course_instance.id}`} className="table-warning">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -86,6 +91,11 @@ export function StudentCoursesCard({
                           <input type="hidden" name="__csrf_token" value={csrfToken} />
                           <input
                             type="hidden"
+                            name="enrollment_id"
+                            value={entry.invitation_enrollment_id}
+                          />
+                          <input
+                            type="hidden"
                             name="course_instance_id"
                             value={entry.course_instance.id}
                           />
@@ -96,11 +106,39 @@ export function StudentCoursesCard({
                         <button
                           type="button"
                           className="btn btn-danger btn-sm"
-                          onClick={() => setRejectingCourseId(entry.course_instance.id)}
+                          onClick={() =>
+                            setRejectingInvitation({
+                              courseInstanceId: entry.course_instance.id,
+                              enrollmentId: entry.invitation_enrollment_id,
+                            })
+                          }
                         >
                           Reject
                         </button>
                       </div>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {rosterAvailable.map((entry) => (
+                <tr key={`roster-${entry.course_instance.id}`} className="table-info">
+                  <td className="align-middle">
+                    <div className="d-flex align-items-center justify-content-between gap-2">
+                      <div>
+                        <span className="fw-semibold">
+                          {entry.course_short_name}: {entry.course_title},{' '}
+                          {entry.course_instance.long_name}
+                        </span>
+                        <span className="ms-2 badge bg-info text-dark">
+                          Available through roster
+                        </span>
+                      </div>
+                      <a
+                        href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}
+                        className="btn btn-primary btn-sm"
+                      >
+                        Open course
+                      </a>
                     </div>
                   </td>
                 </tr>
@@ -130,9 +168,9 @@ export function StudentCoursesCard({
       )}
 
       <Modal
-        show={rejectingCourseId !== null}
+        show={rejectingInvitation !== null}
         backdrop="static"
-        onHide={() => setRejectingCourseId(null)}
+        onHide={() => setRejectingInvitation(null)}
       >
         <Modal.Header closeButton>
           <Modal.Title>Reject invitation</Modal.Title>
@@ -147,14 +185,23 @@ export function StudentCoursesCard({
           <button
             type="button"
             className="btn btn-secondary"
-            onClick={() => setRejectingCourseId(null)}
+            onClick={() => setRejectingInvitation(null)}
           >
             Cancel
           </button>
           <form method="POST">
             <input type="hidden" name="__csrf_token" value={csrfToken} />
             <input type="hidden" name="__action" value="reject_invitation" />
-            <input type="hidden" name="course_instance_id" value={rejectingCourseId ?? ''} />
+            <input
+              type="hidden"
+              name="course_instance_id"
+              value={rejectingInvitation?.courseInstanceId ?? ''}
+            />
+            <input
+              type="hidden"
+              name="enrollment_id"
+              value={rejectingInvitation?.enrollmentId ?? ''}
+            />
             <button type="submit" className="btn btn-danger">
               Reject invitation
             </button>

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -25,16 +25,18 @@ export function StudentCoursesCard({
     courseInstanceId: string;
     enrollmentId: string;
   } | null>(null);
-  const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
+  const [removingCourse, setRemovingCourse] = useState<{
+    courseInstanceId: string;
+    invitationEnrollmentId?: string;
+  } | null>(null);
 
   const uidInvitations = studentCourses.filter(
     (course): course is StudentHomePageCourse & { access_type: 'uid_invitation' } =>
       course.access_type === 'uid_invitation',
   );
-  const institutionUinInvitations = studentCourses.filter(
-    (course) => course.access_type === 'institution_uin_invitation',
+  const accessibleCourses = studentCourses.filter(
+    (course) => course.access_type === 'institution_access' || course.access_type === 'joined',
   );
-  const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
   return (
     <div className="card mb-4">
@@ -120,30 +122,7 @@ export function StudentCoursesCard({
                   </td>
                 </tr>
               ))}
-              {institutionUinInvitations.map((entry) => (
-                <tr key={`institution-invite-${entry.course_instance.id}`} className="table-info">
-                  <td className="align-middle">
-                    <div className="d-flex align-items-center justify-content-between gap-2">
-                      <div>
-                        <span className="fw-semibold">
-                          {entry.course_short_name}: {entry.course_title},{' '}
-                          {entry.course_instance.long_name}
-                        </span>
-                        <span className="ms-2 badge bg-info text-dark">
-                          Available through your institution
-                        </span>
-                      </div>
-                      <a
-                        href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}
-                        className="btn btn-primary btn-sm"
-                      >
-                        Open course
-                      </a>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-              {joined.map((entry) => (
+              {accessibleCourses.map((entry) => (
                 <tr key={entry.course_instance.id}>
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -154,7 +133,14 @@ export function StudentCoursesCard({
                       <button
                         type="button"
                         className="btn btn-danger btn-sm"
-                        onClick={() => setRemovingCourseId(entry.course_instance.id)}
+                        onClick={() =>
+                          setRemovingCourse({
+                            courseInstanceId: entry.course_instance.id,
+                            ...(entry.access_type === 'institution_access'
+                              ? { invitationEnrollmentId: entry.invitation_enrollment_id }
+                              : {}),
+                          })
+                        }
                       >
                         Remove
                       </button>
@@ -210,9 +196,9 @@ export function StudentCoursesCard({
       </Modal>
 
       <Modal
-        show={removingCourseId !== null}
+        show={removingCourse !== null}
         backdrop="static"
-        onHide={() => setRemovingCourseId(null)}
+        onHide={() => setRemovingCourse(null)}
       >
         <Modal.Header closeButton>
           <Modal.Title>Remove course</Modal.Title>
@@ -223,19 +209,41 @@ export function StudentCoursesCard({
             Removing courses here only affects what is visible to you on PrairieLearn. This does not
             change your university course registration.
           </p>
+          {removingCourse?.invitationEnrollmentId !== undefined && (
+            <p>The course may appear again after your institution's enrollment data is updated.</p>
+          )}
         </Modal.Body>
         <Modal.Footer>
           <button
             type="button"
             className="btn btn-secondary"
-            onClick={() => setRemovingCourseId(null)}
+            onClick={() => setRemovingCourse(null)}
           >
             Cancel
           </button>
           <form method="POST">
             <input type="hidden" name="__csrf_token" value={csrfToken} />
-            <input type="hidden" name="__action" value="unenroll" />
-            <input type="hidden" name="course_instance_id" value={removingCourseId ?? ''} />
+            <input
+              type="hidden"
+              name="__action"
+              value={
+                removingCourse?.invitationEnrollmentId === undefined
+                  ? 'unenroll'
+                  : 'remove_institution_access'
+              }
+            />
+            <input
+              type="hidden"
+              name="course_instance_id"
+              value={removingCourse?.courseInstanceId ?? ''}
+            />
+            {removingCourse?.invitationEnrollmentId !== undefined && (
+              <input
+                type="hidden"
+                name="enrollment_id"
+                value={removingCourse.invitationEnrollmentId}
+              />
+            )}
             <button type="submit" className="btn btn-danger">
               Remove course
             </button>

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -27,12 +27,12 @@ export function StudentCoursesCard({
   } | null>(null);
   const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
 
-  const conventionalInvitations = studentCourses.filter(
-    (course): course is StudentHomePageCourse & { access_type: 'conventional_invitation' } =>
-      course.access_type === 'conventional_invitation',
+  const uidInvitations = studentCourses.filter(
+    (course): course is StudentHomePageCourse & { access_type: 'uid_invitation' } =>
+      course.access_type === 'uid_invitation',
   );
-  const rosterAvailable = studentCourses.filter(
-    (course) => course.access_type === 'roster_available',
+  const institutionUinInvitations = studentCourses.filter(
+    (course) => course.access_type === 'institution_uin_invitation',
   );
   const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
@@ -74,7 +74,7 @@ export function StudentCoursesCard({
         <div className="table-responsive">
           <table className="table table-sm table-hover table-striped" aria-label={heading}>
             <tbody>
-              {conventionalInvitations.map((entry) => (
+              {uidInvitations.map((entry) => (
                 <tr key={`invite-${entry.course_instance.id}`} className="table-warning">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -120,8 +120,8 @@ export function StudentCoursesCard({
                   </td>
                 </tr>
               ))}
-              {rosterAvailable.map((entry) => (
-                <tr key={`roster-${entry.course_instance.id}`} className="table-info">
+              {institutionUinInvitations.map((entry) => (
+                <tr key={`institution-invite-${entry.course_instance.id}`} className="table-info">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
                       <div>
@@ -130,7 +130,7 @@ export function StudentCoursesCard({
                           {entry.course_instance.long_name}
                         </span>
                         <span className="ms-2 badge bg-info text-dark">
-                          Available through roster
+                          Available through your institution
                         </span>
                       </div>
                       <a

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -83,7 +83,7 @@ export function StudentCoursesCard({
                     <div className="d-flex align-items-center justify-content-between gap-2">
                       <div>
                         <span className="fw-semibold">
-                          {entry.course_short_name}: {entry.course_title},{' '}
+                          {entry.course.short_name}: {entry.course.title},{' '}
                           {entry.course_instance.long_name}
                         </span>
                         <span className="ms-2 badge bg-warning text-dark">Invitation</span>
@@ -128,7 +128,7 @@ export function StudentCoursesCard({
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
                       <a href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}>
-                        {entry.course_short_name}: {entry.course_title},{' '}
+                        {entry.course.short_name}: {entry.course.title},{' '}
                         {entry.course_instance.long_name}
                       </a>
                       <button

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
 import { Modal } from 'react-bootstrap';
+
+import { useModalState } from '@prairielearn/ui';
 
 import type { StudentHomePageCourse } from '../home.types.js';
 
@@ -21,14 +22,14 @@ export function StudentCoursesCard({
   setShowJoinModal: (value: boolean) => void;
 }) {
   const heading = hasInstructorCourses ? 'Courses with student access' : 'Courses';
-  const [rejectingInvitation, setRejectingInvitation] = useState<{
+  const rejectInvitationModal = useModalState<{
     courseInstanceId: string;
     enrollmentId: string;
-  } | null>(null);
-  const [removingCourse, setRemovingCourse] = useState<{
+  }>();
+  const removeCourseModal = useModalState<{
     courseInstanceId: string;
     invitationEnrollmentId?: string;
-  } | null>(null);
+  }>();
 
   const uidInvitations = studentCourses.filter(
     (course): course is StudentHomePageCourse & { access_type: 'uid_invitation' } =>
@@ -109,7 +110,7 @@ export function StudentCoursesCard({
                           type="button"
                           className="btn btn-danger btn-sm"
                           onClick={() =>
-                            setRejectingInvitation({
+                            rejectInvitationModal.showWithData({
                               courseInstanceId: entry.course_instance.id,
                               enrollmentId: entry.invitation_enrollment_id,
                             })
@@ -134,7 +135,7 @@ export function StudentCoursesCard({
                         type="button"
                         className="btn btn-danger btn-sm"
                         onClick={() =>
-                          setRemovingCourse({
+                          removeCourseModal.showWithData({
                             courseInstanceId: entry.course_instance.id,
                             ...(entry.access_type === 'institution_access'
                               ? { invitationEnrollmentId: entry.invitation_enrollment_id }
@@ -154,9 +155,10 @@ export function StudentCoursesCard({
       )}
 
       <Modal
-        show={rejectingInvitation !== null}
+        show={rejectInvitationModal.show}
         backdrop="static"
-        onHide={() => setRejectingInvitation(null)}
+        onHide={rejectInvitationModal.onHide}
+        onExited={rejectInvitationModal.onExited}
       >
         <Modal.Header closeButton>
           <Modal.Title>Reject invitation</Modal.Title>
@@ -168,11 +170,7 @@ export function StudentCoursesCard({
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => setRejectingInvitation(null)}
-          >
+          <button type="button" className="btn btn-secondary" onClick={rejectInvitationModal.hide}>
             Cancel
           </button>
           <form method="POST">
@@ -181,12 +179,12 @@ export function StudentCoursesCard({
             <input
               type="hidden"
               name="course_instance_id"
-              value={rejectingInvitation?.courseInstanceId ?? ''}
+              value={rejectInvitationModal.data?.courseInstanceId ?? ''}
             />
             <input
               type="hidden"
               name="enrollment_id"
-              value={rejectingInvitation?.enrollmentId ?? ''}
+              value={rejectInvitationModal.data?.enrollmentId ?? ''}
             />
             <button type="submit" className="btn btn-danger">
               Reject invitation
@@ -196,9 +194,10 @@ export function StudentCoursesCard({
       </Modal>
 
       <Modal
-        show={removingCourse !== null}
+        show={removeCourseModal.show}
         backdrop="static"
-        onHide={() => setRemovingCourse(null)}
+        onHide={removeCourseModal.onHide}
+        onExited={removeCourseModal.onExited}
       >
         <Modal.Header closeButton>
           <Modal.Title>Remove course</Modal.Title>
@@ -209,16 +208,12 @@ export function StudentCoursesCard({
             Removing courses here only affects what is visible to you on PrairieLearn. This does not
             change your university course registration.
           </p>
-          {removingCourse?.invitationEnrollmentId !== undefined && (
+          {removeCourseModal.data?.invitationEnrollmentId !== undefined && (
             <p>The course may appear again after your institution's enrollment data is updated.</p>
           )}
         </Modal.Body>
         <Modal.Footer>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => setRemovingCourse(null)}
-          >
+          <button type="button" className="btn btn-secondary" onClick={removeCourseModal.hide}>
             Cancel
           </button>
           <form method="POST">
@@ -227,7 +222,7 @@ export function StudentCoursesCard({
               type="hidden"
               name="__action"
               value={
-                removingCourse?.invitationEnrollmentId === undefined
+                removeCourseModal.data?.invitationEnrollmentId === undefined
                   ? 'unenroll'
                   : 'remove_institution_access'
               }
@@ -235,13 +230,13 @@ export function StudentCoursesCard({
             <input
               type="hidden"
               name="course_instance_id"
-              value={removingCourse?.courseInstanceId ?? ''}
+              value={removeCourseModal.data?.courseInstanceId ?? ''}
             />
-            {removingCourse?.invitationEnrollmentId !== undefined && (
+            {removeCourseModal.data?.invitationEnrollmentId !== undefined && (
               <input
                 type="hidden"
                 name="enrollment_id"
-                value={removingCourse.invitationEnrollmentId}
+                value={removeCourseModal.data.invitationEnrollmentId}
               />
             )}
             <button type="submit" className="btn btn-danger">

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -2,7 +2,6 @@ import { Hydrate } from '@prairielearn/react/server';
 
 import { type StaffInstitution } from '../../lib/client/safe-db-types.js';
 import { type NewsItem } from '../../lib/db-types.js';
-import { computeStatus } from '../../lib/publishing.js';
 
 import { HomeCards } from './components/HomeCards.js';
 import { NewsAlert } from './components/NewsAlert.js';
@@ -33,22 +32,6 @@ export function Home({
   blogUrl: string | null;
   now: Date;
 }) {
-  const listedStudentCourses = studentCourses.filter((ci) => {
-    if (ci.enrollment.status === 'joined') return true;
-    if (ci.enrollment.status === 'invited') {
-      if (!ci.course_instance.modern_publishing) {
-        return false;
-      }
-      return (
-        computeStatus(
-          ci.course_instance.publishing_start_date,
-          ci.course_instance.publishing_end_date,
-        ) === 'published'
-      );
-    }
-    return false;
-  });
-
   return (
     <div className="pt-5 mx-auto" style={{ maxWidth: 960 }}>
       <h1 className="visually-hidden">PrairieLearn Homepage</h1>
@@ -58,7 +41,7 @@ export function Home({
       <InstructorCoursesCard instructorCourses={instructorCourses} urlPrefix={urlPrefix} />
       <Hydrate>
         <HomeCards
-          studentCourses={listedStudentCourses}
+          studentCourses={studentCourses}
           hasInstructorCourses={instructorCourses.length > 0}
           canAddCourses={canAddCourses}
           csrfToken={csrfToken}

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -178,9 +178,7 @@ WITH
       id = $user_id
   )
 SELECT
-  c.id AS course_id,
-  c.short_name AS course_short_name,
-  c.title AS course_title,
+  to_jsonb(c.*) AS course,
   to_jsonb(ci.*) AS course_instance,
   to_jsonb(e.*) AS enrollment,
   CASE

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -267,7 +267,7 @@ ORDER BY
   start_date DESC NULLS LAST,
   end_date DESC NULLS LAST,
   ci.id DESC,
-  e.id;
+  e.id DESC;
 
 -- BLOCK select_admin_institutions
 -- Note that we only consider institutions where the user is explicitly

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -191,11 +191,7 @@ SELECT
   END AS end_date,
   to_jsonb(extension.*) AS latest_publishing_extension,
   coalesce(e.user_id = identity.id, FALSE) AS matches_bound_user,
-  coalesce(
-    e.pending_uid = identity.uid
-    AND e.pending_lti13_course_instance_id IS NULL,
-    FALSE
-  ) AS matches_pending_uid,
+  coalesce(e.pending_uid = identity.uid, FALSE) AS matches_pending_uid,
   coalesce(
     identity.institution_id = c.institution_id
     AND identity.uin IS NOT NULL
@@ -247,10 +243,7 @@ FROM
 WHERE
   (
     e.user_id = identity.id
-    OR (
-      e.pending_uid = identity.uid
-      AND e.pending_lti13_course_instance_id IS NULL
-    )
+    OR e.pending_uid = identity.uid
     OR (
       identity.institution_id = c.institution_id
       AND identity.uin IS NOT NULL

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -260,7 +260,7 @@ ORDER BY
   start_date DESC NULLS LAST,
   end_date DESC NULLS LAST,
   ci.id DESC,
-  e.id;
+  e.id DESC;
 
 -- BLOCK select_admin_institutions
 -- Note that we only consider institutions where the user is explicitly

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -166,116 +166,108 @@ ORDER BY
 
 -- BLOCK select_student_courses
 WITH
-  -- Base query: all enrollments for this user with course/course_instance data
-  base_enrollments AS (
+  user_identity AS (
     SELECT
-      e.id AS enrollment_id,
-      c.id AS course_id,
-      c.short_name AS course_short_name,
-      c.title AS course_title,
-      ci.id AS course_instance_id,
-      ci.modern_publishing,
-      ci.publishing_start_date,
-      ci.publishing_end_date,
-      to_jsonb(ci) AS course_instance,
-      to_jsonb(e) AS enrollment,
-      u.uid,
-      u.institution_id
+      id,
+      institution_id,
+      uid,
+      uin
     FROM
-      enrollments AS e
-      LEFT JOIN users AS u ON (u.id = e.user_id)
-      JOIN course_instances AS ci ON (
-        ci.id = e.course_instance_id
-        AND ci.deleted_at IS NULL
-      )
-      JOIN courses AS c ON (
-        c.id = ci.course_id
-        AND c.deleted_at IS NULL
-        AND (
-          c.example_course IS FALSE
-          OR $include_example_course_enrollments
-        )
-      )
+      users
     WHERE
-      e.user_id = $user_id
-      OR (
-        e.pending_uid = $pending_uid
-        AND e.pending_lti13_course_instance_id IS NULL
-      )
-  ),
-  -- Legacy courses: use access rules for dates and initial filtering
-  legacy_courses AS (
-    SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      NULL::jsonb AS latest_publishing_extension,
-      NULLIF(d.min_start_date, '-infinity'::timestamptz) AS start_date,
-      NULLIF(d.max_end_date, 'infinity'::timestamptz) AS end_date,
-      be.course_instance_id
-    FROM
-      base_enrollments AS be,
-      LATERAL (
-        SELECT
-          min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
-          max(coalesce(ar.end_date, 'infinity'::timestamptz)) AS max_end_date
-        FROM
-          course_instance_access_rules AS ar
-        WHERE
-          ar.course_instance_id = be.course_instance_id
-      ) AS d
-    WHERE
-      be.modern_publishing IS FALSE
-      AND $req_date BETWEEN d.min_start_date AND d.max_end_date
-  ),
-  -- Modern courses: use publishing dates directly and fetch extension data
-  modern_courses AS (
-    SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      to_jsonb(cie) AS latest_publishing_extension,
-      be.publishing_start_date AS start_date,
-      be.publishing_end_date AS end_date,
-      be.course_instance_id
-    FROM
-      base_enrollments AS be
-      LEFT JOIN LATERAL (
-        SELECT
-          cie.*
-        FROM
-          course_instance_publishing_extension_enrollments AS ciee
-          JOIN course_instance_publishing_extensions AS cie ON (
-            cie.id = ciee.course_instance_publishing_extension_id
-          )
-        WHERE
-          ciee.enrollment_id = be.enrollment_id
-        ORDER BY
-          cie.end_date DESC NULLS LAST,
-          cie.id DESC
-        LIMIT
-          1
-      ) AS cie ON TRUE
-    WHERE
-      be.modern_publishing IS TRUE
+      id = $user_id
   )
 SELECT
-  *
+  c.id AS course_id,
+  c.short_name AS course_short_name,
+  c.title AS course_title,
+  to_jsonb(ci.*) AS course_instance,
+  to_jsonb(e.*) AS enrollment,
+  CASE
+    WHEN ci.modern_publishing THEN ci.publishing_start_date
+    ELSE NULLIF(d.min_start_date, '-infinity'::timestamptz)
+  END AS start_date,
+  CASE
+    WHEN ci.modern_publishing THEN ci.publishing_end_date
+    ELSE NULLIF(d.max_end_date, 'infinity'::timestamptz)
+  END AS end_date,
+  to_jsonb(extension.*) AS latest_publishing_extension,
+  coalesce(e.user_id = identity.id, FALSE) AS matches_bound_user,
+  coalesce(
+    e.pending_uid = identity.uid
+    AND e.pending_lti13_course_instance_id IS NULL,
+    FALSE
+  ) AS matches_pending_uid,
+  coalesce(
+    identity.institution_id = c.institution_id
+    AND identity.uin IS NOT NULL
+    AND e.pending_uin = identity.uin,
+    FALSE
+  ) AS matches_institution_uin,
+  FALSE AS matches_lti13
 FROM
-  legacy_courses
-UNION ALL
-SELECT
-  *
-FROM
-  modern_courses
+  enrollments AS e
+  JOIN course_instances AS ci ON (
+    ci.id = e.course_instance_id
+    AND ci.deleted_at IS NULL
+  )
+  JOIN courses AS c ON (
+    c.id = ci.course_id
+    AND c.deleted_at IS NULL
+    AND (
+      c.example_course IS FALSE
+      OR $include_example_course_enrollments
+    )
+  )
+  CROSS JOIN user_identity AS identity
+  CROSS JOIN LATERAL (
+    SELECT
+      min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
+      max(coalesce(ar.end_date, 'infinity'::timestamptz)) AS max_end_date
+    FROM
+      course_instance_access_rules AS ar
+    WHERE
+      ar.course_instance_id = ci.id
+  ) AS d
+  LEFT JOIN LATERAL (
+    SELECT
+      publishing_extension.*
+    FROM
+      course_instance_publishing_extension_enrollments AS extension_enrollment
+      JOIN course_instance_publishing_extensions AS publishing_extension ON (
+        publishing_extension.id = extension_enrollment.course_instance_publishing_extension_id
+      )
+    WHERE
+      extension_enrollment.enrollment_id = e.id
+      AND publishing_extension.course_instance_id = ci.id
+    ORDER BY
+      publishing_extension.end_date DESC,
+      publishing_extension.id DESC
+    LIMIT
+      1
+  ) AS extension ON ci.modern_publishing
+WHERE
+  (
+    e.user_id = identity.id
+    OR (
+      e.pending_uid = identity.uid
+      AND e.pending_lti13_course_instance_id IS NULL
+    )
+    OR (
+      identity.institution_id = c.institution_id
+      AND identity.uin IS NOT NULL
+      AND e.pending_uin = identity.uin
+    )
+  )
+  AND (
+    ci.modern_publishing
+    OR $req_date BETWEEN d.min_start_date AND d.max_end_date
+  )
 ORDER BY
   start_date DESC NULLS LAST,
   end_date DESC NULLS LAST,
-  course_instance_id DESC;
+  ci.id DESC,
+  e.id;
 
 -- BLOCK select_admin_institutions
 -- Note that we only consider institutions where the user is explicitly

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -166,113 +166,101 @@ ORDER BY
 
 -- BLOCK select_student_courses
 WITH
-  -- Base query: all enrollments for this user with course/course_instance data
-  base_enrollments AS (
+  user_identity AS (
     SELECT
-      e.id AS enrollment_id,
-      c.id AS course_id,
-      c.short_name AS course_short_name,
-      c.title AS course_title,
-      ci.id AS course_instance_id,
-      ci.modern_publishing,
-      ci.publishing_start_date,
-      ci.publishing_end_date,
-      to_jsonb(ci) AS course_instance,
-      to_jsonb(e) AS enrollment,
-      u.uid,
-      u.institution_id
+      id,
+      institution_id,
+      uid,
+      uin
     FROM
-      enrollments AS e
-      LEFT JOIN users AS u ON (u.id = e.user_id)
-      JOIN course_instances AS ci ON (
-        ci.id = e.course_instance_id
-        AND ci.deleted_at IS NULL
-      )
-      JOIN courses AS c ON (
-        c.id = ci.course_id
-        AND c.deleted_at IS NULL
-        AND (
-          c.example_course IS FALSE
-          OR $include_example_course_enrollments
-        )
-      )
+      users
     WHERE
-      e.user_id = $user_id
-      OR e.pending_uid = $pending_uid
-  ),
-  -- Legacy courses: use access rules for dates and initial filtering
-  legacy_courses AS (
-    SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      NULL::jsonb AS latest_publishing_extension,
-      NULLIF(d.min_start_date, '-infinity'::timestamptz) AS start_date,
-      NULLIF(d.max_end_date, 'infinity'::timestamptz) AS end_date,
-      be.course_instance_id
-    FROM
-      base_enrollments AS be,
-      LATERAL (
-        SELECT
-          min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
-          max(coalesce(ar.end_date, 'infinity'::timestamptz)) AS max_end_date
-        FROM
-          course_instance_access_rules AS ar
-        WHERE
-          ar.course_instance_id = be.course_instance_id
-      ) AS d
-    WHERE
-      be.modern_publishing IS FALSE
-      AND $req_date BETWEEN d.min_start_date AND d.max_end_date
-  ),
-  -- Modern courses: use publishing dates directly and fetch extension data
-  modern_courses AS (
-    SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      to_jsonb(cie) AS latest_publishing_extension,
-      be.publishing_start_date AS start_date,
-      be.publishing_end_date AS end_date,
-      be.course_instance_id
-    FROM
-      base_enrollments AS be
-      LEFT JOIN LATERAL (
-        SELECT
-          cie.*
-        FROM
-          course_instance_publishing_extension_enrollments AS ciee
-          JOIN course_instance_publishing_extensions AS cie ON (
-            cie.id = ciee.course_instance_publishing_extension_id
-          )
-        WHERE
-          ciee.enrollment_id = be.enrollment_id
-        ORDER BY
-          cie.end_date DESC NULLS LAST,
-          cie.id DESC
-        LIMIT
-          1
-      ) AS cie ON TRUE
-    WHERE
-      be.modern_publishing IS TRUE
+      id = $user_id
   )
 SELECT
-  *
+  c.id AS course_id,
+  c.short_name AS course_short_name,
+  c.title AS course_title,
+  to_jsonb(ci.*) AS course_instance,
+  to_jsonb(e.*) AS enrollment,
+  CASE
+    WHEN ci.modern_publishing THEN ci.publishing_start_date
+    ELSE NULLIF(d.min_start_date, '-infinity'::timestamptz)
+  END AS start_date,
+  CASE
+    WHEN ci.modern_publishing THEN ci.publishing_end_date
+    ELSE NULLIF(d.max_end_date, 'infinity'::timestamptz)
+  END AS end_date,
+  to_jsonb(extension.*) AS latest_publishing_extension,
+  coalesce(e.user_id = identity.id, FALSE) AS matches_bound_user,
+  coalesce(e.pending_uid = identity.uid, FALSE) AS matches_pending_uid,
+  coalesce(
+    identity.institution_id = c.institution_id
+    AND identity.uin IS NOT NULL
+    AND e.pending_uin = identity.uin,
+    FALSE
+  ) AS matches_institution_uin,
+  FALSE AS matches_lti13
 FROM
-  legacy_courses
-UNION ALL
-SELECT
-  *
-FROM
-  modern_courses
+  enrollments AS e
+  JOIN course_instances AS ci ON (
+    ci.id = e.course_instance_id
+    AND ci.deleted_at IS NULL
+  )
+  JOIN courses AS c ON (
+    c.id = ci.course_id
+    AND c.deleted_at IS NULL
+    AND (
+      c.example_course IS FALSE
+      OR $include_example_course_enrollments
+    )
+  )
+  CROSS JOIN user_identity AS identity
+  CROSS JOIN LATERAL (
+    SELECT
+      min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
+      max(coalesce(ar.end_date, 'infinity'::timestamptz)) AS max_end_date
+    FROM
+      course_instance_access_rules AS ar
+    WHERE
+      ar.course_instance_id = ci.id
+  ) AS d
+  LEFT JOIN LATERAL (
+    SELECT
+      publishing_extension.*
+    FROM
+      course_instance_publishing_extension_enrollments AS extension_enrollment
+      JOIN course_instance_publishing_extensions AS publishing_extension ON (
+        publishing_extension.id = extension_enrollment.course_instance_publishing_extension_id
+      )
+    WHERE
+      extension_enrollment.enrollment_id = e.id
+      AND publishing_extension.course_instance_id = ci.id
+    ORDER BY
+      publishing_extension.end_date DESC,
+      publishing_extension.id DESC
+    LIMIT
+      1
+  ) AS extension ON ci.modern_publishing
+WHERE
+  (
+    e.user_id = identity.id
+    OR e.pending_uid = identity.uid
+    OR (
+      identity.institution_id = c.institution_id
+      AND identity.uin IS NOT NULL
+      AND e.pending_uin = identity.uin
+    )
+  )
+  AND (
+    ci.modern_publishing
+    OR $req_date BETWEEN d.min_start_date AND d.max_end_date
+  )
 ORDER BY
   start_date DESC NULLS LAST,
   end_date DESC NULLS LAST,
-  course_instance_id DESC;
+  ci.id DESC,
+  e.id;
 
 -- BLOCK select_admin_institutions
 -- Note that we only consider institutions where the user is explicitly

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -198,7 +198,10 @@ WITH
       )
     WHERE
       e.user_id = $user_id
-      OR e.pending_uid = $pending_uid
+      OR (
+        e.pending_uid = $pending_uid
+        AND e.pending_lti13_course_instance_id IS NULL
+      )
   ),
   -- Legacy courses: use access rules for dates and initial filtering
   legacy_courses AS (

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -97,10 +97,8 @@ function groupStudentCourseCandidates(
     if (group === undefined) {
       group = {
         course: {
-          course_id: row.course_id,
+          course: row.course,
           course_instance: row.course_instance,
-          course_short_name: row.course_short_name,
-          course_title: row.course_title,
           start_date: row.start_date,
           end_date: row.end_date,
           latest_publishing_extension: null,
@@ -187,7 +185,7 @@ router.get(
 
     const visibleStudentCourses = allStudentCourses.filter((entry) => {
       // Filter out courses where user also has instructor access.
-      if (instructorCourses.some((course) => idsEqual(course.id, entry.course_id))) return false;
+      if (instructorCourses.some((course) => idsEqual(course.id, entry.course.id))) return false;
 
       // Legacy courses must be filtered using access rules
       if (!entry.course_instance.modern_publishing) {
@@ -220,13 +218,15 @@ router.get(
     });
 
     const studentCourses = visibleStudentCourses
-      .map(({ classification, ...course }): StudentHomePageCourse | null => {
+      .map(({ classification, course, course_instance }) => {
+        const clientCourse = { course, course_instance };
+
         if (classification.boundCandidate?.enrollment.status === 'joined') {
-          return { ...course, access_type: 'joined' };
+          return { ...clientCourse, access_type: 'joined' };
         }
         if (classification.actionableInstitutionUinInvitation !== null) {
           return {
-            ...course,
+            ...clientCourse,
             access_type: 'institution_access',
             invitation_enrollment_id:
               classification.actionableInstitutionUinInvitation.enrollment.id,
@@ -234,7 +234,7 @@ router.get(
         }
         if (classification.actionableUidInvitation !== null) {
           return {
-            ...course,
+            ...clientCourse,
             access_type: 'uid_invitation',
             invitation_enrollment_id: classification.actionableUidInvitation.enrollment.id,
           };
@@ -322,14 +322,13 @@ router.post(
       is_administrator: res.locals.is_administrator,
     });
 
-    if (authzData === null || courseInstance === null || !hasRole(authzData, ['Student'])) {
+    if (
+      authzData === null ||
+      courseInstance === null ||
+      !hasRole(authzData, ['Student']) ||
+      authzData.course_role !== 'None'
+    ) {
       throw new HttpStatusError(403, 'Access denied');
-    }
-
-    if (!authzData.has_student_access) {
-      flash('error', 'This course instance is not accessible to students');
-      res.redirect(req.originalUrl);
-      return;
     }
 
     switch (body.__action) {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -87,6 +87,7 @@ function groupStudentCourseCandidates(
   const groups = new Map<
     string,
     {
+      boundJoinedPublishingExtension: CourseInstancePublishingExtension | null;
       course: StudentHomePageCourseData;
       candidates: EnrollmentIdentityCandidate[];
     }
@@ -96,6 +97,7 @@ function groupStudentCourseCandidates(
     let group = groups.get(row.course_instance.id);
     if (group === undefined) {
       group = {
+        boundJoinedPublishingExtension: null,
         course: {
           course: row.course,
           course_instance: row.course_instance,
@@ -119,6 +121,9 @@ function groupStudentCourseCandidates(
     });
 
     const extension = row.latest_publishing_extension;
+    if (row.matches_bound_user && row.enrollment.status === 'joined') {
+      group.boundJoinedPublishingExtension = extension;
+    }
     if (
       extension !== null &&
       (group.course.latest_publishing_extension === null ||
@@ -128,10 +133,18 @@ function groupStudentCourseCandidates(
     }
   }
 
-  return [...groups.values()].map((group) => ({
-    ...group.course,
-    classification: classifyEnrollmentIdentityCandidates(group.candidates),
-  }));
+  return [...groups.values()].map((group) => {
+    const classification = classifyEnrollmentIdentityCandidates(group.candidates);
+    return {
+      ...group.course,
+      // Pending rows are merged during admission, but not after the user has joined.
+      latest_publishing_extension:
+        classification.boundCandidate?.enrollment.status === 'joined'
+          ? group.boundJoinedPublishingExtension
+          : group.course.latest_publishing_extension,
+      classification,
+    };
+  });
 }
 
 router.get(

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../lib/enrollment/identity.js';
 import {
   EnrollmentAdmissionDeniedError,
+  rejectInstitutionUinInvitation,
   rejectUidInvitation,
 } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
@@ -205,7 +206,12 @@ router.get(
           return { ...course, access_type: 'joined' };
         }
         if (classification.actionableInstitutionUinInvitation !== null) {
-          return { ...course, access_type: 'institution_uin_invitation' };
+          return {
+            ...course,
+            access_type: 'institution_access',
+            invitation_enrollment_id:
+              classification.actionableInstitutionUinInvitation.enrollment.id,
+          };
         }
         if (classification.actionableUidInvitation !== null) {
           return {
@@ -282,6 +288,11 @@ router.post(
       z.object({
         __action: z.literal('unenroll'),
         course_instance_id: z.string().min(1),
+      }),
+      z.object({
+        __action: z.literal('remove_institution_access'),
+        course_instance_id: z.string().min(1),
+        enrollment_id: z.string().min(1),
       }),
     ]);
     const body = BodySchema.parse(req.body);
@@ -371,6 +382,21 @@ router.post(
           authzData,
           requiredRole: ['Student'],
         });
+        break;
+      }
+      case 'remove_institution_access': {
+        try {
+          await rejectInstitutionUinInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to remove course');
+        }
         break;
       }
       default: {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -6,7 +6,7 @@ import { flash } from '@prairielearn/flash';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { assertNever } from '@prairielearn/utils';
-import { parseRequestBody } from '@prairielearn/zod';
+import { IdSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
@@ -57,17 +57,17 @@ const PostBodySchema = z.discriminatedUnion('__action', [
   z.object({ __action: z.literal('dismiss_news_alert') }),
   z.object({
     __action: z.enum(['accept_invitation', 'reject_invitation']),
-    course_instance_id: z.string().min(1),
-    enrollment_id: z.string().min(1),
+    course_instance_id: IdSchema,
+    enrollment_id: IdSchema,
   }),
   z.object({
     __action: z.literal('unenroll'),
-    course_instance_id: z.string().min(1),
+    course_instance_id: IdSchema,
   }),
   z.object({
     __action: z.literal('remove_institution_access'),
-    course_instance_id: z.string().min(1),
-    enrollment_id: z.string().min(1),
+    course_instance_id: IdSchema,
+    enrollment_id: IdSchema,
   }),
 ]);
 

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../lib/enrollment/identity.js';
 import {
   EnrollmentAdmissionDeniedError,
-  rejectConventionalEnrollmentInvitation,
+  rejectUidInvitation,
 } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
@@ -204,14 +204,14 @@ router.get(
         if (classification.boundCandidate?.enrollment.status === 'joined') {
           return { ...course, access_type: 'joined' };
         }
-        if (classification.actionableInstitutionRosterInvitation !== null) {
-          return { ...course, access_type: 'roster_available' };
+        if (classification.actionableInstitutionUinInvitation !== null) {
+          return { ...course, access_type: 'institution_uin_invitation' };
         }
-        if (classification.actionableConventionalInvitation !== null) {
+        if (classification.actionableUidInvitation !== null) {
           return {
             ...course,
-            access_type: 'conventional_invitation',
-            invitation_enrollment_id: classification.actionableConventionalInvitation.enrollment.id,
+            access_type: 'uid_invitation',
+            invitation_enrollment_id: classification.actionableUidInvitation.enrollment.id,
           };
         }
         return null;
@@ -339,7 +339,7 @@ router.post(
       }
       case 'reject_invitation': {
         try {
-          await rejectConventionalEnrollmentInvitation({
+          await rejectUidInvitation({
             agentAuthnUserId: res.locals.authn_user.id,
             agentUserId: res.locals.authn_user.id,
             courseInstanceId: courseInstance.id,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -10,6 +10,7 @@ import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
+import { hasRole } from '../../lib/authz-data-lib.js';
 import {
   checkCourseInstanceLegacyAccess,
   constructCourseOrInstanceContext,
@@ -17,25 +18,36 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
+import type { CourseInstancePublishingExtension } from '../../lib/db-types.js';
+import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
 import {
-  admitUserFromUidInvitation,
-  rejectUserFromUidInvitation,
-} from '../../lib/enrollment/admission.js';
-import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+  classifyEnrollmentIdentityCandidates,
+  selectEnrollmentAdmissionDecision,
+} from '../../lib/enrollment/identity.js';
+import {
+  EnrollmentAdmissionDeniedError,
+  rejectConventionalEnrollmentInvitation,
+} from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
-import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
-import { selectOptionalEnrollmentByUid, setEnrollmentStatus } from '../../models/enrollment.js';
+import { selectOptionalEnrollmentByUserId, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
 } from '../../models/news-items.js';
 
 import { Home } from './home.html.js';
-import { InstructorHomePageCourseSchema, StudentHomePageCourseSchema } from './home.types.js';
+import {
+  InstructorHomePageCourseSchema,
+  type StudentHomePageCourse,
+  type StudentHomePageCourseCandidateRow,
+  StudentHomePageCourseCandidateRowSchema,
+  type StudentHomePageCourseData,
+} from './home.types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
@@ -43,10 +55,80 @@ const router = Router();
 const PostBodySchema = z.discriminatedUnion('__action', [
   z.object({ __action: z.literal('dismiss_news_alert') }),
   z.object({
-    __action: z.enum(['accept_invitation', 'reject_invitation', 'unenroll']),
+    __action: z.enum(['accept_invitation', 'reject_invitation']),
+    course_instance_id: z.string().min(1),
+    enrollment_id: z.string().min(1),
+  }),
+  z.object({
+    __action: z.literal('unenroll'),
     course_instance_id: z.string().min(1),
   }),
 ]);
+
+function isLaterPublishingExtension(
+  next: CourseInstancePublishingExtension,
+  current: CourseInstancePublishingExtension,
+): boolean {
+  const dateDifference = next.end_date.getTime() - current.end_date.getTime();
+  return dateDifference > 0 || (dateDifference === 0 && BigInt(next.id) > BigInt(current.id));
+}
+
+function groupStudentCourseCandidates(
+  rows: StudentHomePageCourseCandidateRow[],
+): (StudentHomePageCourseData & {
+  classification: EnrollmentIdentityClassification;
+})[] {
+  const groups = new Map<
+    string,
+    {
+      course: StudentHomePageCourseData;
+      candidates: EnrollmentIdentityCandidate[];
+    }
+  >();
+
+  for (const row of rows) {
+    let group = groups.get(row.course_instance.id);
+    if (group === undefined) {
+      group = {
+        course: {
+          course_id: row.course_id,
+          course_instance: row.course_instance,
+          course_short_name: row.course_short_name,
+          course_title: row.course_title,
+          start_date: row.start_date,
+          end_date: row.end_date,
+          latest_publishing_extension: null,
+        },
+        candidates: [],
+      };
+      groups.set(row.course_instance.id, group);
+    }
+
+    group.candidates.push({
+      enrollment: row.enrollment,
+      matches: {
+        boundUser: row.matches_bound_user,
+        institutionUin: row.matches_institution_uin,
+        lti13: row.matches_lti13,
+        pendingUid: row.matches_pending_uid,
+      },
+    });
+
+    const extension = row.latest_publishing_extension;
+    if (
+      extension !== null &&
+      (group.course.latest_publishing_extension === null ||
+        isLaterPublishingExtension(extension, group.course.latest_publishing_extension))
+    ) {
+      group.course.latest_publishing_extension = extension;
+    }
+  }
+
+  return [...groups.values()].map((group) => ({
+    ...group.course,
+    classification: classifyEnrollmentIdentityCandidates(group.candidates),
+  }));
+}
 
 router.get(
   '/',
@@ -71,13 +153,11 @@ router.get(
       InstructorHomePageCourseSchema,
     );
 
-    // Query all student courses (both legacy and modern publishing) in a single query
-    const allStudentCourses = await queryRows(
+    const studentCourseCandidateRows = await queryRows(
       sql.select_student_courses,
       {
         // Use the authenticated user, not the authorized user.
         user_id: res.locals.authn_user.id,
-        pending_uid: res.locals.authn_user.uid,
         // This is a somewhat ugly escape hatch specifically for load testing. In
         // general, we don't want to clutter the home page with example course
         // enrollments, but for load testing we want to enroll a large number of
@@ -87,8 +167,9 @@ router.get(
         include_example_course_enrollments: req.query.include_example_course_enrollments === 'true',
         req_date: res.locals.req_date,
       },
-      StudentHomePageCourseSchema,
+      StudentHomePageCourseCandidateRowSchema,
     );
+    const allStudentCourses = groupStudentCourseCandidates(studentCourseCandidateRows);
 
     const legacyCourseInstancesWithAccess = await checkCourseInstanceLegacyAccess({
       courseInstanceIds: allStudentCourses
@@ -98,7 +179,7 @@ router.get(
       reqDate: res.locals.req_date,
     });
 
-    const studentCourses = allStudentCourses.filter((entry) => {
+    const visibleStudentCourses = allStudentCourses.filter((entry) => {
       // Filter out courses where user also has instructor access.
       if (instructorCourses.some((course) => idsEqual(course.id, entry.course_id))) return false;
 
@@ -131,6 +212,26 @@ router.get(
         res.locals.req_date < endDate
       );
     });
+
+    const studentCourses = visibleStudentCourses
+      .map(({ classification, ...course }): StudentHomePageCourse | null => {
+        if (classification.boundCandidate?.enrollment.status === 'joined') {
+          return { ...course, access_type: 'joined' };
+        }
+        if (classification.actionableInstitutionRosterInvitation !== null) {
+          return { ...course, access_type: 'roster_available' };
+        }
+        if (classification.actionableConventionalInvitation !== null) {
+          return {
+            ...course,
+            access_type: 'conventional_invitation',
+            invitation_enrollment_id:
+              classification.actionableConventionalInvitation.enrollment.id,
+          };
+        }
+        return null;
+      })
+      .filter((entry): entry is StudentHomePageCourse => entry !== null);
 
     const adminInstitutions = await queryRows(
       sql.select_admin_institutions,
@@ -211,28 +312,11 @@ router.post(
       is_administrator: res.locals.is_administrator,
     });
 
-    if (authzData === null || courseInstance === null) {
+    if (authzData === null || courseInstance === null || !hasRole(authzData, ['Student'])) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    // Invitations and rejections are only supported for modern publishing courses.
-    if (
-      !courseInstance.modern_publishing &&
-      ['accept_invitation', 'reject_invitation'].includes(body.__action)
-    ) {
-      flash(
-        'error',
-        'Invitations and rejections are only supported for courses using modern publishing.',
-      );
-      res.redirect(req.originalUrl);
-      return;
-    }
-
-    if (
-      courseInstance.modern_publishing &&
-      computeStatus(courseInstance.publishing_start_date, courseInstance.publishing_end_date) !==
-        'published'
-    ) {
+    if (!authzData.has_student_access) {
       flash('error', 'This course instance is not accessible to students');
       res.redirect(req.originalUrl);
       return;
@@ -245,7 +329,11 @@ router.post(
           source: { type: 'invitation', matchedBy: 'uid' },
           userId: res.locals.authn_user.id,
         });
-        if (!decision.allowed || decision.invitationCandidate === null) {
+        if (
+          !decision.allowed ||
+          decision.invitationCandidate === null ||
+          !idsEqual(decision.invitationCandidate.enrollment.id, body.enrollment_id)
+        ) {
           flash('error', 'Failed to accept invitation');
           break;
         }
@@ -266,18 +354,24 @@ router.post(
         break;
       }
       case 'reject_invitation': {
-        const rejected = await rejectUserFromUidInvitation({
-          authzData,
-          courseInstanceId: courseInstance.id,
-          userId: res.locals.authn_user.id,
-        });
-        if (!rejected) flash('error', 'Failed to reject invitation');
+        try {
+          await rejectConventionalEnrollmentInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to reject invitation');
+        }
         break;
       }
       case 'unenroll': {
-        const enrollment = await selectOptionalEnrollmentByUid({
+        const enrollment = await selectOptionalEnrollmentByUserId({
           courseInstance,
-          uid,
+          userId: res.locals.authn_user.id,
           requiredRole: ['Student'],
           authzData,
         });

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -17,8 +17,12 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
-import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
+import {
+  admitUserFromUidInvitation,
+  rejectUserFromUidInvitation,
+} from '../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
@@ -246,35 +250,28 @@ router.post(
           break;
         }
 
-        await admitUserFromUidInvitation({
-          courseInstanceId: courseInstance.id,
-          expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
-          ip: req.ip ?? null,
-          isAdministrator: res.locals.is_administrator,
-          reqDate: res.locals.req_date,
-          userId: res.locals.authn_user.id,
-        });
+        try {
+          await admitUserFromUidInvitation({
+            courseInstanceId: courseInstance.id,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            reqDate: res.locals.req_date,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to accept invitation');
+        }
         break;
       }
       case 'reject_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
+        const rejected = await rejectUserFromUidInvitation({
           authzData,
+          courseInstanceId: courseInstance.id,
+          userId: res.locals.authn_user.id,
         });
-
-        if (!enrollment || !['invited', 'rejected'].includes(enrollment.status)) {
-          flash('error', 'Failed to reject invitation');
-          break;
-        }
-
-        await setEnrollmentStatus({
-          enrollment,
-          status: 'rejected',
-          authzData,
-          requiredRole: ['Student'],
-        });
+        if (!rejected) flash('error', 'Failed to reject invitation');
         break;
       }
       case 'unenroll': {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -23,7 +23,7 @@ import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import {
-  ensureLegacyEnrollment,
+  ensureEnrollmentWithoutReconciliation,
   selectOptionalEnrollmentByUid,
   setEnrollmentStatus,
 } from '../../models/enrollment.js';
@@ -253,7 +253,7 @@ router.post(
           break;
         }
 
-        await ensureLegacyEnrollment({
+        await ensureEnrollmentWithoutReconciliation({
           institution,
           course,
           courseInstance,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -19,7 +19,6 @@ import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
 import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
 import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
@@ -247,19 +246,14 @@ router.post(
           break;
         }
 
-        try {
-          await admitUserFromUidInvitation({
-            courseInstanceId: courseInstance.id,
-            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
-            ip: req.ip ?? null,
-            isAdministrator: res.locals.is_administrator,
-            reqDate: res.locals.req_date,
-            userId: res.locals.authn_user.id,
-          });
-        } catch (error) {
-          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
-          flash('error', 'Failed to accept invitation');
-        }
+        await admitUserFromUidInvitation({
+          courseInstanceId: courseInstance.id,
+          expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+          ip: req.ip ?? null,
+          isAdministrator: res.locals.is_administrator,
+          reqDate: res.locals.req_date,
+          userId: res.locals.authn_user.id,
+        });
         break;
       }
       case 'reject_invitation': {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -225,8 +225,7 @@ router.get(
           return {
             ...course,
             access_type: 'conventional_invitation',
-            invitation_enrollment_id:
-              classification.actionableConventionalInvitation.enrollment.id,
+            invitation_enrollment_id: classification.actionableConventionalInvitation.enrollment.id,
           };
         }
         return null;

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -312,14 +312,6 @@ router.post(
   typedAsyncHandler<'plain'>(async (req, res) => {
     const body = parseRequestBody(req, PostBodySchema);
 
-    const {
-      authn_user: { uid },
-    } = extractPageContext(res.locals, {
-      pageType: 'plain',
-      accessType: 'student',
-      withAuthzData: false,
-    });
-
     if (body.__action === 'dismiss_news_alert') {
       await markNewsItemsAsReadForUser(res.locals.authn_user);
       res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -9,6 +9,7 @@ import { assertNever } from '@prairielearn/utils';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
+import { hasRole } from '../../lib/authz-data-lib.js';
 import {
   checkCourseInstanceLegacyAccess,
   constructCourseOrInstanceContext,
@@ -16,24 +17,104 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
+import type { CourseInstancePublishingExtension } from '../../lib/db-types.js';
 import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
-import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
+import {
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+  classifyEnrollmentIdentityCandidates,
+  selectEnrollmentAdmissionDecision,
+} from '../../lib/enrollment/identity.js';
+import {
+  EnrollmentAdmissionDeniedError,
+  rejectConventionalEnrollmentInvitation,
+} from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
-import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
-import { selectOptionalEnrollmentByUid, setEnrollmentStatus } from '../../models/enrollment.js';
+import { selectOptionalEnrollmentByUserId, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
 } from '../../models/news-items.js';
 
 import { Home } from './home.html.js';
-import { InstructorHomePageCourseSchema, StudentHomePageCourseSchema } from './home.types.js';
+import {
+  InstructorHomePageCourseSchema,
+  type StudentHomePageCourse,
+  type StudentHomePageCourseCandidateRow,
+  StudentHomePageCourseCandidateRowSchema,
+  type StudentHomePageCourseData,
+} from './home.types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
+
+function isLaterPublishingExtension(
+  next: CourseInstancePublishingExtension,
+  current: CourseInstancePublishingExtension,
+): boolean {
+  const dateDifference = next.end_date.getTime() - current.end_date.getTime();
+  return dateDifference > 0 || (dateDifference === 0 && BigInt(next.id) > BigInt(current.id));
+}
+
+function groupStudentCourseCandidates(
+  rows: StudentHomePageCourseCandidateRow[],
+): (StudentHomePageCourseData & {
+  classification: EnrollmentIdentityClassification;
+})[] {
+  const groups = new Map<
+    string,
+    {
+      course: StudentHomePageCourseData;
+      candidates: EnrollmentIdentityCandidate[];
+    }
+  >();
+
+  for (const row of rows) {
+    let group = groups.get(row.course_instance.id);
+    if (group === undefined) {
+      group = {
+        course: {
+          course_id: row.course_id,
+          course_instance: row.course_instance,
+          course_short_name: row.course_short_name,
+          course_title: row.course_title,
+          start_date: row.start_date,
+          end_date: row.end_date,
+          latest_publishing_extension: null,
+        },
+        candidates: [],
+      };
+      groups.set(row.course_instance.id, group);
+    }
+
+    group.candidates.push({
+      enrollment: row.enrollment,
+      matches: {
+        boundUser: row.matches_bound_user,
+        institutionUin: row.matches_institution_uin,
+        lti13: row.matches_lti13,
+        pendingUid: row.matches_pending_uid,
+      },
+    });
+
+    const extension = row.latest_publishing_extension;
+    if (
+      extension !== null &&
+      (group.course.latest_publishing_extension === null ||
+        isLaterPublishingExtension(extension, group.course.latest_publishing_extension))
+    ) {
+      group.course.latest_publishing_extension = extension;
+    }
+  }
+
+  return [...groups.values()].map((group) => ({
+    ...group.course,
+    classification: classifyEnrollmentIdentityCandidates(group.candidates),
+  }));
+}
 
 router.get(
   '/',
@@ -58,13 +139,11 @@ router.get(
       InstructorHomePageCourseSchema,
     );
 
-    // Query all student courses (both legacy and modern publishing) in a single query
-    const allStudentCourses = await queryRows(
+    const studentCourseCandidateRows = await queryRows(
       sql.select_student_courses,
       {
         // Use the authenticated user, not the authorized user.
         user_id: res.locals.authn_user.id,
-        pending_uid: res.locals.authn_user.uid,
         // This is a somewhat ugly escape hatch specifically for load testing. In
         // general, we don't want to clutter the home page with example course
         // enrollments, but for load testing we want to enroll a large number of
@@ -74,8 +153,9 @@ router.get(
         include_example_course_enrollments: req.query.include_example_course_enrollments === 'true',
         req_date: res.locals.req_date,
       },
-      StudentHomePageCourseSchema,
+      StudentHomePageCourseCandidateRowSchema,
     );
+    const allStudentCourses = groupStudentCourseCandidates(studentCourseCandidateRows);
 
     const legacyCourseInstancesWithAccess = await checkCourseInstanceLegacyAccess({
       courseInstanceIds: allStudentCourses
@@ -85,7 +165,7 @@ router.get(
       reqDate: res.locals.req_date,
     });
 
-    const studentCourses = allStudentCourses.filter((entry) => {
+    const visibleStudentCourses = allStudentCourses.filter((entry) => {
       // Filter out courses where user also has instructor access.
       if (instructorCourses.some((course) => idsEqual(course.id, entry.course_id))) return false;
 
@@ -118,6 +198,26 @@ router.get(
         res.locals.req_date < endDate
       );
     });
+
+    const studentCourses = visibleStudentCourses
+      .map(({ classification, ...course }): StudentHomePageCourse | null => {
+        if (classification.boundCandidate?.enrollment.status === 'joined') {
+          return { ...course, access_type: 'joined' };
+        }
+        if (classification.actionableInstitutionRosterInvitation !== null) {
+          return { ...course, access_type: 'roster_available' };
+        }
+        if (classification.actionableConventionalInvitation !== null) {
+          return {
+            ...course,
+            access_type: 'conventional_invitation',
+            invitation_enrollment_id:
+              classification.actionableConventionalInvitation.enrollment.id,
+          };
+        }
+        return null;
+      })
+      .filter((entry): entry is StudentHomePageCourse => entry !== null);
 
     const adminInstitutions = await queryRows(
       sql.select_admin_institutions,
@@ -173,18 +273,15 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const {
-      authn_user: { uid },
-    } = extractPageContext(res.locals, {
-      pageType: 'plain',
-      accessType: 'student',
-      withAuthzData: false,
-    });
-
     const BodySchema = z.discriminatedUnion('__action', [
       z.object({ __action: z.literal('dismiss_news_alert') }),
       z.object({
-        __action: z.enum(['accept_invitation', 'reject_invitation', 'unenroll']),
+        __action: z.enum(['accept_invitation', 'reject_invitation']),
+        course_instance_id: z.string().min(1),
+        enrollment_id: z.string().min(1),
+      }),
+      z.object({
+        __action: z.literal('unenroll'),
         course_instance_id: z.string().min(1),
       }),
     ]);
@@ -205,28 +302,11 @@ router.post(
       is_administrator: res.locals.is_administrator,
     });
 
-    if (authzData === null || courseInstance === null) {
+    if (authzData === null || courseInstance === null || !hasRole(authzData, ['Student'])) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    // Invitations and rejections are only supported for modern publishing courses.
-    if (
-      !courseInstance.modern_publishing &&
-      ['accept_invitation', 'reject_invitation'].includes(body.__action)
-    ) {
-      flash(
-        'error',
-        'Invitations and rejections are only supported for courses using modern publishing.',
-      );
-      res.redirect(req.originalUrl);
-      return;
-    }
-
-    if (
-      courseInstance.modern_publishing &&
-      computeStatus(courseInstance.publishing_start_date, courseInstance.publishing_end_date) !==
-        'published'
-    ) {
+    if (!authzData.has_student_access) {
       flash('error', 'This course instance is not accessible to students');
       res.redirect(req.originalUrl);
       return;
@@ -239,14 +319,18 @@ router.post(
           source: { type: 'invitation', matchedBy: 'uid' },
           userId: res.locals.authn_user.id,
         });
-        if (!decision.allowed || decision.invitationCandidate === null) {
+        if (
+          !decision.allowed ||
+          decision.invitationCandidate === null ||
+          !idsEqual(decision.invitationCandidate.enrollment.id, body.enrollment_id)
+        ) {
           flash('error', 'Failed to accept invitation');
           break;
         }
 
         await admitUserFromUidInvitation({
           courseInstanceId: courseInstance.id,
-          expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+          expectedInvitationEnrollmentId: body.enrollment_id,
           ip: req.ip ?? null,
           isAdministrator: res.locals.is_administrator,
           reqDate: res.locals.req_date,
@@ -255,30 +339,24 @@ router.post(
         break;
       }
       case 'reject_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
-          authzData,
-        });
-
-        if (!enrollment || !['invited', 'rejected'].includes(enrollment.status)) {
+        try {
+          await rejectConventionalEnrollmentInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
           flash('error', 'Failed to reject invitation');
-          break;
         }
-
-        await setEnrollmentStatus({
-          enrollment,
-          status: 'rejected',
-          authzData,
-          requiredRole: ['Student'],
-        });
         break;
       }
       case 'unenroll': {
-        const enrollment = await selectOptionalEnrollmentByUid({
+        const enrollment = await selectOptionalEnrollmentByUserId({
           courseInstance,
-          uid,
+          userId: res.locals.authn_user.id,
           requiredRole: ['Student'],
           authzData,
         });

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -391,6 +391,10 @@ router.post(
           break;
         }
 
+        // A student may also have a pending UIN invitation for this course. We intentionally do
+        // not reject it here: doing so safely requires locking both enrollment rows in the same
+        // order as reconciliation. The course may therefore reappear using the invitation, which
+        // the student can remove separately.
         await setEnrollmentStatus({
           enrollment,
           status: 'left',

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../lib/enrollment/identity.js';
 import {
   EnrollmentAdmissionDeniedError,
+  rejectInstitutionUinInvitation,
   rejectUidInvitation,
 } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
@@ -62,6 +63,11 @@ const PostBodySchema = z.discriminatedUnion('__action', [
   z.object({
     __action: z.literal('unenroll'),
     course_instance_id: z.string().min(1),
+  }),
+  z.object({
+    __action: z.literal('remove_institution_access'),
+    course_instance_id: z.string().min(1),
+    enrollment_id: z.string().min(1),
   }),
 ]);
 
@@ -219,7 +225,12 @@ router.get(
           return { ...course, access_type: 'joined' };
         }
         if (classification.actionableInstitutionUinInvitation !== null) {
-          return { ...course, access_type: 'institution_uin_invitation' };
+          return {
+            ...course,
+            access_type: 'institution_access',
+            invitation_enrollment_id:
+              classification.actionableInstitutionUinInvitation.enrollment.id,
+          };
         }
         if (classification.actionableUidInvitation !== null) {
           return {
@@ -386,6 +397,21 @@ router.post(
           authzData,
           requiredRole: ['Student'],
         });
+        break;
+      }
+      case 'remove_institution_access': {
+        try {
+          await rejectInstitutionUinInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to remove course');
+        }
         break;
       }
       default: {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../lib/enrollment/identity.js';
 import {
   EnrollmentAdmissionDeniedError,
-  rejectConventionalEnrollmentInvitation,
+  rejectUidInvitation,
 } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
@@ -218,14 +218,14 @@ router.get(
         if (classification.boundCandidate?.enrollment.status === 'joined') {
           return { ...course, access_type: 'joined' };
         }
-        if (classification.actionableInstitutionRosterInvitation !== null) {
-          return { ...course, access_type: 'roster_available' };
+        if (classification.actionableInstitutionUinInvitation !== null) {
+          return { ...course, access_type: 'institution_uin_invitation' };
         }
-        if (classification.actionableConventionalInvitation !== null) {
+        if (classification.actionableUidInvitation !== null) {
           return {
             ...course,
-            access_type: 'conventional_invitation',
-            invitation_enrollment_id: classification.actionableConventionalInvitation.enrollment.id,
+            access_type: 'uid_invitation',
+            invitation_enrollment_id: classification.actionableUidInvitation.enrollment.id,
           };
         }
         return null;
@@ -354,7 +354,7 @@ router.post(
       }
       case 'reject_invitation': {
         try {
-          await rejectConventionalEnrollmentInvitation({
+          await rejectUidInvitation({
             agentAuthnUserId: res.locals.authn_user.id,
             agentUserId: res.locals.authn_user.id,
             courseInstanceId: courseInstance.id,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -211,8 +211,7 @@ router.get(
           return {
             ...course,
             access_type: 'conventional_invitation',
-            invitation_enrollment_id:
-              classification.actionableConventionalInvitation.enrollment.id,
+            invitation_enrollment_id: classification.actionableConventionalInvitation.enrollment.id,
           };
         }
         return null;

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -23,7 +23,7 @@ import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
 import {
-  ensureEnrollment,
+  ensureLegacyEnrollment,
   selectOptionalEnrollmentByUid,
   setEnrollmentStatus,
 } from '../../models/enrollment.js';
@@ -253,7 +253,7 @@ router.post(
           break;
         }
 
-        await ensureEnrollment({
+        await ensureLegacyEnrollment({
           institution,
           course,
           courseInstance,

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -17,16 +17,15 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
+import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
+import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
+import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
 import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
-import {
-  ensureEnrollmentWithoutReconciliation,
-  selectOptionalEnrollmentByUid,
-  setEnrollmentStatus,
-} from '../../models/enrollment.js';
+import { selectOptionalEnrollmentByUid, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
@@ -200,15 +199,14 @@ router.post(
       return;
     }
 
-    const { authzData, courseInstance, institution, course } =
-      await constructCourseOrInstanceContext({
-        user: res.locals.authn_user,
-        course_id: null,
-        course_instance_id: body.course_instance_id,
-        ip: req.ip ?? null,
-        req_date: res.locals.req_date,
-        is_administrator: res.locals.is_administrator,
-      });
+    const { authzData, courseInstance } = await constructCourseOrInstanceContext({
+      user: res.locals.authn_user,
+      course_id: null,
+      course_instance_id: body.course_instance_id,
+      ip: req.ip ?? null,
+      req_date: res.locals.req_date,
+      is_administrator: res.locals.is_administrator,
+    });
 
     if (authzData === null || courseInstance === null) {
       throw new HttpStatusError(403, 'Access denied');
@@ -239,28 +237,29 @@ router.post(
 
     switch (body.__action) {
       case 'accept_invitation': {
-        const enrollment = await selectOptionalEnrollmentByUid({
-          courseInstance,
-          uid,
-          requiredRole: ['Student'],
-          authzData,
+        const decision = await selectEnrollmentAdmissionDecision({
+          courseInstanceId: courseInstance.id,
+          source: { type: 'invitation', matchedBy: 'uid' },
+          userId: res.locals.authn_user.id,
         });
-        if (
-          !enrollment ||
-          !['left', 'removed', 'rejected', 'invited', 'joined'].includes(enrollment.status)
-        ) {
+        if (!decision.allowed || decision.invitationCandidate === null) {
           flash('error', 'Failed to accept invitation');
           break;
         }
 
-        await ensureEnrollmentWithoutReconciliation({
-          institution,
-          course,
-          courseInstance,
-          authzData,
-          requiredRole: ['Student'],
-          actionDetail: 'invitation_accepted',
-        });
+        try {
+          await admitUserFromUidInvitation({
+            courseInstanceId: courseInstance.id,
+            expectedInvitationEnrollmentId: decision.invitationCandidate.enrollment.id,
+            ip: req.ip ?? null,
+            isAdministrator: res.locals.is_administrator,
+            reqDate: res.locals.req_date,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to accept invitation');
+        }
         break;
       }
       case 'reject_invitation': {

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -23,7 +23,7 @@ export const InstructorHomePageCourseSchema = z.object({
 });
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
-export const StudentHomePageCourseDataSchema = z.object({
+const StudentHomePageCourseDataSchema = z.object({
   course_id: RawStudentCourseSchema.shape.id,
   course_instance: RawStudentCourseInstanceSchema,
   course_short_name: RawStudentCourseSchema.shape.short_name,

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -48,6 +48,6 @@ export type StudentHomePageCourseCandidateRow = z.infer<
 export type StudentHomePageCourse = StudentHomePageCourseData &
   (
     | { access_type: 'joined' }
-    | { access_type: 'conventional_invitation'; invitation_enrollment_id: string }
-    | { access_type: 'roster_available' }
+    | { access_type: 'uid_invitation'; invitation_enrollment_id: string }
+    | { access_type: 'institution_uin_invitation' }
   );

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -24,10 +24,8 @@ export const InstructorHomePageCourseSchema = z.object({
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
 const StudentHomePageCourseDataSchema = z.object({
-  course_id: RawStudentCourseSchema.shape.id,
+  course: RawStudentCourseSchema,
   course_instance: RawStudentCourseInstanceSchema,
-  course_short_name: RawStudentCourseSchema.shape.short_name,
-  course_title: RawStudentCourseSchema.shape.title,
   start_date: DateFromISOString.nullable(),
   end_date: DateFromISOString.nullable(),
   latest_publishing_extension: CourseInstancePublishingExtensionSchema.nullable(),
@@ -45,7 +43,7 @@ export type StudentHomePageCourseCandidateRow = z.infer<
   typeof StudentHomePageCourseCandidateRowSchema
 >;
 
-export type StudentHomePageCourse = StudentHomePageCourseData &
+export type StudentHomePageCourse = Pick<StudentHomePageCourseData, 'course' | 'course_instance'> &
   (
     | { access_type: 'joined' }
     | { access_type: 'uid_invitation'; invitation_enrollment_id: string }

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -49,5 +49,5 @@ export type StudentHomePageCourse = StudentHomePageCourseData &
   (
     | { access_type: 'joined' }
     | { access_type: 'uid_invitation'; invitation_enrollment_id: string }
-    | { access_type: 'institution_uin_invitation' }
+    | { access_type: 'institution_access'; invitation_enrollment_id: string }
   );

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -6,10 +6,7 @@ import {
   RawStudentCourseInstanceSchema,
   RawStudentCourseSchema,
 } from '../../lib/client/safe-db-types.js';
-import {
-  CourseInstancePublishingExtensionSchema,
-  EnrollmentSchema,
-} from '../../lib/db-types.js';
+import { CourseInstancePublishingExtensionSchema, EnrollmentSchema } from '../../lib/db-types.js';
 
 export const InstructorHomePageCourseSchema = z.object({
   id: RawStudentCourseSchema.shape.id,

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -5,9 +5,11 @@ import { DateFromISOString } from '@prairielearn/zod';
 import {
   RawStudentCourseInstanceSchema,
   RawStudentCourseSchema,
-  StudentEnrollmentSchema,
 } from '../../lib/client/safe-db-types.js';
-import { CourseInstancePublishingExtensionSchema } from '../../lib/db-types.js';
+import {
+  CourseInstancePublishingExtensionSchema,
+  EnrollmentSchema,
+} from '../../lib/db-types.js';
 
 export const InstructorHomePageCourseSchema = z.object({
   id: RawStudentCourseSchema.shape.id,
@@ -24,14 +26,31 @@ export const InstructorHomePageCourseSchema = z.object({
 });
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
-export const StudentHomePageCourseSchema = z.object({
+export const StudentHomePageCourseDataSchema = z.object({
   course_id: RawStudentCourseSchema.shape.id,
   course_instance: RawStudentCourseInstanceSchema,
   course_short_name: RawStudentCourseSchema.shape.short_name,
   course_title: RawStudentCourseSchema.shape.title,
-  enrollment: StudentEnrollmentSchema,
   start_date: DateFromISOString.nullable(),
   end_date: DateFromISOString.nullable(),
   latest_publishing_extension: CourseInstancePublishingExtensionSchema.nullable(),
 });
-export type StudentHomePageCourse = z.infer<typeof StudentHomePageCourseSchema>;
+export type StudentHomePageCourseData = z.infer<typeof StudentHomePageCourseDataSchema>;
+
+export const StudentHomePageCourseCandidateRowSchema = StudentHomePageCourseDataSchema.extend({
+  enrollment: EnrollmentSchema,
+  matches_bound_user: z.boolean(),
+  matches_institution_uin: z.boolean(),
+  matches_lti13: z.boolean(),
+  matches_pending_uid: z.boolean(),
+});
+export type StudentHomePageCourseCandidateRow = z.infer<
+  typeof StudentHomePageCourseCandidateRowSchema
+>;
+
+export type StudentHomePageCourse = StudentHomePageCourseData &
+  (
+    | { access_type: 'joined' }
+    | { access_type: 'conventional_invitation'; invitation_enrollment_id: string }
+    | { access_type: 'roster_available' }
+  );

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -23,6 +23,7 @@ import {
   updateCourseInstanceSettings,
   withUser,
 } from './utils/auth.js';
+import { createEnrollment } from './utils/enrollment-identity.js';
 import { enrollUser, unenrollUser } from './utils/enrollments.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
@@ -330,23 +331,24 @@ describe('Self-enrollment settings transitions', () => {
       email: 'uin-invitation@example.com',
       institutionId: '1',
     });
-    const invitation = await queryRow(
-      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
-       VALUES ('1', 'invited', $pending_uin)
-       RETURNING *`,
-      { pending_uin: uinUser.uin },
-      EnrollmentSchema,
-    );
+    const invitation = await createEnrollment({
+      courseInstance,
+      pendingUin: uinUser.uin,
+      status: 'invited',
+    });
 
     await withUser(uinUser, async () => {
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
 
-      const enrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const enrollment = await selectOptionalEnrollmentByUserId({
+        userId: uinUser.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(enrollment);
+      assert.equal(enrollment.id, invitation.id);
       assert.equal(enrollment.status, 'joined');
       assert.equal(enrollment.user_id, uinUser.id);
       assert.isNull(enrollment.pending_uin);

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -304,6 +304,8 @@ describe('Self-enrollment settings transitions', () => {
 
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
+      const repeatedResponse = await fetch(assessmentsUrl);
+      assert.equal(repeatedResponse.status, 200);
 
       const finalEnrollment = await selectOptionalEnrollmentByUserId({
         userId: invitedUser.id,

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, assert, beforeAll, describe, it, test } from 'vitest';
+import { afterAll, assert, beforeAll, describe, expect, it, test } from 'vitest';
 
 import { execute, queryOptionalRow, queryRow } from '@prairielearn/postgres';
 
@@ -7,6 +7,7 @@ import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { getSelfEnrollmentLinkUrl } from '../lib/client/url.js';
 import { config } from '../lib/config.js';
 import { type CourseInstance, EnrollmentSchema } from '../lib/db-types.js';
+import { admitUserForCourseInstanceAccess } from '../lib/enrollment/admission.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -23,7 +24,7 @@ import {
   updateCourseInstanceSettings,
   withUser,
 } from './utils/auth.js';
-import { createEnrollment } from './utils/enrollment-identity.js';
+import { createEnrollment, selectEnrollments } from './utils/enrollment-identity.js';
 import { enrollUser, unenrollUser } from './utils/enrollments.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
@@ -316,44 +317,74 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
-  it('admits an institution UIN invitation without self-enrollment or a code', async () => {
-    await deleteEnrollmentsInCourseInstance('1');
-    await updateCourseInstanceSettings('1', {
-      selfEnrollmentEnabled: false,
-      selfEnrollmentUseEnrollmentCode: true,
-      restrictToInstitution: false,
-    });
-
-    const uinUser = await getOrCreateUser({
-      uid: 'uin-invitation@example.com',
-      name: 'UIN Invitation Student',
-      uin: 'invitation-uin',
-      email: 'uin-invitation@example.com',
-      institutionId: '1',
-    });
-    const invitation = await createEnrollment({
-      courseInstance,
-      pendingUin: uinUser.uin,
-      status: 'invited',
-    });
-
-    await withUser(uinUser, async () => {
-      const response = await fetch(assessmentsUrl);
-      assert.equal(response.status, 200);
-
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: uinUser.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
+  it.each([
+    {
+      name: 'without a bound enrollment',
+      prefix: 'uin-invitation',
+      boundStatus: null,
+      expectedHttpStatus: 200,
+      expectedPersistedStatuses: ['joined'],
+    },
+    {
+      name: 'paired with a left enrollment',
+      prefix: 'left-with-invitation',
+      boundStatus: 'left' as const,
+      expectedHttpStatus: 200,
+      expectedPersistedStatuses: ['joined'],
+    },
+    {
+      name: 'paired with a removed enrollment',
+      prefix: 'removed-with-invitation',
+      boundStatus: 'removed' as const,
+      expectedHttpStatus: 403,
+      expectedPersistedStatuses: ['removed', 'invited'],
+    },
+  ])(
+    'handles an institution UIN invitation $name',
+    async ({ prefix, boundStatus, expectedHttpStatus, expectedPersistedStatuses }) => {
+      await deleteEnrollmentsInCourseInstance('1');
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
       });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.id, invitation.id);
-      assert.equal(enrollment.status, 'joined');
-      assert.equal(enrollment.user_id, uinUser.id);
-      assert.isNull(enrollment.pending_uin);
-    });
-  });
+
+      const user = await getOrCreateUser({
+        uid: `${prefix}@example.com`,
+        name: prefix,
+        uin: prefix,
+        email: `${prefix}@example.com`,
+        institutionId: '1',
+      });
+      const enrollmentIds: string[] = [];
+      if (boundStatus !== null) {
+        const boundEnrollment = await createEnrollment({
+          courseInstance,
+          userId: user.id,
+          status: boundStatus,
+          firstJoinedAt: new Date('2024-01-01T00:00:00Z'),
+        });
+        enrollmentIds.push(boundEnrollment.id);
+      }
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingUin: user.uin,
+        status: 'invited',
+      });
+      enrollmentIds.push(invitation.id);
+
+      await withUser(user, async () => {
+        const response = await fetch(assessmentsUrl);
+        assert.equal(response.status, expectedHttpStatus);
+      });
+
+      const persistedEnrollments = await selectEnrollments(enrollmentIds);
+      assert.deepEqual(
+        persistedEnrollments.map((enrollment) => enrollment.status),
+        expectedPersistedStatuses,
+      );
+    },
+  );
 
   it('does not allow rejected user to self-enroll via the assessments endpoint when self-enrollment is disabled', async () => {
     await deleteEnrollmentsInCourseInstance('1');
@@ -494,6 +525,19 @@ describe('Self-enrollment settings transitions', () => {
       });
       assert.isNotNull(finalEnrollment);
       assert.equal(finalEnrollment.status, 'blocked');
+    });
+
+    await expect(
+      admitUserForCourseInstanceAccess({
+        courseInstanceId: courseInstance.id,
+        ip: null,
+        isAdministrator: false,
+        reqDate: new Date(),
+        userId: blockedUser.id,
+      }),
+    ).rejects.toMatchObject({
+      message: 'You are blocked from accessing this course',
+      status: 403,
     });
   });
 

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -315,6 +315,94 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
+  it('admits an institution-roster invitation without self-enrollment or a code', async () => {
+    await deleteEnrollmentsInCourseInstance('1');
+    await updateCourseInstanceSettings('1', {
+      selfEnrollmentEnabled: false,
+      selfEnrollmentUseEnrollmentCode: true,
+      restrictToInstitution: false,
+    });
+
+    const rosterUser = await getOrCreateUser({
+      uid: 'roster@example.com',
+      name: 'Roster Student',
+      uin: 'roster-uin',
+      email: 'roster@example.com',
+      institutionId: '1',
+    });
+    const invitation = await queryRow(
+      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
+       VALUES ('1', 'invited', $pending_uin)
+       RETURNING *`,
+      { pending_uin: rosterUser.uin },
+      EnrollmentSchema,
+    );
+
+    await withUser(rosterUser, async () => {
+      const response = await fetch(assessmentsUrl);
+      assert.equal(response.status, 200);
+
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      assert.equal(enrollment.status, 'joined');
+      assert.equal(enrollment.user_id, rosterUser.id);
+      assert.isNull(enrollment.pending_uin);
+    });
+  });
+
+  it('applies normal self-enrollment policy when a removed user also has a roster row', async () => {
+    await deleteEnrollmentsInCourseInstance('1');
+    await updateCourseInstanceSettings('1', {
+      selfEnrollmentEnabled: false,
+      selfEnrollmentUseEnrollmentCode: true,
+      restrictToInstitution: false,
+    });
+
+    const removedUser = await getOrCreateUser({
+      uid: 'removed-roster@example.com',
+      name: 'Removed Roster Student',
+      uin: 'removed-roster-uin',
+      email: 'removed-roster@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await queryRow(
+      `INSERT INTO enrollments (course_instance_id, first_joined_at, status, user_id)
+       VALUES ('1', now(), 'removed', $user_id)
+       RETURNING *`,
+      { user_id: removedUser.id },
+      EnrollmentSchema,
+    );
+    const invitation = await queryRow(
+      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
+       VALUES ('1', 'invited', $pending_uin)
+       RETURNING *`,
+      { pending_uin: removedUser.uin },
+      EnrollmentSchema,
+    );
+
+    await withUser(removedUser, async () => {
+      const response = await fetch(assessmentsUrl);
+      assert.equal(response.status, 403);
+
+      const persistedBoundEnrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: boundEnrollment.id },
+        EnrollmentSchema,
+      );
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      assert.equal(persistedBoundEnrollment.status, 'removed');
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
+    });
+  });
+
   it('does not allow rejected user to self-enroll via the assessments endpoint when self-enrollment is disabled', async () => {
     await deleteEnrollmentsInCourseInstance('1');
     await updateCourseInstanceSettings('1', {

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -315,7 +315,7 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
-  it('admits an institution-roster invitation without self-enrollment or a code', async () => {
+  it('admits an institution UIN invitation without self-enrollment or a code', async () => {
     await deleteEnrollmentsInCourseInstance('1');
     await updateCourseInstanceSettings('1', {
       selfEnrollmentEnabled: false,
@@ -323,22 +323,22 @@ describe('Self-enrollment settings transitions', () => {
       restrictToInstitution: false,
     });
 
-    const rosterUser = await getOrCreateUser({
-      uid: 'roster@example.com',
-      name: 'Roster Student',
-      uin: 'roster-uin',
-      email: 'roster@example.com',
+    const uinUser = await getOrCreateUser({
+      uid: 'uin-invitation@example.com',
+      name: 'UIN Invitation Student',
+      uin: 'invitation-uin',
+      email: 'uin-invitation@example.com',
       institutionId: '1',
     });
     const invitation = await queryRow(
       `INSERT INTO enrollments (course_instance_id, status, pending_uin)
        VALUES ('1', 'invited', $pending_uin)
        RETURNING *`,
-      { pending_uin: rosterUser.uin },
+      { pending_uin: uinUser.uin },
       EnrollmentSchema,
     );
 
-    await withUser(rosterUser, async () => {
+    await withUser(uinUser, async () => {
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
 
@@ -348,7 +348,7 @@ describe('Self-enrollment settings transitions', () => {
         EnrollmentSchema,
       );
       assert.equal(enrollment.status, 'joined');
-      assert.equal(enrollment.user_id, rosterUser.id);
+      assert.equal(enrollment.user_id, uinUser.id);
       assert.isNull(enrollment.pending_uin);
     });
   });

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -353,56 +353,6 @@ describe('Self-enrollment settings transitions', () => {
     });
   });
 
-  it('applies normal self-enrollment policy when a removed user also has a roster row', async () => {
-    await deleteEnrollmentsInCourseInstance('1');
-    await updateCourseInstanceSettings('1', {
-      selfEnrollmentEnabled: false,
-      selfEnrollmentUseEnrollmentCode: true,
-      restrictToInstitution: false,
-    });
-
-    const removedUser = await getOrCreateUser({
-      uid: 'removed-roster@example.com',
-      name: 'Removed Roster Student',
-      uin: 'removed-roster-uin',
-      email: 'removed-roster@example.com',
-      institutionId: '1',
-    });
-    const boundEnrollment = await queryRow(
-      `INSERT INTO enrollments (course_instance_id, first_joined_at, status, user_id)
-       VALUES ('1', now(), 'removed', $user_id)
-       RETURNING *`,
-      { user_id: removedUser.id },
-      EnrollmentSchema,
-    );
-    const invitation = await queryRow(
-      `INSERT INTO enrollments (course_instance_id, status, pending_uin)
-       VALUES ('1', 'invited', $pending_uin)
-       RETURNING *`,
-      { pending_uin: removedUser.uin },
-      EnrollmentSchema,
-    );
-
-    await withUser(removedUser, async () => {
-      const response = await fetch(assessmentsUrl);
-      assert.equal(response.status, 403);
-
-      const persistedBoundEnrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: boundEnrollment.id },
-        EnrollmentSchema,
-      );
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
-      assert.equal(persistedBoundEnrollment.status, 'removed');
-      assert.equal(persistedInvitation.status, 'invited');
-      assert.isNull(persistedInvitation.user_id);
-    });
-  });
-
   it('does not allow rejected user to self-enroll via the assessments endpoint when self-enrollment is disabled', async () => {
     await deleteEnrollmentsInCourseInstance('1');
     await updateCourseInstanceSettings('1', {

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -304,8 +304,6 @@ describe('Self-enrollment settings transitions', () => {
 
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
-      const repeatedResponse = await fetch(assessmentsUrl);
-      assert.equal(repeatedResponse.status, 200);
 
       const finalEnrollment = await selectOptionalEnrollmentByUserId({
         userId: invitedUser.id,

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -1,10 +1,11 @@
--- BLOCK create_enrollment_with_status
+-- BLOCK create_enrollment
 INSERT INTO
   enrollments (
     user_id,
     course_instance_id,
     status,
     pending_uid,
+    pending_uin,
     first_joined_at
   )
 VALUES
@@ -13,22 +14,56 @@ VALUES
     $course_instance_id,
     $status,
     $pending_uid,
+    $pending_uin,
     $first_joined_at
   )
 RETURNING
   *;
 
--- BLOCK delete_enrollment_by_course_instance_and_user
+-- BLOCK delete_enrollment_by_id
 DELETE FROM enrollments
 WHERE
-  course_instance_id = $course_instance_id
-  AND user_id = $user_id;
+  id = $enrollment_id;
 
--- BLOCK delete_enrollment_by_course_instance_and_pending_uid
-DELETE FROM enrollments
+-- BLOCK select_enrollments_by_ids
+SELECT
+  *
+FROM
+  enrollments
 WHERE
-  course_instance_id = $course_instance_id
-  AND pending_uid = $pending_uid;
+  id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  id;
+
+-- BLOCK count_enrollment_audit_events
+SELECT
+  count(*)::integer
+FROM
+  audit_events
+WHERE
+  enrollment_id = ANY ($enrollment_ids::bigint[]);
+
+-- BLOCK create_publishing_extension
+INSERT INTO
+  course_instance_publishing_extensions (course_instance_id, name, end_date)
+VALUES
+  ($course_instance_id, $name, $end_date)
+RETURNING
+  *;
+
+-- BLOCK add_publishing_extension_enrollment
+INSERT INTO
+  course_instance_publishing_extension_enrollments (
+    course_instance_publishing_extension_id,
+    enrollment_id
+  )
+VALUES
+  ($publishing_extension_id, $enrollment_id);
+
+-- BLOCK delete_publishing_extension
+DELETE FROM course_instance_publishing_extensions
+WHERE
+  id = $publishing_extension_id;
 
 -- BLOCK delete_lti13_course_instance
 DELETE FROM lti13_course_instances
@@ -40,5 +75,31 @@ UPDATE course_instances
 SET
   publishing_start_date = $publishing_start_date,
   publishing_end_date = $publishing_end_date
+WHERE
+  id = $course_instance_id;
+
+-- BLOCK create_unrestricted_access_rule
+INSERT INTO
+  course_instance_access_rules (course_instance_id, number, institution)
+SELECT
+  $course_instance_id,
+  coalesce(max(number), 0) + 1,
+  'Any'
+FROM
+  course_instance_access_rules
+WHERE
+  course_instance_id = $course_instance_id
+RETURNING
+  id;
+
+-- BLOCK delete_access_rule
+DELETE FROM course_instance_access_rules
+WHERE
+  id = $access_rule_id;
+
+-- BLOCK update_modern_publishing
+UPDATE course_instances
+SET
+  modern_publishing = $modern_publishing
 WHERE
   id = $course_instance_id;

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -1,10 +1,11 @@
--- BLOCK create_enrollment_with_status
+-- BLOCK create_enrollment
 INSERT INTO
   enrollments (
     user_id,
     course_instance_id,
     status,
     pending_uid,
+    pending_uin,
     first_joined_at
   )
 VALUES
@@ -13,27 +14,87 @@ VALUES
     $course_instance_id,
     $status,
     $pending_uid,
+    $pending_uin,
     $first_joined_at
   )
 RETURNING
   *;
 
--- BLOCK delete_enrollment_by_course_instance_and_user
+-- BLOCK delete_enrollment_by_id
 DELETE FROM enrollments
 WHERE
-  course_instance_id = $course_instance_id
-  AND user_id = $user_id;
+  id = $enrollment_id;
 
--- BLOCK delete_enrollment_by_course_instance_and_pending_uid
-DELETE FROM enrollments
+-- BLOCK select_enrollments_by_ids
+SELECT
+  *
+FROM
+  enrollments
 WHERE
-  course_instance_id = $course_instance_id
-  AND pending_uid = $pending_uid;
+  id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  id;
+
+-- BLOCK count_enrollment_audit_events
+SELECT
+  count(*)::integer
+FROM
+  audit_events
+WHERE
+  enrollment_id = ANY ($enrollment_ids::bigint[]);
+
+-- BLOCK create_publishing_extension
+INSERT INTO
+  course_instance_publishing_extensions (course_instance_id, name, end_date)
+VALUES
+  ($course_instance_id, $name, $end_date)
+RETURNING
+  *;
+
+-- BLOCK add_publishing_extension_enrollment
+INSERT INTO
+  course_instance_publishing_extension_enrollments (
+    course_instance_publishing_extension_id,
+    enrollment_id
+  )
+VALUES
+  ($publishing_extension_id, $enrollment_id);
+
+-- BLOCK delete_publishing_extension
+DELETE FROM course_instance_publishing_extensions
+WHERE
+  id = $publishing_extension_id;
 
 -- BLOCK update_course_instance_publishing
 UPDATE course_instances
 SET
   publishing_start_date = $publishing_start_date,
   publishing_end_date = $publishing_end_date
+WHERE
+  id = $course_instance_id;
+
+-- BLOCK create_unrestricted_access_rule
+INSERT INTO
+  course_instance_access_rules (course_instance_id, number, institution)
+SELECT
+  $course_instance_id,
+  coalesce(max(number), 0) + 1,
+  'Any'
+FROM
+  course_instance_access_rules
+WHERE
+  course_instance_id = $course_instance_id
+RETURNING
+  id;
+
+-- BLOCK delete_access_rule
+DELETE FROM course_instance_access_rules
+WHERE
+  id = $access_rule_id;
+
+-- BLOCK update_modern_publishing
+UPDATE course_instances
+SET
+  modern_publishing = $modern_publishing
 WHERE
   id = $course_instance_id;

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -30,6 +30,11 @@ WHERE
   course_instance_id = $course_instance_id
   AND pending_uid = $pending_uid;
 
+-- BLOCK delete_lti13_course_instance
+DELETE FROM lti13_course_instances
+WHERE
+  id = $lti13_course_instance_id;
+
 -- BLOCK update_course_instance_publishing
 UPDATE course_instances
 SET

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -1,39 +1,7 @@
--- BLOCK create_enrollment
-INSERT INTO
-  enrollments (
-    user_id,
-    course_instance_id,
-    status,
-    pending_uid,
-    pending_uin,
-    first_joined_at
-  )
-VALUES
-  (
-    $user_id,
-    $course_instance_id,
-    $status,
-    $pending_uid,
-    $pending_uin,
-    $first_joined_at
-  )
-RETURNING
-  *;
-
 -- BLOCK delete_enrollment_by_id
 DELETE FROM enrollments
 WHERE
   id = $enrollment_id;
-
--- BLOCK select_enrollments_by_ids
-SELECT
-  *
-FROM
-  enrollments
-WHERE
-  id = ANY ($enrollment_ids::bigint[])
-ORDER BY
-  id;
 
 -- BLOCK count_enrollment_audit_events
 SELECT
@@ -42,28 +10,6 @@ FROM
   audit_events
 WHERE
   enrollment_id = ANY ($enrollment_ids::bigint[]);
-
--- BLOCK create_publishing_extension
-INSERT INTO
-  course_instance_publishing_extensions (course_instance_id, name, end_date)
-VALUES
-  ($course_instance_id, $name, $end_date)
-RETURNING
-  *;
-
--- BLOCK add_publishing_extension_enrollment
-INSERT INTO
-  course_instance_publishing_extension_enrollments (
-    course_instance_publishing_extension_id,
-    enrollment_id
-  )
-VALUES
-  ($publishing_extension_id, $enrollment_id);
-
--- BLOCK delete_publishing_extension
-DELETE FROM course_instance_publishing_extensions
-WHERE
-  id = $publishing_extension_id;
 
 -- BLOCK delete_lti13_course_instance
 DELETE FROM lti13_course_instances

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -18,6 +18,11 @@ import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
 import { getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
+import {
+  createEnrollment,
+  createLti13CourseInstance,
+  selectEnrollments,
+} from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
@@ -206,6 +211,54 @@ describe('Homepage enrollment actions', () => {
       course_instance_id: '1',
       pending_uid: user.uid,
     });
+  });
+
+  it('does not show or reject an LTI invitation that only matches by UID', async () => {
+    const user = await getOrCreateUser({
+      uid: 'lti-uid-only@example.com',
+      name: 'UID-only LTI user',
+      uin: 'different-uin',
+      email: 'lti-uid-only@example.com',
+      institutionId: '1',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
+    const invitation = await createEnrollment({
+      courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: 'rightful-student-sub',
+      pendingUid: user.uid,
+      pendingUin: 'rightful-student-uin',
+    });
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        assert.lengthOf(
+          page.$(`form:has(input[name="course_instance_id"][value="${courseInstance.id}"])`),
+          0,
+        );
+
+        const response = await fetchCheerio(homeUrl, {
+          method: 'POST',
+          body: new URLSearchParams({
+            __action: 'reject_invitation',
+            course_instance_id: courseInstance.id,
+            __csrf_token: await getCsrfToken(homeUrl),
+          }),
+        });
+        assert.equal(response.status, 200);
+        assertAlert(response.$, 'Failed to reject invitation');
+      });
+
+      const enrollments = await selectEnrollments([invitation.id]);
+      assert.lengthOf(enrollments, 1);
+      assert.equal(enrollments[0].status, 'invited');
+    } finally {
+      await execute(sql.delete_lti13_course_instance, {
+        lti13_course_instance_id: lti13CourseInstance.id,
+      });
+    }
   });
 
   it('shows error when rejecting after accepting invitation', async () => {

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -25,6 +25,10 @@ import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
 import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
+import {
+  createEnrollment as createIdentityEnrollment,
+  createLti13CourseInstance,
+} from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
@@ -114,6 +118,52 @@ describe('Homepage student courses', () => {
       assert.equal(await countAuditEvents([invitation.id]), beforeAuditCount);
     } finally {
       await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
+  });
+
+  it('does not show or reject an LTI invitation that only matches by UID', async () => {
+    const user = await getOrCreateUser({
+      uid: 'lti-uid-only@example.com',
+      name: 'UID-only LTI user',
+      uin: 'different-uin',
+      email: 'lti-uid-only@example.com',
+      institutionId: '1',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
+    const invitation = await createIdentityEnrollment({
+      courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: 'rightful-student-sub',
+      pendingUid: user.uid,
+      pendingUin: 'rightful-student-uin',
+    });
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        assert.lengthOf(
+          page.$(`form:has(input[name="course_instance_id"][value="${courseInstance.id}"])`),
+          0,
+        );
+
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: courseInstance.id,
+            enrollment_id: invitation.id,
+          }),
+        );
+        assertAlert(response.$, 'Failed to reject invitation');
+      });
+
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
+      assert.equal(persistedInvitation.status, 'invited');
+    } finally {
+      await execute(sql.delete_lti13_course_instance, {
+        lti13_course_instance_id: lti13CourseInstance.id,
+      });
     }
   });
 

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -239,7 +239,7 @@ describe('Homepage enrollment actions', () => {
           0,
         );
 
-        const response = await fetchCheerio(homeUrl, {
+        const response = await fetchCookie(fetch)(homeUrl, {
           method: 'POST',
           body: new URLSearchParams({
             __action: 'reject_invitation',
@@ -248,7 +248,8 @@ describe('Homepage enrollment actions', () => {
           }),
         });
         assert.equal(response.status, 200);
-        assertAlert(response.$, 'Failed to reject invitation');
+        const cheerio = await import('cheerio');
+        assertAlert(cheerio.load(await response.text()), 'Failed to reject invitation');
       });
 
       const enrollments = await selectEnrollments([invitation.id]);

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -43,7 +43,9 @@ async function createEnrollmentWithStatus({
       course_instance_id: courseInstanceId,
       status,
       pending_uid: pendingUid,
-      first_joined_at: status === 'joined' ? new Date() : null,
+      first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
+        ? new Date()
+        : null,
     },
     EnrollmentSchema,
   );
@@ -279,78 +281,71 @@ describe('Homepage enrollment actions', () => {
     });
   });
 
-  it('allows accepting invitation after rejecting it', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited4@example.com',
-      name: 'Invited User 4',
-      uin: 'invited4',
-      email: 'invited4@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First reject the invitation
-      const rejectResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
+  it.each(['left', 'removed', 'rejected'] as const)(
+    'does not treat a %s enrollment as an invitation',
+    async (status) => {
+      const user = await getOrCreateUser({
+        uid: `non-actionable-${status}@example.com`,
+        name: `Non-actionable ${status} user`,
+        uin: `non-actionable-${status}`,
+        email: `non-actionable-${status}@example.com`,
+        institutionId: '1',
       });
-      assert.equal(rejectResponse.status, 200);
-      assert.equal(rejectResponse.url, homeUrl);
-
-      // Verify enrollment is rejected
-      const courseInstance = await selectCourseInstanceById('1');
-      const rejectedEnrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
+      const isPending = status === 'rejected';
+      await createEnrollmentWithStatus({
+        userId: isPending ? null : user.id,
+        courseInstanceId: '1',
+        status,
+        pendingUid: isPending ? user.uid : null,
       });
-      assert.isNotNull(rejectedEnrollment);
-      assert.equal(rejectedEnrollment.status, 'rejected');
 
-      // Now accept the invitation (should succeed)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const acceptResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(acceptResponse.status, 200);
-      assert.equal(acceptResponse.url, homeUrl);
+      try {
+        await withUser(user, async () => {
+          const fetchWithCookies = fetchCookie(fetch);
+          const response = await fetchWithCookies(homeUrl, {
+            method: 'POST',
+            body: new URLSearchParams({
+              __action: 'accept_invitation',
+              course_instance_id: '1',
+              __csrf_token: await getCsrfToken(homeUrl),
+            }),
+          });
+          assert.equal(response.status, 200);
+          const $ = (await import('cheerio')).load(await response.text());
+          assertAlert($, 'Failed to accept invitation');
 
-      // Verify enrollment is now joined
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
+          const courseInstance = await selectCourseInstanceById('1');
+          const enrollment = isPending
+            ? await selectOptionalEnrollmentByPendingUid({
+                pendingUid: user.uid,
+                courseInstance,
+                requiredRole: ['System'],
+                authzData: dangerousFullSystemAuthz(),
+              })
+            : await selectOptionalEnrollmentByUserId({
+                userId: user.id,
+                courseInstance,
+                requiredRole: ['System'],
+                authzData: dangerousFullSystemAuthz(),
+              });
+          assert.isNotNull(enrollment);
+          assert.equal(enrollment.status, status);
+        });
+      } finally {
+        if (isPending) {
+          await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
+            course_instance_id: '1',
+            pending_uid: user.uid,
+          });
+        } else {
+          await execute(sql.delete_enrollment_by_course_instance_and_user, {
+            course_instance_id: '1',
+            user_id: user.id,
+          });
+        }
+      }
+    },
+  );
 
   it('does not show invited course that is not published', async () => {
     const user = await getOrCreateUser({

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -71,7 +71,7 @@ async function countAuditEvents(ids: string[]) {
   return await queryScalar(sql.count_enrollment_audit_events, { enrollment_ids: ids }, z.number());
 }
 
-describe('Homepage enrollment candidates', () => {
+describe('Homepage student courses', () => {
   beforeAll(async () => {
     await helperServer.before()();
     await helperCourse.syncCourse(EXAMPLE_COURSE_PATH);
@@ -117,7 +117,7 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('groups bound-left and pending UIN candidates once using their maximum extension', async () => {
+  it('shows a left enrollment and matching UIN invitation once with their latest extension', async () => {
     const user = await getOrCreateUser({
       uid: 'grouped-uin-invitation@example.com',
       name: 'Grouped UIN invitation user',
@@ -146,7 +146,7 @@ describe('Homepage enrollment candidates', () => {
       sql.create_publishing_extension,
       {
         course_instance_id: '1',
-        name: 'Homepage expired candidate extension',
+        name: 'Homepage bound enrollment extension',
         end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
       },
       CourseInstancePublishingExtensionSchema,
@@ -155,7 +155,7 @@ describe('Homepage enrollment candidates', () => {
       sql.create_publishing_extension,
       {
         course_instance_id: '1',
-        name: 'Homepage active candidate extension',
+        name: 'Homepage UIN invitation extension',
         end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
       },
       CourseInstancePublishingExtensionSchema,

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -3,17 +3,16 @@ import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 import { z } from 'zod';
 
-import { execute, loadSqlEquiv, queryRow, queryRows, queryScalar } from '@prairielearn/postgres';
+import { execute, loadSqlEquiv, queryRow, queryScalar } from '@prairielearn/postgres';
 
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import {
-  CourseInstancePublishingExtensionSchema,
-  type Enrollment,
-  EnrollmentSchema,
-  type EnumEnrollmentStatus,
-} from '../lib/db-types.js';
+import { type Enrollment } from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
+import {
+  createPublishingExtensionWithEnrollments,
+  deletePublishingExtension,
+} from '../models/course-instance-publishing-extensions.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
   selectOptionalEnrollmentByPendingUid,
@@ -26,8 +25,9 @@ import * as helperServer from './helperServer.js';
 import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
 import {
-  createEnrollment as createIdentityEnrollment,
+  createEnrollment,
   createLti13CourseInstance,
+  selectEnrollments,
 } from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
@@ -38,37 +38,6 @@ const homeUrl = siteUrl + '/';
 async function postHome(body: URLSearchParams) {
   const response = await fetchCookie(fetch)(homeUrl, { method: 'POST', body });
   return { $: cheerio.load(await response.text()), response };
-}
-
-async function createEnrollment({
-  userId,
-  pendingUid,
-  pendingUin,
-  status,
-}: {
-  userId: string | null;
-  pendingUid?: string | null;
-  pendingUin?: string | null;
-  status: EnumEnrollmentStatus;
-}): Promise<Enrollment> {
-  return await queryRow(
-    sql.create_enrollment,
-    {
-      user_id: userId,
-      course_instance_id: '1',
-      pending_uid: pendingUid,
-      pending_uin: pendingUin,
-      status,
-      first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
-        ? new Date()
-        : null,
-    },
-    EnrollmentSchema,
-  );
-}
-
-async function selectEnrollments(ids: string[]) {
-  return await queryRows(sql.select_enrollments_by_ids, { enrollment_ids: ids }, EnrollmentSchema);
 }
 
 async function countAuditEvents(ids: string[]) {
@@ -86,6 +55,7 @@ describe('Homepage student courses', () => {
   afterAll(helperServer.after);
 
   it('does not discover or mutate a same-UIN invitation from another institution', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const user = await getOrCreateUser({
       uid: 'foreign-uin-invitation@other.example.com',
       name: 'Foreign UIN invitation user',
@@ -94,9 +64,8 @@ describe('Homepage student courses', () => {
       institutionId: '900002',
     });
     const invitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUin: user.uin,
-      status: 'invited',
     });
 
     try {
@@ -131,7 +100,7 @@ describe('Homepage student courses', () => {
     });
     const courseInstance = await selectCourseInstanceById('1');
     const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
-    const invitation = await createIdentityEnrollment({
+    const invitation = await createEnrollment({
       courseInstance,
       pendingLti13CourseInstanceId: lti13CourseInstance.id,
       pendingLti13Sub: 'rightful-student-sub',
@@ -168,6 +137,7 @@ describe('Homepage student courses', () => {
   });
 
   it('shows a left enrollment and matching UIN invitation once with their latest extension', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const user = await getOrCreateUser({
       uid: 'grouped-uin-invitation@example.com',
       name: 'Grouped UIN invitation user',
@@ -176,47 +146,32 @@ describe('Homepage student courses', () => {
       institutionId: '1',
     });
     const boundEnrollment = await createEnrollment({
+      courseInstance,
+      firstJoinedAt: new Date(),
       userId: user.id,
       status: 'left',
     });
     const uinInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUin: user.uin,
-      status: 'invited',
     });
     const uidInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: user.uid,
-      status: 'invited',
     });
     const enrollmentIds = [boundEnrollment.id, uinInvitation.id, uidInvitation.id];
-    const courseInstance = await selectCourseInstanceById('1');
     const now = new Date();
-    const expiredExtension = await queryRow(
-      sql.create_publishing_extension,
-      {
-        course_instance_id: '1',
-        name: 'Homepage bound enrollment extension',
-        end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
-      },
-      CourseInstancePublishingExtensionSchema,
-    );
-    const activeExtension = await queryRow(
-      sql.create_publishing_extension,
-      {
-        course_instance_id: '1',
-        name: 'Homepage UIN invitation extension',
-        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-      },
-      CourseInstancePublishingExtensionSchema,
-    );
-    await execute(sql.add_publishing_extension_enrollment, {
-      publishing_extension_id: expiredExtension.id,
-      enrollment_id: boundEnrollment.id,
+    const expiredExtension = await createPublishingExtensionWithEnrollments({
+      courseInstance,
+      name: 'Homepage bound enrollment extension',
+      endDate: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+      enrollments: [boundEnrollment],
     });
-    await execute(sql.add_publishing_extension_enrollment, {
-      publishing_extension_id: activeExtension.id,
-      enrollment_id: uinInvitation.id,
+    const activeExtension = await createPublishingExtensionWithEnrollments({
+      courseInstance,
+      name: 'Homepage UIN invitation extension',
+      endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      enrollments: [uinInvitation],
     });
     await execute(sql.update_course_instance_publishing, {
       course_instance_id: '1',
@@ -272,11 +227,13 @@ describe('Homepage student courses', () => {
         publishing_start_date: courseInstance.publishing_start_date,
         publishing_end_date: courseInstance.publishing_end_date,
       });
-      await execute(sql.delete_publishing_extension, {
-        publishing_extension_id: activeExtension.id,
+      await deletePublishingExtension({
+        extension: activeExtension,
+        courseInstance,
       });
-      await execute(sql.delete_publishing_extension, {
-        publishing_extension_id: expiredExtension.id,
+      await deletePublishingExtension({
+        extension: expiredExtension,
+        courseInstance,
       });
       for (const enrollmentId of enrollmentIds) {
         await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
@@ -285,6 +242,7 @@ describe('Homepage student courses', () => {
   });
 
   it('does not substitute a new UID invitation for stale accept or reject targets', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const user = await getOrCreateUser({
       uid: 'stale-home-invitation@example.com',
       name: 'Stale homepage invitation user',
@@ -293,9 +251,8 @@ describe('Homepage student courses', () => {
       institutionId: '1',
     });
     const originalInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: user.uid,
-      status: 'invited',
     });
     let replacementInvitation: Enrollment | null = null;
 
@@ -314,9 +271,8 @@ describe('Homepage student courses', () => {
 
       await execute(sql.delete_enrollment_by_id, { enrollment_id: originalInvitation.id });
       replacementInvitation = await createEnrollment({
-        userId: null,
+        courseInstance,
         pendingUid: user.uid,
-        status: 'invited',
       });
 
       await withUser(user, async () => {
@@ -343,7 +299,7 @@ describe('Homepage student courses', () => {
 
       const remainingInvitation = await selectOptionalEnrollmentByPendingUid({
         pendingUid: user.uid,
-        courseInstance: await selectCourseInstanceById('1'),
+        courseInstance,
         requiredRole: ['System'],
         authzData: dangerousFullSystemAuthz(),
       });
@@ -360,6 +316,7 @@ describe('Homepage student courses', () => {
   it.each(['left', 'removed', 'rejected'] as const)(
     'does not treat a %s enrollment as a UID invitation',
     async (status) => {
+      const courseInstance = await selectCourseInstanceById('1');
       const user = await getOrCreateUser({
         uid: `non-actionable-${status}@example.com`,
         name: `Non-actionable ${status} user`,
@@ -368,6 +325,8 @@ describe('Homepage student courses', () => {
         institutionId: '1',
       });
       const enrollment = await createEnrollment({
+        courseInstance,
+        firstJoinedAt: status === 'rejected' ? null : new Date(),
         userId: status === 'rejected' ? null : user.id,
         pendingUid: status === 'rejected' ? user.uid : null,
         status,
@@ -396,6 +355,7 @@ describe('Homepage student courses', () => {
   );
 
   it('accepts and rejects UID invitations for legacy course instances', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const acceptingUser = await getOrCreateUser({
       uid: 'legacy-accept@example.com',
       name: 'Legacy accept user',
@@ -411,16 +371,13 @@ describe('Homepage student courses', () => {
       institutionId: '1',
     });
     const acceptingInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: acceptingUser.uid,
-      status: 'invited',
     });
     const rejectingInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: rejectingUser.uid,
-      status: 'invited',
     });
-    const courseInstance = await selectCourseInstanceById('1');
     const accessRule = await queryRow(
       sql.create_unrestricted_access_rule,
       { course_instance_id: '1' },

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -1,11 +1,18 @@
+import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+import { z } from 'zod';
 
-import { execute, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+import { execute, loadSqlEquiv, queryRow, queryRows, queryScalar } from '@prairielearn/postgres';
 
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import { type Enrollment, EnrollmentSchema, type EnumEnrollmentStatus } from '../lib/db-types.js';
+import {
+  CourseInstancePublishingExtensionSchema,
+  type Enrollment,
+  EnrollmentSchema,
+  type EnumEnrollmentStatus,
+} from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -16,7 +23,7 @@ import {
 import { assertAlert, fetchCheerio } from './helperClient.js';
 import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
-import { getOrCreateUser, withUser } from './utils/auth.js';
+import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
 
 const sql = loadSqlEquiv(import.meta.url);
@@ -24,25 +31,30 @@ const sql = loadSqlEquiv(import.meta.url);
 const siteUrl = 'http://localhost:' + config.serverPort;
 const homeUrl = siteUrl + '/';
 
-/** Helper function to create enrollments with specific statuses for testing */
-async function createEnrollmentWithStatus({
+async function postHome(body: URLSearchParams) {
+  const response = await fetchCookie(fetch)(homeUrl, { method: 'POST', body });
+  return { $: cheerio.load(await response.text()), response };
+}
+
+async function createEnrollment({
   userId,
-  courseInstanceId,
-  status,
   pendingUid,
+  pendingUin,
+  status,
 }: {
   userId: string | null;
-  courseInstanceId: string;
-  status: EnumEnrollmentStatus;
   pendingUid?: string | null;
+  pendingUin?: string | null;
+  status: EnumEnrollmentStatus;
 }): Promise<Enrollment> {
   return await queryRow(
-    sql.create_enrollment_with_status,
+    sql.create_enrollment,
     {
       user_id: userId,
-      course_instance_id: courseInstanceId,
-      status,
+      course_instance_id: '1',
       pending_uid: pendingUid,
+      pending_uin: pendingUin,
+      status,
       first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
         ? new Date()
         : null,
@@ -51,431 +63,320 @@ async function createEnrollmentWithStatus({
   );
 }
 
-describe('Homepage enrollment actions', () => {
+async function selectEnrollments(ids: string[]) {
+  return await queryRows(sql.select_enrollments_by_ids, { enrollment_ids: ids }, EnrollmentSchema);
+}
+
+async function countAuditEvents(ids: string[]) {
+  return await queryScalar(
+    sql.count_enrollment_audit_events,
+    { enrollment_ids: ids },
+    z.number(),
+  );
+}
+
+describe('Homepage enrollment candidates', () => {
   beforeAll(async () => {
     await helperServer.before()();
     await helperCourse.syncCourse(EXAMPLE_COURSE_PATH);
-
-    // Set uid_regexp for the default institution to allow @example.com UIDs
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$' WHERE id = 1");
+    await createInstitution('900002', 'other.example.com', 'Other institution');
   });
 
   afterAll(helperServer.after);
 
-  it('handles double accept invitation (no-op)', async () => {
+  it('does not discover or mutate a same-UIN roster invitation from another institution', async () => {
     const user = await getOrCreateUser({
-      uid: 'invited1@example.com',
-      name: 'Invited User 1',
-      uin: 'invited1',
-      email: 'invited1@example.com',
-      institutionId: '1',
+      uid: 'foreign-roster@other.example.com',
+      name: 'Foreign roster user',
+      uin: 'shared-roster-uin',
+      email: 'foreign-roster@other.example.com',
+      institutionId: '900002',
     });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
+    const invitation = await createEnrollment({
       userId: null,
-      courseInstanceId: '1',
+      pendingUin: user.uin,
       status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First accept
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now joined
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'joined');
-
-      // Second accept (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still joined
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
-
-  it('handles double reject invitation (no-op)', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited2@example.com',
-      name: 'Invited User 2',
-      uin: 'invited2',
-      email: 'invited2@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First reject
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now rejected
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'rejected');
-
-      // Second reject (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still rejected
-      const finalEnrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'rejected');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
-      course_instance_id: '1',
-      pending_uid: user.uid,
-    });
-  });
-
-  it('shows error when rejecting after accepting invitation', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited3@example.com',
-      name: 'Invited User 3',
-      uin: 'invited3',
-      email: 'invited3@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const fetchWithCookies = fetchCookie(fetch);
-
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First accept the invitation
-      const acceptResponse = await fetchWithCookies(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(acceptResponse.status, 200);
-      assert.equal(acceptResponse.url, homeUrl);
-
-      // Now try to reject (should fail with error)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const rejectResponse = await fetchWithCookies(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(rejectResponse.status, 200);
-      assert.equal(rejectResponse.url, homeUrl);
-
-      // Get the HTML to check for flash message
-      const rejectResponseText = await rejectResponse.text();
-      const cheerio = await import('cheerio');
-      const $ = cheerio.load(rejectResponseText);
-
-      // Verify error message is shown
-      assertAlert($, 'Failed to reject invitation');
-
-      // Verify enrollment is still joined
-      const courseInstance = await selectCourseInstanceById('1');
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
-
-  it.each(['left', 'removed', 'rejected'] as const)(
-    'does not treat a %s enrollment as an invitation',
-    async (status) => {
-      const user = await getOrCreateUser({
-        uid: `non-actionable-${status}@example.com`,
-        name: `Non-actionable ${status} user`,
-        uin: `non-actionable-${status}`,
-        email: `non-actionable-${status}@example.com`,
-        institutionId: '1',
-      });
-      const isPending = status === 'rejected';
-      await createEnrollmentWithStatus({
-        userId: isPending ? null : user.id,
-        courseInstanceId: '1',
-        status,
-        pendingUid: isPending ? user.uid : null,
-      });
-
-      try {
-        await withUser(user, async () => {
-          const fetchWithCookies = fetchCookie(fetch);
-          const response = await fetchWithCookies(homeUrl, {
-            method: 'POST',
-            body: new URLSearchParams({
-              __action: 'accept_invitation',
-              course_instance_id: '1',
-              __csrf_token: await getCsrfToken(homeUrl),
-            }),
-          });
-          assert.equal(response.status, 200);
-          const $ = (await import('cheerio')).load(await response.text());
-          assertAlert($, 'Failed to accept invitation');
-
-          const courseInstance = await selectCourseInstanceById('1');
-          const enrollment = isPending
-            ? await selectOptionalEnrollmentByPendingUid({
-                pendingUid: user.uid,
-                courseInstance,
-                requiredRole: ['System'],
-                authzData: dangerousFullSystemAuthz(),
-              })
-            : await selectOptionalEnrollmentByUserId({
-                userId: user.id,
-                courseInstance,
-                requiredRole: ['System'],
-                authzData: dangerousFullSystemAuthz(),
-              });
-          assert.isNotNull(enrollment);
-          assert.equal(enrollment.status, status);
-        });
-      } finally {
-        if (isPending) {
-          await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
-            course_instance_id: '1',
-            pending_uid: user.uid,
-          });
-        } else {
-          await execute(sql.delete_enrollment_by_course_instance_and_user, {
-            course_instance_id: '1',
-            user_id: user.id,
-          });
-        }
-      }
-    },
-  );
-
-  it('does not show invited course that is not published', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited5@example.com',
-      name: 'Invited User 5',
-      uin: 'invited5',
-      email: 'invited5@example.com',
-      institutionId: '1',
-    });
-
-    const futureStart = new Date();
-    futureStart.setFullYear(futureStart.getFullYear() + 1);
-    const futureEnd = new Date();
-    futureEnd.setFullYear(futureEnd.getFullYear() + 2);
-
-    const existingCourseInstance = await selectCourseInstanceById('1');
-    assert.isNotNull(existingCourseInstance);
-    assert.equal(existingCourseInstance.modern_publishing, true);
-    assert.isNotNull(existingCourseInstance.publishing_start_date);
-    assert.isNotNull(existingCourseInstance.publishing_end_date);
-
-    await execute(sql.update_course_instance_publishing, {
-      course_instance_id: '1',
-      publishing_start_date: futureStart,
-      publishing_end_date: futureEnd,
     });
 
     try {
-      // Create an invited enrollment
-      await createEnrollmentWithStatus({
-        userId: null,
-        courseInstanceId: '1',
-        status: 'invited',
-        pendingUid: user.uid,
-      });
+      const before = await selectEnrollments([invitation.id]);
+      const beforeAuditCount = await countAuditEvents([invitation.id]);
 
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-
-        const studentCoursesTable = response.$(
-          'table[aria-label="Courses with student access"], table[aria-label="Courses"]',
-        );
-
-        const studentRows = studentCoursesTable.find('tr');
-        assert.equal(studentRows.length, 0, 'No course rows should be visible');
+        assert.notInclude(response.$('body').text(), 'Available through roster');
       });
+
+      assert.deepEqual(await selectEnrollments([invitation.id]), before);
+      assert.equal(await countAuditEvents([invitation.id]), beforeAuditCount);
     } finally {
-      await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
+  });
+
+  it('groups bound-left and pending roster candidates once using their maximum extension', async () => {
+    const user = await getOrCreateUser({
+      uid: 'grouped-roster@example.com',
+      name: 'Grouped roster user',
+      uin: 'grouped-roster-uin',
+      email: 'grouped-roster@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await createEnrollment({
+      userId: user.id,
+      status: 'left',
+    });
+    const rosterInvitation = await createEnrollment({
+      userId: null,
+      pendingUin: user.uin,
+      status: 'invited',
+    });
+    const conventionalInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    const enrollmentIds = [
+      boundEnrollment.id,
+      rosterInvitation.id,
+      conventionalInvitation.id,
+    ];
+    const courseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const expiredExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
         course_instance_id: '1',
-        pending_uid: user.uid,
+        name: 'Homepage expired candidate extension',
+        end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    const activeExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
+        course_instance_id: '1',
+        name: 'Homepage active candidate extension',
+        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: expiredExtension.id,
+      enrollment_id: boundEnrollment.id,
+    });
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: activeExtension.id,
+      enrollment_id: rosterInvitation.id,
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: '1',
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      const before = await selectEnrollments(enrollmentIds);
+      const beforeAuditCount = await countAuditEvents(enrollmentIds);
+
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const rows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(rows, 1);
+        assert.include(rows.text(), 'Available through roster');
+        assert.lengthOf(
+          rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
+          1,
+        );
+        assert.lengthOf(rows.find('input[name="__action"][value="accept_invitation"]'), 0);
+        assert.lengthOf(rows.find('input[name="__action"][value="reject_invitation"]'), 0);
+        assert.lengthOf(
+          rows.find('button').filter((_, el) => response.$(el).text().trim() === 'Remove'),
+          0,
+        );
       });
 
+      assert.deepEqual(await selectEnrollments(enrollmentIds), before);
+      assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount);
+    } finally {
       await execute(sql.update_course_instance_publishing, {
         course_instance_id: '1',
-        publishing_start_date: existingCourseInstance.publishing_start_date,
-        publishing_end_date: existingCourseInstance.publishing_end_date,
+        publishing_start_date: courseInstance.publishing_start_date,
+        publishing_end_date: courseInstance.publishing_end_date,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: activeExtension.id,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: expiredExtension.id,
+      });
+      for (const enrollmentId of enrollmentIds) {
+        await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
+      }
+    }
+  });
+
+  it('does not substitute a new conventional invitation for stale accept or reject targets', async () => {
+    const user = await getOrCreateUser({
+      uid: 'stale-home-invitation@example.com',
+      name: 'Stale homepage invitation user',
+      uin: 'stale-home-invitation-uin',
+      email: 'stale-home-invitation@example.com',
+      institutionId: '1',
+    });
+    const originalInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    let replacementInvitation: Enrollment | null = null;
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        const invitationIdInput = page.$(
+          `input[name="enrollment_id"][value="${originalInvitation.id}"]`,
+        );
+        assert.lengthOf(invitationIdInput, 1);
+        assert.equal(
+          invitationIdInput.closest('form').find('input[name="__action"]').attr('value'),
+          'accept_invitation',
+        );
+      });
+
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: originalInvitation.id });
+      replacementInvitation = await createEnrollment({
+        userId: null,
+        pendingUid: user.uid,
+        status: 'invited',
+      });
+
+      await withUser(user, async () => {
+        const acceptResponse = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(acceptResponse.$, 'Failed to accept invitation');
+
+        const rejectResponse = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(rejectResponse.$, 'Failed to reject invitation');
+      });
+
+      const remainingInvitation = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: user.uid,
+        courseInstance: await selectCourseInstanceById('1'),
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(remainingInvitation);
+      assert.equal(remainingInvitation.id, replacementInvitation.id);
+      assert.equal(remainingInvitation.status, 'invited');
+    } finally {
+      await execute(sql.delete_enrollment_by_id, {
+        enrollment_id: replacementInvitation?.id ?? originalInvitation.id,
       });
     }
   });
 
-  it('handles double unenroll (no-op)', async () => {
-    const user = await getOrCreateUser({
-      uid: 'joined1@example.com',
-      name: 'Joined User 1',
-      uin: 'joined1',
-      email: 'joined1@example.com',
+  it('accepts and rejects conventional invitations for legacy course instances', async () => {
+    const acceptingUser = await getOrCreateUser({
+      uid: 'legacy-accept@example.com',
+      name: 'Legacy accept user',
+      uin: 'legacy-accept-uin',
+      email: 'legacy-accept@example.com',
       institutionId: '1',
     });
-
-    // Create a joined enrollment
-    await createEnrollmentWithStatus({
-      userId: user.id,
-      courseInstanceId: '1',
-      status: 'joined',
+    const rejectingUser = await getOrCreateUser({
+      uid: 'legacy-reject@example.com',
+      name: 'Legacy reject user',
+      uin: 'legacy-reject-uin',
+      email: 'legacy-reject@example.com',
+      institutionId: '1',
     });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First unenroll
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'unenroll',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now left
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'left');
-
-      // Second unenroll (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'unenroll',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still left
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'left');
+    const acceptingInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: acceptingUser.uid,
+      status: 'invited',
     });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
+    const rejectingInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: rejectingUser.uid,
+      status: 'invited',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const accessRule = await queryRow(
+      sql.create_unrestricted_access_rule,
+      { course_instance_id: '1' },
+      z.object({ id: z.string() }),
+    );
+    await execute(sql.update_modern_publishing, {
       course_instance_id: '1',
-      user_id: user.id,
+      modern_publishing: false,
     });
+
+    try {
+      await withUser(acceptingUser, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: acceptingInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to accept invitation');
+      });
+      const acceptedEnrollment = await selectOptionalEnrollmentByUserId({
+        userId: acceptingUser.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(acceptedEnrollment);
+      assert.equal(acceptedEnrollment.status, 'joined');
+
+      await withUser(rejectingUser, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: rejectingInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to reject invitation');
+      });
+      const rejectedEnrollment = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: rejectingUser.uid,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(rejectedEnrollment);
+      assert.equal(rejectedEnrollment.status, 'rejected');
+    } finally {
+      await execute(sql.update_modern_publishing, {
+        course_instance_id: '1',
+        modern_publishing: courseInstance.modern_publishing,
+      });
+      await execute(sql.delete_access_rule, { access_rule_id: accessRule.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: acceptingInvitation.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: rejectingInvitation.id });
+    }
   });
 });

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 
@@ -248,7 +249,6 @@ describe('Homepage enrollment actions', () => {
           }),
         });
         assert.equal(response.status, 200);
-        const cheerio = await import('cheerio');
         assertAlert(cheerio.load(await response.text()), 'Failed to reject invitation');
       });
 
@@ -311,7 +311,6 @@ describe('Homepage enrollment actions', () => {
 
       // Get the HTML to check for flash message
       const rejectResponseText = await rejectResponse.text();
-      const cheerio = await import('cheerio');
       const $ = cheerio.load(rejectResponseText);
 
       // Verify error message is shown
@@ -365,7 +364,7 @@ describe('Homepage enrollment actions', () => {
             }),
           });
           assert.equal(response.status, 200);
-          const $ = (await import('cheerio')).load(await response.text());
+          const $ = cheerio.load(await response.text());
           assertAlert($, 'Failed to accept invitation');
 
           const courseInstance = await selectCourseInstanceById('1');

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -81,12 +81,12 @@ describe('Homepage enrollment candidates', () => {
 
   afterAll(helperServer.after);
 
-  it('does not discover or mutate a same-UIN roster invitation from another institution', async () => {
+  it('does not discover or mutate a same-UIN invitation from another institution', async () => {
     const user = await getOrCreateUser({
-      uid: 'foreign-roster@other.example.com',
-      name: 'Foreign roster user',
-      uin: 'shared-roster-uin',
-      email: 'foreign-roster@other.example.com',
+      uid: 'foreign-uin-invitation@other.example.com',
+      name: 'Foreign UIN invitation user',
+      uin: 'shared-invitation-uin',
+      email: 'foreign-uin-invitation@other.example.com',
       institutionId: '900002',
     });
     const invitation = await createEnrollment({
@@ -102,7 +102,7 @@ describe('Homepage enrollment candidates', () => {
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-        assert.notInclude(response.$('body').text(), 'Available through roster');
+        assert.notInclude(response.$('body').text(), 'Available through your institution');
       });
 
       assert.deepEqual(await selectEnrollments([invitation.id]), before);
@@ -112,29 +112,29 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('groups bound-left and pending roster candidates once using their maximum extension', async () => {
+  it('groups bound-left and pending UIN candidates once using their maximum extension', async () => {
     const user = await getOrCreateUser({
-      uid: 'grouped-roster@example.com',
-      name: 'Grouped roster user',
-      uin: 'grouped-roster-uin',
-      email: 'grouped-roster@example.com',
+      uid: 'grouped-uin-invitation@example.com',
+      name: 'Grouped UIN invitation user',
+      uin: 'grouped-invitation-uin',
+      email: 'grouped-uin-invitation@example.com',
       institutionId: '1',
     });
     const boundEnrollment = await createEnrollment({
       userId: user.id,
       status: 'left',
     });
-    const rosterInvitation = await createEnrollment({
+    const uinInvitation = await createEnrollment({
       userId: null,
       pendingUin: user.uin,
       status: 'invited',
     });
-    const conventionalInvitation = await createEnrollment({
+    const uidInvitation = await createEnrollment({
       userId: null,
       pendingUid: user.uid,
       status: 'invited',
     });
-    const enrollmentIds = [boundEnrollment.id, rosterInvitation.id, conventionalInvitation.id];
+    const enrollmentIds = [boundEnrollment.id, uinInvitation.id, uidInvitation.id];
     const courseInstance = await selectCourseInstanceById('1');
     const now = new Date();
     const expiredExtension = await queryRow(
@@ -161,7 +161,7 @@ describe('Homepage enrollment candidates', () => {
     });
     await execute(sql.add_publishing_extension_enrollment, {
       publishing_extension_id: activeExtension.id,
-      enrollment_id: rosterInvitation.id,
+      enrollment_id: uinInvitation.id,
     });
     await execute(sql.update_course_instance_publishing, {
       course_instance_id: '1',
@@ -179,7 +179,7 @@ describe('Homepage enrollment candidates', () => {
           'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
         );
         assert.lengthOf(rows, 1);
-        assert.include(rows.text(), 'Available through roster');
+        assert.include(rows.text(), 'Available through your institution');
         assert.lengthOf(
           rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
           1,
@@ -212,7 +212,7 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('does not substitute a new conventional invitation for stale accept or reject targets', async () => {
+  it('does not substitute a new UID invitation for stale accept or reject targets', async () => {
     const user = await getOrCreateUser({
       uid: 'stale-home-invitation@example.com',
       name: 'Stale homepage invitation user',
@@ -285,7 +285,7 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('accepts and rejects conventional invitations for legacy course instances', async () => {
+  it('accepts and rejects UID invitations for legacy course instances', async () => {
     const acceptingUser = await getOrCreateUser({
       uid: 'legacy-accept@example.com',
       name: 'Legacy accept user',

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -138,6 +138,7 @@ describe('Homepage student courses', () => {
 
   it('shows a left enrollment and matching UIN invitation once with their latest extension', async () => {
     const courseInstance = await selectCourseInstanceById('1');
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
     const user = await getOrCreateUser({
       uid: 'grouped-uin-invitation@example.com',
       name: 'Grouped UIN invitation user',
@@ -155,11 +156,14 @@ describe('Homepage student courses', () => {
       courseInstance,
       pendingUin: user.uin,
     });
-    const uidInvitation = await createEnrollment({
+    const ltiLinkedUidCandidate = await createEnrollment({
       courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: 'grouped-lti-sub',
       pendingUid: user.uid,
+      pendingUin: 'grouped-lti-uin',
     });
-    const enrollmentIds = [boundEnrollment.id, uinInvitation.id, uidInvitation.id];
+    const enrollmentIds = [boundEnrollment.id, uinInvitation.id, ltiLinkedUidCandidate.id];
     const now = new Date();
     const expiredExtension = await createPublishingExtensionWithEnrollments({
       courseInstance,
@@ -169,9 +173,9 @@ describe('Homepage student courses', () => {
     });
     const activeExtension = await createPublishingExtensionWithEnrollments({
       courseInstance,
-      name: 'Homepage UIN invitation extension',
+      name: 'Homepage LTI-linked UID candidate extension',
       endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-      enrollments: [uinInvitation],
+      enrollments: [ltiLinkedUidCandidate],
     });
     await execute(sql.update_course_instance_publishing, {
       course_instance_id: '1',
@@ -215,11 +219,11 @@ describe('Homepage student courses', () => {
         assert.notInclude(response.$('body').text(), 'Failed to remove course');
       });
 
-      const [updatedBoundEnrollment, updatedUinInvitation, updatedUidInvitation] =
+      const [updatedBoundEnrollment, updatedUinInvitation, updatedLtiLinkedUidCandidate] =
         await selectEnrollments(enrollmentIds);
       assert.equal(updatedBoundEnrollment.status, 'left');
       assert.equal(updatedUinInvitation.status, 'rejected');
-      assert.equal(updatedUidInvitation.status, 'invited');
+      assert.equal(updatedLtiLinkedUidCandidate.status, 'invited');
       assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount + 1);
     } finally {
       await execute(sql.update_course_instance_publishing, {
@@ -238,6 +242,61 @@ describe('Homepage student courses', () => {
       for (const enrollmentId of enrollmentIds) {
         await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
       }
+      await execute(sql.delete_lti13_course_instance, {
+        lti13_course_instance_id: lti13CourseInstance.id,
+      });
+    }
+  });
+
+  it("does not use a pending invitation's extension after the user has joined", async () => {
+    const courseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const user = await getOrCreateUser({
+      uid: 'joined-with-pending-invitation@example.com',
+      name: 'Joined with pending invitation user',
+      uin: 'joined-with-pending-invitation-uin',
+      email: 'joined-with-pending-invitation@example.com',
+      institutionId: '1',
+    });
+    const joinedEnrollment = await createEnrollment({
+      courseInstance,
+      firstJoinedAt: new Date(),
+      userId: user.id,
+      status: 'joined',
+    });
+    const pendingInvitation = await createEnrollment({
+      courseInstance,
+      pendingUin: user.uin,
+    });
+    const extension = await createPublishingExtensionWithEnrollments({
+      courseInstance,
+      name: 'Homepage stale pending invitation extension',
+      endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      enrollments: [pendingInvitation],
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: courseInstance.id,
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const rows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(rows, 0);
+      });
+    } finally {
+      await execute(sql.update_course_instance_publishing, {
+        course_instance_id: courseInstance.id,
+        publishing_start_date: courseInstance.publishing_start_date,
+        publishing_end_date: courseInstance.publishing_end_date,
+      });
+      await deletePublishingExtension({ extension, courseInstance });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: joinedEnrollment.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: pendingInvitation.id });
     }
   });
 

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -102,7 +102,12 @@ describe('Homepage enrollment candidates', () => {
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-        assert.notInclude(response.$('body').text(), 'Available through your institution');
+        assert.lengthOf(
+          response.$(
+            'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+          ),
+          0,
+        );
       });
 
       assert.deepEqual(await selectEnrollments([invitation.id]), before);
@@ -179,21 +184,38 @@ describe('Homepage enrollment candidates', () => {
           'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
         );
         assert.lengthOf(rows, 1);
-        assert.include(rows.text(), 'Available through your institution');
-        assert.lengthOf(
-          rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
-          1,
-        );
+        assert.lengthOf(rows.find(`a[href="/pl/course_instance/${courseInstance.id}"]`), 1);
+        assert.notInclude(rows.text(), 'Available through your institution');
+        assert.notInclude(rows.text(), 'Open course');
         assert.lengthOf(rows.find('input[name="__action"][value="accept_invitation"]'), 0);
         assert.lengthOf(rows.find('input[name="__action"][value="reject_invitation"]'), 0);
         assert.lengthOf(
           rows.find('button').filter((_, el) => response.$(el).text().trim() === 'Remove'),
-          0,
+          1,
         );
       });
 
       assert.deepEqual(await selectEnrollments(enrollmentIds), before);
       assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount);
+
+      await withUser(user, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'remove_institution_access',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: courseInstance.id,
+            enrollment_id: uinInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to remove course');
+      });
+
+      const [updatedBoundEnrollment, updatedUinInvitation, updatedUidInvitation] =
+        await selectEnrollments(enrollmentIds);
+      assert.equal(updatedBoundEnrollment.status, 'left');
+      assert.equal(updatedUinInvitation.status, 'rejected');
+      assert.equal(updatedUidInvitation.status, 'invited');
+      assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount + 1);
     } finally {
       await execute(sql.update_course_instance_publishing, {
         course_instance_id: '1',

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -1,12 +1,18 @@
 import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+import { z } from 'zod';
 
-import { execute, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+import { execute, loadSqlEquiv, queryRow, queryRows, queryScalar } from '@prairielearn/postgres';
 
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import { type Enrollment, EnrollmentSchema, type EnumEnrollmentStatus } from '../lib/db-types.js';
+import {
+  CourseInstancePublishingExtensionSchema,
+  type Enrollment,
+  EnrollmentSchema,
+  type EnumEnrollmentStatus,
+} from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -17,38 +23,38 @@ import {
 import { assertAlert, fetchCheerio } from './helperClient.js';
 import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
-import { getOrCreateUser, withUser } from './utils/auth.js';
+import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
-import {
-  createEnrollment,
-  createLti13CourseInstance,
-  selectEnrollments,
-} from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const homeUrl = siteUrl + '/';
 
-/** Helper function to create enrollments with specific statuses for testing */
-async function createEnrollmentWithStatus({
+async function postHome(body: URLSearchParams) {
+  const response = await fetchCookie(fetch)(homeUrl, { method: 'POST', body });
+  return { $: cheerio.load(await response.text()), response };
+}
+
+async function createEnrollment({
   userId,
-  courseInstanceId,
-  status,
   pendingUid,
+  pendingUin,
+  status,
 }: {
   userId: string | null;
-  courseInstanceId: string;
-  status: EnumEnrollmentStatus;
   pendingUid?: string | null;
+  pendingUin?: string | null;
+  status: EnumEnrollmentStatus;
 }): Promise<Enrollment> {
   return await queryRow(
-    sql.create_enrollment_with_status,
+    sql.create_enrollment,
     {
       user_id: userId,
-      course_instance_id: courseInstanceId,
-      status,
+      course_instance_id: '1',
       pending_uid: pendingUid,
+      pending_uin: pendingUin,
+      status,
       first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
         ? new Date()
         : null,
@@ -57,478 +63,320 @@ async function createEnrollmentWithStatus({
   );
 }
 
-describe('Homepage enrollment actions', () => {
+async function selectEnrollments(ids: string[]) {
+  return await queryRows(sql.select_enrollments_by_ids, { enrollment_ids: ids }, EnrollmentSchema);
+}
+
+async function countAuditEvents(ids: string[]) {
+  return await queryScalar(
+    sql.count_enrollment_audit_events,
+    { enrollment_ids: ids },
+    z.number(),
+  );
+}
+
+describe('Homepage enrollment candidates', () => {
   beforeAll(async () => {
     await helperServer.before()();
     await helperCourse.syncCourse(EXAMPLE_COURSE_PATH);
-
-    // Set uid_regexp for the default institution to allow @example.com UIDs
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$' WHERE id = 1");
+    await createInstitution('900002', 'other.example.com', 'Other institution');
   });
 
   afterAll(helperServer.after);
 
-  it('handles double accept invitation (no-op)', async () => {
+  it('does not discover or mutate a same-UIN roster invitation from another institution', async () => {
     const user = await getOrCreateUser({
-      uid: 'invited1@example.com',
-      name: 'Invited User 1',
-      uin: 'invited1',
-      email: 'invited1@example.com',
-      institutionId: '1',
+      uid: 'foreign-roster@other.example.com',
+      name: 'Foreign roster user',
+      uin: 'shared-roster-uin',
+      email: 'foreign-roster@other.example.com',
+      institutionId: '900002',
     });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First accept
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now joined
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'joined');
-
-      // Second accept (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still joined
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
-
-  it('handles double reject invitation (no-op)', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited2@example.com',
-      name: 'Invited User 2',
-      uin: 'invited2',
-      email: 'invited2@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First reject
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now rejected
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'rejected');
-
-      // Second reject (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still rejected
-      const finalEnrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'rejected');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
-      course_instance_id: '1',
-      pending_uid: user.uid,
-    });
-  });
-
-  it('does not show or reject an LTI invitation that only matches by UID', async () => {
-    const user = await getOrCreateUser({
-      uid: 'lti-uid-only@example.com',
-      name: 'UID-only LTI user',
-      uin: 'different-uin',
-      email: 'lti-uid-only@example.com',
-      institutionId: '1',
-    });
-    const courseInstance = await selectCourseInstanceById('1');
-    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
     const invitation = await createEnrollment({
-      courseInstance,
-      pendingLti13CourseInstanceId: lti13CourseInstance.id,
-      pendingLti13Sub: 'rightful-student-sub',
-      pendingUid: user.uid,
-      pendingUin: 'rightful-student-uin',
-    });
-
-    try {
-      await withUser(user, async () => {
-        const page = await fetchCheerio(homeUrl);
-        assert.lengthOf(
-          page.$(`form:has(input[name="course_instance_id"][value="${courseInstance.id}"])`),
-          0,
-        );
-
-        const response = await fetchCookie(fetch)(homeUrl, {
-          method: 'POST',
-          body: new URLSearchParams({
-            __action: 'reject_invitation',
-            course_instance_id: courseInstance.id,
-            __csrf_token: await getCsrfToken(homeUrl),
-          }),
-        });
-        assert.equal(response.status, 200);
-        assertAlert(cheerio.load(await response.text()), 'Failed to reject invitation');
-      });
-
-      const enrollments = await selectEnrollments([invitation.id]);
-      assert.lengthOf(enrollments, 1);
-      assert.equal(enrollments[0].status, 'invited');
-    } finally {
-      await execute(sql.delete_lti13_course_instance, {
-        lti13_course_instance_id: lti13CourseInstance.id,
-      });
-    }
-  });
-
-  it('shows error when rejecting after accepting invitation', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited3@example.com',
-      name: 'Invited User 3',
-      uin: 'invited3',
-      email: 'invited3@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
       userId: null,
-      courseInstanceId: '1',
+      pendingUin: user.uin,
       status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const fetchWithCookies = fetchCookie(fetch);
-
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First accept the invitation
-      const acceptResponse = await fetchWithCookies(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(acceptResponse.status, 200);
-      assert.equal(acceptResponse.url, homeUrl);
-
-      // Now try to reject (should fail with error)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const rejectResponse = await fetchWithCookies(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(rejectResponse.status, 200);
-      assert.equal(rejectResponse.url, homeUrl);
-
-      // Get the HTML to check for flash message
-      const rejectResponseText = await rejectResponse.text();
-      const $ = cheerio.load(rejectResponseText);
-
-      // Verify error message is shown
-      assertAlert($, 'Failed to reject invitation');
-
-      // Verify enrollment is still joined
-      const courseInstance = await selectCourseInstanceById('1');
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
-
-  it.each(['left', 'removed', 'rejected'] as const)(
-    'does not treat a %s enrollment as an invitation',
-    async (status) => {
-      const user = await getOrCreateUser({
-        uid: `non-actionable-${status}@example.com`,
-        name: `Non-actionable ${status} user`,
-        uin: `non-actionable-${status}`,
-        email: `non-actionable-${status}@example.com`,
-        institutionId: '1',
-      });
-      const isPending = status === 'rejected';
-      await createEnrollmentWithStatus({
-        userId: isPending ? null : user.id,
-        courseInstanceId: '1',
-        status,
-        pendingUid: isPending ? user.uid : null,
-      });
-
-      try {
-        await withUser(user, async () => {
-          const fetchWithCookies = fetchCookie(fetch);
-          const response = await fetchWithCookies(homeUrl, {
-            method: 'POST',
-            body: new URLSearchParams({
-              __action: 'accept_invitation',
-              course_instance_id: '1',
-              __csrf_token: await getCsrfToken(homeUrl),
-            }),
-          });
-          assert.equal(response.status, 200);
-          const $ = cheerio.load(await response.text());
-          assertAlert($, 'Failed to accept invitation');
-
-          const courseInstance = await selectCourseInstanceById('1');
-          const enrollment = isPending
-            ? await selectOptionalEnrollmentByPendingUid({
-                pendingUid: user.uid,
-                courseInstance,
-                requiredRole: ['System'],
-                authzData: dangerousFullSystemAuthz(),
-              })
-            : await selectOptionalEnrollmentByUserId({
-                userId: user.id,
-                courseInstance,
-                requiredRole: ['System'],
-                authzData: dangerousFullSystemAuthz(),
-              });
-          assert.isNotNull(enrollment);
-          assert.equal(enrollment.status, status);
-        });
-      } finally {
-        if (isPending) {
-          await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
-            course_instance_id: '1',
-            pending_uid: user.uid,
-          });
-        } else {
-          await execute(sql.delete_enrollment_by_course_instance_and_user, {
-            course_instance_id: '1',
-            user_id: user.id,
-          });
-        }
-      }
-    },
-  );
-
-  it('does not show invited course that is not published', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited5@example.com',
-      name: 'Invited User 5',
-      uin: 'invited5',
-      email: 'invited5@example.com',
-      institutionId: '1',
-    });
-
-    const futureStart = new Date();
-    futureStart.setFullYear(futureStart.getFullYear() + 1);
-    const futureEnd = new Date();
-    futureEnd.setFullYear(futureEnd.getFullYear() + 2);
-
-    const existingCourseInstance = await selectCourseInstanceById('1');
-    assert.isNotNull(existingCourseInstance);
-    assert.equal(existingCourseInstance.modern_publishing, true);
-    assert.isNotNull(existingCourseInstance.publishing_start_date);
-    assert.isNotNull(existingCourseInstance.publishing_end_date);
-
-    await execute(sql.update_course_instance_publishing, {
-      course_instance_id: '1',
-      publishing_start_date: futureStart,
-      publishing_end_date: futureEnd,
     });
 
     try {
-      // Create an invited enrollment
-      await createEnrollmentWithStatus({
-        userId: null,
-        courseInstanceId: '1',
-        status: 'invited',
-        pendingUid: user.uid,
-      });
+      const before = await selectEnrollments([invitation.id]);
+      const beforeAuditCount = await countAuditEvents([invitation.id]);
 
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-
-        const studentCoursesTable = response.$(
-          'table[aria-label="Courses with student access"], table[aria-label="Courses"]',
-        );
-
-        const studentRows = studentCoursesTable.find('tr');
-        assert.equal(studentRows.length, 0, 'No course rows should be visible');
+        assert.notInclude(response.$('body').text(), 'Available through roster');
       });
+
+      assert.deepEqual(await selectEnrollments([invitation.id]), before);
+      assert.equal(await countAuditEvents([invitation.id]), beforeAuditCount);
     } finally {
-      await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
+  });
+
+  it('groups bound-left and pending roster candidates once using their maximum extension', async () => {
+    const user = await getOrCreateUser({
+      uid: 'grouped-roster@example.com',
+      name: 'Grouped roster user',
+      uin: 'grouped-roster-uin',
+      email: 'grouped-roster@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await createEnrollment({
+      userId: user.id,
+      status: 'left',
+    });
+    const rosterInvitation = await createEnrollment({
+      userId: null,
+      pendingUin: user.uin,
+      status: 'invited',
+    });
+    const conventionalInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    const enrollmentIds = [
+      boundEnrollment.id,
+      rosterInvitation.id,
+      conventionalInvitation.id,
+    ];
+    const courseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const expiredExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
         course_instance_id: '1',
-        pending_uid: user.uid,
+        name: 'Homepage expired candidate extension',
+        end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    const activeExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
+        course_instance_id: '1',
+        name: 'Homepage active candidate extension',
+        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: expiredExtension.id,
+      enrollment_id: boundEnrollment.id,
+    });
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: activeExtension.id,
+      enrollment_id: rosterInvitation.id,
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: '1',
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      const before = await selectEnrollments(enrollmentIds);
+      const beforeAuditCount = await countAuditEvents(enrollmentIds);
+
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const rows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(rows, 1);
+        assert.include(rows.text(), 'Available through roster');
+        assert.lengthOf(
+          rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
+          1,
+        );
+        assert.lengthOf(rows.find('input[name="__action"][value="accept_invitation"]'), 0);
+        assert.lengthOf(rows.find('input[name="__action"][value="reject_invitation"]'), 0);
+        assert.lengthOf(
+          rows.find('button').filter((_, el) => response.$(el).text().trim() === 'Remove'),
+          0,
+        );
       });
 
+      assert.deepEqual(await selectEnrollments(enrollmentIds), before);
+      assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount);
+    } finally {
       await execute(sql.update_course_instance_publishing, {
         course_instance_id: '1',
-        publishing_start_date: existingCourseInstance.publishing_start_date,
-        publishing_end_date: existingCourseInstance.publishing_end_date,
+        publishing_start_date: courseInstance.publishing_start_date,
+        publishing_end_date: courseInstance.publishing_end_date,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: activeExtension.id,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: expiredExtension.id,
+      });
+      for (const enrollmentId of enrollmentIds) {
+        await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
+      }
+    }
+  });
+
+  it('does not substitute a new conventional invitation for stale accept or reject targets', async () => {
+    const user = await getOrCreateUser({
+      uid: 'stale-home-invitation@example.com',
+      name: 'Stale homepage invitation user',
+      uin: 'stale-home-invitation-uin',
+      email: 'stale-home-invitation@example.com',
+      institutionId: '1',
+    });
+    const originalInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    let replacementInvitation: Enrollment | null = null;
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        const invitationIdInput = page.$(
+          `input[name="enrollment_id"][value="${originalInvitation.id}"]`,
+        );
+        assert.lengthOf(invitationIdInput, 1);
+        assert.equal(
+          invitationIdInput.closest('form').find('input[name="__action"]').attr('value'),
+          'accept_invitation',
+        );
+      });
+
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: originalInvitation.id });
+      replacementInvitation = await createEnrollment({
+        userId: null,
+        pendingUid: user.uid,
+        status: 'invited',
+      });
+
+      await withUser(user, async () => {
+        const acceptResponse = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(acceptResponse.$, 'Failed to accept invitation');
+
+        const rejectResponse = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(rejectResponse.$, 'Failed to reject invitation');
+      });
+
+      const remainingInvitation = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: user.uid,
+        courseInstance: await selectCourseInstanceById('1'),
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(remainingInvitation);
+      assert.equal(remainingInvitation.id, replacementInvitation.id);
+      assert.equal(remainingInvitation.status, 'invited');
+    } finally {
+      await execute(sql.delete_enrollment_by_id, {
+        enrollment_id: replacementInvitation?.id ?? originalInvitation.id,
       });
     }
   });
 
-  it('handles double unenroll (no-op)', async () => {
-    const user = await getOrCreateUser({
-      uid: 'joined1@example.com',
-      name: 'Joined User 1',
-      uin: 'joined1',
-      email: 'joined1@example.com',
+  it('accepts and rejects conventional invitations for legacy course instances', async () => {
+    const acceptingUser = await getOrCreateUser({
+      uid: 'legacy-accept@example.com',
+      name: 'Legacy accept user',
+      uin: 'legacy-accept-uin',
+      email: 'legacy-accept@example.com',
       institutionId: '1',
     });
-
-    // Create a joined enrollment
-    await createEnrollmentWithStatus({
-      userId: user.id,
-      courseInstanceId: '1',
-      status: 'joined',
+    const rejectingUser = await getOrCreateUser({
+      uid: 'legacy-reject@example.com',
+      name: 'Legacy reject user',
+      uin: 'legacy-reject-uin',
+      email: 'legacy-reject@example.com',
+      institutionId: '1',
     });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First unenroll
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'unenroll',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now left
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'left');
-
-      // Second unenroll (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'unenroll',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still left
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'left');
+    const acceptingInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: acceptingUser.uid,
+      status: 'invited',
     });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
+    const rejectingInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: rejectingUser.uid,
+      status: 'invited',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const accessRule = await queryRow(
+      sql.create_unrestricted_access_rule,
+      { course_instance_id: '1' },
+      z.object({ id: z.string() }),
+    );
+    await execute(sql.update_modern_publishing, {
       course_instance_id: '1',
-      user_id: user.id,
+      modern_publishing: false,
     });
+
+    try {
+      await withUser(acceptingUser, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: acceptingInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to accept invitation');
+      });
+      const acceptedEnrollment = await selectOptionalEnrollmentByUserId({
+        userId: acceptingUser.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(acceptedEnrollment);
+      assert.equal(acceptedEnrollment.status, 'joined');
+
+      await withUser(rejectingUser, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: rejectingInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to reject invitation');
+      });
+      const rejectedEnrollment = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: rejectingUser.uid,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(rejectedEnrollment);
+      assert.equal(rejectedEnrollment.status, 'rejected');
+    } finally {
+      await execute(sql.update_modern_publishing, {
+        course_instance_id: '1',
+        modern_publishing: courseInstance.modern_publishing,
+      });
+      await execute(sql.delete_access_rule, { access_rule_id: accessRule.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: acceptingInvitation.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: rejectingInvitation.id });
+    }
   });
 });

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -68,11 +68,7 @@ async function selectEnrollments(ids: string[]) {
 }
 
 async function countAuditEvents(ids: string[]) {
-  return await queryScalar(
-    sql.count_enrollment_audit_events,
-    { enrollment_ids: ids },
-    z.number(),
-  );
+  return await queryScalar(sql.count_enrollment_audit_events, { enrollment_ids: ids }, z.number());
 }
 
 describe('Homepage enrollment candidates', () => {
@@ -138,11 +134,7 @@ describe('Homepage enrollment candidates', () => {
       pendingUid: user.uid,
       status: 'invited',
     });
-    const enrollmentIds = [
-      boundEnrollment.id,
-      rosterInvitation.id,
-      conventionalInvitation.id,
-    ];
+    const enrollmentIds = [boundEnrollment.id, rosterInvitation.id, conventionalInvitation.id];
     const courseInstance = await selectCourseInstanceById('1');
     const now = new Date();
     const expiredExtension = await queryRow(

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -307,6 +307,44 @@ describe('Homepage student courses', () => {
     }
   });
 
+  it.each(['left', 'removed', 'rejected'] as const)(
+    'does not treat a %s enrollment as a UID invitation',
+    async (status) => {
+      const user = await getOrCreateUser({
+        uid: `non-actionable-${status}@example.com`,
+        name: `Non-actionable ${status} user`,
+        uin: `non-actionable-${status}`,
+        email: `non-actionable-${status}@example.com`,
+        institutionId: '1',
+      });
+      const enrollment = await createEnrollment({
+        userId: status === 'rejected' ? null : user.id,
+        pendingUid: status === 'rejected' ? user.uid : null,
+        status,
+      });
+
+      try {
+        await withUser(user, async () => {
+          const response = await postHome(
+            new URLSearchParams({
+              __action: 'accept_invitation',
+              __csrf_token: await getCsrfToken(homeUrl),
+              course_instance_id: '1',
+              enrollment_id: enrollment.id,
+            }),
+          );
+          assertAlert(response.$, 'Failed to accept invitation');
+        });
+
+        const [persistedEnrollment] = await selectEnrollments([enrollment.id]);
+        assert.equal(persistedEnrollment.status, status);
+        assert.equal(persistedEnrollment.user_id, status === 'rejected' ? null : user.id);
+      } finally {
+        await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollment.id });
+      }
+    },
+  );
+
   it('accepts and rejects UID invitations for legacy course instances', async () => {
     const acceptingUser = await getOrCreateUser({
       uid: 'legacy-accept@example.com',

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -37,6 +37,7 @@ import {
   Lti13CourseInstanceSchema,
 } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
+import { createPublishingExtensionWithEnrollments } from '../models/course-instance-publishing-extensions.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
 import { selectOptionalUserByUid, selectOrInsertUserByUid } from '../models/user.js';
@@ -399,10 +400,14 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         selfEnrollmentUseEnrollmentCode: false,
         restrictToInstitution: false,
       });
+      await execute(
+        "UPDATE course_instances SET publishing_end_date = $publishing_end_date WHERE id = '1'",
+        { publishing_end_date: courseInstance.publishing_end_date },
+      );
       await execute("UPDATE course_instances SET enrollment_limit = NULL WHERE id = '1'");
     });
 
-    test('admits only the exact link and sub from the fresh launch', async () => {
+    test('admits an exact link and sub using its publishing extension', async () => {
       await updateCourseInstanceSettings('1', {
         selfEnrollmentEnabled: false,
         selfEnrollmentUseEnrollmentCode: true,
@@ -417,6 +422,17 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         pendingUin: 'exact-invitation-unmatched-uin',
         status: 'invited',
       });
+      const now = new Date();
+      await createPublishingExtensionWithEnrollments({
+        courseInstance,
+        name: 'Exact LTI invitation extension',
+        endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+        enrollments: [invitation],
+      });
+      await execute(
+        "UPDATE course_instances SET publishing_end_date = $publishing_end_date WHERE id = '1'",
+        { publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000) },
+      );
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -71,7 +71,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
   }
 
-  async function insertLtiRosterInvitation({
+  async function insertLti13Invitation({
     lti13CourseInstanceId,
     pendingUin,
     sub,
@@ -397,7 +397,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.notInclude(res.url, '/instructor/');
   });
 
-  describe('LTI 1.3 roster admission', () => {
+  describe('LTI 1.3 invitation admission', () => {
     beforeAll(async () => {
       const linkedCourseInstance = await queryOptionalRow(
         `SELECT *
@@ -439,19 +439,19 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'exact-roster-admission-sub';
-      const invitation = await insertLtiRosterInvitation({
+      const sub = 'exact-invitation-admission-sub';
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'exact-roster-unmatched-uin',
+        pendingUin: 'exact-invitation-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Exact Roster Admission',
-          email: 'exact-roster-admission@example.com',
-          uin: 'exact-roster-user-uin',
+          name: 'Exact Invitation Admission',
+          email: 'exact-invitation-admission@example.com',
+          uin: 'exact-invitation-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -466,7 +466,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const response = await executor.login();
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
-      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      const user = await selectOptionalUserByUid('exact-invitation-admission@example.com');
       assert.ok(user);
       const enrollment = await queryRow(
         'SELECT * FROM enrollments WHERE id = $enrollment_id',
@@ -478,12 +478,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
+    test('rejects a wrong sub and falls back to self-enrollment', async () => {
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const invitation = await insertLtiRosterInvitation({
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
         pendingUin: 'wrong-sub-unmatched-uin',
-        sub: 'expected-roster-sub',
+        sub: 'expected-invitation-sub',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -492,7 +492,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
           name: 'Wrong Sub Student',
           email: 'wrong-sub-student@example.com',
           uin: 'wrong-sub-user-uin',
-          sub: 'actual-roster-sub',
+          sub: 'actual-invitation-sub',
         },
         fetchWithCookies,
         oidcProviderPort,
@@ -515,7 +515,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       );
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const ordinaryEnrollment = await queryRow(
+      const selfEnrollment = await queryRow(
         `SELECT *
          FROM enrollments
          WHERE course_instance_id = '1'
@@ -523,7 +523,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { user_id: user.id },
         EnrollmentSchema,
       );
-      assert.equal(ordinaryEnrollment.status, 'joined');
+      assert.equal(selfEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
@@ -537,19 +537,19 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'upgrade-exact-roster-sub';
-      const invitation = await insertLtiRosterInvitation({
+      const sub = 'upgrade-exact-invitation-sub';
+      const invitation = await insertLti13Invitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'upgrade-exact-roster-unmatched-uin',
+        pendingUin: 'upgrade-exact-invitation-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Upgrade Exact Roster',
-          email: 'upgrade-exact-roster@example.com',
-          uin: 'upgrade-exact-roster-user-uin',
+          name: 'Upgrade Exact Invitation',
+          email: 'upgrade-exact-invitation@example.com',
+          uin: 'upgrade-exact-invitation-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -573,7 +573,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       );
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
+      const user = await selectOptionalUserByUid('upgrade-exact-invitation@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,7 +6,8 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, assert, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { z } from 'zod';
 
 import {
   execute,
@@ -25,7 +26,11 @@ import {
   updateLti13Scores,
 } from '../ee/lib/lti13.js';
 import { config } from '../lib/config.js';
-import { Lti13AssessmentSchema, Lti13CourseInstanceSchema } from '../lib/db-types.js';
+import {
+  EnrollmentSchema,
+  Lti13AssessmentSchema,
+  Lti13CourseInstanceSchema,
+} from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectOptionalUserByUid, selectOrInsertUserByUid } from '../models/user.js';
@@ -49,6 +54,64 @@ const siteUrl = 'http://localhost:' + config.serverPort;
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
+
+  async function selectLinkedLtiCourseInstance() {
+    return await queryRow(
+      `SELECT *
+       FROM lti13_course_instances
+       WHERE lti13_instance_id = '1'
+       AND deployment_id = $deployment_id
+       AND context_id = $context_id`,
+      { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+      Lti13CourseInstanceSchema,
+    );
+  }
+
+  async function insertLtiRosterInvitation({
+    lti13CourseInstanceId,
+    pendingUin,
+    sub,
+  }: {
+    lti13CourseInstanceId: string;
+    pendingUin: string;
+    sub: string;
+  }) {
+    return await queryRow(
+      `INSERT INTO enrollments (
+         course_instance_id,
+         pending_lti13_course_instance_id,
+         pending_lti13_sub,
+         pending_uin,
+         status
+       )
+       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
+       RETURNING *`,
+      {
+        lti13_course_instance_id: lti13CourseInstanceId,
+        pending_uin: pendingUin,
+        sub,
+      },
+      EnrollmentSchema,
+    );
+  }
+
+  async function selectLatestSessionData(userId: string) {
+    return await queryScalar(
+      `SELECT data
+       FROM user_sessions
+       WHERE user_id = $user_id
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+      { user_id: userId },
+      z.record(z.string(), z.unknown()),
+    );
+  }
+
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await selectLatestSessionData(userId);
+    assert.notProperty(sessionData, 'lti13_claims');
+    assert.notProperty(sessionData, 'authn_lti13_instance_id');
+  }
 
   beforeAll(async () => {
     config.isEnterprise = true;
@@ -328,6 +391,206 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     assert.equal(res.status, 200);
     assert.include(res.url, '/pl/course_instance/1/');
     assert.notInclude(res.url, '/instructor/');
+  });
+
+  describe('LTI 1.3 roster admission', () => {
+    beforeAll(async () => {
+      const linkedCourseInstance = await queryOptionalRow(
+        `SELECT *
+         FROM lti13_course_instances
+         WHERE lti13_instance_id = '1'
+         AND deployment_id = $deployment_id
+         AND context_id = $context_id`,
+        { deployment_id: LTI_DEPLOYMENT_ID, context_id: LTI_CONTEXT_ID },
+        Lti13CourseInstanceSchema,
+      );
+      if (linkedCourseInstance === null) {
+        await linkLtiContext({
+          lti13InstanceId: '1',
+          deploymentId: LTI_DEPLOYMENT_ID,
+          contextId: LTI_CONTEXT_ID,
+          courseInstanceId: '1',
+        });
+      }
+    });
+
+    afterEach(async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = NULL,
+           self_enrollment_enabled = TRUE,
+           self_enrollment_use_enrollment_code = FALSE
+         WHERE id = '1'`,
+      );
+    });
+
+    test('admits only the exact link and sub from the fresh launch', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'exact-roster-admission-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Exact Roster Admission',
+          email: 'exact-roster-admission@example.com',
+          uin: 'exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
+      assert.ok(user);
+      const enrollment = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(enrollment).toMatchObject({
+        pending_lti13_course_instance_id: null,
+        pending_lti13_sub: null,
+        pending_uin: null,
+        status: 'joined',
+        user_id: user.id,
+      });
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchResponse.status, 403);
+    });
+
+    test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'wrong-sub-unmatched-uin',
+        sub: 'expected-roster-sub',
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Wrong Sub Student',
+          email: 'wrong-sub-student@example.com',
+          uin: 'wrong-sub-user-uin',
+          sub: 'actual-roster-sub',
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/course_instance/1/assessments');
+
+      const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
+      assert.ok(user);
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: 'expected-roster-sub',
+        status: 'invited',
+        user_id: null,
+      });
+      const ordinaryEnrollment = await queryRow(
+        `SELECT *
+         FROM enrollments
+         WHERE course_instance_id = '1'
+         AND user_id = $user_id`,
+        { user_id: user.id },
+        EnrollmentSchema,
+      );
+      assert.notEqual(ordinaryEnrollment.id, invitation.id);
+      assert.equal(ordinaryEnrollment.status, 'joined');
+      await assertLtiLaunchConsumed(user.id);
+    });
+
+    test('consumes the launch before an exact admission limit redirect', async () => {
+      await execute(
+        `UPDATE course_instances
+         SET
+           enrollment_limit = 0,
+           self_enrollment_enabled = FALSE,
+           self_enrollment_use_enrollment_code = TRUE
+         WHERE id = '1'`,
+      );
+      const lti13CourseInstance = await selectLinkedLtiCourseInstance();
+      const sub = 'limited-exact-roster-sub';
+      const invitation = await insertLtiRosterInvitation({
+        lti13CourseInstanceId: lti13CourseInstance.id,
+        pendingUin: 'limited-exact-roster-unmatched-uin',
+        sub,
+      });
+      const fetchWithCookies = fetchCookie(fetch);
+      const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
+      const executor = await makeLoginExecutor({
+        user: {
+          name: 'Limited Exact Roster',
+          email: 'limited-exact-roster@example.com',
+          uin: 'limited-exact-roster-user-uin',
+          sub,
+        },
+        fetchWithCookies,
+        oidcProviderPort,
+        keystore,
+        loginUrl: `${siteUrl}/pl/lti13_instance/1/auth/login`,
+        callbackUrl: `${siteUrl}/pl/lti13_instance/1/auth/callback`,
+        targetLinkUri,
+        isInstructor: false,
+      });
+
+      const response = await executor.login();
+      assert.equal(response.status, 200);
+      assert.include(response.url, '/pl/enroll/limit_exceeded');
+
+      const persistedInvitation = await queryRow(
+        'SELECT * FROM enrollments WHERE id = $enrollment_id',
+        { enrollment_id: invitation.id },
+        EnrollmentSchema,
+      );
+      expect(persistedInvitation).toMatchObject({
+        pending_lti13_course_instance_id: lti13CourseInstance.id,
+        pending_lti13_sub: sub,
+        status: 'invited',
+        user_id: null,
+      });
+      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.ok(user);
+      await assertLtiLaunchConsumed(user.id);
+      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
+      assert.equal(consumedLaunchResponse.status, 403);
+    });
   });
 
   describe('LTI 1.3 linking authorization', () => {

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -492,7 +492,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('requires a fresh launch after an exact admission plan upgrade', async () => {
+    test('finishes LTI invitation admission after the required plan is granted', async () => {
       await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
       await updateCourseInstanceSettings('1', {
         selfEnrollmentEnabled: false,
@@ -543,11 +543,14 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         [{ plan: 'basic', grantType: 'stripe' }],
         '1',
       );
-      const relaunchResponse = await fetchWithCookies(
+      const admissionResponse = await fetchWithCookies(
         `${siteUrl}/pl/course_instance/1/upgrade?lti13_relaunch=1`,
       );
-      assert.equal(relaunchResponse.status, 200);
-      assert.include(await relaunchResponse.text(), 'Return to your LMS');
+      assert.include(admissionResponse.url, '/pl/course_instance/1/assessments');
+
+      const [admittedEnrollment] = await selectEnrollments([invitation.id]);
+      assert.equal(admittedEnrollment.status, 'joined');
+      assert.equal(admittedEnrollment.user_id, user.id);
     });
   });
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, test } from 'vitest';
 import { z } from 'zod';
 
 import {
@@ -18,6 +18,10 @@ import {
 } from '@prairielearn/postgres';
 import { IdSchema } from '@prairielearn/zod';
 
+import {
+  reconcilePlanGrantsForCourseInstanceUser,
+  updateRequiredPlansForCourseInstance,
+} from '../ee/lib/billing/plans.js';
 import {
   type Lti13CombinedInstance,
   Lti13CombinedInstanceSchema,
@@ -415,6 +419,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     });
 
     afterEach(async () => {
+      await updateRequiredPlansForCourseInstance('1', [], '1');
       await execute(
         `UPDATE course_instances
          SET
@@ -459,7 +464,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
       const user = await selectOptionalUserByUid('exact-roster-admission@example.com');
@@ -469,16 +473,9 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(enrollment).toMatchObject({
-        pending_lti13_course_instance_id: null,
-        pending_lti13_sub: null,
-        pending_uin: null,
-        status: 'joined',
-        user_id: user.id,
-      });
+      assert.equal(enrollment.status, 'joined');
+      assert.equal(enrollment.user_id, user.id);
       await assertLtiLaunchConsumed(user.id);
-      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
-      assert.equal(consumedLaunchResponse.status, 403);
     });
 
     test('rejects a wrong sub and falls back to ordinary self-enrollment', async () => {
@@ -507,7 +504,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
       assert.include(response.url, '/pl/course_instance/1/assessments');
 
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
@@ -517,12 +513,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: 'expected-roster-sub',
-        status: 'invited',
-        user_id: null,
-      });
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
       const ordinaryEnrollment = await queryRow(
         `SELECT *
          FROM enrollments
@@ -531,34 +523,33 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         { user_id: user.id },
         EnrollmentSchema,
       );
-      assert.notEqual(ordinaryEnrollment.id, invitation.id);
       assert.equal(ordinaryEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
-    test('consumes the launch before an exact admission limit redirect', async () => {
+    test('requires a fresh launch after an exact admission plan upgrade', async () => {
+      await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
       await execute(
         `UPDATE course_instances
          SET
-           enrollment_limit = 0,
            self_enrollment_enabled = FALSE,
            self_enrollment_use_enrollment_code = TRUE
          WHERE id = '1'`,
       );
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const sub = 'limited-exact-roster-sub';
+      const sub = 'upgrade-exact-roster-sub';
       const invitation = await insertLtiRosterInvitation({
         lti13CourseInstanceId: lti13CourseInstance.id,
-        pendingUin: 'limited-exact-roster-unmatched-uin',
+        pendingUin: 'upgrade-exact-roster-unmatched-uin',
         sub,
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({
         user: {
-          name: 'Limited Exact Roster',
-          email: 'limited-exact-roster@example.com',
-          uin: 'limited-exact-roster-user-uin',
+          name: 'Upgrade Exact Roster',
+          email: 'upgrade-exact-roster@example.com',
+          uin: 'upgrade-exact-roster-user-uin',
           sub,
         },
         fetchWithCookies,
@@ -571,25 +562,31 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       });
 
       const response = await executor.login();
-      assert.equal(response.status, 200);
-      assert.include(response.url, '/pl/enroll/limit_exceeded');
+      assert.include(response.url, '/pl/course_instance/1/upgrade?lti13_relaunch=1');
+      const $ = cheerio.load(await response.text());
+      assert.include($('body').text(), 'Upgrade required');
 
       const persistedInvitation = await queryRow(
         'SELECT * FROM enrollments WHERE id = $enrollment_id',
         { enrollment_id: invitation.id },
         EnrollmentSchema,
       );
-      expect(persistedInvitation).toMatchObject({
-        pending_lti13_course_instance_id: lti13CourseInstance.id,
-        pending_lti13_sub: sub,
-        status: 'invited',
-        user_id: null,
-      });
-      const user = await selectOptionalUserByUid('limited-exact-roster@example.com');
+      assert.equal(persistedInvitation.status, 'invited');
+      assert.isNull(persistedInvitation.user_id);
+      const user = await selectOptionalUserByUid('upgrade-exact-roster@example.com');
       assert.ok(user);
       await assertLtiLaunchConsumed(user.id);
-      const consumedLaunchResponse = await fetchWithCookies(targetLinkUri, { redirect: 'manual' });
-      assert.equal(consumedLaunchResponse.status, 403);
+
+      await reconcilePlanGrantsForCourseInstanceUser(
+        { institution_id: '1', course_instance_id: '1', user_id: user.id },
+        [{ plan: 'basic', grantType: 'stripe' }],
+        '1',
+      );
+      const relaunchResponse = await fetchWithCookies(
+        `${siteUrl}/pl/course_instance/1/upgrade?lti13_relaunch=1`,
+      );
+      assert.equal(relaunchResponse.status, 200);
+      assert.include(await relaunchResponse.text(), 'Return to your LMS');
     });
   });
 

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import fetchCookie from 'fetch-cookie';
 import getPort from 'get-port';
 import nodeJose from 'node-jose';
-import { afterAll, afterEach, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, describe, expect, test } from 'vitest';
 import { z } from 'zod';
 
 import {

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -29,14 +29,16 @@ import {
   queryAndLinkLineitem,
   updateLti13Scores,
 } from '../ee/lib/lti13.js';
+import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
 import {
-  EnrollmentSchema,
+  type CourseInstance,
   Lti13AssessmentSchema,
   Lti13CourseInstanceSchema,
 } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
+import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
 import { selectOptionalUserByUid, selectOrInsertUserByUid } from '../models/user.js';
 
 import { fetchCheerio } from './helperClient.js';
@@ -52,10 +54,13 @@ import {
   makeLoginExecutor,
   withServer,
 } from './lti13TestHelpers.js';
+import { updateCourseInstanceSettings } from './utils/auth.js';
+import { createEnrollment, selectEnrollments } from './utils/enrollment-identity.js';
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 
 describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
+  let courseInstance: CourseInstance;
   let oidcProviderPort: number;
   let keystore: nodeJose.JWK.KeyStore;
 
@@ -71,36 +76,8 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
     );
   }
 
-  async function insertLti13Invitation({
-    lti13CourseInstanceId,
-    pendingUin,
-    sub,
-  }: {
-    lti13CourseInstanceId: string;
-    pendingUin: string;
-    sub: string;
-  }) {
-    return await queryRow(
-      `INSERT INTO enrollments (
-         course_instance_id,
-         pending_lti13_course_instance_id,
-         pending_lti13_sub,
-         pending_uin,
-         status
-       )
-       VALUES ('1', $lti13_course_instance_id, $sub, $pending_uin, 'invited')
-       RETURNING *`,
-      {
-        lti13_course_instance_id: lti13CourseInstanceId,
-        pending_uin: pendingUin,
-        sub,
-      },
-      EnrollmentSchema,
-    );
-  }
-
-  async function selectLatestSessionData(userId: string) {
-    return await queryScalar(
+  async function assertLtiLaunchConsumed(userId: string) {
+    const sessionData = await queryScalar(
       `SELECT data
        FROM user_sessions
        WHERE user_id = $user_id
@@ -109,10 +86,6 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       { user_id: userId },
       z.record(z.string(), z.unknown()),
     );
-  }
-
-  async function assertLtiLaunchConsumed(userId: string) {
-    const sessionData = await selectLatestSessionData(userId);
     assert.notProperty(sessionData, 'lti13_claims');
     assert.notProperty(sessionData, 'authn_lti13_instance_id');
   }
@@ -120,6 +93,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
   beforeAll(async () => {
     config.isEnterprise = true;
     await helperServer.before()();
+    courseInstance = await selectCourseInstanceById('1');
 
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$'");
 
@@ -420,30 +394,28 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
     afterEach(async () => {
       await updateRequiredPlansForCourseInstance('1', [], '1');
-      await execute(
-        `UPDATE course_instances
-         SET
-           enrollment_limit = NULL,
-           self_enrollment_enabled = TRUE,
-           self_enrollment_use_enrollment_code = FALSE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: true,
+        selfEnrollmentUseEnrollmentCode: false,
+        restrictToInstitution: false,
+      });
+      await execute("UPDATE course_instances SET enrollment_limit = NULL WHERE id = '1'");
     });
 
     test('admits only the exact link and sub from the fresh launch', async () => {
-      await execute(
-        `UPDATE course_instances
-         SET
-           self_enrollment_enabled = FALSE,
-           self_enrollment_use_enrollment_code = TRUE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
+      });
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
       const sub = 'exact-invitation-admission-sub';
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: sub,
         pendingUin: 'exact-invitation-unmatched-uin',
-        sub,
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -468,11 +440,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
       const user = await selectOptionalUserByUid('exact-invitation-admission@example.com');
       assert.ok(user);
-      const enrollment = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [enrollment] = await selectEnrollments([invitation.id]);
       assert.equal(enrollment.status, 'joined');
       assert.equal(enrollment.user_id, user.id);
       await assertLtiLaunchConsumed(user.id);
@@ -480,10 +448,12 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
     test('rejects a wrong sub and falls back to self-enrollment', async () => {
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: 'expected-invitation-sub',
         pendingUin: 'wrong-sub-unmatched-uin',
-        sub: 'expected-invitation-sub',
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -508,40 +478,35 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
 
       const user = await selectOptionalUserByUid('wrong-sub-student@example.com');
       assert.ok(user);
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
-      const selfEnrollment = await queryRow(
-        `SELECT *
-         FROM enrollments
-         WHERE course_instance_id = '1'
-         AND user_id = $user_id`,
-        { user_id: user.id },
-        EnrollmentSchema,
-      );
+      const selfEnrollment = await selectOptionalEnrollmentByUserId({
+        userId: user.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(selfEnrollment);
       assert.equal(selfEnrollment.status, 'joined');
       await assertLtiLaunchConsumed(user.id);
     });
 
     test('requires a fresh launch after an exact admission plan upgrade', async () => {
       await updateRequiredPlansForCourseInstance('1', ['basic'], '1');
-      await execute(
-        `UPDATE course_instances
-         SET
-           self_enrollment_enabled = FALSE,
-           self_enrollment_use_enrollment_code = TRUE
-         WHERE id = '1'`,
-      );
+      await updateCourseInstanceSettings('1', {
+        selfEnrollmentEnabled: false,
+        selfEnrollmentUseEnrollmentCode: true,
+        restrictToInstitution: false,
+      });
       const lti13CourseInstance = await selectLinkedLtiCourseInstance();
       const sub = 'upgrade-exact-invitation-sub';
-      const invitation = await insertLti13Invitation({
-        lti13CourseInstanceId: lti13CourseInstance.id,
+      const invitation = await createEnrollment({
+        courseInstance,
+        pendingLti13CourseInstanceId: lti13CourseInstance.id,
+        pendingLti13Sub: sub,
         pendingUin: 'upgrade-exact-invitation-unmatched-uin',
-        sub,
+        status: 'invited',
       });
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
@@ -566,11 +531,7 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
       const $ = cheerio.load(await response.text());
       assert.include($('body').text(), 'Upgrade required');
 
-      const persistedInvitation = await queryRow(
-        'SELECT * FROM enrollments WHERE id = $enrollment_id',
-        { enrollment_id: invitation.id },
-        EnrollmentSchema,
-      );
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
       assert.equal(persistedInvitation.status, 'invited');
       assert.isNull(persistedInvitation.user_id);
       const user = await selectOptionalUserByUid('upgrade-exact-invitation@example.com');

--- a/apps/prairielearn/src/tests/utils/enrollments.ts
+++ b/apps/prairielearn/src/tests/utils/enrollments.ts
@@ -7,7 +7,7 @@ import '../helperServer.js';
 import { type PotentialEnrollmentStatus } from '../../ee/models/enrollment.js';
 import { constructCourseOrInstanceContext } from '../../lib/authz-data.js';
 import { config } from '../../lib/config.js';
-import { ensureEnrollment } from '../../models/enrollment.js';
+import { ensureLegacyEnrollment } from '../../models/enrollment.js';
 
 import { type AuthUser, getOrCreateUser, withUser } from './auth.js';
 import { getCsrfToken } from './csrf.js';
@@ -40,7 +40,7 @@ export async function enrollUser(
 
   const { authzData, course, institution, courseInstance } = context;
 
-  return ensureEnrollment({
+  return ensureLegacyEnrollment({
     institution,
     course,
     courseInstance,

--- a/apps/prairielearn/src/tests/utils/enrollments.ts
+++ b/apps/prairielearn/src/tests/utils/enrollments.ts
@@ -7,7 +7,7 @@ import '../helperServer.js';
 import { type PotentialEnrollmentStatus } from '../../ee/models/enrollment.js';
 import { constructCourseOrInstanceContext } from '../../lib/authz-data.js';
 import { config } from '../../lib/config.js';
-import { ensureLegacyEnrollment } from '../../models/enrollment.js';
+import { ensureEnrollmentWithoutReconciliation } from '../../models/enrollment.js';
 
 import { type AuthUser, getOrCreateUser, withUser } from './auth.js';
 import { getCsrfToken } from './csrf.js';
@@ -40,7 +40,7 @@ export async function enrollUser(
 
   const { authzData, course, institution, courseInstance } = context;
 
-  return ensureLegacyEnrollment({
+  return ensureEnrollmentWithoutReconciliation({
     institution,
     course,
     courseInstance,

--- a/database/tables/enrollments.pg
+++ b/database/tables/enrollments.pg
@@ -15,9 +15,9 @@ columns
 
 indexes
     enrollments_pkey: PRIMARY KEY (id) USING btree (id)
-    enrollments_course_instance_id_pending_uin_key: UNIQUE (course_instance_id, pending_uin) USING btree (course_instance_id, pending_uin)
     enrollments_pending_lti13_ciid_sub_course_instance_id_key: UNIQUE (pending_lti13_course_instance_id, pending_lti13_sub, course_instance_id) USING btree (pending_lti13_course_instance_id, pending_lti13_sub, course_instance_id)
     enrollments_pending_uid_course_instance_id_key: UNIQUE (pending_uid, course_instance_id) USING btree (pending_uid, course_instance_id)
+    enrollments_pending_uin_course_instance_id_key: UNIQUE (pending_uin, course_instance_id) USING btree (pending_uin, course_instance_id)
     enrollments_user_id_course_instance_id_key: UNIQUE (user_id, course_instance_id) USING btree (user_id, course_instance_id)
     enrollments_course_instance_id_idx: USING btree (course_instance_id)
 


### PR DESCRIPTION
# Description

Implements the fifth and final review slice for [PrairieLearnInc/planning#51](https://github.com/PrairieLearnInc/planning/issues/51).

Uses one homepage query to find enrollments bound to the user and invitations matching the user's UID or institution-scoped UIN, then groups all matching rows once per course instance with the shared classifier. A bound `left` row plus a pending UIN invitation appears once as institution-provided access rather than as a joined enrollment, and the effective publishing extension is the latest extension assigned to any matching row.

Presents institution-provided access with the same linked course row and Remove control as a joined course, while UID invitations retain their explicit Accept and Reject controls. Following the course link uses the normal checked-admission path. Remove rejects the displayed pending UIN invitation by ID without binding the user or changing a paired `left` enrollment, and a later institutional import may make the course available again. Homepage GET remains read-only, and UID invitation POST actions require both a currently actionable invitation and the same enrollment ID rendered in the form.

Modern course authorization recognizes a live extension across the same matching rows only for joined users or pending UID and institution-scoped UIN invitations that can currently be accepted. `has_student_access_with_enrollment` remains true only for joined users, so extension-backed invitations still pass through checked admission before course access.

Stack: 5 of 5. Depends on #15518.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance disclosure: Codex produced the majority of the implementation and tests under human-directed design, manager inspection, and independent adversarial review.

# Testing

Focused homepage integration coverage verifies cross-institution UIN isolation, bound-left and pending-UIN grouping, the latest extension across matching rows, no mutation on GET, unified joined/institution-provided presentation, removal of only the displayed UIN invitation, stale UID-form denial, non-invitation `left`/`removed`/`rejected` posts, and UID invitation Accept/Reject behavior. Authorization coverage verifies that invitation extensions allow navigation without claiming that the user is already joined.
