### PR TITLE
Fix symbolic input prefix insertion

### DIFF
--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
@@ -370,7 +370,7 @@
     const signKey = {
       class: 'small',
       latex: '\\mathrm{sign}',
-      insert: '\\operatorname{sign}\\left({#@}\\right)',
+      insert: '\\operatorname{sign}\\left({#0}\\right)',
     };
 
     /** A key that is only present if `allowSets` */
@@ -391,7 +391,7 @@
       {
         id: 'sqrt',
         label: '√',
-        onMenuSelect: () => mf.insert('\\sqrt{#@}'),
+        onMenuSelect: () => mf.insert('\\sqrt{#0}'),
       },
       {
         id: 'pi',
@@ -443,17 +443,17 @@
         ],
         [
           ...onlyIfSets('[separator]'),
-          { class: 'small', latex: '\\sqrt', insert: '\\sqrt{#@}' },
+          { class: 'small', latex: '\\sqrt', insert: '\\sqrt{#0}' },
           logAsLn
             ? {
                 class: 'small',
                 latex: '\\ln',
-                insert: '\\operatorname{ln}\\left({#@}\\right)',
+                insert: '\\operatorname{ln}\\left({#0}\\right)',
               }
             : {
                 class: 'small',
                 latex: '\\log',
-                insert: '\\operatorname{log}\\left({#@}\\right)',
+                insert: '\\operatorname{log}\\left({#0}\\right)',
               },
           { class: 'small', latex: '!' },
           '[separator]',
@@ -469,9 +469,9 @@
         ],
         [
           ...onlyIfSets('[separator]'),
-          { class: 'small', latex: '|#@|', insert: '|{#@}|' },
-          { class: 'small', latex: '\\min', insert: '\\operatorname{min}\\left({#@}\\right)' },
-          { class: 'small', latex: '\\max', insert: '\\operatorname{max}\\left({#@}\\right)' },
+          { class: 'small', latex: '|#0|', insert: '|{#0}|' },
+          { class: 'small', latex: '\\min', insert: '\\operatorname{min}\\left({#0}\\right)' },
+          { class: 'small', latex: '\\max', insert: '\\operatorname{max}\\left({#0}\\right)' },
           '[separator]',
           '1',
           '2',
@@ -496,27 +496,27 @@
                 class: 'small',
                 latex: '\\sin',
 
-                insert: '\\operatorname{sin}\\left({#@}\\right)',
+                insert: '\\operatorname{sin}\\left({#0}\\right)',
                 variants: [
                   {
                     class: 'small',
                     latex: '\\csc',
-                    insert: '\\operatorname{csc}\\left({#@}\\right)',
+                    insert: '\\operatorname{csc}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\arcsin',
-                    insert: '\\operatorname{arcsin}\\left({#@}\\right)',
+                    insert: '\\operatorname{arcsin}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{sinh}',
-                    insert: '\\operatorname{sinh}\\left({#@}\\right)',
+                    insert: '\\operatorname{sinh}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{asinh}',
-                    insert: '\\operatorname{asinh}\\left({#@}\\right)',
+                    insert: '\\operatorname{asinh}\\left({#0}\\right)',
                   },
                 ],
               }
@@ -525,27 +525,27 @@
             ? {
                 class: 'small',
                 latex: '\\cos',
-                insert: '\\operatorname{cos}\\left({#@}\\right)',
+                insert: '\\operatorname{cos}\\left({#0}\\right)',
                 variants: [
                   {
                     class: 'small',
                     latex: '\\sec',
-                    insert: '\\operatorname{sec}\\left({#@}\\right)',
+                    insert: '\\operatorname{sec}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\arccos',
-                    insert: '\\operatorname{arccos}\\left({#@}\\right)',
+                    insert: '\\operatorname{arccos}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{cosh}',
-                    insert: '\\operatorname{cosh}\\left({#@}\\right)',
+                    insert: '\\operatorname{cosh}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{acosh}',
-                    insert: '\\operatorname{acosh}\\left({#@}\\right)',
+                    insert: '\\operatorname{acosh}\\left({#0}\\right)',
                   },
                 ],
               }
@@ -554,32 +554,32 @@
             ? {
                 class: 'small',
                 latex: '\\tan',
-                insert: '\\operatorname{tan}\\left({#@}\\right)',
+                insert: '\\operatorname{tan}\\left({#0}\\right)',
                 variants: [
                   {
                     class: 'small',
                     latex: '\\cot',
-                    insert: '\\operatorname{cot}\\left({#@}\\right)',
+                    insert: '\\operatorname{cot}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\arctan',
-                    insert: '\\operatorname{arctan}\\left({#@}\\right)',
+                    insert: '\\operatorname{arctan}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{tanh}',
-                    insert: '\\operatorname{tanh}\\left({#@}\\right)',
+                    insert: '\\operatorname{tanh}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{atanh}',
-                    insert: '\\operatorname{atanh}\\left({#@}\\right)',
+                    insert: '\\operatorname{atanh}\\left({#0}\\right)',
                   },
                   {
                     class: 'small',
                     latex: '\\mathrm{arctan2}',
-                    insert: '\\operatorname{arctan2}\\left({#@}\\right)',
+                    insert: '\\operatorname{arctan2}\\left({#0}\\right)',
                   },
                 ],
               }
