### PR TITLE
Display instance log data in user-friendly format

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
@@ -805,11 +805,11 @@ function formattedLogData(data: any): HtmlSafeString {
         (typeof value === 'object' && Object.keys(value ?? {}).length > 0)
           ? html`<li>
               <details>
-                <summary><strong>${key}</strong></summary>
+                <summary><em>${key}</em></summary>
                 ${formattedLogData(value)}
               </details>
             </li>`
-          : html`<li><strong>${key}</strong>: ${formattedLogData(value)}</li>`,
+          : html`<li><em>${key}</em>: ${formattedLogData(value)}</li>`,
       )}
     </ul>`;
   }

--- a/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstance/instructorAssessmentInstance.html.tsx
@@ -2,7 +2,7 @@ import { UAParser } from 'ua-parser-js';
 import { z } from 'zod';
 
 import { formatDate, formatInterval } from '@prairielearn/formatter';
-import { escapeHtml, html } from '@prairielearn/html';
+import { type HtmlSafeString, escapeHtml, html } from '@prairielearn/html';
 import { run } from '@prairielearn/run';
 import { DateFromISOString, IdSchema } from '@prairielearn/zod';
 
@@ -743,7 +743,7 @@ export function InstructorAssessmentInstance({
                     </td>
                     ${row.event_name !== 'External grading results'
                       ? html`<td style="word-break: break-all;">
-                          ${row.data != null ? JSON.stringify(row.data) : ''}
+                          ${row.data != null ? formattedLogData(row.data) : ''}
                         </td>`
                       : html`
                           <td>
@@ -789,6 +789,31 @@ export function InstructorAssessmentInstance({
       </div>
     `,
   });
+}
+
+function formattedLogData(data: any): HtmlSafeString {
+  if (data == null) return html`<code>null</code>`;
+  if (Array.isArray(data) && data.length > 0) {
+    return html`<ol>
+      ${data.map((entry) => html`<li>${formattedLogData(entry)}</li>`)}
+    </ol>`;
+  }
+  if (typeof data === 'object' && Object.keys(data).length > 0) {
+    return html`<ul>
+      ${Object.entries(data).map(([key, value]) =>
+        (Array.isArray(value) && value.length > 0) ||
+        (typeof value === 'object' && Object.keys(value ?? {}).length > 0)
+          ? html`<li>
+              <details>
+                <summary><strong>${key}</strong></summary>
+                ${formattedLogData(value)}
+              </details>
+            </li>`
+          : html`<li><strong>${key}</strong>: ${formattedLogData(value)}</li>`,
+      )}
+    </ul>`;
+  }
+  return html`<code>${JSON.stringify(data)}</code>`;
 }
 
 function FingerprintContent({ fingerprint }: { fingerprint: ClientFingerprint }) {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

This is a WIP proposal to resolve #15501. It shows the assessment instance log data in a more user-friendly format, particularly when working with arrays or objects.

<img width="424" height="757" alt="image" src="https://github.com/user-attachments/assets/d4b28be8-71ea-4b4f-a6e0-6bcdee79e37d" />

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [ ] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
