### PR TITLE
Remove unused Azure authentication configuration

### DIFF
--- a/apps/prairielearn/src/ee/auth/azure/index.ts
+++ b/apps/prairielearn/src/ee/auth/azure/index.ts
@@ -9,7 +9,6 @@ export function getAzureStrategy() {
       clientID: config.azureClientID,
       redirectUrl: config.azureRedirectUrl,
       allowHttpForRedirectUrl: config.azureAllowHttpForRedirectUrl,
-      clientSecret: config.azureClientSecret,
       cookieEncryptionKeys: config.azureCookieEncryptionKeys,
       loggingLevel: config.azureLoggingLevel,
       scope: ['openid', 'profile', 'email'],

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -558,21 +558,6 @@ export const ConfigSchema = z.object({
     )
     .default([]),
   azureLoggingLevel: z.enum(['error', 'warn', 'info']).default('warn'),
-  /**
-   * If you want to get access_token for a specific resource, you can provide the
-   * resource here; otherwise, set the value to null.
-   * Note that in order to get access_token, the responseType must be 'code', 'code id_token' or 'id_token code'.
-   */
-  azureResourceURL: z.string().nullable().default('https://graph.windows.net'),
-  /**
-   * The URL to which the user will be redirected to destroy the session.
-   */
-  azureDestroySessionUrl: z
-    .string()
-    .nullable()
-    .default(
-      'https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000',
-    ),
   features: z.record(z.string(), z.boolean()).default({}),
   /**
    * Determines if sharing validation should be performed. In essence checks

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -542,8 +542,6 @@ export const ConfigSchema = z.object({
   azureRedirectUrl: z.string().default('<your_redirect_url>'),
   /** Required if the redirect URL uses the HTTP protocol. */
   azureAllowHttpForRedirectUrl: z.boolean().default(false),
-  /** Required. If the app key contains `\`, replace it with `\\`. */
-  azureClientSecret: z.string().default('<your_client_secret>'),
   /**
    * Required to encrypt cookies. Multiple key/iv pairs can be provided for key
    * rotation. The first key/iv pair will be used to encrypt cookies, but all

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -1389,28 +1389,6 @@
       "type": "string",
       "enum": ["error", "warn", "info"]
     },
-    "azureResourceURL": {
-      "default": "https://graph.windows.net",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "azureDestroySessionUrl": {
-      "default": "https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "features": {
       "default": {},
       "type": "object",

--- a/docs/assets/config-prairielearn.schema.json
+++ b/docs/assets/config-prairielearn.schema.json
@@ -1363,10 +1363,6 @@
       "default": false,
       "type": "boolean"
     },
-    "azureClientSecret": {
-      "default": "<your_client_secret>",
-      "type": "string"
-    },
     "azureCookieEncryptionKeys": {
       "default": [],
       "type": "array",

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -1591,28 +1591,6 @@
       "type": "string",
       "enum": ["error", "warn", "info"]
     },
-    "azureResourceURL": {
-      "default": "https://graph.windows.net",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "azureDestroySessionUrl": {
-      "default": "https://login.microsoftonline.com/common/oauth2/logout?post_logout_redirect_uri=http://localhost:3000",
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "features": {
       "default": {},
       "type": "object",

--- a/docs/assets/config-unified.schema.json
+++ b/docs/assets/config-unified.schema.json
@@ -1565,10 +1565,6 @@
       "default": false,
       "type": "boolean"
     },
-    "azureClientSecret": {
-      "default": "<your_client_secret>",
-      "type": "string"
-    },
     "azureCookieEncryptionKeys": {
       "default": [],
       "type": "array",


### PR DESCRIPTION
# Description

PrairieLearn's Azure authentication contains three configuration values that have no runtime effect:

- `azureClientSecret` is not used by `passport-azure-ad` with PrairieLearn's `responseType: 'id_token'` flow, which does not redeem an authorization code or acquire access or refresh tokens.
- `azureResourceURL` is never passed to `passport.authenticate`, and the ID-token-only flow does not request an access token for a resource.
- `azureDestroySessionUrl` has no runtime consumer; `/pl/logout` clears PrairieLearn cookies and its local session without redirecting to Microsoft logout.

Remove all three values from the PrairieLearn configuration and generated configuration schemas, and stop passing the client secret to `OIDCStrategy`. The Azure client ID remains required.

Existing deployments do not need a coordinated configuration rollout: PrairieLearn's runtime configuration schema strips unknown top-level properties, so lingering values are ignored. The generated JSON schemas will flag the obsolete properties so they can be cleaned up from deployment configuration.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex performed the implementation and prepared this pull request.

# Testing

Azure login with `azureClientSecret` removed was verified on staging. The other removed settings had no runtime consumers, so their removal does not alter the existing login or logout paths. No automated tests were added for these configuration-only removals.
