### PR TITLE
Add accessible contextual popovers

### DIFF
--- a/.changeset/accessible-popovers.md
+++ b/.changeset/accessible-popovers.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': minor
+---
+
+Add an accessible React Aria popover component styled with Bootstrap.

--- a/apps/prairielearn/assets/scripts/behaviors/clipboard-popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/clipboard-popover.ts
@@ -26,6 +26,9 @@ observe('.js-copy-button[data-clipboard-text], .js-copy-button[data-clipboard-ta
           return;
         }
 
+        // This transient copy confirmation is a status message, not a contextual
+        // dialog managed by the shared popover behavior.
+        button.dataset.plPopoverMode = 'status';
         const popover = window.bootstrap.Popover.getOrCreateInstance(button, {
           title: '',
           content: 'Copied!',

--- a/apps/prairielearn/assets/scripts/behaviors/popover.ts
+++ b/apps/prairielearn/assets/scripts/behaviors/popover.ts
@@ -8,6 +8,29 @@ import { getPopoverContainerForTrigger, getPopoverTriggerForContainer } from '..
 
 const openPopovers = new Set<Popover>();
 
+function usesDialogSemantics(trigger: HTMLElement) {
+  return !isFocusTrigger(trigger) && trigger.dataset.plPopoverMode !== 'status';
+}
+
+function configureDialogSemantics(trigger: HTMLElement, container: HTMLElement) {
+  trigger.setAttribute('aria-haspopup', 'dialog');
+  trigger.setAttribute('aria-expanded', 'true');
+  trigger.setAttribute('aria-controls', container.id);
+  trigger.removeAttribute('aria-describedby');
+
+  container.setAttribute('role', 'dialog');
+  container.tabIndex = -1;
+
+  const heading = container.querySelector<HTMLElement>('.popover-header');
+  if (heading) {
+    heading.id ||= `${container.id}-title`;
+    container.setAttribute('aria-labelledby', heading.id);
+  } else {
+    trigger.id ||= `${container.id}-trigger`;
+    container.setAttribute('aria-labelledby', trigger.id);
+  }
+}
+
 function closeOpenPopovers() {
   openPopovers.forEach((popover) => popover.hide());
   openPopovers.clear();
@@ -46,6 +69,11 @@ onDocumentReady(() => {
     add(el) {
       new window.bootstrap.Popover(el, { sanitize: false });
 
+      if (usesDialogSemantics(el)) {
+        el.setAttribute('aria-haspopup', 'dialog');
+        el.setAttribute('aria-expanded', 'false');
+      }
+
       // Bootstrap will by default copy the `title` attribute to `aria-label`,
       // but it won't do that for `data-bs-title`. We do that here in the interest
       // of making things maximally accessible by default. If an `aria-label`
@@ -75,15 +103,19 @@ onDocumentReady(() => {
     window.bootstrap.Popover.getInstance(trigger)?.hide();
   });
 
-  // Close open popovers if the user hits the escape key.
-  //
-  // Note that this does not gracefully handle popovers inside of modals, as
-  // Bootstrap has its own escape key handling for modals.
-  on('keydown', 'body', (event) => {
-    if (event.key === 'Escape') {
+  // Bootstrap 6 handles Escape in the capture phase so the first press closes a
+  // popover inside a dialog without also closing the dialog. Remove this listener
+  // after upgrading: https://github.com/twbs/bootstrap/pull/42472
+  document.addEventListener(
+    'keydown',
+    (event) => {
+      if (event.key !== 'Escape' || openPopovers.size === 0) return;
+      event.preventDefault();
+      event.stopPropagation();
       closeOpenPopovers();
-    }
-  });
+    },
+    true,
+  );
 
   on('click', 'body', (e) => {
     if (openPopovers.size === 0) return;
@@ -105,6 +137,15 @@ onDocumentReady(() => {
     const target = event.target as HTMLElement;
     const container = getPopoverContainerForTrigger(target);
 
+    // Bootstrap 5 intentionally exposes popovers as tooltip-like descriptions:
+    // https://github.com/twbs/bootstrap/pull/38978
+    // Our press-triggered popovers behave as contextual dialogs instead, matching
+    // the React Aria implementation. Bootstrap considered these semantics but
+    // closed them as not planned: https://github.com/twbs/bootstrap/issues/28446
+    if (container && usesDialogSemantics(target)) {
+      configureDialogSemantics(target, container);
+    }
+
     // If MathJax is loaded on this page, attempt to typeset any math
     // that may be in the popover.
     if (container && window.MathJax !== undefined) {
@@ -123,7 +164,7 @@ onDocumentReady(() => {
     // If the popover is focus-triggered, we'll skip the focus trap and
     // autofocus logic. If we move the focus off the trigger, the popover
     // will immediately close, which we don't want.
-    if (container && !isFocusTrigger(target)) {
+    if (container && usesDialogSemantics(target)) {
       // Trap focus inside this new popover.
       const trap = trapFocus(container);
 
@@ -135,13 +176,19 @@ onDocumentReady(() => {
       target.addEventListener('hide.bs.popover', removeFocusTrap);
 
       // Attempt to place focus on the correct item inside the popover.
-      const popoverBody = container.querySelector<HTMLElement>('.popover-body')!;
-      focusFirstFocusableChild(popoverBody);
+      focusFirstFocusableChild(container);
     }
   });
 
   on('hide.bs.popover', 'body', (event) => {
-    const popover = window.bootstrap.Popover.getInstance(event.target as HTMLElement);
+    const target = event.target as HTMLElement;
+    const popover = window.bootstrap.Popover.getInstance(target);
     if (popover) openPopovers.delete(popover);
+    if (usesDialogSemantics(target)) target.setAttribute('aria-expanded', 'false');
+  });
+
+  on('hidden.bs.popover', 'body', (event) => {
+    const target = event.target as HTMLElement;
+    if (usesDialogSemantics(target)) target.removeAttribute('aria-controls');
   });
 });

--- a/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
+++ b/apps/prairielearn/assets/scripts/instructorAssessmentManualGradingInstanceQuestion.js
@@ -339,20 +339,13 @@ function addInstanceQuestionGroupSelectionDropdownListeners() {
     );
     groupSelectionDropdownSpan.innerHTML = selectedGroupName;
 
-    const groupDescriptionTooltip = document.querySelector(
-      '#instance-question-group-description-tooltip',
+    const groupDescriptionPopover = document.querySelector(
+      '#instance-question-group-description-popover',
     );
 
-    groupDescriptionTooltip.setAttribute('data-bs-title', selectedGroupDescription);
-    groupDescriptionTooltip.setAttribute('aria-label', selectedGroupDescription);
-
-    // Update the tooltip title
-    const tooltip = window.bootstrap.Tooltip.getInstance(groupDescriptionTooltip);
-    if (tooltip) {
-      // Dispose the current tooltip instance
-      tooltip.dispose();
-      // Re-initialize the tooltip
-      new window.bootstrap.Tooltip(groupDescriptionTooltip);
-    }
+    groupDescriptionPopover.setAttribute('data-bs-content', selectedGroupDescription);
+    window.bootstrap.Popover.getOrCreateInstance(groupDescriptionPopover).setContent({
+      '.popover-body': selectedGroupDescription,
+    });
   });
 }

--- a/apps/prairielearn/assets/scripts/lib/popover.ts
+++ b/apps/prairielearn/assets/scripts/lib/popover.ts
@@ -2,7 +2,8 @@
  * Given a popover trigger element, returns the container. Only works if the popover is open.
  */
 export function getPopoverContainerForTrigger(trigger: HTMLElement): HTMLElement | null {
-  const popoverId = trigger.getAttribute('aria-describedby');
+  const popoverId =
+    trigger.getAttribute('aria-controls') ?? trigger.getAttribute('aria-describedby');
   if (!popoverId) return null;
 
   const popoverContainer = document.querySelector<HTMLElement>(`#${popoverId}`);
@@ -16,6 +17,9 @@ export function getPopoverTriggerForContainer(container: HTMLElement): HTMLEleme
   const popoverId = container.getAttribute('id');
   if (!popoverId) return null;
 
-  const popoverTrigger = document.querySelector<HTMLElement>(`[aria-describedby="${popoverId}"]`);
+  const escapedId = CSS.escape(popoverId);
+  const popoverTrigger = document.querySelector<HTMLElement>(
+    `[aria-controls="${escapedId}"], [aria-describedby="${escapedId}"]`,
+  );
   return popoverTrigger;
 }

--- a/apps/prairielearn/public/stylesheets/local.css
+++ b/apps/prairielearn/public/stylesheets/local.css
@@ -284,6 +284,31 @@ mjx-container {
   font-size: 0.7rem;
 }
 
+/* Bootstrap 6 includes `.btn-icon`; remove this backport after upgrading to v6.
+ * https://github.com/twbs/bootstrap/pull/41928 */
+.btn-icon {
+  --bs-btn-min-height: 2.25rem;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--bs-btn-min-height);
+  aspect-ratio: 1;
+  padding: 0;
+}
+
+.btn-icon.btn-xs {
+  --bs-btn-min-height: 1.5rem;
+}
+
+.btn-icon.btn-sm {
+  --bs-btn-min-height: 2rem;
+}
+
+.btn-icon.btn-lg {
+  --bs-btn-min-height: 2.75rem;
+}
+
 a.badge {
   text-decoration: none;
 }

--- a/apps/prairielearn/src/components/CalculatorDrawer.ts
+++ b/apps/prairielearn/src/components/CalculatorDrawer.ts
@@ -46,7 +46,7 @@ export function CalculatorDrawerToggle({
           ? html`
               <button
                 type="button"
-                class="btn btn-link btn-sm ms-auto text-white border-0 p-0"
+                class="btn btn-link btn-sm btn-icon ms-auto text-white border-0"
                 data-bs-toggle="popover"
                 data-bs-container="body"
                 data-bs-html="true"

--- a/apps/prairielearn/src/components/CalculatorDrawer.ts
+++ b/apps/prairielearn/src/components/CalculatorDrawer.ts
@@ -275,12 +275,7 @@ export function CalculatorDrawer({ storageKey }: { storageKey: string }): HtmlSa
             </div>
 
             <div class="d-flex align-items-center gap-3">
-              <div
-                class="form-check form-switch d-flex align-items-center text-nowrap small ps-0"
-                data-bs-toggle="tooltip"
-                data-bs-placement="bottom"
-                title="decimal or fractional"
-              >
+              <div class="form-check form-switch d-flex align-items-center text-nowrap small ps-0">
                 <span class="toggle-label">dec</span>
                 <input
                   class="form-check-input mx-1"
@@ -291,12 +286,7 @@ export function CalculatorDrawer({ storageKey }: { storageKey: string }): HtmlSa
                 <span class="toggle-label">frac</span>
               </div>
 
-              <div
-                class="form-check form-switch d-flex align-items-center text-nowrap small ps-0"
-                data-bs-toggle="tooltip"
-                data-bs-placement="bottom"
-                title="radian or degree"
-              >
+              <div class="form-check form-switch d-flex align-items-center text-nowrap small ps-0">
                 <span class="toggle-label">rad</span>
                 <input
                   class="form-check-input mx-1"

--- a/apps/prairielearn/src/components/CopyButton.tsx
+++ b/apps/prairielearn/src/components/CopyButton.tsx
@@ -32,23 +32,28 @@ export function CopyButton({
   }, [text]);
 
   return (
-    <OverlayTrigger
-      tooltip={{
-        body: copied ? 'Copied!' : 'Copy',
-        props: { id: tooltipId },
-      }}
-    >
-      <button
-        type="button"
-        className={clsx('btn', className)}
-        aria-label={ariaLabel}
-        onClick={(e) => {
-          e.stopPropagation();
-          void handleCopy();
+    <>
+      <OverlayTrigger
+        tooltip={{
+          body: copied ? 'Copied!' : 'Copy',
+          props: { id: tooltipId },
         }}
       >
-        <i className={copied ? 'bi bi-check' : 'bi bi-clipboard'} /> {label}
-      </button>
-    </OverlayTrigger>
+        <button
+          type="button"
+          className={clsx('btn', className)}
+          aria-label={ariaLabel}
+          onClick={(e) => {
+            e.stopPropagation();
+            void handleCopy();
+          }}
+        >
+          <i className={copied ? 'bi bi-check' : 'bi bi-clipboard'} aria-hidden="true" /> {label}
+        </button>
+      </OverlayTrigger>
+      <span className="visually-hidden" role="status">
+        {copied ? 'Copied.' : ''}
+      </span>
+    </>
   );
 }

--- a/apps/prairielearn/src/components/CourseInstancePublishingForm.tsx
+++ b/apps/prairielearn/src/components/CourseInstancePublishingForm.tsx
@@ -256,7 +256,7 @@ export function CourseInstancePublishingForm({
                     <FriendlyDate
                       date={plainDateTimeStringToDate(endDate, displayTimezone)}
                       timezone={displayTimezone}
-                      tooltip={true}
+                      withPopover={true}
                       options={{ timeFirst: true }}
                     />
                     .
@@ -297,14 +297,14 @@ export function CourseInstancePublishingForm({
                   <FriendlyDate
                     date={Temporal.PlainDateTime.from(startDate)}
                     timezone={displayTimezone}
-                    tooltip={true}
+                    withPopover={true}
                     options={{ timeFirst: true }}
                   />{' '}
                   and will be unpublished at{' '}
                   <FriendlyDate
                     date={Temporal.PlainDateTime.from(endDate)}
                     timezone={displayTimezone}
-                    tooltip={true}
+                    withPopover={true}
                     options={{ timeFirst: true }}
                   />
                   .
@@ -432,14 +432,14 @@ export function CourseInstancePublishingForm({
                   <FriendlyDate
                     date={Temporal.PlainDateTime.from(startDate)}
                     timezone={displayTimezone}
-                    tooltip={true}
+                    withPopover={true}
                     options={{ timeFirst: true }}
                   />{' '}
                   and will be unpublished at{' '}
                   <FriendlyDate
                     date={Temporal.PlainDateTime.from(endDate)}
                     timezone={displayTimezone}
-                    tooltip={true}
+                    withPopover={true}
                     options={{ timeFirst: true }}
                   />
                   .

--- a/apps/prairielearn/src/components/EnrollmentStatusIcon.tsx
+++ b/apps/prairielearn/src/components/EnrollmentStatusIcon.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 import { assertNever } from '@prairielearn/utils';
 
 import type { EnumEnrollmentStatus } from '../lib/db-types.js';
@@ -90,19 +90,15 @@ export function EnrollmentStatusIcon({
       <i className={clsx('bi', iconClass)} aria-hidden="true" />
       <span className="text-nowrap">{capitalize(getFriendlyStatus(status))}</span>
       {status === 'rejected' && (
-        <OverlayTrigger
-          tooltip={{
-            body: (
-              <div>
-                This student has rejected the invitation to join the course. They can still join
-                while self-enrollment is enabled.
-              </div>
-            ),
-            props: { id: 'rejected-info-tooltip' },
-          }}
-        >
-          <i className="bi bi-info-circle" aria-hidden="true" />
-        </OverlayTrigger>
+        <Popover content="This student has rejected the invitation to join the course. They can still join while self-enrollment is enabled.">
+          <button
+            type="button"
+            className="btn btn-xs btn-ghost p-0 border-0"
+            aria-label="More information about rejected enrollment"
+          >
+            <i className="bi bi-info-circle" aria-hidden="true" />
+          </button>
+        </Popover>
       )}
     </span>
   );

--- a/apps/prairielearn/src/components/EnrollmentStatusIcon.tsx
+++ b/apps/prairielearn/src/components/EnrollmentStatusIcon.tsx
@@ -93,7 +93,7 @@ export function EnrollmentStatusIcon({
         <Popover content="This student has rejected the invitation to join the course. They can still join while self-enrollment is enabled.">
           <button
             type="button"
-            className="btn btn-xs btn-ghost p-0 border-0"
+            className="btn btn-xs btn-ghost btn-icon border-0"
             aria-label="More information about rejected enrollment"
           >
             <i className="bi bi-info-circle" aria-hidden="true" />

--- a/apps/prairielearn/src/components/FriendlyDate.tsx
+++ b/apps/prairielearn/src/components/FriendlyDate.tsx
@@ -1,14 +1,13 @@
 import { type Temporal } from '@js-temporal/polyfill';
 import { type FC, createContext, use } from 'react';
-import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
-import Tooltip from 'react-bootstrap/Tooltip';
 
 import { formatDate, formatDateFriendly } from '@prairielearn/formatter';
+import { Popover } from '@prairielearn/ui';
 
 interface FriendlyDateProps {
   date: Date | Temporal.PlainDateTime;
   timezone?: string;
-  tooltip?: boolean;
+  withPopover?: boolean;
   options?: Parameters<typeof formatDateFriendly>[2];
   fullOptions?: Parameters<typeof formatDate>[2];
 }
@@ -16,7 +15,7 @@ interface FriendlyDateProps {
 export const FriendlyDate: FC<FriendlyDateProps> = ({
   date,
   timezone = null,
-  tooltip = false,
+  withPopover = false,
   options,
   fullOptions,
 }) => {
@@ -25,15 +24,19 @@ export const FriendlyDate: FC<FriendlyDateProps> = ({
 
   const friendlyString = formatDateFriendly(date, timezone, options);
   const fullString = formatDate(date, timezone, fullOptions);
-  if (!tooltip) return <span style={{ fontVariantNumeric: 'tabular-nums' }}>{friendlyString}</span>;
+  if (!withPopover) {
+    return <span style={{ fontVariantNumeric: 'tabular-nums' }}>{friendlyString}</span>;
+  }
   return (
-    <OverlayTrigger
-      placement="top"
-      delay={{ show: 100, hide: 100 }}
-      overlay={<Tooltip>{fullString}</Tooltip>}
-    >
-      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{friendlyString}</span>
-    </OverlayTrigger>
+    <Popover content={fullString} placement="top">
+      <button
+        type="button"
+        className="btn btn-link link-body-emphasis border-0 p-0 align-baseline text-decoration-none"
+        style={{ fontVariantNumeric: 'tabular-nums' }}
+      >
+        {friendlyString}
+      </button>
+    </Popover>
   );
 };
 

--- a/apps/prairielearn/src/components/HelpPopover.tsx
+++ b/apps/prairielearn/src/components/HelpPopover.tsx
@@ -1,24 +1,21 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
-import type { Placement } from 'react-bootstrap/types';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover, type PopoverProps } from '@prairielearn/ui';
 
-export function HelpTooltip({
-  body,
-  id,
+export function HelpPopover({
+  children,
   ariaLabel,
   placement = 'top',
   className,
 }: {
-  body: ReactNode;
-  id: string;
+  children: ReactNode;
   ariaLabel: string;
-  placement?: Placement;
+  placement?: PopoverProps['placement'];
   className?: string;
 }) {
   return (
-    <OverlayTrigger placement={placement} tooltip={{ body, props: { id } }}>
+    <Popover content={children} placement={placement}>
       <button
         type="button"
         className={clsx('btn btn-xs btn-ghost p-0 border-0 lh-1 align-middle', className)}
@@ -26,6 +23,6 @@ export function HelpTooltip({
       >
         <i className="bi bi-question-circle text-muted" aria-hidden="true" />
       </button>
-    </OverlayTrigger>
+    </Popover>
   );
 }

--- a/apps/prairielearn/src/components/HelpPopover.tsx
+++ b/apps/prairielearn/src/components/HelpPopover.tsx
@@ -18,7 +18,7 @@ export function HelpPopover({
     <Popover content={children} placement={placement}>
       <button
         type="button"
-        className={clsx('btn btn-xs btn-ghost p-0 border-0 lh-1 align-middle', className)}
+        className={clsx('btn btn-xs btn-ghost btn-icon border-0 align-middle', className)}
         aria-label={ariaLabel}
       >
         <i className="bi bi-question-circle text-muted" aria-hidden="true" />

--- a/apps/prairielearn/src/components/QuestionScore.tsx
+++ b/apps/prairielearn/src/components/QuestionScore.tsx
@@ -319,9 +319,9 @@ export function InstanceQuestionPoints({
             <button
               type="button"
               class="btn btn-xs"
-              data-bs-toggle="tooltip"
+              data-bs-toggle="popover"
               aria-label="Not included in grade"
-              title="This zone uses only the best questions for score, and this question is not included."
+              data-bs-content="This zone uses only the best questions for score, and this question is not included."
             >
               <i class="far fa-question-circle" aria-hidden="true"></i>
             </button>

--- a/apps/prairielearn/src/components/ReorderableTable.tsx
+++ b/apps/prairielearn/src/components/ReorderableTable.tsx
@@ -17,7 +17,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { type ReactNode, useMemo } from 'react';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 /**
  * Drag-and-drop context for a table whose rows can be reordered. Rows are
@@ -83,11 +83,10 @@ type ReorderableRowHandle = ReturnType<typeof useReorderableRow>;
 
 /**
  * The drag/edit/delete actions cell of a reorderable row. When
- * `deleteDisabledReason` is set, the delete button is inert and explains why
- * in a click tooltip instead.
+ * `deleteDisabledReason` is set, the delete action is unavailable and its
+ * button explains why in a popover instead.
  */
 export function ReorderableRowActionsCell({
-  trackingId,
   dragHandleProps,
   editLabel,
   deleteLabel,
@@ -95,7 +94,6 @@ export function ReorderableRowActionsCell({
   onEdit,
   onDelete,
 }: {
-  trackingId: string;
   dragHandleProps: ReorderableRowHandle['dragHandleProps'];
   editLabel: string;
   deleteLabel: string;
@@ -124,22 +122,15 @@ export function ReorderableRowActionsCell({
           <i className="fa fa-edit" aria-hidden="true" />
         </button>
         {deleteDisabledReason ? (
-          <OverlayTrigger
-            trigger="click"
-            tooltip={{
-              body: deleteDisabledReason,
-              props: { id: `delete-tooltip-${trackingId}` },
-            }}
-            rootClose
-          >
+          <Popover content={deleteDisabledReason}>
             <button
               className="btn btn-sm btn-ghost"
               type="button"
-              aria-label={deleteDisabledReason}
+              aria-label={`${deleteLabel}: ${deleteDisabledReason}`}
             >
               <i className="fa fa-trash text-muted" aria-hidden="true" />
             </button>
-          </OverlayTrigger>
+          </Popover>
         ) : (
           <button
             className="btn btn-sm btn-ghost"

--- a/apps/prairielearn/src/components/ReorderableTable.tsx
+++ b/apps/prairielearn/src/components/ReorderableTable.tsx
@@ -124,9 +124,9 @@ export function ReorderableRowActionsCell({
         {deleteDisabledReason ? (
           <Popover content={deleteDisabledReason}>
             <button
-              className="btn btn-sm btn-ghost"
+              className="btn btn-sm btn-ghost opacity-50"
               type="button"
-              aria-label={`${deleteLabel}: ${deleteDisabledReason}`}
+              aria-label={`Why ${deleteLabel} is unavailable`}
             >
               <i className="fa fa-trash text-muted" aria-hidden="true" />
             </button>

--- a/apps/prairielearn/src/components/RubricSettings.tsx
+++ b/apps/prairielearn/src/components/RubricSettings.tsx
@@ -637,9 +637,9 @@ export function RubricSettings({
                         <button
                           type="button"
                           className="btn btn-sm btn-ghost"
-                          data-bs-toggle="tooltip"
+                          data-bs-toggle="popover"
                           data-bs-placement="bottom"
-                          data-bs-title="If the rubric is applied to manual points only, then a student's auto points are kept, and the rubric items will be added to (or subtracted from) the autograder results."
+                          data-bs-content="If the rubric is applied to manual points only, then a student's auto points are kept, and the rubric items will be added to (or subtracted from) the autograder results."
                           aria-label="More information about applying rubric to manual points"
                         >
                           <i className="fas fa-circle-info" aria-hidden="true" />
@@ -667,9 +667,9 @@ export function RubricSettings({
                         <button
                           type="button"
                           className="btn btn-sm btn-ghost"
-                          data-bs-toggle="tooltip"
+                          data-bs-toggle="popover"
                           data-bs-placement="bottom"
-                          data-bs-title={`If the rubric is applied to total points, then a student's auto points will be ignored, and the rubric items will be based on the total points of the question (${assessmentQuestion.max_points} points).`}
+                          data-bs-content={`If the rubric is applied to total points, then a student's auto points will be ignored, and the rubric items will be based on the total points of the question (${assessmentQuestion.max_points} points).`}
                           aria-label="More information about applying rubric to total points"
                         >
                           <i className="fas fa-circle-info" aria-hidden="true" />
@@ -719,9 +719,9 @@ export function RubricSettings({
                   <button
                     type="button"
                     className="btn btn-sm btn-ghost"
-                    data-bs-toggle="tooltip"
+                    data-bs-toggle="popover"
                     data-bs-placement="bottom"
-                    data-bs-title="This setting only affects starting points. Rubric items may always be added with positive or negative points."
+                    data-bs-content="This setting only affects starting points. Rubric items may always be added with positive or negative points."
                     aria-label="More information about grading mode"
                   >
                     <i className="fas fa-circle-info" aria-hidden="true" />
@@ -737,9 +737,9 @@ export function RubricSettings({
                       <button
                         type="button"
                         className="btn btn-sm btn-ghost"
-                        data-bs-toggle="tooltip"
+                        data-bs-toggle="popover"
                         data-bs-placement="bottom"
-                        data-bs-title="By default, penalties applied by rubric items cannot cause the rubric to have negative points. This value overrides this limit, e.g., for penalties that affect auto points or the assessment as a whole."
+                        data-bs-content="By default, penalties applied by rubric items cannot cause the rubric to have negative points. This value overrides this limit, e.g., for penalties that affect auto points or the assessment as a whole."
                         aria-label="More information about minimum rubric score"
                       >
                         <i className="fas fa-circle-info" aria-hidden="true" />
@@ -764,9 +764,9 @@ export function RubricSettings({
                       <button
                         type="button"
                         className="btn btn-sm btn-ghost"
-                        data-bs-toggle="tooltip"
+                        data-bs-toggle="popover"
                         data-bs-placement="bottom"
-                        data-bs-title="By default, points are limited to the maximum points assigned to the question, and credit assigned by rubric items do not violate this limit. This value allows rubric points to extend beyond this limit, e.g., for bonus credit."
+                        data-bs-content="By default, points are limited to the maximum points assigned to the question, and credit assigned by rubric items do not violate this limit. This value allows rubric points to extend beyond this limit, e.g., for bonus credit."
                         aria-label="More information about maximum extra credit"
                       >
                         <i className="fas fa-circle-info" aria-hidden="true" />
@@ -984,9 +984,9 @@ export function RubricSettings({
               <button
                 type="button"
                 className="btn btn-sm btn-ghost"
-                data-bs-toggle="tooltip"
+                data-bs-toggle="popover"
                 data-bs-placement="bottom"
-                data-bs-title="Imported rubric point values will be scaled to match the maximum points for this question."
+                data-bs-content="Imported rubric point values will be scaled to match the maximum points for this question."
                 aria-label="More information about importing rubrics"
               >
                 <i className="fas fa-circle-info" aria-hidden="true" />
@@ -1047,9 +1047,9 @@ export function RubricSettings({
             <button
               type="button"
               className="btn btn-sm btn-ghost"
-              data-bs-toggle="tooltip"
+              data-bs-toggle="popover"
               data-bs-placement="bottom"
-              data-bs-title="Changes in rubric item values update the points for all previously graded submissions. If this option is selected, these submissions will also be tagged for manual grading, requiring a review by a grader."
+              data-bs-content="Changes in rubric item values update the points for all previously graded submissions. If this option is selected, these submissions will also be tagged for manual grading, requiring a review by a grader."
               aria-label="More information about requiring manual grading"
             >
               <i className="fas fa-circle-info" aria-hidden="true" />

--- a/apps/prairielearn/src/ee/components/ai-grading-credits/BalanceCards.tsx
+++ b/apps/prairielearn/src/ee/components/ai-grading-credits/BalanceCards.tsx
@@ -48,7 +48,7 @@ export function BalanceCards({
               <Popover content={tooltips.transferable} placement="top">
                 <button
                   type="button"
-                  className="btn btn-link p-0 border-0 align-baseline"
+                  className="btn btn-link btn-icon border-0 align-baseline"
                   aria-label="More information about transferable credits"
                 >
                   <i className="bi bi-info-circle" aria-hidden="true" />
@@ -67,7 +67,7 @@ export function BalanceCards({
               <Popover content={tooltips.nonTransferable} placement="top">
                 <button
                   type="button"
-                  className="btn btn-link p-0 border-0 align-baseline"
+                  className="btn btn-link btn-icon border-0 align-baseline"
                   aria-label="More information about non-transferable credits"
                 >
                   <i className="bi bi-info-circle" aria-hidden="true" />

--- a/apps/prairielearn/src/ee/components/ai-grading-credits/BalanceCards.tsx
+++ b/apps/prairielearn/src/ee/components/ai-grading-credits/BalanceCards.tsx
@@ -1,6 +1,4 @@
-import { useId } from 'react';
-
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import { formatMilliDollars } from '../../../lib/ai-grading-credits.js';
 
@@ -30,8 +28,6 @@ export function BalanceCards({
   context: 'instructor' | 'admin';
   dimmed?: boolean;
 }) {
-  const transferableTooltipId = useId();
-  const nonTransferableTooltipId = useId();
   const tooltips = TOOLTIP_TEXT[context];
 
   const dimStyle = dimmed ? { opacity: 0.4 } : undefined;
@@ -49,13 +45,7 @@ export function BalanceCards({
           <div className="border rounded p-3 text-center" style={dimStyle}>
             <div className="text-muted small">
               Transferable{' '}
-              <OverlayTrigger
-                placement="top"
-                tooltip={{
-                  body: tooltips.transferable,
-                  props: { id: transferableTooltipId },
-                }}
-              >
+              <Popover content={tooltips.transferable} placement="top">
                 <button
                   type="button"
                   className="btn btn-link p-0 border-0 align-baseline"
@@ -63,7 +53,7 @@ export function BalanceCards({
                 >
                   <i className="bi bi-info-circle" aria-hidden="true" />
                 </button>
-              </OverlayTrigger>
+              </Popover>
             </div>
             <div className="h5 mb-0">
               {formatMilliDollars(pool.credit_transferable_milli_dollars)}
@@ -74,13 +64,7 @@ export function BalanceCards({
           <div className="border rounded p-3 text-center" style={dimStyle}>
             <div className="text-muted small">
               Non-transferable{' '}
-              <OverlayTrigger
-                placement="top"
-                tooltip={{
-                  body: tooltips.nonTransferable,
-                  props: { id: nonTransferableTooltipId },
-                }}
-              >
+              <Popover content={tooltips.nonTransferable} placement="top">
                 <button
                   type="button"
                   className="btn btn-link p-0 border-0 align-baseline"
@@ -88,7 +72,7 @@ export function BalanceCards({
                 >
                   <i className="bi bi-info-circle" aria-hidden="true" />
                 </button>
-              </OverlayTrigger>
+              </Popover>
             </div>
             <div className="h5 mb-0">
               {formatMilliDollars(pool.credit_non_transferable_milli_dollars)}

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/RichTextEditor/extensions/pl-panel.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/RichTextEditor/extensions/pl-panel.tsx
@@ -10,8 +10,6 @@ import {
 } from '@tiptap/react';
 import { type ComponentType } from 'react';
 
-import { OverlayTrigger } from '@prairielearn/ui';
-
 export const panelMeta = {
   'pl-question-panel': {
     color: 'primary',
@@ -72,16 +70,11 @@ export const PlPanel = Node.create({
               className="d-flex align-items-center justify-content-center"
               style={{ width: '2em' }}
             >
-              <OverlayTrigger
-                placement="top"
-                tooltip={{ body: style.label, props: { id: `pl-panel-${tag}-tooltip` } }}
-              >
-                <i
-                  className={`bi ${style.icon} text-${style.color}`}
-                  aria-label={style.label}
-                  role="img"
-                />
-              </OverlayTrigger>
+              <i
+                className={`bi ${style.icon} text-${style.color}`}
+                aria-label={style.label}
+                role="img"
+              />
             </div>
             <div className="flex-grow-1 ps-2 pe-2 py-2">
               <NodeViewContent />

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/RichTextEditor/extensions/raw-html.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/RichTextEditor/extensions/raw-html.tsx
@@ -41,7 +41,7 @@ const RawHtmlComponent = (
               >
                 <button
                   type="button"
-                  className="btn btn-xs btn-ghost p-0 border-0"
+                  className="btn btn-xs btn-ghost btn-icon border-0"
                   aria-label="Raw HTML warning"
                 >
                   <i className="bi bi-exclamation-triangle text-danger" aria-hidden="true" />
@@ -60,7 +60,7 @@ const RawHtmlComponent = (
           >
             <button
               type="button"
-              className="btn btn-xs btn-ghost p-0 border-0"
+              className="btn btn-xs btn-ghost btn-icon border-0"
               aria-label="Raw HTML help"
             >
               <i className="bi bi-question-circle" aria-hidden="true" />

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/RichTextEditor/extensions/raw-html.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/RichTextEditor/extensions/raw-html.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { type ComponentType, useState } from 'react';
 import { Card } from 'react-bootstrap';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 interface RawHtmlAttrs {
   html: string;
@@ -29,41 +29,43 @@ const RawHtmlComponent = (
           <div className="d-flex gap-2">
             Raw HTML
             {nodes !== null && nodes.length !== 1 ? (
-              <OverlayTrigger
+              <Popover
                 placement="right"
-                tooltip={{
-                  body: (
-                    <>
-                      You must have exactly one parent element, but you have {nodes.length} (
-                      {nodes.join(', ')}). Either remove the extra elements, or combine them into a
-                      single element by wrapping both of them in a single div.
-                    </>
-                  ),
-                  props: { id: 'raw-html-warning-tooltip' },
-                }}
+                content={
+                  <>
+                    You must have exactly one parent element, but you have {nodes.length} (
+                    {nodes.join(', ')}). Either remove the extra elements, or combine them into a
+                    single element by wrapping both of them in a single div.
+                  </>
+                }
               >
-                <i
-                  className="bi bi-exclamation-triangle text-danger"
+                <button
+                  type="button"
+                  className="btn btn-xs btn-ghost p-0 border-0"
                   aria-label="Raw HTML warning"
-                  role="img"
-                />
-              </OverlayTrigger>
+                >
+                  <i className="bi bi-exclamation-triangle text-danger" aria-hidden="true" />
+                </button>
+              </Popover>
             ) : null}
           </div>
-          <OverlayTrigger
+          <Popover
             placement="left"
-            tooltip={{
-              body: (
-                <>
-                  This node type isn't supported by the rich text editor yet. You can edit the
-                  underlying HTML here.
-                </>
-              ),
-              props: { id: 'raw-html-help-tooltip' },
-            }}
+            content={
+              <>
+                This node type isn't supported by the rich text editor yet. You can edit the
+                underlying HTML here.
+              </>
+            }
           >
-            <i className="bi bi-question-circle" aria-label="Raw HTML help" role="img" />
-          </OverlayTrigger>
+            <button
+              type="button"
+              className="btn btn-xs btn-ghost p-0 border-0"
+              aria-label="Raw HTML help"
+            >
+              <i className="bi bi-question-circle" aria-hidden="true" />
+            </button>
+          </Popover>
         </Card.Header>
         <Card.Body>
           <textarea

--- a/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/components/AiQuestionGenerationEditor.tsx
+++ b/apps/prairielearn/src/ee/pages/instructorAiGenerateDraftEditor/components/AiQuestionGenerationEditor.tsx
@@ -147,8 +147,6 @@ function AiQuestionGenerationEditorInner({
               <button
                 type="button"
                 className="btn btn-sm btn-primary"
-                data-bs-toggle="tooltip"
-                data-bs-title="Finalize a question to use it on assessments and make manual edits"
                 disabled={isGenerating}
                 onClick={() => setShowFinalizeModal(true)}
               >

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -481,8 +481,8 @@ function CourseRequestApproveModalContent({
                 >
                   <button
                     type="button"
-                    className="btn btn-sm btn-outline-secondary"
-                    aria-label="Check legitimacy unavailable: OpenAI API key is not configured"
+                    className="btn btn-sm btn-outline-secondary opacity-50"
+                    aria-label="Why checking legitimacy is unavailable"
                   >
                     <i className="fa fa-search" aria-hidden="true" /> Check legitimacy
                   </button>

--- a/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
+++ b/apps/prairielearn/src/pages/administratorCourseRequests/components/CourseRequestsTable.tsx
@@ -5,7 +5,7 @@ import { Alert, Dropdown, Modal } from 'react-bootstrap';
 import { FormProvider, useForm } from 'react-hook-form';
 import ReactMarkdown from 'react-markdown';
 
-import { OverlayTrigger, useModalState } from '@prairielearn/ui';
+import { OverlayTrigger, Popover, useModalState } from '@prairielearn/ui';
 
 import {
   AdministratorCourseFormFields,
@@ -456,36 +456,38 @@ function CourseRequestApproveModalContent({
           <div className="card mb-3">
             <div className="card-header d-flex align-items-center justify-content-between py-2">
               <strong>Requesting instructor</strong>
-              <OverlayTrigger
-                trigger={['hover', 'focus']}
-                placement="bottom"
-                tooltip={{
-                  body: aiSecretsConfigured
-                    ? 'Uses AI web search to verify whether the instructor appears in faculty directories or professional profiles at their stated institution.'
-                    : 'AI features require the corresponding OpenAI key to be configured.',
-                  props: { id: 'check-instructor-legitimacy-tooltip' },
-                }}
-              >
-                <span className="d-inline-block">
+              {aiSecretsConfigured ? (
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-secondary"
+                  disabled={legitimacyQuery.isFetching}
+                  aria-busy={legitimacyQuery.isFetching}
+                  onClick={() => legitimacyQuery.refetch()}
+                >
+                  {legitimacyQuery.isFetching ? (
+                    <>
+                      <i className="fa fa-spinner fa-spin" aria-hidden="true" /> Checking...
+                    </>
+                  ) : (
+                    <>
+                      <i className="fa fa-search" aria-hidden="true" /> Check legitimacy
+                    </>
+                  )}
+                </button>
+              ) : (
+                <Popover
+                  content="AI features require the corresponding OpenAI key to be configured."
+                  placement="bottom"
+                >
                   <button
                     type="button"
                     className="btn btn-sm btn-outline-secondary"
-                    disabled={legitimacyQuery.isFetching || !aiSecretsConfigured}
-                    aria-busy={legitimacyQuery.isFetching}
-                    onClick={() => legitimacyQuery.refetch()}
+                    aria-label="Check legitimacy unavailable: OpenAI API key is not configured"
                   >
-                    {legitimacyQuery.isFetching ? (
-                      <>
-                        <i className="fa fa-spinner fa-spin" aria-hidden="true" /> Checking...
-                      </>
-                    ) : (
-                      <>
-                        <i className="fa fa-search" aria-hidden="true" /> Check legitimacy
-                      </>
-                    )}
+                    <i className="fa fa-search" aria-hidden="true" /> Check legitimacy
                   </button>
-                </span>
-              </OverlayTrigger>
+                </Popover>
+              )}
             </div>
             <div className="card-body py-2">
               <div className="row g-2 small">

--- a/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
+++ b/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
@@ -4,7 +4,7 @@ import { Modal } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import ReactMarkdown from 'react-markdown';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import { AppErrorAlert, getAppError } from '../../../lib/client/errors.js';
 import type { StaffAuthnProvider } from '../../../lib/client/safe-db-types.js';
@@ -77,6 +77,11 @@ export function AddInstitutionModal({
   });
 
   const validTimezoneNames = new Set(availableTimezones.map((tz) => tz.name));
+  const suggestTimezoneDisabledReason = !aiSecretsConfigured
+    ? 'AI features require the corresponding OpenAI key to be configured.'
+    : !institutionName || !emailDomain
+      ? 'Fill in the short name and long name first.'
+      : null;
 
   async function handleSuggestTimezone() {
     const { data } = await timezoneQuery.refetch();
@@ -161,34 +166,28 @@ export function AddInstitutionModal({
                   </option>
                 ))}
               </select>
-              <OverlayTrigger
-                trigger={['hover', 'focus']}
-                placement="top"
-                tooltip={{
-                  body: aiSecretsConfigured
-                    ? 'Uses AI web search to suggest the correct timezone based on the institution name and domain. Fill in the short name and long name first.'
-                    : 'AI features require the corresponding OpenAI key to be configured.',
-                  props: { id: 'suggest-timezone-tooltip' },
-                }}
-              >
-                <span className="d-inline-block">
+              {suggestTimezoneDisabledReason ? (
+                <Popover content={suggestTimezoneDisabledReason} placement="top">
                   <button
                     type="button"
                     className="btn btn-secondary"
-                    aria-label="Suggest timezone"
-                    aria-busy={timezoneQuery.isFetching}
-                    disabled={
-                      timezoneQuery.isFetching ||
-                      !aiSecretsConfigured ||
-                      !institutionName ||
-                      !emailDomain
-                    }
-                    onClick={handleSuggestTimezone}
+                    aria-label={`Suggest timezone unavailable: ${suggestTimezoneDisabledReason}`}
                   >
-                    {timezoneQuery.isFetching ? 'Suggesting...' : 'Suggest'}
+                    Suggest
                   </button>
-                </span>
-              </OverlayTrigger>
+                </Popover>
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  aria-label="Suggest timezone"
+                  aria-busy={timezoneQuery.isFetching}
+                  disabled={timezoneQuery.isFetching}
+                  onClick={handleSuggestTimezone}
+                >
+                  {timezoneQuery.isFetching ? 'Suggesting...' : 'Suggest'}
+                </button>
+              )}
             </div>
             {errors.display_timezone && (
               <div id="display_timezone-error" className="invalid-feedback d-block">

--- a/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
+++ b/apps/prairielearn/src/pages/administratorInstitutions/components/AddInstitutionModal.tsx
@@ -170,8 +170,8 @@ export function AddInstitutionModal({
                 <Popover content={suggestTimezoneDisabledReason} placement="top">
                   <button
                     type="button"
-                    className="btn btn-secondary"
-                    aria-label={`Suggest timezone unavailable: ${suggestTimezoneDisabledReason}`}
+                    className="btn btn-secondary opacity-50"
+                    aria-label="Why suggesting a timezone is unavailable"
                   >
                     Suggest
                   </button>

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
@@ -93,8 +93,8 @@ export function CourseSyncs({
                     ? html`
                         <button
                           type="button"
-                          class="btn btn-sm btn-primary opacity-75"
-                          aria-label="Pull from remote git repository unavailable in development mode"
+                          class="btn btn-sm btn-primary opacity-50"
+                          aria-label="Why pulling from the remote git repository is unavailable"
                           data-bs-toggle="popover"
                           data-bs-content="Pulling from a remote repository is not supported in development mode."
                         >

--- a/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
+++ b/apps/prairielearn/src/pages/courseSyncs/courseSyncs.html.ts
@@ -91,17 +91,16 @@ export function CourseSyncs({
                 <td>
                   ${config.devMode
                     ? html`
-                        <span
-                          class="d-inline-block"
-                          tabindex="0"
-                          data-bs-toggle="tooltip"
-                          data-bs-title="Pulling from a remote repository is not supported in development mode."
+                        <button
+                          type="button"
+                          class="btn btn-sm btn-primary opacity-75"
+                          aria-label="Pull from remote git repository unavailable in development mode"
+                          data-bs-toggle="popover"
+                          data-bs-content="Pulling from a remote repository is not supported in development mode."
                         >
-                          <button type="button" class="btn btn-sm btn-primary" disabled>
-                            <i class="fa fa-cloud-download-alt" aria-hidden="true"></i>
-                            Pull from remote git repository
-                          </button>
-                        </span>
+                          <i class="fa fa-cloud-download-alt" aria-hidden="true"></i>
+                          Pull from remote git repository
+                        </button>
                       `
                     : html`
                         <form name="confirm-form" method="POST">

--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/RuleSummary.tsx
@@ -205,7 +205,7 @@ export function generateDefaultRuleDateTableRows(
           date={Temporal.PlainDateTime.from(releaseDate)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       ) : (
         'No date set'
@@ -225,7 +225,7 @@ export function generateDefaultRuleDateTableRows(
           date={Temporal.PlainDateTime.from(deadline.date)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       ) : (
         'No date set'
@@ -249,7 +249,7 @@ export function generateDefaultRuleDateTableRows(
           date={Temporal.PlainDateTime.from(dueDate)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       ),
       label: 'Due',
@@ -286,7 +286,7 @@ export function generateDefaultRuleDateTableRows(
           date={Temporal.PlainDateTime.from(deadline.date)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       ) : (
         'No date set'
@@ -395,7 +395,7 @@ function AfterCompleteTimeRange({
         date={Temporal.PlainDateTime.from(date)}
         timezone={displayTimezone}
         options={{ includeTz: false }}
-        tooltip
+        withPopover
       />
     </>
   );
@@ -518,7 +518,7 @@ function formatDeadlineEntries(
           date={Temporal.PlainDateTime.from(entry.date)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />{' '}
         ({formatCreditPercent(entry.credit)} credit)
       </>
@@ -565,14 +565,14 @@ function HiddenAfterCompletionVisibility({
           date={Temporal.PlainDateTime.from(visibleFromDate)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />{' '}
         until{' '}
         <FriendlyDate
           date={Temporal.PlainDateTime.from(visibleUntilDate)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       </>
     );
@@ -586,7 +586,7 @@ function HiddenAfterCompletionVisibility({
           date={Temporal.PlainDateTime.from(visibleFromDate)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       </>
     );
@@ -613,7 +613,7 @@ function generateOverrideFieldItems(
           date={Temporal.PlainDateTime.from(rule.release.date)}
           timezone={displayTimezone}
           options={{ includeTz: false }}
-          tooltip
+          withPopover
         />
       ) : (
         'Not released'
@@ -651,7 +651,7 @@ function generateOverrideFieldItems(
             date={Temporal.PlainDateTime.from(rule.due.date)}
             timezone={displayTimezone}
             options={{ includeTz: false }}
-            tooltip
+            withPopover
           />
           {creditLabel}
         </>
@@ -1046,7 +1046,12 @@ function buildDefaultRuleCurrentIndicator(
   }
 
   const friendlyDate = (date: Date) => (
-    <FriendlyDate date={date} timezone={displayTimezone} options={{ includeTz: false }} tooltip />
+    <FriendlyDate
+      date={date}
+      timezone={displayTimezone}
+      options={{ includeTz: false }}
+      withPopover
+    />
   );
 
   if (segment.kind === 'beforeRelease') {

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
@@ -430,36 +430,46 @@ export function GroupSettingsCard({
                     <tr>
                       <th scope="col">Name</th>
                       <th scope="col">
-                        Min assignees{' '}
-                        <HelpPopover ariaLabel="Min assignees help">
-                          Minimum number of students that must be assigned to this role.
-                        </HelpPopover>
+                        <span className="d-inline-flex align-items-center gap-1 text-nowrap">
+                          Min assignees
+                          <HelpPopover ariaLabel="Min assignees help">
+                            Minimum number of students that must be assigned to this role.
+                          </HelpPopover>
+                        </span>
                       </th>
                       <th scope="col">
-                        Max assignees{' '}
-                        <HelpPopover ariaLabel="Max assignees help">
-                          Maximum number of students that can be assigned to this role. Leave blank
-                          for unlimited.
-                        </HelpPopover>
+                        <span className="d-inline-flex align-items-center gap-1 text-nowrap">
+                          Max assignees
+                          <HelpPopover ariaLabel="Max assignees help">
+                            Maximum number of students that can be assigned to this role. Leave
+                            blank for unlimited.
+                          </HelpPopover>
+                        </span>
                       </th>
                       <th scope="col" className="text-center">
-                        Can assign{' '}
-                        <HelpPopover ariaLabel="Can assign roles help">
-                          Students with this role can assign roles to other students in the group.
-                        </HelpPopover>
+                        <span className="d-inline-flex align-items-center gap-1 text-nowrap">
+                          Can assign
+                          <HelpPopover ariaLabel="Can assign roles help">
+                            Students with this role can assign roles to other students in the group.
+                          </HelpPopover>
+                        </span>
                       </th>
                       <th scope="col" className="text-center">
-                        Can view{' '}
-                        <HelpPopover ariaLabel="Can view help">
-                          Students with this role can view assessment questions by default.
-                        </HelpPopover>
+                        <span className="d-inline-flex align-items-center gap-1 text-nowrap">
+                          Can view
+                          <HelpPopover ariaLabel="Can view help">
+                            Students with this role can view assessment questions by default.
+                          </HelpPopover>
+                        </span>
                       </th>
                       <th scope="col" className="text-center">
-                        Can submit{' '}
-                        <HelpPopover ariaLabel="Can submit help">
-                          Students with this role can submit answers to assessment questions by
-                          default.
-                        </HelpPopover>
+                        <span className="d-inline-flex align-items-center gap-1 text-nowrap">
+                          Can submit
+                          <HelpPopover ariaLabel="Can submit help">
+                            Students with this role can submit answers to assessment questions by
+                            default.
+                          </HelpPopover>
+                        </span>
                       </th>
                       <th scope="col" />
                     </tr>

--- a/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentGroups/components/GroupSettingsCard.tsx
@@ -6,7 +6,7 @@ import { useFieldArray, useForm } from 'react-hook-form';
 
 import { run } from '@prairielearn/run';
 
-import { HelpTooltip } from '../../../components/HelpTooltip.js';
+import { HelpPopover } from '../../../components/HelpPopover.js';
 import { getAppError } from '../../../lib/client/errors.js';
 import { type StaffGroupConfig } from '../../../lib/client/safe-db-types.js';
 import { type GroupSettingsFormValues, makeRole } from '../../../lib/group-config.js';
@@ -431,43 +431,35 @@ export function GroupSettingsCard({
                       <th scope="col">Name</th>
                       <th scope="col">
                         Min assignees{' '}
-                        <HelpTooltip
-                          body="Minimum number of students that must be assigned to this role."
-                          id="role-min-assignees-tooltip"
-                          ariaLabel="Min assignees help"
-                        />
+                        <HelpPopover ariaLabel="Min assignees help">
+                          Minimum number of students that must be assigned to this role.
+                        </HelpPopover>
                       </th>
                       <th scope="col">
                         Max assignees{' '}
-                        <HelpTooltip
-                          body="Maximum number of students that can be assigned to this role. Leave blank for unlimited."
-                          id="role-max-assignees-tooltip"
-                          ariaLabel="Max assignees help"
-                        />
+                        <HelpPopover ariaLabel="Max assignees help">
+                          Maximum number of students that can be assigned to this role. Leave blank
+                          for unlimited.
+                        </HelpPopover>
                       </th>
                       <th scope="col" className="text-center">
                         Can assign{' '}
-                        <HelpTooltip
-                          body="Students with this role can assign roles to other students in the group."
-                          id="role-can-assign-tooltip"
-                          ariaLabel="Can assign roles help"
-                        />
+                        <HelpPopover ariaLabel="Can assign roles help">
+                          Students with this role can assign roles to other students in the group.
+                        </HelpPopover>
                       </th>
                       <th scope="col" className="text-center">
                         Can view{' '}
-                        <HelpTooltip
-                          body="Students with this role can view assessment questions by default."
-                          id="role-can-view-tooltip"
-                          ariaLabel="Can view help"
-                        />
+                        <HelpPopover ariaLabel="Can view help">
+                          Students with this role can view assessment questions by default.
+                        </HelpPopover>
                       </th>
                       <th scope="col" className="text-center">
                         Can submit{' '}
-                        <HelpTooltip
-                          body="Students with this role can submit answers to assessment questions by default."
-                          id="role-can-submit-tooltip"
-                          ariaLabel="Can submit help"
-                        />
+                        <HelpPopover ariaLabel="Can submit help">
+                          Students with this role can submit answers to assessment questions by
+                          default.
+                        </HelpPopover>
                       </th>
                       <th scope="col" />
                     </tr>

--- a/apps/prairielearn/src/pages/instructorAssessmentInstances/components/AssessmentInstancesTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentInstances/components/AssessmentInstancesTable.tsx
@@ -433,7 +433,7 @@ export function AssessmentInstancesTable({
           if (!date) return null;
           return (
             <span className="text-nowrap">
-              <FriendlyDate date={date} timezone={courseInstance.display_timezone} tooltip />
+              <FriendlyDate date={date} timezone={courseInstance.display_timezone} withPopover />
             </span>
           );
         },

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
@@ -189,10 +189,10 @@ function AssessmentQuestionRow({
         {question.manual_rubric_id != null && (
           <button
             type="button"
-            className="btn btn-xs btn-ghost p-0 border-0 ms-2 text-info"
+            className="btn btn-xs btn-ghost btn-icon border-0 ms-2 text-info"
             data-bs-toggle="popover"
             data-bs-content="This question uses a rubric"
-            aria-label="This question uses a rubric"
+            aria-label="View rubric status"
           >
             <i className="fas fa-list-check" aria-hidden="true" />
           </button>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessment/assessment.html.tsx
@@ -114,11 +114,9 @@ export function ManualGradingAssessment({
                       <button
                         type="submit"
                         class="btn btn-sm btn-light grading-tag-button"
-                        aria-label="Delete all AI grading data"
-                        data-bs-toggle="tooltip"
-                        data-bs-title="Delete all AI grading results for this assessment's questions"
+                        aria-label="Delete all AI grading results for this assessment's questions"
                       >
-                        Delete AI grading data
+                        Delete all AI grading results
                       </button>
                     </form>
                   `.toString(),
@@ -189,16 +187,15 @@ function AssessmentQuestionRow({
           {question.title}
         </a>
         {question.manual_rubric_id != null && (
-          // TODO: Fix this
-          // eslint-disable-next-line jsx-a11y-x/anchor-is-valid
-          <a
-            href="#"
-            className="ms-2 text-info"
-            data-bs-toggle="tooltip"
-            data-bs-title="This question uses a rubric"
+          <button
+            type="button"
+            className="btn btn-xs btn-ghost p-0 border-0 ms-2 text-info"
+            data-bs-toggle="popover"
+            data-bs-content="This question uses a rubric"
+            aria-label="This question uses a rubric"
           >
-            <i className="fas fa-list-check" />
-          </a>
+            <i className="fas fa-list-check" aria-hidden="true" />
+          </button>
         )}
       </td>
       <td className="align-middle">{question.qid}</td>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AiGradingModelSelectionModal.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AiGradingModelSelectionModal.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import { Alert, Button, Form, Modal, Spinner } from 'react-bootstrap';
 
 import { run } from '@prairielearn/run';
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 import { assertNever } from '@prairielearn/utils';
 
 import {
@@ -98,6 +98,7 @@ function ModelOption({
             <div>
               <span className="fw-medium">{model.name}</span>
               <div className="text-muted small">{model.sublabel}</div>
+              {!isAvailable && <div className="text-danger small">API key not configured</div>}
               {/* Cost shown below sublabel on xs viewports */}
               <div className="text-muted small d-sm-none">{relativeCost}</div>
             </div>
@@ -110,20 +111,7 @@ function ModelOption({
     </label>
   );
 
-  return isAvailable ? (
-    option
-  ) : (
-    <OverlayTrigger
-      key={model.modelId}
-      placement="top"
-      tooltip={{
-        props: { id: `model-tooltip-${model.modelId}` },
-        body: 'No API key configured for this provider',
-      }}
-    >
-      {option}
-    </OverlayTrigger>
-  );
+  return option;
 }
 
 function ModelList({
@@ -151,15 +139,18 @@ function ModelList({
           <span className="fw-semibold">Recommended</span>
           <span className="text-muted small text-end">
             Relative cost{' '}
-            <OverlayTrigger
+            <Popover
+              content="Relative cost compared to the default model, based on standard token usage."
               placement="top"
-              tooltip={{
-                props: { id: 'cost-tooltip' },
-                body: 'Relative cost compared to the default model, based on standard token usage.',
-              }}
             >
-              <i className="bi bi-question-circle" aria-hidden="true" />
-            </OverlayTrigger>
+              <button
+                type="button"
+                className="btn btn-xs btn-ghost p-0 border-0"
+                aria-label="More information about relative cost"
+              >
+                <i className="bi bi-question-circle" aria-hidden="true" />
+              </button>
+            </Popover>
           </span>
         </div>
         <div className="d-flex flex-column gap-1">

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AiGradingModelSelectionModal.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AiGradingModelSelectionModal.tsx
@@ -145,7 +145,7 @@ function ModelList({
             >
               <button
                 type="button"
-                className="btn btn-xs btn-ghost p-0 border-0"
+                className="btn btn-xs btn-ghost btn-icon border-0"
                 aria-label="More information about relative cost"
               >
                 <i className="bi bi-question-circle" aria-hidden="true" />

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
@@ -17,7 +17,7 @@ import { run } from '@prairielearn/run';
 import {
   type MultiSelectFilterValue,
   type NumericColumnFilterValue,
-  OverlayTrigger,
+  Popover,
   TanstackTableCard,
   parseAsColumnPinningState,
   parseAsColumnVisibilityStateWithColumns,
@@ -757,24 +757,16 @@ export function AssessmentQuestionTable({
                 </Dropdown>
                 {aiSubmissionGroupingEnabled &&
                   (!availableAiGradingProviders.includes('openai') ? (
-                    <OverlayTrigger
-                      tooltip={{
-                        body: 'No OpenAI API key is configured. Add a key in AI grading settings to use submission grouping.',
-                        props: { id: 'ai-grouping-no-openai-tooltip' },
-                      }}
-                    >
-                      <span style={{ display: 'inline-block' }}>
-                        <Button
-                          variant="light"
-                          size="sm"
-                          style={{ pointerEvents: 'none' }}
-                          disabled
-                        >
-                          <i className="bi bi-stars" aria-hidden="true" />
-                          <span className="d-none d-sm-inline">AI submission grouping</span>
-                        </Button>
-                      </span>
-                    </OverlayTrigger>
+                    <Popover content="No OpenAI API key is configured. Add a key in AI grading settings to use submission grouping.">
+                      <Button
+                        variant="light"
+                        size="sm"
+                        aria-label="AI submission grouping unavailable: No OpenAI API key is configured"
+                      >
+                        <i className="bi bi-stars" aria-hidden="true" />
+                        <span className="d-none d-sm-inline">AI submission grouping</span>
+                      </Button>
+                    </Popover>
                   ) : (
                     <Dropdown>
                       <Dropdown.Toggle variant="light" size="sm">
@@ -828,21 +820,15 @@ export function AssessmentQuestionTable({
                 <Dropdown.Menu align="end">
                   <Dropdown.Header className="d-flex align-items-center gap-1">
                     Assign for grading
-                    <OverlayTrigger
-                      tooltip={{
-                        body: (
-                          <>
-                            Only staff with student data editor permissions can be assigned as
-                            graders
-                          </>
-                        ),
-                        props: { id: 'assign-for-grading-tooltip' },
-                      }}
-                    >
-                      <span>
-                        <i className="fas fa-question-circle text-secondary" />
-                      </span>
-                    </OverlayTrigger>
+                    <Popover content="Only staff with student data editor permissions can be assigned as graders">
+                      <button
+                        type="button"
+                        className="btn btn-xs btn-ghost p-0 border-0"
+                        aria-label="More information about assigning graders"
+                      >
+                        <i className="fas fa-question-circle text-secondary" aria-hidden="true" />
+                      </button>
+                    </Popover>
                   </Dropdown.Header>
                   {courseStaff.map((grader) => (
                     <Dropdown.Item

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/AssessmentQuestionTable.tsx
@@ -761,7 +761,8 @@ export function AssessmentQuestionTable({
                       <Button
                         variant="light"
                         size="sm"
-                        aria-label="AI submission grouping unavailable: No OpenAI API key is configured"
+                        className="opacity-50"
+                        aria-label="Why AI submission grouping is unavailable"
                       >
                         <i className="bi bi-stars" aria-hidden="true" />
                         <span className="d-none d-sm-inline">AI submission grouping</span>
@@ -823,7 +824,7 @@ export function AssessmentQuestionTable({
                     <Popover content="Only staff with student data editor permissions can be assigned as graders">
                       <button
                         type="button"
-                        className="btn btn-xs btn-ghost p-0 border-0"
+                        className="btn btn-xs btn-ghost btn-icon border-0"
                         aria-label="More information about assigning graders"
                       >
                         <i className="fas fa-question-circle text-secondary" aria-hidden="true" />

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/GradingStatusCell.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/components/GradingStatusCell.tsx
@@ -1,4 +1,3 @@
-import { OverlayTrigger } from '@prairielearn/ui';
 import { assertNever } from '@prairielearn/utils';
 
 import { JobItemStatus } from '../../../../lib/serverJobProgressSocket.shared.js';
@@ -18,7 +17,7 @@ export function GradingStatusCell({
   if (!aiGradingMode || aiGradingStatus === undefined) {
     return requiresGrading ? 'Requires grading' : 'Graded';
   }
-  return <AiGradingStatusCell rowId={instanceQuestionId} aiGradingStatus={aiGradingStatus} />;
+  return <AiGradingStatusCell aiGradingStatus={aiGradingStatus} />;
 }
 
 /**
@@ -26,71 +25,38 @@ export function GradingStatusCell({
  * when an instance question is being AI graded,
  * this cell displays its grading status.
  */
-function AiGradingStatusCell({
-  rowId,
-  aiGradingStatus,
-}: {
-  rowId: string;
-  aiGradingStatus: JobItemStatus;
-}) {
+function AiGradingStatusCell({ aiGradingStatus }: { aiGradingStatus: JobItemStatus }) {
   switch (aiGradingStatus) {
     case JobItemStatus.queued:
       return (
-        <OverlayTrigger
-          tooltip={{
-            body: 'AI grading queued',
-            props: { id: `ai-status-${rowId}-queued-tooltip` },
-          }}
-        >
-          <span className="d-flex align-items-center gap-2">
-            <i className="bi bi-clock text-secondary" aria-hidden="true" />
-            <span>Queued</span>
-          </span>
-        </OverlayTrigger>
+        <span className="d-flex align-items-center gap-2">
+          <i className="bi bi-clock text-secondary" aria-hidden="true" />
+          <span>Queued</span>
+        </span>
       );
     case JobItemStatus.in_progress:
       return (
-        <OverlayTrigger
-          tooltip={{
-            body: 'AI grading in progress',
-            props: { id: `ai-status-${rowId}-progress-tooltip` },
-          }}
-        >
-          <span className="d-flex align-items-center gap-2">
-            <div className="spinner-grow spinner-grow-sm text-secondary bg-secondary" role="status">
-              <span className="visually-hidden">Loading...</span>
-            </div>
-            <span>AI grading...</span>
-          </span>
-        </OverlayTrigger>
+        <span className="d-flex align-items-center gap-2">
+          <span
+            className="spinner-grow spinner-grow-sm text-secondary bg-secondary"
+            aria-hidden="true"
+          />
+          <span>AI grading...</span>
+        </span>
       );
     case JobItemStatus.failed:
       return (
-        <OverlayTrigger
-          tooltip={{
-            body: 'AI grading failed',
-            props: { id: `ai-status-${rowId}-failed-tooltip` },
-          }}
-        >
-          <span className="d-flex align-items-center gap-2">
-            <i className="bi bi-exclamation-octagon-fill text-danger" aria-hidden="true" />
-            <span>Failed</span>
-          </span>
-        </OverlayTrigger>
+        <span className="d-flex align-items-center gap-2">
+          <i className="bi bi-exclamation-octagon-fill text-danger" aria-hidden="true" />
+          <span>Failed</span>
+        </span>
       );
     case JobItemStatus.complete:
       return (
-        <OverlayTrigger
-          tooltip={{
-            body: 'AI grading completed successfully',
-            props: { id: `ai-status-${rowId}-success-tooltip` },
-          }}
-        >
-          <span className="d-flex align-items-center gap-2">
-            <i className="bi bi-check-circle-fill text-success" aria-hidden="true" />
-            <span>Graded</span>
-          </span>
-        </OverlayTrigger>
+        <span className="d-flex align-items-center gap-2">
+          <i className="bi bi-check-circle-fill text-success" aria-hidden="true" />
+          <span>Graded</span>
+        </span>
       );
     default:
       assertNever(aiGradingStatus);

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/utils/columnDefinitions.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/utils/columnDefinitions.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import { run } from '@prairielearn/run';
 import {
   type MultiSelectFilterValue,
-  OverlayTrigger,
+  Popover,
   applyMultiSelectFilter,
   numericColumnFilterFn,
 } from '@prairielearn/ui';
@@ -115,7 +115,6 @@ export function createColumns({
       header: 'Instance',
       cell: (info) => {
         const row = info.row.original;
-        const rowId = row.instance_question.id;
         return (
           <div className="d-flex align-items-center gap-2">
             <a
@@ -124,36 +123,23 @@ export function createColumns({
               Instance {info.getValue() + 1}
             </a>
             {row.open_issue_count ? (
-              <OverlayTrigger
-                tooltip={{
-                  props: { id: `instance-${rowId}-issue-tooltip` },
-                  body: (
-                    <>
-                      Instance question has {row.open_issue_count} open{' '}
-                      {row.open_issue_count > 1 ? 'issues' : 'issue'}
-                    </>
-                  ),
-                }}
+              <Popover
+                content={
+                  <>
+                    Instance question has {row.open_issue_count} open{' '}
+                    {row.open_issue_count > 1 ? 'issues' : 'issue'}
+                  </>
+                }
               >
-                <button className="btn btn-danger badge rounded-pill">
+                <button type="button" className="btn btn-danger badge rounded-pill">
                   {row.open_issue_count}
                 </button>
-              </OverlayTrigger>
+              </Popover>
             ) : null}
             {row.assessment_open ? (
-              <OverlayTrigger
-                tooltip={{
-                  body: 'Assessment instance is still open',
-                  props: { id: `assessment-instance-${rowId}-open-tooltip` },
-                }}
-              >
+              <Popover content="Assessment instance is still open">
                 <button
-                  // This is a tricky case: we need an interactive element to trigger the tooltip
-                  // for keyboard users, but we don't want it to be announced as a button by screen
-                  // readers. So we give it role="status" to indicate that it's just a status indicator.
-                  // It's possible there are better ways to handle this?
-                  // eslint-disable-next-line jsx-a11y-x/no-interactive-element-to-noninteractive-role
-                  role="status"
+                  type="button"
                   className="btn btn-xs btn-ghost"
                   aria-label="Assessment instance is still open"
                 >
@@ -162,7 +148,7 @@ export function createColumns({
                     aria-hidden="true"
                   />
                 </button>
-              </OverlayTrigger>
+              </Popover>
             ) : null}
           </div>
         );
@@ -179,24 +165,22 @@ export function createColumns({
           return <span className="text-secondary">No Group</span>;
         }
         const group = instanceQuestionGroups.find((g) => g.instance_question_group_name === value);
-        const rowId = info.row.original.instance_question.id;
         return (
           <span className="d-flex align-items-center gap-2">
             {value}
             {group && (
-              <OverlayTrigger
-                tooltip={{
-                  body: group.instance_question_group_description,
-                  props: { id: `submission-group-${rowId}-description-tooltip` },
-                }}
-              >
-                <button className="btn btn-xs btn-ghost" aria-label="Group description">
+              <Popover content={group.instance_question_group_description}>
+                <button
+                  type="button"
+                  className="btn btn-xs btn-ghost"
+                  aria-label="Group description"
+                >
                   <i
                     className="fas fa-circle-info fa-width-auto text-secondary"
                     aria-hidden="true"
                   />
                 </button>
-              </OverlayTrigger>
+              </Popover>
             )}
           </span>
         );
@@ -403,7 +387,6 @@ export function createColumns({
       },
       cell: (info) => {
         const row = info.row.original;
-        const rowId = row.instance_question.id;
         if (row.instance_question.point_difference === null) {
           return '—';
         }
@@ -424,14 +407,15 @@ export function createColumns({
 
         if (row.instance_question.rubric_difference.length === 0) {
           return (
-            <OverlayTrigger
-              tooltip={{
-                body: 'AI and human grading are in agreement',
-                props: { id: `ai-agreement-${rowId}-agreement-tooltip` },
-              }}
-            >
-              <i className="bi bi-check-square-fill text-success" />
-            </OverlayTrigger>
+            <Popover content="AI and human grading are in agreement">
+              <button
+                type="button"
+                className="btn btn-xs btn-ghost p-0 border-0"
+                aria-label="AI and human grading are in agreement"
+              >
+                <i className="bi bi-check-square-fill text-success" aria-hidden="true" />
+              </button>
+            </Popover>
           );
         }
 
@@ -440,23 +424,25 @@ export function createColumns({
             {row.instance_question.rubric_difference.map((item) => (
               <div key={item.description}>
                 {item.false_positive ? (
-                  <OverlayTrigger
-                    tooltip={{
-                      body: 'Selected by AI but not by human',
-                      props: { id: `ai-agreement-${rowId}-false-positive-tooltip` },
-                    }}
-                  >
-                    <i className="bi bi-plus-square-fill text-danger" />
-                  </OverlayTrigger>
+                  <Popover content="Selected by AI but not by human">
+                    <button
+                      type="button"
+                      className="btn btn-xs btn-ghost p-0 border-0"
+                      aria-label="Selected by AI but not by human"
+                    >
+                      <i className="bi bi-plus-square-fill text-danger" aria-hidden="true" />
+                    </button>
+                  </Popover>
                 ) : (
-                  <OverlayTrigger
-                    tooltip={{
-                      body: 'Selected by human but not by AI',
-                      props: { id: `ai-agreement-${rowId}-false-negative-tooltip` },
-                    }}
-                  >
-                    <i className="bi bi-dash-square-fill text-danger" />
-                  </OverlayTrigger>
+                  <Popover content="Selected by human but not by AI">
+                    <button
+                      type="button"
+                      className="btn btn-xs btn-ghost p-0 border-0"
+                      aria-label="Selected by human but not by AI"
+                    >
+                      <i className="bi bi-dash-square-fill text-danger" aria-hidden="true" />
+                    </button>
+                  </Popover>
                 )}{' '}
                 <span>{item.description}</span>
               </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/utils/columnDefinitions.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/assessmentQuestion/utils/columnDefinitions.tsx
@@ -141,7 +141,7 @@ export function createColumns({
                 <button
                   type="button"
                   className="btn btn-xs btn-ghost"
-                  aria-label="Assessment instance is still open"
+                  aria-label="View assessment instance status"
                 >
                   <i
                     className="fas fa-exclamation-triangle fa-width-auto text-warning"
@@ -410,8 +410,8 @@ export function createColumns({
             <Popover content="AI and human grading are in agreement">
               <button
                 type="button"
-                className="btn btn-xs btn-ghost p-0 border-0"
-                aria-label="AI and human grading are in agreement"
+                className="btn btn-xs btn-ghost btn-icon border-0"
+                aria-label="View AI grading comparison"
               >
                 <i className="bi bi-check-square-fill text-success" aria-hidden="true" />
               </button>
@@ -427,8 +427,8 @@ export function createColumns({
                   <Popover content="Selected by AI but not by human">
                     <button
                       type="button"
-                      className="btn btn-xs btn-ghost p-0 border-0"
-                      aria-label="Selected by AI but not by human"
+                      className="btn btn-xs btn-ghost btn-icon border-0"
+                      aria-label="View AI grading difference"
                     >
                       <i className="bi bi-plus-square-fill text-danger" aria-hidden="true" />
                     </button>
@@ -437,8 +437,8 @@ export function createColumns({
                   <Popover content="Selected by human but not by AI">
                     <button
                       type="button"
-                      className="btn btn-xs btn-ghost p-0 border-0"
-                      aria-label="Selected by human but not by AI"
+                      className="btn btn-xs btn-ghost btn-icon border-0"
+                      aria-label="View AI grading difference"
                     >
                       <i className="bi bi-dash-square-fill text-danger" aria-hidden="true" />
                     </button>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -173,14 +173,17 @@ export function GradingPanel({
                   Submission Group:
                   ${instanceQuestionGroups && instanceQuestionGroups.length > 0
                     ? html`
-                        <div
-                          id="instance-question-group-description-tooltip"
-                          data-bs-toggle="tooltip"
+                        <button
+                          type="button"
+                          class="btn btn-xs btn-ghost p-0 border-0"
+                          id="instance-question-group-description-popover"
+                          data-bs-toggle="popover"
                           data-bs-html="true"
-                          data-bs-title="${displayedSelectedGroup.instance_question_group_description}"
+                          data-bs-content="${displayedSelectedGroup.instance_question_group_description}"
+                          aria-label="Submission group description"
                         >
-                          <i class="fas fa-circle-info text-secondary"></i>
-                        </div>
+                          <i class="fas fa-circle-info text-secondary" aria-hidden="true"></i>
+                        </button>
                       `
                     : ''}
                 </label>

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -175,7 +175,7 @@ export function GradingPanel({
                     ? html`
                         <button
                           type="button"
-                          class="btn btn-xs btn-ghost p-0 border-0"
+                          class="btn btn-xs btn-ghost btn-icon border-0"
                           id="instance-question-group-description-popover"
                           data-bs-toggle="popover"
                           data-bs-html="true"

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
@@ -139,12 +139,24 @@ function RubricItems({
       <div class="d-flex align-items-center gap-2 text-secondary" style="padding-left: 3px;">
         ${aiGradingInfo?.submissionManuallyGraded
           ? html`
-              <div data-bs-toggle="tooltip" data-bs-title="AI grading">
-                <i class="bi bi-stars"></i>
-              </div>
-              <div data-bs-toggle="tooltip" data-bs-title="Human grading">
-                <i class="bi bi-person-fill"></i>
-              </div>
+              <button
+                type="button"
+                class="btn btn-xs btn-ghost p-0 border-0 text-secondary"
+                data-bs-toggle="popover"
+                data-bs-content="AI grading"
+                aria-label="AI grading"
+              >
+                <i class="bi bi-stars" aria-hidden="true"></i>
+              </button>
+              <button
+                type="button"
+                class="btn btn-xs btn-ghost p-0 border-0 text-secondary"
+                data-bs-toggle="popover"
+                data-bs-content="Human grading"
+                aria-label="Human grading"
+              >
+                <i class="bi bi-person-fill" aria-hidden="true"></i>
+              </button>
             `
           : ''}
       </div>
@@ -203,9 +215,7 @@ function RubricItem({
                 value="${item.rubric_item.id}"
                 ${ai_checked ? 'checked' : ''}
                 disabled
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-                title="${ai_checked ? 'Selected by AI' : 'Not selected by AI'}"
+                aria-label="${ai_checked ? 'Selected by AI' : 'Not selected by AI'}"
               />
             `
           : ''}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/rubricInputSection.html.ts
@@ -141,19 +141,19 @@ function RubricItems({
           ? html`
               <button
                 type="button"
-                class="btn btn-xs btn-ghost p-0 border-0 text-secondary"
+                class="btn btn-xs btn-ghost btn-icon border-0 text-secondary"
                 data-bs-toggle="popover"
                 data-bs-content="AI grading"
-                aria-label="AI grading"
+                aria-label="View AI grading source"
               >
                 <i class="bi bi-stars" aria-hidden="true"></i>
               </button>
               <button
                 type="button"
-                class="btn btn-xs btn-ghost p-0 border-0 text-secondary"
+                class="btn btn-xs btn-ghost btn-icon border-0 text-secondary"
                 data-bs-toggle="popover"
                 data-bs-content="Human grading"
-                aria-label="Human grading"
+                aria-label="View human grading source"
               >
                 <i class="bi bi-person-fill" aria-hidden="true"></i>
               </button>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentBadges.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentBadges.tsx
@@ -41,8 +41,8 @@ function MarkedBadge({
       <Popover content={tooltipLabel} placement="top">
         <button
           type="button"
-          className="btn btn-xs btn-ghost text-warning p-0 border-0"
-          aria-label={tooltipLabel}
+          className="btn btn-xs btn-ghost btn-icon text-warning border-0"
+          aria-label="View assessment warning"
         >
           <i className="bi bi-exclamation-triangle-fill" aria-hidden="true" />
         </button>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentBadges.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/AssessmentBadges.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { OverlayTrigger, Popover } from '@prairielearn/ui';
 
 import { AssessmentBadge } from '../../../components/AssessmentBadge.js';
 import type { AssessmentForPicker } from '../types.js';
@@ -21,35 +21,33 @@ function MarkedBadge({
   marked,
   useSetColor,
   tooltipLabel,
-  tooltipIdPrefix,
 }: {
   assessment: AssessmentForPicker;
   courseInstanceId: string;
   marked: boolean;
   useSetColor: boolean;
   tooltipLabel: string;
-  tooltipIdPrefix: string;
 }) {
   const badge = (
     <AssessmentBadge
       courseInstanceId={courseInstanceId}
       assessment={toBadgeProps(assessment, useSetColor)}
-      prefix={marked ? WARNING_PREFIX : undefined}
     />
   );
   if (!marked) return badge;
   return (
-    <OverlayTrigger
-      placement="top"
-      tooltip={{
-        body: tooltipLabel,
-        props: { id: `${tooltipIdPrefix}-${courseInstanceId}-${assessment.assessment_id}` },
-      }}
-    >
-      <span className="d-inline-block" data-testid="zone-removal-marker">
-        {badge}
-      </span>
-    </OverlayTrigger>
+    <span className="d-inline-flex align-items-center gap-1" data-testid="zone-removal-marker">
+      {badge}
+      <Popover content={tooltipLabel} placement="top">
+        <button
+          type="button"
+          className="btn btn-xs btn-ghost text-warning p-0 border-0"
+          aria-label={tooltipLabel}
+        >
+          <i className="bi bi-exclamation-triangle-fill" aria-hidden="true" />
+        </button>
+      </Popover>
+    </span>
   );
 }
 
@@ -116,14 +114,13 @@ export function AssessmentBadges({
   }
 
   const isMarked = (id: string) => markedAssessmentIds?.has(id) ?? false;
-  const renderBadge = (assessment: AssessmentForPicker, useSetColor: boolean, idPrefix: string) => (
+  const renderBadge = (assessment: AssessmentForPicker, useSetColor: boolean) => (
     <MarkedBadge
       assessment={assessment}
       courseInstanceId={courseInstanceId}
       marked={isMarked(assessment.assessment_id)}
       useSetColor={useSetColor}
       tooltipLabel={markedSingleLabel}
-      tooltipIdPrefix={idPrefix}
     />
   );
 
@@ -134,7 +131,7 @@ export function AssessmentBadges({
       <>
         {assessments.slice(0, 3).map((assessment) => (
           <span key={assessment.assessment_id} className="d-inline-block me-1">
-            {renderBadge(assessment, false, 'zone-removal')}
+            {renderBadge(assessment, false)}
           </span>
         ))}
         {assessments.length > 3 && (
@@ -151,7 +148,7 @@ export function AssessmentBadges({
       for (const assessment of items) {
         elements.push(
           <span key={assessment.assessment_id} className="d-inline-block me-1">
-            {renderBadge(assessment, true, 'zone-removal')}
+            {renderBadge(assessment, true)}
           </span>,
         );
       }
@@ -173,7 +170,7 @@ export function AssessmentBadges({
               <div className="d-flex flex-wrap gap-1">
                 {items.map((assessment) => (
                   <span key={assessment.assessment_id} className="d-inline-block">
-                    {renderBadge(assessment, true, 'zone-removal-popover')}
+                    {renderBadge(assessment, true)}
                   </span>
                 ))}
               </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/EditModeToolbar.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/EditModeToolbar.tsx
@@ -106,12 +106,11 @@ export function EditModeToolbar({
       className={clsx(
         'btn btn-sm mx-1',
         saveButtonDisabled ? 'btn-outline-secondary' : 'btn-primary',
+        saveButtonDisabledReason && 'opacity-50',
       )}
       type={saveButtonDisabledReason ? 'button' : 'submit'}
       disabled={saveButtonDisabled && !saveButtonDisabledReason}
-      aria-label={
-        saveButtonDisabledReason ? `Save unavailable: ${saveButtonDisabledReason}` : 'Save'
-      }
+      aria-label={saveButtonDisabledReason ? 'Why saving is unavailable' : 'Save'}
     >
       <i className="bi bi-floppy" aria-hidden="true" />{' '}
       <span className="toolbar-btn-label">Save</span>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/EditModeToolbar.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/EditModeToolbar.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
-import { useId } from 'react';
 
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import type { ZoneAssessmentJson } from '../../../schemas/infoAssessment.js';
 import type { ViewType } from '../types.js';
@@ -89,8 +88,6 @@ export function EditModeToolbar({
   onSubmit: () => void;
   onCancel: () => void;
 }) {
-  const saveTooltipId = useId();
-
   if (!editMode) {
     if (!canEdit) return null;
     return (
@@ -110,10 +107,11 @@ export function EditModeToolbar({
         'btn btn-sm mx-1',
         saveButtonDisabled ? 'btn-outline-secondary' : 'btn-primary',
       )}
-      type="submit"
-      disabled={saveButtonDisabled}
-      aria-label="Save"
-      {...(saveButtonDisabledReason && { 'aria-describedby': saveTooltipId })}
+      type={saveButtonDisabledReason ? 'button' : 'submit'}
+      disabled={saveButtonDisabled && !saveButtonDisabledReason}
+      aria-label={
+        saveButtonDisabledReason ? `Save unavailable: ${saveButtonDisabledReason}` : 'Save'
+      }
     >
       <i className="bi bi-floppy" aria-hidden="true" />{' '}
       <span className="toolbar-btn-label">Save</span>
@@ -127,15 +125,9 @@ export function EditModeToolbar({
       <input type="hidden" name="orig_hash" value={origHash} />
       <input type="hidden" name="zones" value={JSON.stringify(zones)} />
       {saveButtonDisabledReason ? (
-        <OverlayTrigger
-          placement="bottom"
-          tooltip={{
-            props: { id: saveTooltipId },
-            body: saveButtonDisabledReason,
-          }}
-        >
-          <span style={{ cursor: 'not-allowed' }}>{saveButton}</span>
-        </OverlayTrigger>
+        <Popover content={saveButtonDisabledReason} placement="bottom">
+          {saveButton}
+        </Popover>
       ) : (
         saveButton
       )}

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/QuestionDetailPanel.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/detail/QuestionDetailPanel.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react-hook-form';
 
 import { run } from '@prairielearn/run';
-import { OverlayTrigger } from '@prairielearn/ui';
 
 import { CopyButton } from '../../../../components/CopyButton.js';
 import type { EditorQuestionMetadata } from '../../../../lib/assessment-question.shared.js';
@@ -652,21 +651,13 @@ export function QuestionDetailPanel({
         {!editMode &&
           hasCourseInstancePermissionEdit &&
           questionData?.assessment_question_id != null && (
-            <OverlayTrigger
-              placement="top"
-              tooltip={{
-                props: { id: 'reset-variants-tooltip' },
-                body: 'Resets all existing variants for this question on this assessment, so students will get new variants on their next visit.',
-              }}
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-secondary"
+              onClick={() => onResetButtonClick(questionData.assessment_question_id!)}
             >
-              <button
-                type="button"
-                className="btn btn-sm btn-outline-secondary"
-                onClick={() => onResetButtonClick(questionData.assessment_question_id!)}
-              >
-                Reset question variants
-              </button>
-            </OverlayTrigger>
+              Reset question variants
+            </button>
           )}
       </div>
     </div>

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/ChangeIndicatorBadges.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/ChangeIndicatorBadges.tsx
@@ -1,6 +1,4 @@
-import { useId } from 'react';
-
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import { isRenderableComment } from '../../../../lib/comments.js';
 import type { ChangeTrackingResult } from '../../types.js';
@@ -24,38 +22,31 @@ export function ChangeIndicatorBadges({
   editMode: boolean;
   changeTracking: ChangeTrackingResult;
 }) {
-  const changeTooltipId = useId();
-  const commentTooltipId = useId();
-
   return (
     <>
       {editMode && changeTracking.newIds.has(trackingId) && (
-        <OverlayTrigger placement="top" tooltip={{ props: { id: changeTooltipId }, body: 'New' }}>
-          <span className="text-primary ms-1" role="img" aria-label="New">
-            ●
-          </span>
-        </OverlayTrigger>
+        <span className="text-primary ms-1" role="img" aria-label="New">
+          ●
+        </span>
       )}
       {editMode && changeTracking.modifiedIds.has(trackingId) && (
-        <OverlayTrigger
-          placement="top"
-          tooltip={{ props: { id: changeTooltipId }, body: 'Modified' }}
-        >
-          <span className="text-primary ms-1" role="img" aria-label="Modified">
-            ●
-          </span>
-        </OverlayTrigger>
+        <span className="text-primary ms-1" role="img" aria-label="Modified">
+          ●
+        </span>
       )}
       {isRenderableComment(comment) && (
-        <OverlayTrigger
+        <Popover
+          content={truncateWithEllipsis(commentToString(comment) ?? '', COMMENT_TOOLTIP_MAX_LENGTH)}
           placement="top"
-          tooltip={{
-            props: { id: commentTooltipId },
-            body: truncateWithEllipsis(commentToString(comment) ?? '', COMMENT_TOOLTIP_MAX_LENGTH),
-          }}
         >
-          <i className="bi bi-chat-left-text text-muted ms-1" aria-hidden="true" />
-        </OverlayTrigger>
+          <button
+            type="button"
+            className="btn btn-xs btn-ghost p-0 border-0 ms-1"
+            aria-label="View comment"
+          >
+            <i className="bi bi-chat-left-text text-muted" aria-hidden="true" />
+          </button>
+        </Popover>
       )}
     </>
   );

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/ChangeIndicatorBadges.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/ChangeIndicatorBadges.tsx
@@ -41,7 +41,7 @@ export function ChangeIndicatorBadges({
         >
           <button
             type="button"
-            className="btn btn-xs btn-ghost p-0 border-0 ms-1"
+            className="btn btn-xs btn-ghost btn-icon border-0 ms-1"
             aria-label="View comment"
           >
             <i className="bi bi-chat-left-text text-muted" aria-hidden="true" />

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { useCallback, useMemo } from 'react';
 
 import { run } from '@prairielearn/run';
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import type {
   TreeActions,
@@ -231,14 +231,12 @@ export function TreeQuestionBlockNode({
             <span className="d-inline-flex align-items-center gap-1 flex-wrap ms-2">
               {pointsMismatch && (
                 <WarningIndicator
-                  tooltipId={`points-mismatch-${zoneQuestionBlock.trackingId}`}
                   label="Inconsistent points"
                   body="Students will receive different total points because this pool has alternatives with different point values"
                 />
               )}
               {chooseExceeds && (
                 <WarningIndicator
-                  tooltipId={`choose-exceeds-${zoneQuestionBlock.trackingId}`}
                   label="Choose exceeds count"
                   body="Number to choose exceeds the number of alternatives in this pool"
                 />
@@ -271,13 +269,7 @@ export function TreeQuestionBlockNode({
                     {tag.name}
                   </span>
                 ))}
-                <OverlayTrigger
-                  placement="top"
-                  tooltip={{
-                    props: { id: `shared-tags-${zoneQuestionBlock.trackingId}` },
-                    body: 'Tags shared across all alternatives',
-                  }}
-                >
+                <Popover content="Tags shared across all alternatives" placement="top">
                   <button
                     type="button"
                     className="btn btn-xs btn-ghost p-0"
@@ -285,7 +277,7 @@ export function TreeQuestionBlockNode({
                   >
                     <i className="bi bi-question-circle text-muted" aria-hidden="true" />
                   </button>
-                </OverlayTrigger>
+                </Popover>
               </div>
             );
           })}

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionBlockNode.tsx
@@ -272,7 +272,7 @@ export function TreeQuestionBlockNode({
                 <Popover content="Tags shared across all alternatives" placement="top">
                   <button
                     type="button"
-                    className="btn btn-xs btn-ghost p-0"
+                    className="btn btn-xs btn-ghost btn-icon"
                     aria-label="Tags shared across all alternatives"
                   >
                     <i className="bi bi-question-circle text-muted" aria-hidden="true" />

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeQuestionRow.tsx
@@ -1,9 +1,9 @@
 import type { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import clsx from 'clsx';
-import { type ReactElement, useId } from 'react';
+import { type ReactElement } from 'react';
 
 import { run } from '@prairielearn/run';
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import { AssessmentQuestionNumber } from '../../../../components/AssessmentQuestions.js';
 import { CopyButton } from '../../../../components/CopyButton.js';
@@ -38,7 +38,6 @@ export function PointsBadge({
   zoneQuestionBlock: ZoneQuestionBlockForm;
   assessmentType: EnumAssessmentType;
 }): ReactElement | null {
-  const tooltipId = useId();
   const forceMax = question.forceMaxPoints ?? zoneQuestionBlock.forceMaxPoints;
   const autoPoints = question.autoPoints ?? zoneQuestionBlock.autoPoints;
   const manualPoints = question.manualPoints ?? zoneQuestionBlock.manualPoints;
@@ -49,18 +48,19 @@ export function PointsBadge({
     if (forceMax) {
       const total = computeQuestionTotalPoints(question, assessmentType, zoneQuestionBlock);
       return (
-        <OverlayTrigger
+        <Popover
+          content={`Force max points: student receives ${total} pts on regrade`}
           placement="top"
-          tooltip={{
-            props: { id: tooltipId },
-            body: `Force max points: student receives ${total} pts on regrade`,
-          }}
         >
-          <span className="text-muted small text-nowrap ms-2">
+          <button
+            type="button"
+            className="btn btn-link text-muted text-decoration-none p-0 border-0 small text-nowrap ms-2"
+            onClick={(event) => event.stopPropagation()}
+          >
             <i className="bi bi-pin-angle-fill me-1" aria-hidden="true" />
             {total}
-          </span>
-        </OverlayTrigger>
+          </button>
+        </Popover>
       );
     }
 
@@ -97,12 +97,15 @@ export function PointsBadge({
     }
 
     return (
-      <OverlayTrigger
-        placement="top"
-        tooltip={{ props: { id: tooltipId }, body: tooltipParts.join(' · ') }}
-      >
-        <span className="text-muted small text-nowrap ms-2">{compactParts}</span>
-      </OverlayTrigger>
+      <Popover content={tooltipParts.join(' · ')} placement="top">
+        <button
+          type="button"
+          className="btn btn-link text-muted text-decoration-none p-0 border-0 small text-nowrap ms-2"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {compactParts}
+        </button>
+      </Popover>
     );
   }
 
@@ -116,18 +119,19 @@ export function PointsBadge({
   if (forceMax) {
     const total = computeQuestionTotalPoints(question, assessmentType, zoneQuestionBlock);
     return (
-      <OverlayTrigger
+      <Popover
+        content={`Force max points: student receives ${total} pts on regrade`}
         placement="top"
-        tooltip={{
-          props: { id: tooltipId },
-          body: `Force max points: student receives ${total} pts on regrade`,
-        }}
       >
-        <span className="text-muted small text-nowrap ms-2">
+        <button
+          type="button"
+          className="btn btn-link text-muted text-decoration-none p-0 border-0 small text-nowrap ms-2"
+          onClick={(event) => event.stopPropagation()}
+        >
           <i className="bi bi-pin-angle-fill me-1" aria-hidden="true" />
           {total}
-        </span>
-      </OverlayTrigger>
+        </button>
+      </Popover>
     );
   }
 
@@ -165,12 +169,15 @@ export function PointsBadge({
   }
 
   return (
-    <OverlayTrigger
-      placement="top"
-      tooltip={{ props: { id: tooltipId }, body: tooltipParts.join(' · ') }}
-    >
-      <span className="text-muted small text-nowrap ms-2">{compactParts}</span>
-    </OverlayTrigger>
+    <Popover content={tooltipParts.join(' · ')} placement="top">
+      <button
+        type="button"
+        className="btn btn-link text-muted text-decoration-none p-0 border-0 small text-nowrap ms-2"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {compactParts}
+      </button>
+    </Popover>
   );
 }
 
@@ -301,7 +308,6 @@ export function TreeQuestionRow({
           )}
           {hasManualGradingAutoPointsWarning && (
             <WarningIndicator
-              tooltipId={`manual-auto-points-${question.trackingId}`}
               label="Auto points ignored"
               body="Auto points have no effect on manually-graded questions"
             />

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeZoneNode.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/TreeZoneNode.tsx
@@ -1,10 +1,9 @@
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import clsx from 'clsx';
-import { useId } from 'react';
 
 import { run } from '@prairielearn/run';
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import type { EnumAssessmentType } from '../../../../lib/db-types.js';
 import type { TreeActions, TreeState, ZoneAssessmentForm } from '../../types.js';
@@ -44,7 +43,6 @@ export function TreeZoneNode({
 }) {
   const { editMode, selectedItem, collapsedZones, changeTracking, assessmentType } = state;
   const { setSelectedItem, dispatch, onAddQuestion, onAddAltPool, onDeleteZone } = actions;
-  const badgeTooltipId = useId();
   const isCollapsed = collapsedZones.has(zone.trackingId);
   const zonePointsMismatch = getZonePointsMismatch(zone, assessmentType);
   // This warning triggers when questions are deleted from a zone, reducing
@@ -144,15 +142,10 @@ export function TreeZoneNode({
           </span>
           <span className="d-inline-flex align-items-center gap-1 flex-wrap ms-2">
             {zonePointsMismatch && (
-              <WarningIndicator
-                tooltipId={`points-mismatch-${zone.trackingId}`}
-                label={zonePointsMismatch.label}
-                body={zonePointsMismatch.body}
-              />
+              <WarningIndicator label={zonePointsMismatch.label} body={zonePointsMismatch.body} />
             )}
             {zoneChooseExceeds && (
               <WarningIndicator
-                tooltipId={`choose-exceeds-${zone.trackingId}`}
                 label="Choose exceeds count"
                 body="Number to choose or best questions exceeds the number of questions in this zone"
               />
@@ -162,76 +155,74 @@ export function TreeZoneNode({
               // ZonePointsBadge already shows "No questions" when the zone is empty.
               if (count === 0) return null;
               return (
-                <OverlayTrigger
-                  placement="top"
-                  tooltip={{
-                    props: { id: `${badgeTooltipId}-count` },
-                    body: 'Total questions in this zone',
-                  }}
-                >
-                  <button type="button" className="btn btn-badge color-blue3">
+                <Popover content="Total questions in this zone" placement="top">
+                  <button
+                    type="button"
+                    className="btn btn-badge color-blue3"
+                    onClick={(event) => event.stopPropagation()}
+                  >
                     {count} question{count !== 1 ? 's' : ''}
                   </button>
-                </OverlayTrigger>
+                </Popover>
               );
             })}
             {zone.numberChoose != null && (
-              <OverlayTrigger
+              <Popover
+                content={`${zone.numberChoose} question${zone.numberChoose !== 1 ? 's are' : ' is'} randomly selected from this zone, spread across pools as evenly as possible.`}
                 placement="top"
-                tooltip={{
-                  props: { id: `${badgeTooltipId}-choose` },
-                  body: `${zone.numberChoose} question${zone.numberChoose !== 1 ? 's are' : ' is'} randomly selected from this zone, spread across pools as evenly as possible.`,
-                }}
               >
-                <button type="button" className="btn btn-badge color-blue3">
+                <button
+                  type="button"
+                  className="btn btn-badge color-blue3"
+                  onClick={(event) => event.stopPropagation()}
+                >
                   Choose {zone.numberChoose}
                 </button>
-              </OverlayTrigger>
+              </Popover>
             )}
-            <ZonePointsBadge
-              zone={zone}
-              assessmentType={assessmentType}
-              tooltipId={`${badgeTooltipId}-points`}
-            />
+            <ZonePointsBadge zone={zone} assessmentType={assessmentType} />
             {zone.maxPoints != null && (
-              <OverlayTrigger
+              <Popover
+                content="Maximum total points from this zone that count toward the assessment"
                 placement="top"
-                tooltip={{
-                  props: { id: `${badgeTooltipId}-max` },
-                  body: 'Maximum total points from this zone that count toward the assessment',
-                }}
               >
-                <button type="button" className="btn btn-badge color-blue3">
+                <button
+                  type="button"
+                  className="btn btn-badge color-blue3"
+                  onClick={(event) => event.stopPropagation()}
+                >
                   Max {zone.maxPoints} pts
                 </button>
-              </OverlayTrigger>
+              </Popover>
             )}
             {zone.bestQuestions != null && (
-              <OverlayTrigger
+              <Popover
+                content="Only the highest-scoring questions in this zone count toward the total"
                 placement="top"
-                tooltip={{
-                  props: { id: `${badgeTooltipId}-best` },
-                  body: 'Only the highest-scoring questions in this zone count toward the total',
-                }}
               >
-                <button type="button" className="btn btn-badge color-blue3">
+                <button
+                  type="button"
+                  className="btn btn-badge color-blue3"
+                  onClick={(event) => event.stopPropagation()}
+                >
                   Best {zone.bestQuestions}
                 </button>
-              </OverlayTrigger>
+              </Popover>
             )}
             {zone.lockpoint && (
-              <OverlayTrigger
+              <Popover
+                content="Students must complete this zone before proceeding to the next"
                 placement="top"
-                tooltip={{
-                  props: { id: `${badgeTooltipId}-lock` },
-                  body: 'Students must complete this zone before proceeding to the next',
-                }}
               >
-                <button type="button" className="btn btn-badge color-blue3">
+                <button
+                  type="button"
+                  className="btn btn-badge color-blue3"
+                  onClick={(event) => event.stopPropagation()}
+                >
                   <i className="bi bi-lock-fill me-1" aria-hidden="true" />
                   Lockpoint
                 </button>
-              </OverlayTrigger>
+              </Popover>
             )}
           </span>
           <span className="flex-grow-1" />
@@ -309,11 +300,9 @@ export function TreeZoneNode({
 function ZonePointsBadge({
   zone,
   assessmentType,
-  tooltipId,
 }: {
   zone: ZoneAssessmentForm;
   assessmentType: EnumAssessmentType;
-  tooltipId: string;
 }) {
   const { autoPoints, manualPoints } = computeZonePointTotals(zone.questions, {
     bestQuestions: zone.bestQuestions,
@@ -335,16 +324,14 @@ function ZonePointsBadge({
   });
 
   return (
-    <OverlayTrigger
-      placement="top"
-      tooltip={{
-        props: { id: tooltipId },
-        body: 'Total points a student can earn in this zone',
-      }}
-    >
-      <button type="button" className="btn btn-badge color-blue3">
+    <Popover content="Total points a student can earn in this zone" placement="top">
+      <button
+        type="button"
+        className="btn btn-badge color-blue3"
+        onClick={(event) => event.stopPropagation()}
+      >
         {label}
       </button>
-    </OverlayTrigger>
+    </Popover>
   );
 }

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/WarningIndicator.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/WarningIndicator.tsx
@@ -14,7 +14,7 @@ export function WarningIndicator({
       <button
         type="button"
         className={`btn btn-badge ${variant === 'error' ? 'color-red2' : 'color-yellow2'}`}
-        aria-label={body}
+        aria-label={`View details for ${label}`}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') e.stopPropagation();

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/WarningIndicator.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/components/tree/WarningIndicator.tsx
@@ -1,24 +1,16 @@
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 export function WarningIndicator({
-  tooltipId,
   label,
   body,
   variant = 'warning',
 }: {
-  tooltipId: string;
   label: string;
   body: string;
   variant?: 'warning' | 'error';
 }) {
   return (
-    <OverlayTrigger
-      placement="top"
-      tooltip={{
-        props: { id: tooltipId },
-        body,
-      }}
-    >
+    <Popover content={body} placement="top">
       <button
         type="button"
         className={`btn btn-badge ${variant === 'error' ? 'color-red2' : 'color-yellow2'}`}
@@ -31,6 +23,6 @@ export function WarningIndicator({
         <i className="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
         {label}
       </button>
-    </OverlayTrigger>
+    </Popover>
   );
 }

--- a/apps/prairielearn/src/pages/instructorCourseAdminModules/components/AssessmentModulesPage.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminModules/components/AssessmentModulesPage.tsx
@@ -78,7 +78,6 @@ function AssessmentModuleRow({
     <tr ref={ref} style={style}>
       {editMode && allowEdit && (
         <ReorderableRowActionsCell
-          trackingId={module.trackingId}
           dragHandleProps={dragHandleProps}
           editLabel={`Edit module ${module.name}`}
           deleteLabel={`Delete module ${module.name}`}

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/components/AssessmentSetsPage.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/components/AssessmentSetsPage.tsx
@@ -52,7 +52,6 @@ function AssessmentSetRow({
     <tr ref={ref} style={style}>
       {editMode && allowEdit && (
         <ReorderableRowActionsCell
-          trackingId={assessmentSet.trackingId}
           dragHandleProps={dragHandleProps}
           editLabel={`Edit assessment set ${assessmentSet.name}`}
           deleteLabel={`Delete assessment set ${assessmentSet.name}`}

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -24,6 +24,7 @@ import {
   type MultiSelectFilterValue,
   NuqsAdapter,
   OverlayTrigger,
+  Popover,
   TanstackTableCard,
   applyMultiSelectFilter,
   parseAsColumnPinningState,
@@ -949,15 +950,19 @@ function StaffTableInner({
           return name ? (
             <span>{name}</span>
           ) : (
-            <OverlayTrigger
+            <Popover
+              content={
+                'Users with name "Unknown user" either have never logged in or have an incorrect UID.'
+              }
               placement="top"
-              tooltip={{
-                body: 'Users with name "Unknown user" either have never logged in or have an incorrect UID.',
-                props: { id: `staff-unknown-user-tooltip-${info.row.original.user.id}` },
-              }}
             >
-              <span className="text-danger">Unknown user</span>
-            </OverlayTrigger>
+              <button
+                type="button"
+                className="btn btn-link text-danger text-decoration-none p-0 border-0"
+              >
+                Unknown user
+              </button>
+            </Popover>
           );
         },
       }),

--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/ExtensionTableRow.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/components/ExtensionTableRow.tsx
@@ -1,5 +1,5 @@
 import { formatDateFriendly } from '@prairielearn/formatter';
-import { OverlayTrigger } from '@prairielearn/ui';
+import { Popover } from '@prairielearn/ui';
 
 import { ExpandableUserList } from '../../../components/ExpandableUserList.js';
 import type { StaffCourseInstance } from '../../../lib/client/safe-db-types.js';
@@ -39,14 +39,7 @@ export function ExtensionTableRow({
             courseInstance.display_timezone,
           )}
           {isBeforeInstanceEndDate && (
-            <OverlayTrigger
-              tooltip={{
-                props: {
-                  id: `extension-end-date-warning-${extension.course_instance_publishing_extension.id}`,
-                },
-                body: 'This date is before the course instance end date and will be ignored',
-              }}
-            >
+            <Popover content="This date is before the course instance end date and will be ignored">
               <button
                 type="button"
                 className="btn btn-xs btn-ghost"
@@ -54,7 +47,7 @@ export function ExtensionTableRow({
               >
                 <i className="fas fa-exclamation-triangle text-warning" aria-hidden="true" />
               </button>
-            </OverlayTrigger>
+            </Popover>
           )}
         </div>
       </td>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
@@ -285,9 +285,9 @@ function IssueRow({
               <button
                 type="button"
                 className="badge text-bg-warning badge-sm"
-                data-bs-toggle="tooltip"
+                data-bs-toggle="popover"
                 data-bs-html="true"
-                title={`This issue was raised in course instance <strong>${issue.course_instance_short_name}</strong>. You do not have student data access for ${issue.course_instance_short_name}, so you can't view some of the issue details. Student data access can be granted by a course owner on the Staff page.`}
+                data-bs-content={`This issue was raised in course instance <strong>${issue.course_instance_short_name}</strong>. You do not have student data access for ${issue.course_instance_short_name}, so you can't view some of the issue details. Student data access can be granted by a course owner on the Staff page.`}
               >
                 No student data access
               </button>

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
@@ -182,8 +182,8 @@ function StudentInformationUnavailable() {
     <Popover content="Student information is not yet available.">
       <button
         type="button"
-        className="btn btn-xs btn-ghost p-0 border-0"
-        aria-label="Student information is not yet available"
+        className="btn btn-xs btn-ghost btn-icon border-0"
+        aria-label="Why student information is unavailable"
       >
         <i className="bi bi-question-circle" aria-hidden="true" />
       </button>
@@ -694,8 +694,8 @@ function StudentsCard({
                     <Popover content={`Select at most ${MAX_LABEL_UIDS} students to apply labels.`}>
                       <button
                         type="button"
-                        className="btn btn-light btn-sm"
-                        aria-label={`Labels unavailable: Select at most ${MAX_LABEL_UIDS} students`}
+                        className="btn btn-light btn-sm opacity-50"
+                        aria-label="Why labeling is unavailable"
                       >
                         Labels
                       </button>

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
@@ -24,7 +24,7 @@ import {
   MultiSelectColumnFilter,
   type MultiSelectFilterValue,
   NuqsAdapter,
-  OverlayTrigger,
+  Popover,
   TanstackTableCard,
   TanstackTableEmptyState,
   applyMultiSelectFilter,
@@ -139,54 +139,55 @@ function ManageEnrollmentsDropdown({
   const canEdit = authzData.has_course_instance_permission_edit;
 
   return (
-    <DropdownButton as={ButtonGroup} title="Manage enrollments" size="sm" variant="light">
-      <Dropdown.Item as="button" type="button" disabled={!canEdit} onClick={onInvite}>
-        <i className="bi bi-person-plus me-2" aria-hidden="true" />
-        Invite students
-      </Dropdown.Item>
-      <Dropdown.Item as="button" type="button" disabled={!canEdit} onClick={onSync}>
-        <i className="bi bi-arrow-left-right me-2" aria-hidden="true" />
-        Synchronize student list
-      </Dropdown.Item>
+    <>
+      <DropdownButton as={ButtonGroup} title="Manage enrollments" size="sm" variant="light">
+        <Dropdown.Item as="button" type="button" disabled={!canEdit} onClick={onInvite}>
+          <i className="bi bi-person-plus me-2" aria-hidden="true" />
+          Invite students
+        </Dropdown.Item>
+        <Dropdown.Item as="button" type="button" disabled={!canEdit} onClick={onSync}>
+          <i className="bi bi-arrow-left-right me-2" aria-hidden="true" />
+          Synchronize student list
+        </Dropdown.Item>
 
-      <Dropdown.Divider />
-      {courseInstance.self_enrollment_enabled &&
-        courseInstance.self_enrollment_use_enrollment_code && (
-          <OverlayTrigger
-            placement="right"
-            tooltip={{
-              body: copiedCode ? 'Copied!' : 'Copy',
-              props: { id: 'students-copy-code-tooltip' },
-            }}
-            show={copiedCode ? true : undefined}
-          >
+        <Dropdown.Divider />
+        {courseInstance.self_enrollment_enabled &&
+          courseInstance.self_enrollment_use_enrollment_code && (
             <Dropdown.Item as="button" type="button" onClick={handleCopyCode}>
               <i className="bi bi-key me-2" aria-hidden="true" />
               Copy enrollment code
             </Dropdown.Item>
-          </OverlayTrigger>
-        )}
+          )}
 
-      {courseInstance.self_enrollment_enabled && (
-        <OverlayTrigger
-          placement="right"
-          tooltip={{
-            body: copiedLink ? 'Copied!' : 'Copy',
-            props: { id: 'students-copy-link-tooltip' },
-          }}
-          show={copiedLink ? true : undefined}
-        >
+        {courseInstance.self_enrollment_enabled && (
           <Dropdown.Item as="button" type="button" onClick={handleCopyLink}>
             <i className="bi bi-link-45deg me-2" aria-hidden="true" />
             Copy enrollment link
           </Dropdown.Item>
-        </OverlayTrigger>
-      )}
-      <Dropdown.Item as="a" href={getSelfEnrollmentSettingsUrl(courseInstance.id)}>
-        <i className="bi bi-gear me-2" aria-hidden="true" />
-        Manage settings
-      </Dropdown.Item>
-    </DropdownButton>
+        )}
+        <Dropdown.Item as="a" href={getSelfEnrollmentSettingsUrl(courseInstance.id)}>
+          <i className="bi bi-gear me-2" aria-hidden="true" />
+          Manage settings
+        </Dropdown.Item>
+      </DropdownButton>
+      <span className="visually-hidden" role="status">
+        {copiedCode ? 'Enrollment code copied.' : copiedLink ? 'Enrollment link copied.' : ''}
+      </span>
+    </>
+  );
+}
+
+function StudentInformationUnavailable() {
+  return (
+    <Popover content="Student information is not yet available.">
+      <button
+        type="button"
+        className="btn btn-xs btn-ghost p-0 border-0"
+        aria-label="Student information is not yet available"
+      >
+        <i className="bi bi-question-circle" aria-hidden="true" />
+      </button>
+    </Popover>
   );
 }
 
@@ -444,16 +445,7 @@ function StudentsCard({
           if (info.row.original.user) {
             return info.getValue() || '—';
           }
-          return (
-            <OverlayTrigger
-              tooltip={{
-                body: 'Student information is not yet available.',
-                props: { id: 'students-name-tooltip' },
-              }}
-            >
-              <i className="bi bi-question-circle" />
-            </OverlayTrigger>
-          );
+          return <StudentInformationUnavailable />;
         },
       }),
       columnHelper.accessor((row) => row.enrollment.status, {
@@ -472,16 +464,7 @@ function StudentsCard({
           if (info.row.original.user) {
             return info.getValue() || '—';
           }
-          return (
-            <OverlayTrigger
-              tooltip={{
-                body: 'Student information is not yet available.',
-                props: { id: 'students-uin-tooltip' },
-              }}
-            >
-              <i className="bi bi-question-circle" />
-            </OverlayTrigger>
-          );
+          return <StudentInformationUnavailable />;
         },
       }),
       columnHelper.accessor((row) => row.user?.email, {
@@ -491,16 +474,7 @@ function StudentsCard({
           if (info.row.original.user) {
             return info.getValue() || '—';
           }
-          return (
-            <OverlayTrigger
-              tooltip={{
-                body: 'Student information is not yet available.',
-                props: { id: 'students-email-tooltip' },
-              }}
-            >
-              <i className="bi bi-question-circle" />
-            </OverlayTrigger>
-          );
+          return <StudentInformationUnavailable />;
         },
       }),
 
@@ -539,7 +513,12 @@ function StudentsCard({
           const date = info.getValue();
           if (date == null) return '—';
           return (
-            <FriendlyDate date={date} timezone={timezone} options={{ includeTz: false }} tooltip />
+            <FriendlyDate
+              date={date}
+              timezone={timezone}
+              options={{ includeTz: false }}
+              withPopover
+            />
           );
         },
       }),
@@ -712,16 +691,15 @@ function StudentsCard({
               selectedEnrollmentIds.length > 0 && (
                 <Dropdown autoClose="outside">
                   {tooManySelectedForLabels ? (
-                    <OverlayTrigger
-                      tooltip={{
-                        body: `Select at most ${MAX_LABEL_UIDS} students to apply labels.`,
-                        props: { id: 'students-label-limit-tooltip' },
-                      }}
-                    >
-                      <Dropdown.Toggle variant="light" size="sm" disabled>
+                    <Popover content={`Select at most ${MAX_LABEL_UIDS} students to apply labels.`}>
+                      <button
+                        type="button"
+                        className="btn btn-light btn-sm"
+                        aria-label={`Labels unavailable: Select at most ${MAX_LABEL_UIDS} students`}
+                      >
                         Labels
-                      </Dropdown.Toggle>
-                    </OverlayTrigger>
+                      </button>
+                    </Popover>
                   ) : (
                     <Dropdown.Toggle variant="light" size="sm">
                       Labels

--- a/apps/prairielearn/src/pages/publicAssessments/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/publicAssessments/components/CopyCourseInstanceModal.tsx
@@ -1,7 +1,9 @@
-import { useRef, useState } from 'react';
-import { Modal, Overlay, Tooltip } from 'react-bootstrap';
+import { useState } from 'react';
+import { Modal } from 'react-bootstrap';
 import { FormProvider, useForm } from 'react-hook-form';
 import z from 'zod';
+
+import { Popover } from '@prairielearn/ui';
 
 import {
   CourseInstancePermissionsForm,
@@ -51,7 +53,6 @@ export function CopyCourseInstanceModal({
   const [selectedCourseId, setSelectedCourseId] = useState(
     courseInstanceCopyTargets?.[0]?.id ?? '',
   );
-  const buttonRef = useRef<HTMLButtonElement>(null);
   // Calculate question stats
   const questionsToCopy = questionsForCopy.filter((q) => q.should_copy).length;
   const questionsToLink = questionsForCopy.filter((q) => !q.should_copy).length;
@@ -84,22 +85,31 @@ export function CopyCourseInstanceModal({
 
   return (
     <>
-      <Overlay placement="bottom" show={!hasSharingName && show} target={buttonRef}>
-        <Tooltip show={!hasSharingName && show}>
-          This course has not set a sharing name. You cannot copy this course instance to your
-          course.
-        </Tooltip>
-      </Overlay>
-      <button
-        ref={buttonRef}
-        className="btn btn-sm btn-outline-light"
-        type="button"
-        aria-label="Copy course instance"
-        onClick={() => setShow(!show)}
-      >
-        <i className="fa fa-clone" />
-        <span className="d-none d-sm-inline">Copy course instance</span>
-      </button>
+      {hasSharingName ? (
+        <button
+          className="btn btn-sm btn-outline-light"
+          type="button"
+          aria-label="Copy course instance"
+          onClick={() => setShow(true)}
+        >
+          <i className="fa fa-clone" aria-hidden="true" />
+          <span className="d-none d-sm-inline">Copy course instance</span>
+        </button>
+      ) : (
+        <Popover
+          content="This course has not set a sharing name. You cannot copy this course instance to your course."
+          placement="bottom"
+        >
+          <button
+            className="btn btn-sm btn-outline-light"
+            type="button"
+            aria-label="Copy course instance unavailable: This course has not set a sharing name"
+          >
+            <i className="fa fa-clone" aria-hidden="true" />
+            <span className="d-none d-sm-inline">Copy course instance</span>
+          </button>
+        </Popover>
+      )}
 
       <Modal show={show && hasSharingName} size="lg" onHide={() => setShow(false)}>
         <Modal.Header closeButton>

--- a/apps/prairielearn/src/pages/publicAssessments/components/CopyCourseInstanceModal.tsx
+++ b/apps/prairielearn/src/pages/publicAssessments/components/CopyCourseInstanceModal.tsx
@@ -101,9 +101,9 @@ export function CopyCourseInstanceModal({
           placement="bottom"
         >
           <button
-            className="btn btn-sm btn-outline-light"
+            className="btn btn-sm btn-outline-light opacity-50"
             type="button"
-            aria-label="Copy course instance unavailable: This course has not set a sharing name"
+            aria-label="Why copying this course instance is unavailable"
           >
             <i className="fa fa-clone" aria-hidden="true" />
             <span className="d-none d-sm-inline">Copy course instance</span>

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -151,7 +151,9 @@ The `color` property maps to PrairieLearn's badge color classes (e.g., `color-bl
 
 ### Popover
 
-Use `Popover` for contextual help, disabled reasons, warnings, and other information that must be available on touch devices. Its trigger must be an interactive element that forwards its ref to the underlying DOM element.
+Use `Popover` for contextual help, unavailable-action reasons, warnings, and other information that must be available on touch devices. Its trigger must be an interactive element that forwards its ref to the underlying DOM element.
+
+An unavailable action that opens an explanation is still interactive, so do not set `disabled` or `aria-disabled` on its trigger. Give it a visually inactive treatment and a concise accessible name that describes the explanation it opens.
 
 ```tsx
 import { Popover } from '@prairielearn/ui';
@@ -159,8 +161,8 @@ import { Popover } from '@prairielearn/ui';
 <Popover content="This action is unavailable until the course has been synced.">
   <button
     type="button"
-    className="btn btn-outline-secondary"
-    aria-label="Publish unavailable until the course has been synced"
+    className="btn btn-outline-secondary opacity-50"
+    aria-label="Why publishing is unavailable"
   >
     Publish
   </button>

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -149,6 +149,24 @@ const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
 The `color` property maps to PrairieLearn's badge color classes (e.g., `color-blue1`). Custom rendering can be provided via `renderItem`.
 
+### Popover
+
+Use `Popover` for contextual help, disabled reasons, warnings, and other information that must be available on touch devices. Its trigger must be an interactive element that forwards its ref to the underlying DOM element.
+
+```tsx
+import { Popover } from '@prairielearn/ui';
+
+<Popover content="This action is unavailable until the course has been synced.">
+  <button
+    type="button"
+    className="btn btn-outline-secondary"
+    aria-label="Publish unavailable until the course has been synced"
+  >
+    Publish
+  </button>
+</Popover>;
+```
+
 ## nuqs Utilities
 
 This package provides utilities for integrating [nuqs](https://nuqs.47ng.com/) (type-safe URL query state management) with server-side rendering and TanStack Table.

--- a/packages/ui/src/components/Popover.tsx
+++ b/packages/ui/src/components/Popover.tsx
@@ -1,0 +1,68 @@
+import clsx from 'clsx';
+import { type ComponentProps, type ReactNode } from 'react';
+import {
+  Popover as AriaPopover,
+  type PopoverProps as AriaPopoverProps,
+  Dialog,
+  DialogTrigger,
+  Heading,
+  OverlayArrow,
+  Pressable,
+} from 'react-aria-components';
+
+export interface PopoverProps {
+  /** The interactive element that opens the popover. */
+  children: ComponentProps<typeof Pressable>['children'];
+  /** The popover body. */
+  content: ReactNode;
+  /** An optional heading for the popover. */
+  heading?: ReactNode;
+  /** Controls whether the popover is open. */
+  isOpen?: ComponentProps<typeof DialogTrigger>['isOpen'];
+  /** Called when the popover opens or closes. */
+  onOpenChange?: ComponentProps<typeof DialogTrigger>['onOpenChange'];
+  placement?: AriaPopoverProps['placement'];
+}
+
+/**
+ * An accessible, press-triggered popover built on React Aria and styled with Bootstrap.
+ *
+ * The trigger must be an interactive element that forwards its ref to the underlying DOM element.
+ */
+export function Popover({
+  children,
+  content,
+  heading,
+  isOpen,
+  onOpenChange,
+  placement = 'top',
+}: PopoverProps) {
+  return (
+    <DialogTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Pressable>{children}</Pressable>
+      <AriaPopover
+        className={({ placement: actualPlacement, isEntering, isExiting }) =>
+          clsx('popover fade', {
+            show: !isEntering && !isExiting,
+            'bs-popover-top': actualPlacement === 'top',
+            'bs-popover-end': actualPlacement === 'right',
+            'bs-popover-bottom': actualPlacement === 'bottom',
+            'bs-popover-start': actualPlacement === 'left',
+          })
+        }
+        placement={placement}
+        offset={8}
+      >
+        <OverlayArrow className="popover-arrow" />
+        <Dialog style={{ outline: 'none' }}>
+          {heading && (
+            <Heading slot="title" className="popover-header">
+              {heading}
+            </Heading>
+          )}
+          <div className="popover-body">{content}</div>
+        </Dialog>
+      </AriaPopover>
+    </DialogTrigger>
+  );
+}

--- a/packages/ui/src/components/StickySaveBar.tsx
+++ b/packages/ui/src/components/StickySaveBar.tsx
@@ -53,8 +53,8 @@ export function StickySaveBar({
       <Popover content={saveDisabledReason} placement="top">
         <button
           type="button"
-          className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1"
-          aria-label={`Save unavailable: ${saveDisabledReason}`}
+          className="btn btn-sm btn-outline-secondary opacity-50 d-inline-flex align-items-center gap-1"
+          aria-label="Why saving is unavailable"
         >
           <i className="bi bi-floppy" aria-hidden="true" />
           Save

--- a/packages/ui/src/components/StickySaveBar.tsx
+++ b/packages/ui/src/components/StickySaveBar.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import Alert from 'react-bootstrap/Alert';
 
-import { OverlayTrigger } from './OverlayTrigger.js';
+import { Popover } from './Popover.js';
 
 export interface StickySaveBarAlert {
   variant: 'success' | 'danger';
@@ -21,7 +21,7 @@ export interface StickySaveBarProps {
   formId?: string;
   /**
    * Optional reason the save button is disabled. When set, the save button is
-   * disabled and a tooltip with this message is shown on hover/focus.
+   * unavailable and a popover with this message is shown when it is pressed.
    */
   saveDisabledReason?: string | null;
   /**
@@ -48,22 +48,32 @@ export function StickySaveBar({
   alert,
   fullWidth,
 }: StickySaveBarProps) {
-  const isSaveDisabled = isSaving || Boolean(saveDisabledReason);
-
-  const saveButton = (
-    <button
-      type="submit"
-      form={formId}
-      className={clsx(
-        'btn btn-sm d-inline-flex align-items-center gap-1',
-        isSaveDisabled ? 'btn-outline-secondary' : 'btn-primary',
-      )}
-      disabled={isSaveDisabled}
-    >
-      <i className="bi bi-floppy" aria-hidden="true" />
-      {isSaving ? 'Saving...' : 'Save'}
-    </button>
-  );
+  const saveButton =
+    saveDisabledReason && !isSaving ? (
+      <Popover content={saveDisabledReason} placement="top">
+        <button
+          type="button"
+          className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1"
+          aria-label={`Save unavailable: ${saveDisabledReason}`}
+        >
+          <i className="bi bi-floppy" aria-hidden="true" />
+          Save
+        </button>
+      </Popover>
+    ) : (
+      <button
+        type="submit"
+        form={formId}
+        className={clsx(
+          'btn btn-sm d-inline-flex align-items-center gap-1',
+          isSaving ? 'btn-outline-secondary' : 'btn-primary',
+        )}
+        disabled={isSaving}
+      >
+        <i className="bi bi-floppy" aria-hidden="true" />
+        {isSaving ? 'Saving...' : 'Save'}
+      </button>
+    );
 
   return (
     <div className="pl-ui-sticky-save-bar">
@@ -94,18 +104,7 @@ export function StickySaveBar({
           >
             Cancel
           </button>
-          {saveDisabledReason ? (
-            <OverlayTrigger
-              tooltip={{
-                props: { id: 'pl-ui-sticky-save-bar-tooltip' },
-                body: saveDisabledReason,
-              }}
-            >
-              <span className="d-inline-block">{saveButton}</span>
-            </OverlayTrigger>
-          ) : (
-            saveButton
-          )}
+          {saveButton}
         </div>
       </div>
     </div>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -31,6 +31,7 @@ export {
 export { useShiftClickCheckbox } from './components/useShiftClickCheckbox.js';
 export { useAutoSizeColumns } from './components/useAutoSizeColumns.js';
 export { OverlayTrigger, type OverlayTriggerProps } from './components/OverlayTrigger.js';
+export { Popover, type PopoverProps } from './components/Popover.js';
 export { PresetFilterDropdown } from './components/PresetFilterDropdown.js';
 export {
   NuqsAdapter,


### PR DESCRIPTION
# Description

Part of #15790.

This introduces press-triggered contextual popovers for information that must be available on touch devices, separating contextual help and unavailable-action explanations from transient hover/focus tooltips.

- Add a shared React Aria `Popover` component to `@prairielearn/ui`, styled with Bootstrap and documented for PrairieLearn and PrairieTest.
- Migrate contextual help, unavailable-action explanations, warnings, and other essential information from tooltips to press-triggered popovers or visible text.
- Use Bootstrap popovers for equivalent vanilla JavaScript call sites so the React and vanilla paths have matching behavior and presentation.
- Remove redundant status tooltips and expose copy confirmation to assistive technology with live status text.

This is the foundational PR for #15549, which will retain the changes for genuine hover/focus tooltips and be retargeted to this branch.

- [x] AI assistance was used for the majority of the implementation.

# Testing

- Manually verified React contextual-help and unavailable-action popovers with mouse and keyboard input, including Escape dismissal and focus restoration.
- Manually verified the vanilla Bootstrap popover path on the course sync page.
- Compared React and vanilla rendering to confirm that both use Bootstrap popover presentation.
