### PR TITLE
Fix access control when copying course instances

### DIFF
--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -1104,7 +1104,8 @@ async function updateInfoAssessmentFilesForTargetCourse(
 
     // We do not want to preserve certain settings when copying an assessment to another course
     delete infoJson.shareSourcePublicly;
-    infoJson.allowAccess = [];
+    delete infoJson.allowAccess;
+    infoJson.accessControl = [];
 
     function shouldAddSharingPrefix(qid: string) {
       return qid && !qid.startsWith('@') && questionsToImport.has(qid);

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -81,6 +81,11 @@ function assertNoEnrollmentSpecificAccessControlRules(infoJson: any) {
   ]);
 }
 
+function assertAccessControlCleared(infoJson: any) {
+  assert.notProperty(infoJson, 'allowAccess');
+  assert.deepEqual(infoJson.accessControl, []);
+}
+
 function getCourseInstanceCreatePostInfo(page: cheerio.Cheerio<any>) {
   const csrfToken = page.find('#test_csrf_token').text();
 
@@ -507,7 +512,8 @@ const publicCopyTestData: EditData[] = [
       end_date: '',
       course_instance_permission: 'Student Data Editor',
     },
-    info: 'questions/shared-publicly/info.json',
+    info: 'courseInstances/Fa19/assessments/test/infoAssessment.json',
+    validateInfo: assertAccessControlCleared,
     files: new Set([
       'README.md',
       'infoCourse.json',
@@ -805,6 +811,7 @@ async function createSharedCourse() {
     },
   ];
   sharingCourseData.courseInstances['Fa19'].assessments['test'].shareSourcePublicly = true;
+  sharingCourseData.courseInstances['Fa19'].assessments['test'].accessControl = [{}];
   sharingCourseData.courseInstances['Fa19'].courseInstance.shareSourcePublicly = true;
 
   sharingCourseData.courseInstances['Fa19'].assessments['nested/dir/test'] = structuredClone(

--- a/apps/prairielearn/src/tests/courseEditor.test.ts
+++ b/apps/prairielearn/src/tests/courseEditor.test.ts
@@ -81,11 +81,6 @@ function assertNoEnrollmentSpecificAccessControlRules(infoJson: any) {
   ]);
 }
 
-function assertAccessControlCleared(infoJson: any) {
-  assert.notProperty(infoJson, 'allowAccess');
-  assert.deepEqual(infoJson.accessControl, []);
-}
-
 function getCourseInstanceCreatePostInfo(page: cheerio.Cheerio<any>) {
   const csrfToken = page.find('#test_csrf_token').text();
 
@@ -513,7 +508,10 @@ const publicCopyTestData: EditData[] = [
       course_instance_permission: 'Student Data Editor',
     },
     info: 'courseInstances/Fa19/assessments/test/infoAssessment.json',
-    validateInfo: assertAccessControlCleared,
+    validateInfo: (infoJson) => {
+      assert.notProperty(infoJson, 'allowAccess');
+      assert.deepEqual(infoJson.accessControl, []);
+    },
     files: new Set([
       'README.md',
       'infoCourse.json',


### PR DESCRIPTION
# Description

Cross-course course instance copying unconditionally wrote `allowAccess: []` to copied assessments. Assessments using modern `accessControl` therefore ended up with both fields and failed validation.

Remove the legacy key and initialize `accessControl: []` instead. This preserves the existing behavior that copied assessments start inaccessible while producing valid modern access control configuration.

Add regression coverage using an assessment with modern access control and verify that the copied assessment has an empty `accessControl` array without an `allowAccess` property.

- [x] I have disclosed the level of AI assistance used (majority of implementation completed with Codex assistance).

# Testing

The cross-course course instance copy integration test now covers copying an assessment with modern access control and verifies the copied configuration.
