### PR TITLE
Remove dependabot CI workflow to pin actions

### DIFF
--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -29,7 +29,6 @@ jobs:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-workflows: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -54,23 +53,6 @@ jobs:
         run: |
           git add .
           git diff --cached --quiet || git commit -m 'Dedupe dependencies'
-
-      # While dependabot uses hash versions for GitHub Actions if the action is
-      # pinned to a hash, it will not include the comment with the corresponding
-      # tag in the format used by our package. Therefore, we run the package to
-      # add the comment after deduping.
-      - name: 'Pin GitHub Actions'
-        run: |
-          pnpm --filter @prairielearn/pin-github-actions build
-          pnpm exec pin-github-actions
-        env:
-          # Use GitHub token to avoid hitting the GitHub API rate limit when
-          # checking for the latest version of each action.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'Commit changes'
-        run: |
-          git add .
-          git diff --cached --quiet || git commit -m 'Pin GitHub Actions'
 
       - name: 'Push changes'
         run: |

--- a/.knip.ts
+++ b/.knip.ts
@@ -86,6 +86,7 @@ const CLI_ONLY_DEPS = [
   's3rver',
   '@postgres-language-server/cli',
   '@typescript/native-preview',
+  '@prairielearn/pin-github-actions',
 ];
 
 // Collect packages referenced by element / question `info.json` files.


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

#15484 updated GitHub actions to pin them to hashed versions. It also updated the dependabot CI actions to re-run the formatting process when a dependabot PR is created, on the assumption that dependabot would not follow the same format. Turns out dependabot does adapt to the format (as evidenced by [the passing CI in a recent update](https://github.com/PrairieLearn/PrairieLearn/actions/runs/30677824178/job/91308556209?pr=15538)). Also, the update to the CI process had permission requests in the [token generation that were invalid](https://github.com/PrairieLearn/PrairieLearn/actions/runs/30677824201/job/91308556276?pr=15538). This PR reverts that portion of #15484, to ensure that the CI action properly runs as expected.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

This can only be tested after merging this PR to master and recreating (via `@dependabot recreate`) #15538 and #15539.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