@@ -717,10 +717,10 @@
         value: '{#@}\\cdot',
       },
       '|': {
-        value: '|{#@}|',
+        value: '|{#0}|',
       },
       sqrt: {
-        value: '\\sqrt{#@}',
+        value: '\\sqrt{#0}',
       },
       pi: {
         value: '\\pi',

--- a/apps/prairielearn/src/tests/e2e/plSymbolicInput.e2e.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/plSymbolicInput.e2e.spec.ts
@@ -1,0 +1,136 @@
+import type { Locator, Page } from '@playwright/test';
+
+import type { CourseInstance } from '../../lib/db-types.js';
+import { selectQuestionByQid } from '../../models/question.js';
+
+import { expect, test } from './fixtures.js';
+
+async function openSymbolicInputEditorQuestion(
+  page: Page,
+  courseInstance: CourseInstance,
+): Promise<void> {
+  const question = await selectQuestionByQid({
+    qid: 'symbolicInputEditor',
+    course_id: courseInstance.course_id,
+  });
+
+  await page.goto(
+    `/pl/course_instance/${courseInstance.id}/instructor/question/${question.id}/preview`,
+  );
+}
+
+async function fillFormulaEditor(formulaEditor: Locator, latex: string): Promise<void> {
+  await formulaEditor.evaluate((el, latex) => {
+    (el as HTMLElement & { value: string }).value = latex;
+    el.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+  }, latex);
+}
+
+async function expectPrefixInsertion(
+  page: Page,
+  formulaEditor: Locator,
+  answersName: string,
+  insert: () => Promise<void>,
+): Promise<void> {
+  await fillFormulaEditor(formulaEditor, '');
+  await formulaEditor.press('3');
+  await insert();
+  await page.keyboard.press('y');
+
+  await expect(page.locator(`#symbolic-input-latex-${answersName}`)).toHaveValue(/^3.*y.+$/);
+}
+
+test.describe('pl-symbolic-input prefix insertion', () => {
+  test.beforeEach(async ({ page, courseInstance }) => {
+    await openSymbolicInputEditorQuestion(page, courseInstance);
+  });
+
+  test('keeps preceding content outside typed square roots and absolute values', async ({
+    page,
+  }) => {
+    const formulaEditor = page.locator('#symbolic-input-x');
+    await expect(formulaEditor).toBeVisible();
+
+    await fillFormulaEditor(formulaEditor, '');
+    for (const key of '3sqrty') await formulaEditor.press(key);
+    await expect(page.locator('#symbolic-input-latex-x')).toHaveValue(/^3\\sqrt/);
+
+    await fillFormulaEditor(formulaEditor, '');
+    for (const key of '3|y') await formulaEditor.press(key);
+    await expect(page.locator('#symbolic-input-latex-x')).toHaveValue(/^3.*y.+$/);
+  });
+
+  test('keeps preceding content outside square roots inserted from the context menu', async ({
+    page,
+  }) => {
+    const formulaEditor = page.locator('#symbolic-input-x');
+    await expect(formulaEditor).toBeVisible();
+    await formulaEditor.press('3');
+    await formulaEditor.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: /√/ }).click();
+
+    await expect(page.locator('#symbolic-input-latex-x')).toHaveValue(/^3\\sqrt/);
+  });
+
+  test('keeps preceding content outside virtual keyboard prefix functions', async ({ page }) => {
+    const formulaEditor = page.locator('#symbolic-input-x');
+    await expect(formulaEditor).toBeVisible();
+    await formulaEditor.getByRole('button', { name: /Toggle Virtual Keyboard/ }).click();
+
+    const cases = [
+      /sqrt/,
+      /operatorname\{log\}/,
+      /^\|\{#0\}\|$/,
+      /operatorname\{min\}/,
+      /operatorname\{max\}/,
+      /operatorname\{sign\}/,
+      /operatorname\{sin\}/,
+      /operatorname\{cos\}/,
+      /operatorname\{tan\}/,
+    ];
+
+    for (const label of cases) {
+      await expectPrefixInsertion(page, formulaEditor, 'x', async () => {
+        await page.getByLabel(label).click();
+      });
+    }
+
+    const variantCases = [
+      { label: /operatorname\{sin\}/, count: 4 },
+      { label: /operatorname\{cos\}/, count: 4 },
+      { label: /operatorname\{tan\}/, count: 5 },
+    ];
+
+    for (const { label, count } of variantCases) {
+      for (let index = 0; index < count; index++) {
+        await expectPrefixInsertion(page, formulaEditor, 'x', async () => {
+          await page.getByLabel(label).dispatchEvent('pointerdown', {
+            button: 0,
+            isPrimary: true,
+            pointerId: 1,
+            pointerType: 'mouse',
+          });
+
+          const variants = page.locator('.MLK__variant-panel.is-visible .item');
+          await expect(variants).toHaveCount(count);
+          await variants.nth(index).dispatchEvent('pointerup', {
+            button: 0,
+            isPrimary: true,
+            pointerId: 1,
+            pointerType: 'mouse',
+          });
+        });
+      }
+    }
+  });
+
+  test('keeps preceding content outside natural log when configured', async ({ page }) => {
+    const formulaEditor = page.locator('#symbolic-input-lnx');
+    await expect(formulaEditor).toBeVisible();
+    await formulaEditor.getByRole('button', { name: /Toggle Virtual Keyboard/ }).click();
+
+    await expectPrefixInsertion(page, formulaEditor, 'lnx', async () => {
+      await page.getByLabel(/operatorname\{ln\}/).click();
+    });
+  });
+});


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

Fix symbolic-input prefix operations so existing content remains outside newly inserted roots, functions, and absolute values.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->

Added Playwright coverage for typed shortcuts, context-menu insertion, virtual keyboard buttons, trig variants, and configured `ln`.

- open any question that has a symbolic input element
- enter `$3sqrty$`
- should produce $3\sqrt{y}$, not $\sqrt{3}y$.
