### PR TITLE
Update typescript-cp to 0.1.10

### DIFF
--- a/.changeset/remove-typescript-cp-tar.md
+++ b/.changeset/remove-typescript-cp-tar.md
@@ -1,0 +1,7 @@
+---
+'@prairielearn/migrations': patch
+'@prairielearn/postgres-tools': patch
+'@prairielearn/ui': patch
+---
+
+Update typescript-cp to remove its transitive tar dependency.

--- a/apps/grader-host/package.json
+++ b/apps/grader-host/package.json
@@ -52,7 +52,7 @@
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.9",
     "tsx": "^4.23.0",
-    "typescript-cp": "^0.1.9",
+    "typescript-cp": "^0.1.10",
     "vitest": "^4.1.9"
   }
 }

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -323,7 +323,7 @@
     "get-port": "^7.2.0",
     "jsdom": "^29.1.1",
     "tsx": "^4.23.0",
-    "typescript-cp": "^0.1.9",
+    "typescript-cp": "^0.1.10",
     "vitest": "^4.1.9"
   }
 }

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -55,7 +55,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "fast-glob": "^3.3.3",
     "tsx": "^4.23.0",
-    "typescript-cp": "^0.1.9",
+    "typescript-cp": "^0.1.10",
     "vitest": "^4.1.9"
   }
 }

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -32,7 +32,7 @@
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.9",
     "tmp-promise": "^3.0.3",
-    "typescript-cp": "^0.1.9",
+    "typescript-cp": "^0.1.10",
     "vitest": "^4.1.9"
   }
 }

--- a/packages/postgres-tools/package.json
+++ b/packages/postgres-tools/package.json
@@ -35,6 +35,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.13.2",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.9"
+    "typescript-cp": "^0.1.10"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,7 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^24.13.2",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.9",
+    "typescript-cp": "^0.1.10",
     "vitest": "^4.1.9"
   }
 }

--- a/packages/workspace-utils/package.json
+++ b/packages/workspace-utils/package.json
@@ -30,6 +30,6 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^24.13.2",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.9"
+    "typescript-cp": "^0.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,7 +215,6 @@ overrides:
   linkinator>marked: ^18
   markdownlint-cli2>smol-toml: ^1
   notebookjs>jsdom: '*'
-  typescript-cp>tar: '*'
 
 importers:
 
@@ -440,8 +439,8 @@ importers:
         specifier: ^4.23.0
         version: 4.23.0
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1347,8 +1346,8 @@ importers:
         specifier: ^4.23.0
         version: 4.23.0
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1474,8 +1473,8 @@ importers:
         specifier: ^4.23.0
         version: 4.23.0
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -2160,8 +2159,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -2417,8 +2416,8 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
 
   packages/question-conversion:
     dependencies:
@@ -2737,8 +2736,8 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.101.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -2842,8 +2841,8 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
       typescript-cp:
-        specifier: ^0.1.9
-        version: 0.1.9(typescript@6.0.3)
+        specifier: ^0.1.10
+        version: 0.1.10(typescript@6.0.3)
 
   packages/zod:
     dependencies:
@@ -10248,8 +10247,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-cp@0.1.9:
-    resolution: {integrity: sha512-RMPUMzQENR42R7vXc737M5kR4+BbJ/GnDpKyD4qK3Db/g3n+dyEhmly0sVyZehnFTsy/1EGlVpP0jrt9Jq+8uw==}
+  typescript-cp@0.1.10:
+    resolution: {integrity: sha512-5hAVy1WlFzYHAqhfFkB1zpDe1us4NWgjggXGglH79v2SRCiUj22c05HAi3L3SbjwcktOr1EM49Fus69pVelEFg==}
     hasBin: true
     peerDependencies:
       typescript: '>=4.2.3'
@@ -19001,7 +19000,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-cp@0.1.9(typescript@6.0.3):
+  typescript-cp@0.1.10(typescript@6.0.3):
     dependencies:
       chokidar: 3.6.0
       commander: 10.0.1
@@ -19010,7 +19009,6 @@ snapshots:
       globby: 11.1.0
       lodash: 4.18.1
       rimraf: 5.0.10
-      tar: 7.5.19
       typescript: 6.0.3
 
   typescript-eslint@8.62.1(eslint@10.6.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,6 @@ overrides:
   'linkinator>marked': ^18
   'markdownlint-cli2>smol-toml': ^1
   'notebookjs>jsdom': '*'
-  'typescript-cp>tar': '*'
 
 # Delay newly published npm packages for 3 days.
 minimumReleaseAge: 4320


### PR DESCRIPTION
# Description

Update all `typescript-cp` consumers to 0.1.10, which removes the package's transitive dependency on `tar`. Remove the now-obsolete `typescript-cp>tar` override, regenerate the pnpm lockfile, and add patch changesets for the affected public packages.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Codex performed the majority of the implementation and validation.

# Testing

Ran `tscp` directly for `@prairielearn/workspace-utils` and verified that it copied `src/index.sql` byte-for-byte to `dist/index.sql`.

`pnpm audit` reports 33 existing advisories (16 high, 16 moderate, and 1 low), including a `brace-expansion` advisory through `typescript-cp`'s `rimraf` dependency; the regenerated dependency graph has no `typescript-cp` to `tar` edge.
