### PR TITLE
Include Markdown Python blocks in ruff formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,9 +23,20 @@
       "source.fixAll.eslint": "explicit"
     }
   },
-  "[html][css][scss][json][jsonc][yaml][github-actions-workflow][sql][markdown][toml][shellscript]": {
+  "[html][css][scss][json][jsonc][yaml][github-actions-workflow][sql][toml][shellscript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
+  },
+  "[markdown]": {
+    // Ruff must be specified as default to format Python blocks in Markdown files, but prettier will still run on save because of the codeActionsOnSave config below.
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      // We want to run both Prettier and Ruff on Markdown files, so we need to explicitly specify both.
+      "source.fixAll.prettier": "explicit",
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    }
   },
   "[json]": {
     "files.insertFinalNewline": true

--- a/docs/c-grader/index.md
+++ b/docs/c-grader/index.md
@@ -92,12 +92,10 @@ After compiling the student and instructor code, tests may be created using one 
 To compile a C or C++ file, you may use the method `self.compile_file()`. A typical call to this method, assuming students write a complete C file including the `main` function, will include two parameters: the name of the C or C++ file to be compiled (the file submitted by the student), and the name of an executable file to be created.
 
 ```python
-self.compile_file(
-    "square.c", "square"
-)  # Compile the file, but do not create a unit test result
-self.test_compile_file(
-    "square.c", "square"
-)  # Compile the file and give one point to student if compilation is successful
+# Compile the file, but do not create a unit test result
+self.compile_file("square.c", "square")
+# Compile the file and give one point to student if compilation is successful
+self.test_compile_file("square.c", "square")
 ```
 
 By default, these methods use `gcc` and `g++` (for `CGrader` and `CPPGrader`, respectively) to compile the code. To use a different compiler (e.g., `clang`), set the `compiler` argument:
@@ -222,9 +220,8 @@ self.compile_file(
 To create a test result based on the compilation itself, use `self.test_compile_file()` instead of `self.compile_file()`. This method accepts the same arguments as `self.compile_file()`, but will create a test named "Compilation" worth one point by default.
 
 ```python
-self.test_compile_file(
-    "square.c", "square"
-)  # Compile the file and give one point to student if compilation is successful
+# Compile the file and give one point to student if compilation is successful
+self.test_compile_file("square.c", "square")
 ```
 
 To change the name and/or points, set the `name` or `points` argument as follows:
@@ -266,14 +263,14 @@ The `exp_output` argument can also be used to check for multiple output patterns
 - `must_match_all_outputs="partial"`: the points assigned to the test are based on the number of patterns that are found in the program output (for example, if three patterns out of four are found, then the test is assigned 0.75 points).
 
 ```python
-self.test_run(
-    "./square", exp_output=["SUCCESS", "CORRECT"]
-)  # default, either SUCCESS or CORRECT are enough for full points
+# default, either SUCCESS or CORRECT are enough for full points
+self.test_run("./square", exp_output=["SUCCESS", "CORRECT"])
+# Test passes with 0, 0.5 or 1, depending on if none, one or two patterns are found
 self.test_run(
     "./square",
     exp_output=["TEST 1 PASSED", "TEST 2 PASSED"],
     must_match_all_outputs="partial",
-)  # Test passes with 0, 0.5 or 1, depending on if none, one or two patterns are found
+)
 ```
 
 Sometimes a test must ensure that some strings are _not_ found in the output of the program. This can be achieved with the `reject_output` argument, which again can be an array or a single string.

--- a/docs/c-grader/index.md
+++ b/docs/c-grader/index.md
@@ -92,8 +92,12 @@ After compiling the student and instructor code, tests may be created using one 
 To compile a C or C++ file, you may use the method `self.compile_file()`. A typical call to this method, assuming students write a complete C file including the `main` function, will include two parameters: the name of the C or C++ file to be compiled (the file submitted by the student), and the name of an executable file to be created.
 
 ```python
-self.compile_file("square.c", "square")      # Compile the file, but do not create a unit test result
-self.test_compile_file("square.c", "square") # Compile the file and give one point to student if compilation is successful
+self.compile_file(
+    "square.c", "square"
+)  # Compile the file, but do not create a unit test result
+self.test_compile_file(
+    "square.c", "square"
+)  # Compile the file and give one point to student if compilation is successful
 ```
 
 By default, these methods use `gcc` and `g++` (for `CGrader` and `CPPGrader`, respectively) to compile the code. To use a different compiler (e.g., `clang`), set the `compiler` argument:
@@ -119,15 +123,17 @@ self.compile_file("square.c", "square", add_warning_result_msg=False)
 You may also include additional compilation flags accepted by `gcc` (or `g++`) with the `flags` argument, which can be invoked with a single string for flags, or with an array of strings:
 
 ```python
-self.compile_file("square.c", "square", flags="-Wall -O3") # single string
-self.compile_file("square.c", "square", flags=["-Wall", "-O3"]) # array
+self.compile_file("square.c", "square", flags="-Wall -O3")  # single string
+self.compile_file("square.c", "square", flags=["-Wall", "-O3"])  # array
 ```
 
 For flags based on `pkg-config`, use `pkg_config_flags` with the library or libraries that should be queried.
 
 ```python
-self.compile_file("square.c", "square", pkg_config_flags="check ncurses") # single string
-self.compile_file("square.c", "square", pkg_config_flags=["check", "ncurses"]) # array
+self.compile_file(
+    "square.c", "square", pkg_config_flags="check ncurses"
+)  # single string
+self.compile_file("square.c", "square", pkg_config_flags=["check", "ncurses"])  # array
 ```
 
 ### Working with multiple files
@@ -144,10 +150,15 @@ If the student implements any function that is also implemented by the instructo
 
 ```python
 self.compile_file(
-  "square.c",
-  "square",
-  add_c_file="/grade/tests/main.c",
-  objcopy_args=["--redefine-sym", "main=student_main", "--globalize-symbol", "my_static_fn"],
+    "square.c",
+    "square",
+    add_c_file="/grade/tests/main.c",
+    objcopy_args=[
+        "--redefine-sym",
+        "main=student_main",
+        "--globalize-symbol",
+        "my_static_fn",
+    ],
 )
 ```
 
@@ -167,15 +178,20 @@ If the compilation involves include (`.h`) files, the flags `-I/grade/tests` (fo
 If the executable name is not provided, then the files will be compiled only into equivalent object files (with `.o` extension). To link these files into an executable, the `link_object_files` can be used. This function receives three mandatory arguments: the student object files, the additional object files (which can be set to `None` if there are none), and the executable name. This separation allows for more fine-tuned compilation flags between different C files or between compilation and linking, as well as additional operations to be performed with the generated object files. For example, the following sequence compiles student files and instructor files with different flags.
 
 ```python
-self.compile_file(["student_file1.c", "student_file2.c"],
-                  flags=["-I/grade/tests", "-I/grade/student", "-Wall", "-g"])
-self.compile_file([], # No student files in this invocation
-                  add_c_file=["/grade/tests/question_file1.c",
-                              "/grade/tests/question_file2.c"],
-                  flags=["-I/grade/tests", "-I/grade/student"])
-self.link_object_files(["student_file1.o", "student_file2.o"],
-                       ["/grade/tests/question_file1.o", "/grade/tests/question_file2.o"],
-                       "executable")
+self.compile_file(
+    ["student_file1.c", "student_file2.c"],
+    flags=["-I/grade/tests", "-I/grade/student", "-Wall", "-g"],
+)
+self.compile_file(
+    [],  # No student files in this invocation
+    add_c_file=["/grade/tests/question_file1.c", "/grade/tests/question_file2.c"],
+    flags=["-I/grade/tests", "-I/grade/student"],
+)
+self.link_object_files(
+    ["student_file1.o", "student_file2.o"],
+    ["/grade/tests/question_file1.o", "/grade/tests/question_file2.o"],
+    "executable",
+)
 ```
 
 The `link_object_files` also accepts arguments like `flags`, `pkg_config_flags`, `add_warning_result_msg=False` and `ungradable_if_failed=False`, with the same functionality as `self.compile_file()` or `self.test_compile_file()`.
@@ -190,7 +206,14 @@ self.compile_file(
     "executable",
     add_c_file=["/grade/tests/question_file1.c", "/grade/tests/question_file2.c"],
     flags=["-I/grade/tests", "-I/grade/student", "-lrt"],
-    reject_symbols=["system", "vfork", "clone", "clone3", "posix_spawn", "posix_spawnp"],
+    reject_symbols=[
+        "system",
+        "vfork",
+        "clone",
+        "clone3",
+        "posix_spawn",
+        "posix_spawnp",
+    ],
 )
 ```
 
@@ -199,13 +222,17 @@ self.compile_file(
 To create a test result based on the compilation itself, use `self.test_compile_file()` instead of `self.compile_file()`. This method accepts the same arguments as `self.compile_file()`, but will create a test named "Compilation" worth one point by default.
 
 ```python
-self.test_compile_file("square.c", "square") # Compile the file and give one point to student if compilation is successful
+self.test_compile_file(
+    "square.c", "square"
+)  # Compile the file and give one point to student if compilation is successful
 ```
 
 To change the name and/or points, set the `name` or `points` argument as follows:
 
 ```python
-self.test_compile_file("square.c", "square", name="Compilation of the first file", points=3)
+self.test_compile_file(
+    "square.c", "square", name="Compilation of the first file", points=3
+)
 ```
 
 Note that you can set the `points` to zero if you want to create a test result for the compilation, but do not want to assign any points to it. This may be useful in combination with the `add_warning_result_msg=False` argument, which in this case will cause the warning to be shown in the test output instead of the main results message.
@@ -239,9 +266,14 @@ The `exp_output` argument can also be used to check for multiple output patterns
 - `must_match_all_outputs="partial"`: the points assigned to the test are based on the number of patterns that are found in the program output (for example, if three patterns out of four are found, then the test is assigned 0.75 points).
 
 ```python
-self.test_run("./square", exp_output=["SUCCESS", "CORRECT"]) # default, either SUCCESS or CORRECT are enough for full points
-self.test_run("./square", exp_output=["TEST 1 PASSED", "TEST 2 PASSED"],
-              must_match_all_outputs="partial") # Test passes with 0, 0.5 or 1, depending on if none, one or two patterns are found
+self.test_run(
+    "./square", exp_output=["SUCCESS", "CORRECT"]
+)  # default, either SUCCESS or CORRECT are enough for full points
+self.test_run(
+    "./square",
+    exp_output=["TEST 1 PASSED", "TEST 2 PASSED"],
+    must_match_all_outputs="partial",
+)  # Test passes with 0, 0.5 or 1, depending on if none, one or two patterns are found
 ```
 
 Sometimes a test must ensure that some strings are _not_ found in the output of the program. This can be achieved with the `reject_output` argument, which again can be an array or a single string.
@@ -253,18 +285,23 @@ self.test_run("diff -q output.txt expected.txt", reject_output=["differ"])
 If you would like to highlight, in the test message or output, the expected and rejected outputs, you can use the `highlight_matches` argument. This option will highlight in green (for expected outputs) and red (for rejected outputs) all strings that matched in the program output.
 
 ```python
-self.test_run("./square",
-              exp_output=["TEST 1 PASSED", "TEST 2 PASSED"],
-              reject_output=["ERROR", "FAIL"],
-              must_match_all_outputs="all",
-              highlight_matches=True)
+self.test_run(
+    "./square",
+    exp_output=["TEST 1 PASSED", "TEST 2 PASSED"],
+    reject_output=["ERROR", "FAIL"],
+    must_match_all_outputs="all",
+    highlight_matches=True,
+)
 ```
 
 By default, any sequence of space-like characters (space, line break, carriage return, tab) in the program output, expected output and rejected output strings will be treated as a single space for comparison. This means difference in the number and type of spacing will be ignored. So, for example, if the output prints two numbers as `1 \n 2`, while the expected output is `1 2`, the test will pass. If, however, the intention is that spaces must match a pattern exactly, the `ignore_consec_spaces` option can be set to `False`:
 
 ```python
-self.test_run("./pattern", exp_output="  1  2  3\n  4  5  6\n  7  8  9",
-              ignore_consec_spaces=False)
+self.test_run(
+    "./pattern",
+    exp_output="  1  2  3\n  4  5  6\n  7  8  9",
+    ignore_consec_spaces=False,
+)
 ```
 
 By default, differences in cases are ignored. To make all comparisons case-sensitive, set the `ignore_case` argument to `False`:
@@ -276,7 +313,10 @@ self.test_run("./lowercase ABC", exp_output="abc", ignore_case=False)
 For both `exp_output` and `reject_output`, regular expressions may be used, by providing a compiled pattern object from [Python's `re` module](https://docs.python.org/3/library/re.html#re.compile). Note: if a pattern object is used, arguments `ignore_consec_spaces` and `ignore_case` do not take effect. If these patterns should ignore consecutive spaces, a pattern such as `\\s+` may be used instead of spaces, while case may be ignored by using the [`re.I` flag](https://docs.python.org/3/library/re.html#re.I);
 
 ```python
-self.test_run("./valid_date", exp_output=re.compile('([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))'))
+self.test_run(
+    "./valid_date",
+    exp_output=re.compile("([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))"),
+)
 ```
 
 ### Providing input to the executed program
@@ -290,11 +330,11 @@ self.test_run("./square", input="3\n", exp_output="9")
 To use command-line arguments for a command, the arguments can be included either in the `command` itself, or with the `args` argument, which can be a single argument set as a string, or multiple arguments in a list:
 
 ```python
-self.test_run("./square 3 5", exp_output=["9", "25"],
-              must_match_all_outputs="all")
+self.test_run("./square 3 5", exp_output=["9", "25"], must_match_all_outputs="all")
 self.test_run("./square", args="3", exp_output="9")
-self.test_run("./square", args=["3", "5"], exp_output=["9", "25"],
-              must_match_all_outputs="all")
+self.test_run(
+    "./square", args=["3", "5"], exp_output=["9", "25"], must_match_all_outputs="all"
+)
 ```
 
 ### Limiting the execution time and output size
@@ -316,9 +356,13 @@ self.test_run("./verboseprogram", exp_output="COMPLETED", size_limit=102400)
 The test will be created and shown to the user, worth 1 point by default. The default name for a test that includes an `input` argument is: `Test with input "<INPUT>"` (where `INPUT` is the provided input). For a test that uses `args`, the default name is `Test with arguments "<ARGS>"` (where `ARGS` is the set of arguments separated by spaces). A message will also be included with a summary of expected and rejected outputs. To change these settings, use the `max_points`, `msg` and/or `name` arguments:
 
 ```python
-self.test_run("diff -q output.txt expected.txt", reject_output=["differ"],
-              name="Comparing final output", max_points=3,
-              msg="Output file should match expected file.")
+self.test_run(
+    "diff -q output.txt expected.txt",
+    reject_output=["differ"],
+    name="Comparing final output",
+    max_points=3,
+    msg="Output file should match expected file.",
+)
 ```
 
 ## Running a Check framework test suite
@@ -366,12 +410,18 @@ A typical `test.py` file for a Check-based suite will look something like this, 
 ```python title="test.py"
 import cgrader
 
+
 class DemoGrader(cgrader.CGrader):
     def tests(self):
-        self.compile_file("student_code.c", "main", add_c_file="/grade/tests/main.c",
-                          # The following must be included if compiling a Check test
-                          pkg_config_flags="check")
+        self.compile_file(
+            "student_code.c",
+            "main",
+            add_c_file="/grade/tests/main.c",
+            # The following must be included if compiling a Check test
+            pkg_config_flags="check",
+        )
         self.run_check_suite("./main")
+
 
 g = DemoGrader()
 g.start()
@@ -425,7 +475,7 @@ self.compile_file(..., enable_asan=True)
 By default, the options above will compile the code with flags that will cause the application to abort immediately when an invalid memory access is identified, or before exiting in case of memory leaks. If you are using the autograder workflow that checks the program's standard output, this functionality should capture the majority of cases, though you may want to include some reject strings that capture memory leaks. For example:
 
 ```python
-self.test_run(..., reject_output=['AddressSanitizer'])
+self.test_run(..., reject_output=["AddressSanitizer"])
 ```
 
 If you are using the check-based workflow, note that while the setup above will cause the tests to fail in these scenarios, it may not provide a useful message to students. To provide a more detailed feedback to students in this case, you are strongly encouraged to add a call to `pl_setup_asan_hooks()` at the start of your main function, like this:
@@ -497,17 +547,18 @@ self.add_test_result("Bonus point for submitting something!")
 You may also optionally add a description, message and output to the test:
 
 ```python
-self.add_test_result("Bonus point for submitting something!",
-                     description="This is for all my students, thank you for submitting.",
-                     msg="Nothing to be expected.",
-                     output=submitted_answer)
+self.add_test_result(
+    "Bonus point for submitting something!",
+    description="This is for all my students, thank you for submitting.",
+    msg="Nothing to be expected.",
+    output=submitted_answer,
+)
 ```
 
 To set the number of points the test is worth, and/or its maximum number of points, use the `points` and `max_points` arguments. The `max_points` value must be a number (integer or float), and defaults to `1` if not provided. The `points` argument can be a number, in which case it is based on the maximum number of points; or you may set `points` to a boolean-like expression, in which case `points` will be set to 0 if the expression is `False`, and to `max_points` if the expression is `True`.
 
 ```python
-self.add_test_result("I am lazy, everyone gets 70%",
-                     points=70, max_points=100)
+self.add_test_result("I am lazy, everyone gets 70%", points=70, max_points=100)
 ```
 
 This method also allows you to add one or more images to the result. Images must follow the format described in the [external grading](../externalGrading.md) documentation.

--- a/docs/clientServerFiles.md
+++ b/docs/clientServerFiles.md
@@ -102,8 +102,11 @@ So, for example, if your question generation code requires a data file named `da
 ```python
 import os
 
+
 def generate(data):
-    data_file_path = os.path.join(data["options"]["server_files_course_path"], "data.csv")
+    data_file_path = os.path.join(
+        data["options"]["server_files_course_path"], "data.csv"
+    )
     # Now you can read from data_file_path to access the contents of data.csv
 ```
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -79,12 +79,17 @@ def generate(data):
             else:
                 data["correct_answers"]["y"] = 3 * data["params"]["x"]
 
+
         def parse(data):
             if "y" not in data["format_errors"] and data["submitted_answers"]["y"] < 0:
                 data["format_errors"]["y"] = "Negative numbers are not allowed"
 
+
         def grade(data):
-            if math.isclose(data["score"], 0.0) and data["submitted_answers"]["y"] > data["params"]["x"]:
+            if (
+                math.isclose(data["score"], 0.0)
+                and data["submitted_answers"]["y"] > data["params"]["x"]
+            ):
                 data["partial_scores"]["y"]["score"] = 0.5
                 data["score"] = 0.5
                 data["feedback"]["y"] = "Your value for $y$ is larger than $x$, but incorrect."

--- a/docs/elementExtensions.md
+++ b/docs/elementExtensions.md
@@ -53,6 +53,7 @@ The host element could then call this by running the following:
 ```python
 import prairielearn as pl
 
+
 def render(element_html, data):
     extension = pl.load_extension(data, "extension_name")
     contents = extension.my_cool_function()
@@ -71,6 +72,7 @@ import prairielearn as pl
 
 STATIC_VARIABLE = "hello"
 
+
 def render(element_html, data):
     extension = pl.load_extension(data, "extension_name")
     contents = extension.my_cool_function()
@@ -83,6 +85,7 @@ The extension could then access `STATIC_VARIABLE` by importing the host script:
 import prairielearn as pl
 
 host_element = pl.load_host_script("pl-host-element.py")
+
 
 def my_cool_function():
     return host_element.STATIC_VARIABLE

--- a/docs/elements/pl-dataframe.md
+++ b/docs/elements/pl-dataframe.md
@@ -12,6 +12,7 @@ Displays a formatted display of Pandas DataFrames, with various options for disp
 import prairielearn as pl
 import pandas as pd
 
+
 def generate(data):
     df = pd.read_csv("breast-cancer-train.dat", header=None)
     data["params"]["df"] = pl.to_json(df.head(15))

--- a/docs/elements/pl-dropdown.md
+++ b/docs/elements/pl-dropdown.md
@@ -39,7 +39,7 @@ def generate(data):
     data["params"][QUESTION1] = [
         {"tag": "true", "ans": "whole"},
         {"tag": "false", "ans": "part"},
-        {"tag": "false", "ans": "inverse"}
+        {"tag": "false", "ans": "inverse"},
     ]
 ```
 

--- a/docs/elements/pl-external-grader-variables.md
+++ b/docs/elements/pl-external-grader-variables.md
@@ -13,7 +13,7 @@ If stored in `data["params"]`, the variables list has the following format:
 ```python
 data["params"]["names_for_user"] = [
     {"name": "var1", "description": "Human-readable description.", "type": "type"},
-    {"name": "var2", "description": "...", "type": "..."}
+    {"name": "var2", "description": "...", "type": "..."},
 ]
 data["params"]["names_from_user"] = [
     {"name": "result1", "description": "...", "type": "..."}
@@ -39,9 +39,13 @@ data["params"]["names_from_user"] = [
 ```python title="server.py"
 def generate(data):
     data["params"]["names_for_user"] = [
-        {"name": "n", "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.", "type": "integer"},
+        {
+            "name": "n",
+            "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.",
+            "type": "integer",
+        },
         {"name": "A", "description": r"Matrix $\mathbf{A}$.", "type": "numpy array"},
-        {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"}
+        {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"},
     ]
 ```
 

--- a/docs/elements/pl-figure.md
+++ b/docs/elements/pl-figure.md
@@ -44,7 +44,7 @@ If `type="dynamic"`, then the contents of the image file must be returned by a f
 ```python title="server.py"
 def file(data):
     if data["filename"] == "figure.png":
-        plt.plot([1,2,3], [3,4,-2])
+        plt.plot([1, 2, 3], [3, 4, -2])
         buf = io.BytesIO()
         plt.savefig(buf, format="png")
         return buf

--- a/docs/elements/pl-graph.md
+++ b/docs/elements/pl-graph.md
@@ -22,6 +22,7 @@ Using the [PyGraphviz](https://pygraphviz.github.io/) library, create Graphviz D
 import prairielearn as pl
 import numpy as np
 
+
 def generate(data):
     mat = np.random.random((3, 3))
     mat = mat / np.linalg.norm(mat, 1, axis=0)
@@ -41,6 +42,7 @@ import string
 
 import prairielearn as pl
 import networkx as nx
+
 
 def generate(data):
     random_graph = nx.gnm_random_graph(5, 6)
@@ -105,6 +107,7 @@ For a **randomly generated** graph, a fixed string like "a random graph" tells a
 ```python title="server.py"
 import prairielearn as pl
 import networkx as nx
+
 
 def generate(data):
     graph = nx.gnm_random_graph(5, 6)
@@ -175,9 +178,7 @@ def custom_type(element, data):
 In order to register these custom types, your extension should define the global `backends` dictionary. This will map a value of `params-type` to your function above:
 
 ```python
-backends = {
-    'my-custom-type': custom_type
-}
+backends = {"my-custom-type": custom_type}
 ```
 
 This will automatically get picked up when the extension gets imported. If your extension needs extra attributes to be defined, you may optionally define the global `optional_attribs` array that contains a list of attributes that the element may use.

--- a/docs/elements/pl-integer-input.md
+++ b/docs/elements/pl-integer-input.md
@@ -13,6 +13,7 @@ Fill in the blank field that requires an **integer** input.
 ```python title="server.py"
 import random
 
+
 def generate(data):
 
     # Generate a random whole number

--- a/docs/elements/pl-matrix-component-input.md
+++ b/docs/elements/pl-matrix-component-input.md
@@ -16,6 +16,7 @@ the same shape of the variable stored in `answers-name`
 import prairielearn as pl
 import numpy as np
 
+
 def generate(data):
 
     # Generate a random 3x3 matrix

--- a/docs/elements/pl-matrix-input.md
+++ b/docs/elements/pl-matrix-input.md
@@ -16,6 +16,7 @@ format (either MATLAB or Python's numpy).
 import prairielearn as pl
 import numpy as np
 
+
 def generate(data):
     # Randomly generate a 2x2 matrix
     matrixB = np.random.random((2, 2))

--- a/docs/elements/pl-matrix-latex.md
+++ b/docs/elements/pl-matrix-latex.md
@@ -14,6 +14,7 @@ $$C = <pl-matrix-latex params-name="matrixC"></pl-matrix-latex>$$
 import prairielearn as pl
 import numpy as np
 
+
 def generate(data):
 
     # Construct a matrix

--- a/docs/elements/pl-number-input.md
+++ b/docs/elements/pl-number-input.md
@@ -14,6 +14,7 @@ tolerances.
 ```python title="server.py"
 import random
 
+
 def generate(data):
 
     # Generate a random value
@@ -34,6 +35,7 @@ def generate(data):
 
 ```python title="server.py"
 import random
+
 
 def generate(data):
 

--- a/docs/elements/pl-python-variable.md
+++ b/docs/elements/pl-python-variable.md
@@ -13,8 +13,9 @@ Displays the value of a Python variable. It uses options similar to the [pprint]
 ```python title="server.py"
 import prairielearn as pl
 
+
 def generate(data):
-    data_dictionary = { "a": 1, "b": 2, "c": 3 }
+    data_dictionary = {"a": 1, "b": 2, "c": 3}
     data["params"]["variable"] = pl.to_json(data_dictionary)
 ```
 

--- a/docs/elements/pl-symbolic-input.md
+++ b/docs/elements/pl-symbolic-input.md
@@ -14,6 +14,7 @@ Fill in the blank field that allows for mathematical symbol input.
 import prairielearn as pl
 import sympy
 
+
 def generate(data):
 
     # Declare math symbols

--- a/docs/elements/pl-variable-output.md
+++ b/docs/elements/pl-variable-output.md
@@ -18,6 +18,7 @@ Displays a list of variables that are formatted for import into the supported pr
 import prairielearn as pl
 import numpy as np
 
+
 def generate(data):
 
     # Create fixed matrix
@@ -88,7 +89,7 @@ A = [1.23; 4.56]; (* matrix *)
 ```python
 import numpy as np
 
-A = np.array([[1.23], [4.56]]) # matrix
+A = np.array([[1.23], [4.56]])  # matrix
 ```
 
 **R format:**
@@ -103,7 +104,7 @@ A = matrix(c(1.23, 4.56, 8.90, 1.23), nrow = 2, ncol = 2, byrow = TRUE) # matrix
 ```python
 from sympy import *
 
-A = Matrix([[1.23], [4.56]]) # matrix
+A = Matrix([[1.23], [4.56]])  # matrix
 ```
 
 If a variable `v` is a complex object, you should use `import prairielearn as pl` and `data["params"][params-name] = pl.to_json(v)`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -361,6 +361,7 @@ When loading some assessment download files, such as `*_all_submissions.csv`, in
 
 ```python
 import pandas as pd
+
 df = pd.read_csv("PREFIX_all_submissions.csv")
 
 # Strip the JSON Params data and save to a new CSV

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -118,6 +118,7 @@ A question's [`server.py`](../question/server.md) generates random parameters pe
 ```python title="server.py"
 import random
 
+
 def generate(data):
     a = random.randint(2, 5)
     b = random.randint(11, 19)

--- a/docs/pl-drawing/index.md
+++ b/docs/pl-drawing/index.md
@@ -1911,7 +1911,7 @@ class Point(BaseElement):
             "originY": "center",
             "fill": color,
             "selectable": drawing_defaults["selectable"],
-            "evented": drawing_defaults["selectable"]
+            "evented": drawing_defaults["selectable"],
         }
 
     def is_gradable():

--- a/docs/python-grader/index.md
+++ b/docs/python-grader/index.md
@@ -64,12 +64,20 @@ There are two ways to do specify these variables.
     ```python title="server.py"
     def generate(data):
         data["params"]["names_for_user"] = [
-            {"name": "n", "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.", "type": "integer"},
+            {
+                "name": "n",
+                "description": r"Dimensionality of $\mathbf{A}$ and $\mathbf{b}$.",
+                "type": "integer",
+            },
             {"name": "A", "description": r"Matrix $\mathbf{A}$.", "type": "numpy array"},
-            {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"}
+            {"name": "b", "description": r"Vector $\mathbf{b}$.", "type": "numpy array"},
         ]
         data["params"]["names_from_user"] = [
-            {"name": "x", "description": r"Solution to $\mathbf{Ax}=\mathbf{b}$.", "type": "numpy array"}
+            {
+                "name": "x",
+                "description": r"Solution to $\mathbf{Ax}=\mathbf{b}$.",
+                "type": "numpy array",
+            }
         ]
     ```
 
@@ -112,13 +120,15 @@ The test cases for each coding problem are defined as methods of a `Test` class 
 ```python title="tests/test.py"
 from pl_unit_test import PLTestCase, PLTestCaseWithPlot
 
+
 # No plot grading
 class Test(PLTestCase):
-  pass
+    pass
+
 
 # Plot grading enabled
 class Test(PLTestCaseWithPlot):
-  pass
+    pass
 ```
 
 These classes themselves extend `unittest.TestCase`, so any functionality from there is also available.
@@ -131,11 +141,12 @@ Adding a name and point value to the test case is done by means of python decora
 from pl_unit_test import PLTestCase
 from pl_helpers import name, points
 
+
 class Test(PLTestCase):
-  @points(10)
-  @name("Check basic math")
-  def test_0(self):
-    assert 1 == 1
+    @points(10)
+    @name("Check basic math")
+    def test_0(self):
+        assert 1 == 1
 ```
 
 Inside the test case implementation, the student answer variables and reference answer variables can be accessed as children of the tuples `self.st` and `self.ref`, respectively. There are various helper functions to check correctness of different types of variables, these are defined in `code_feedback.py`. These are taken from the RELATE grader, so this may be familiar to those with prior experience with RELATE.
@@ -149,14 +160,17 @@ from pl_unit_test import PLTestCase
 from pl_helpers import name, points
 from code_feedback import Feedback
 
+
 class Test(PLTestCase):
-  @points(10)
-  @name("name of the test case")
-  def test_0(self):
-    if Feedback.check_scalar("name of the variable", self.ref.variable_name, self.st.variable_names):
-        Feedback.set_score(1)
-    else:
-        Feedback.set_score(0)
+    @points(10)
+    @name("name of the test case")
+    def test_0(self):
+        if Feedback.check_scalar(
+            "name of the variable", self.ref.variable_name, self.st.variable_names
+        ):
+            Feedback.set_score(1)
+        else:
+            Feedback.set_score(0)
 ```
 
 Note that `Feedback.set_score()` is used to set the correctness of the test case between `0` and `1`, this is then multiplied by the number of points awarded by the test case. For example, if a test case is worth 10 points and `Feedback.set_score(0.5)` is run, the student will be awarded 5 points.

--- a/docs/question/overview.md
+++ b/docs/question/overview.md
@@ -224,6 +224,7 @@ The `server.py` file for each question creates randomized question variants by g
 ```python title="server.py"
 import random
 
+
 def generate(data):
     # Generate random parameters
     data["params"]["m"] = random.randint(1, 10)

--- a/docs/question/preferences.md
+++ b/docs/question/preferences.md
@@ -174,6 +174,7 @@ A question can support different unit systems by defining a preference:
 import random
 import math
 
+
 def generate(data):
     if data["preferences"]["unit_system"] == "SI":
         g = 9.8
@@ -188,7 +189,9 @@ def generate(data):
     data["params"]["v0"] = v0
     data["params"]["angle"] = angle
     data["params"]["unit"] = unit
-    data["correct_answers"]["range"] = round(v0**2 * math.sin(2 * math.radians(angle)) / g, 2)
+    data["correct_answers"]["range"] = round(
+        v0**2 * math.sin(2 * math.radians(angle)) / g, 2
+    )
 ```
 
 Then one assessment can use `"preferences": { "unit_system": "SI" }` and another can use `"preferences": { "unit_system": "imperial" }`, reusing the same question.

--- a/docs/question/server.md
+++ b/docs/question/server.md
@@ -28,6 +28,7 @@ First, the `generate` function is called to generate the question variant. It sh
 ```python title="server.py"
 import random
 
+
 def generate(data):
     # Generate random parameters for the question and store them in the data["params"] dict:
     data["params"]["x"] = random.randint(5, 10)
@@ -57,6 +58,7 @@ Question variants are randomized based on the variant seed (`data["variant_seed"
 
     ```python title="server.py"
     from faker import Faker
+
     fake = Faker()
 
     fake.name()
@@ -74,8 +76,8 @@ For generated floating point answers, it's important to use consistent rounding 
         # Rounds numbers at the beginning
         a = np.round(33.33337, 2)
         b = np.round(33.33333, 2)
-        data["params"]["a_for_student"] = f'{a:.2f}'
-        data["params"]["b_for_student"] = f'{b:.2f}'
+        data["params"]["a_for_student"] = f"{a:.2f}"
+        data["params"]["b_for_student"] = f"{b:.2f}"
         data["correct_answers"]["c"] = a - b
     ```
 
@@ -85,8 +87,8 @@ For generated floating point answers, it's important to use consistent rounding 
     def generate(data):
         a = 33.33337
         b = 33.33333
-        data["params"]["a_for_student"] = f'{a:.2f}'
-        data["params"]["b_for_student"] = f'{a:.2f}'
+        data["params"]["a_for_student"] = f"{a:.2f}"
+        data["params"]["b_for_student"] = f"{a:.2f}"
         # Correct answer is computed with full precision,
         # but the parameters displayed to students are rounded.
         data["correct_answers"]["c"] = a - b
@@ -145,8 +147,9 @@ The `parse()` function can also be used to create custom files to be sent to an 
 ```python title="server.py"
 import prairielearn as pl
 
+
 def parse(data):
-    code = f"x = {data["submitted_answers"]["expression"]}"
+    code = f"x = {data['submitted_answers']['expression']}"
     pl.add_submitted_file(data, "user_code.py", raw_contents=code)
 ```
 
@@ -176,6 +179,7 @@ You can set `data["format_errors"][NAME]` to mark the submission as invalid. Thi
 ```python title="server.py"
 import math
 import prairielearn as pl
+
 
 def grade(data):
     # Give half points for incorrect answers larger than "x", only if not already correct.
@@ -233,6 +237,7 @@ This can be used like so:
 ```python title="server.py"
 import prairielearn as pl
 
+
 def grade(data):
     # update partial_scores as necessary
     data["partial_scores"]["y"]["score"] = 0.5
@@ -249,6 +254,7 @@ If you prefer not to show score badges for individual parts, you can unset the d
 
     ```python title="server.py"
     import prairielearn as pl
+
 
     def grade(data):
         # update partial_scores as necessary
@@ -287,6 +293,7 @@ import random
 import math
 import prairielearn as pl
 
+
 def generate(data):
     # Generate random parameters for the question and store them in the data["params"] dict:
     data["params"]["x"] = random.randint(5, 10)
@@ -294,10 +301,12 @@ def generate(data):
     # Also compute the correct answer (if there is one) and store in the data["correct_answers"] dict:
     data["correct_answers"]["y"] = 2 * data["params"]["x"]
 
+
 def parse(data):
     # Reject negative numbers for "y" if we don't already have a format error
     if "y" not in data["format_errors"] and int(data["submitted_answers"]["y"]) < 0:
         data["format_errors"]["y"] = "Negative numbers are not allowed"
+
 
 def grade(data):
     # Give half points for incorrect answers larger than "x", only if not already correct.
@@ -395,8 +404,10 @@ The `prairielearn` Python library provides the utility functions [`to_json`][pra
 import numpy as np
 import prairielearn as pl
 
+
 def generate(data):
     data["params"]["numpy_array"] = pl.to_json(np.array([1.2, 3.5, 5.1]))
+
 
 def grade(data):
     pl.from_json(data["params"]["numpy_array"])
@@ -418,7 +429,7 @@ Courses can opt in so that `server.py` receives user and group identity. A cours
 
 ```python
 def generate(data):
-    user = data["options"]["user"]    # Variant owner; None on group assessments
+    user = data["options"]["user"]  # Variant owner; None on group assessments
     # { "uid": "student@example.com", "uin": "123456", "name": "John Doe" }
     group = data["options"]["group"]  # None on individual assessments
     # { "name": "Group 1", "members": [ { "uid": "student@example.com", "uin": "123456", "name": "John Doe" } ] }
@@ -462,8 +473,10 @@ import random
 import io
 import matplotlib.pyplot as plt
 
+
 def generate(data):
     data["params"]["a"] = random.choice([0.25, 0.5, 1, 2, 4])
+
 
 def file(data):
     # check for the appropriate filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ docs = [
 packages = []
 
 [tool.ruff]
-# Also runs ruff on markdown files containing Python code blocks in docs.
+# Also runs ruff on markdown files containing Python code blocks.
 include = ["**/*.py", "**/*.md"]
 
 extend-exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,8 @@ docs = [
 packages = []
 
 [tool.ruff]
-include = ["**/*.py"]
+# Also runs ruff on markdown files containing Python code blocks in docs.
+include = ["**/*.py", "docs/**/*.md"]
 
 extend-exclude = [
   # These files are intentionally not parseable as Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ packages = []
 
 [tool.ruff]
 # Also runs ruff on markdown files containing Python code blocks in docs.
-include = ["**/*.py", "docs/**/*.md"]
+include = ["**/*.py", "**/*.md"]
 
 extend-exclude = [
   # These files are intentionally not parseable as Python.


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

A recent update to Ruff includes the ability to [format Markdown files containing Python blocks](https://docs.astral.sh/ruff/formatter/#markdown-code-formatting). This PR enables this setting and formats all docs files using ruff.

The rule explicitly applies to all Markdown files in the repo, not just docs. So it will include question README.md files in example/test course, README.md files in special directories (workspaces, graders, migrations, etc.), and the root files (contributing guidelines, agent skills, etc.). However, none of these files had Python blocks, so they were not affected.

VSCode settings have been updated to run both prettier and ruff on Markdown files on save. Ruff was set as the default formatter because it didn't work without setting that, while prettier was able to run even without being the default, but both are executed successfully.

Note that, in order to fully format a Markdown file locally (if not relying on VSCode auto-save), one must run both `make format-js` (to run prettier) and `make format-python` (to run ruff). Ruff will not affect any markdown outside Python blocks, while Prettier will not affect Python blocks.


<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: Gemini was used to help set up the vscode settings.

# Testing

Tested with VSCode settings and using `make format-python`.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
