### PR TITLE
Add pending migration inspection

### DIFF
--- a/.changeset/inspect-pending-migrations.md
+++ b/.changeset/inspect-pending-migrations.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/migrations': minor
+---
+
+Add a read-only API for inspecting pending migrations.

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -98,11 +98,14 @@ import { courseInstanceTrpcRouter } from './trpc/courseInstance/trpc.js';
 process.on('warning', (e) => console.warn(e));
 
 const argv = minimist(process.argv.slice(2));
+const migrationDirectories = [path.join(import.meta.dirname, 'migrations'), SCHEMA_MIGRATIONS_PATH];
+const migrationsProject = 'prairielearn';
 
 if ('h' in argv || 'help' in argv) {
   const msg = `PrairieLearn command line options:
     -h, --help                          Display this help and exit
     --config <filename>                 Use the specified configuration file
+    --list-pending-migrations           List pending migrations as JSON and exit
     --migrate-and-exit                  Run the DB initialization parts and exit
     --refresh-workspace-hosts-and-exit  Refresh the workspace hosts and exit
     --sync-course <course_id>           Synchronize a course and exit
@@ -2198,6 +2201,19 @@ function idleErrorHandler(err: Error) {
   void Sentry.close().finally(() => process.exit(1));
 }
 
+function getPostgresConfig() {
+  return {
+    user: config.postgresqlUser,
+    database: config.postgresqlDatabase,
+    host: config.postgresqlHost,
+    password: config.postgresqlPassword ?? undefined,
+    max: config.postgresqlPoolSize,
+    idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
+    ssl: config.postgresqlSsl,
+    errorOnUnusedParameters: config.devMode,
+  };
+}
+
 const isHMR = DEV_EXECUTION_MODE === 'hmr';
 
 if (isHMR && isServerPending()) {
@@ -2248,6 +2264,27 @@ if (shouldStartServer) {
 
     // Load config immediately so we can use it configure everything else.
     await loadConfig(configPaths);
+
+    if (argv['list-pending-migrations']) {
+      await sqldb.initAsync(getPostgresConfig(), idleErrorHandler);
+      const pendingMigrations = await migrations.getPendingMigrations({
+        directories: migrationDirectories,
+        project: migrationsProject,
+      });
+
+      // On Linux, writes to piped stdout can be asynchronous. Wait for this write to finish
+      // before process.exit() closes the process.
+      await new Promise<void>((resolve, reject) => {
+        process.stdout.write(`${JSON.stringify({ pendingMigrations })}\n`, (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+      process.exit(0);
+    }
 
     // This should be done as soon as we load our config so that we can
     // start exporting spans.
@@ -2360,16 +2397,7 @@ if (shouldStartServer) {
       passport.use(strategy);
     }
 
-    const pgConfig = {
-      user: config.postgresqlUser,
-      database: config.postgresqlDatabase,
-      host: config.postgresqlHost,
-      password: config.postgresqlPassword ?? undefined,
-      max: config.postgresqlPoolSize,
-      idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
-      ssl: config.postgresqlSsl,
-      errorOnUnusedParameters: config.devMode,
-    };
+    const pgConfig = getPostgresConfig();
 
     logger.verbose(`Connecting to ${pgConfig.user}@${pgConfig.host}:${pgConfig.database}`);
 
@@ -2412,8 +2440,8 @@ if (shouldStartServer) {
     // running migrations as we do when we start the server.
     if (config.runMigrations || argv['migrate-and-exit']) {
       await migrations.init({
-        directories: [path.join(import.meta.dirname, 'migrations'), SCHEMA_MIGRATIONS_PATH],
-        project: 'prairielearn',
+        directories: migrationDirectories,
+        project: migrationsProject,
       });
     }
 

--- a/packages/migrations/README.md
+++ b/packages/migrations/README.md
@@ -117,12 +117,28 @@ In most cases, you'll want to do your best to ensure that the given batched migr
 
 ### Server setup
 
-To execute any pending regular migrations, call `init()` early on in your application startup code. The first argument is an array of directory paths containing migration files as described above. The second argument is a project identifier, which is used to isolate multiple migration sequences from each other when two or more applications share a single database.
+To execute any pending regular migrations, call `init()` early on in your application startup code. The `directories` option contains paths with migration files as described above. The `project` option identifies the application's migration sequence, isolating it from other applications that share the same database.
 
 ```ts
 import { init } from '@prairielearn/migrations';
 
-await init([path.join(__dirname, 'migrations')], 'prairielearn');
+await init({
+  directories: [path.join(__dirname, 'migrations')],
+  project: 'prairielearn',
+});
+```
+
+### Inspecting pending migrations
+
+To inspect pending migrations without creating or altering tables, call `getPendingMigrations()` after initializing `@prairielearn/postgres`. The result includes only migration filenames and timestamps, so applications can safely serialize it without exposing database configuration. If the migrations table does not exist yet, all discovered migrations are reported as pending.
+
+```ts
+import { getPendingMigrations } from '@prairielearn/migrations';
+
+const pendingMigrations = await getPendingMigrations({
+  directories: [path.join(__dirname, 'migrations')],
+  project: 'prairielearn',
+});
 ```
 
 If you want to make use of batched migrations, you'll need to do some additional setup. Since batched migrations are typically used with regular migrations, you'll need to take care to call `init()` after `initBatchedMigrations()` but before `startBatchedMigrations()`.
@@ -143,7 +159,10 @@ runner.on('error', (error) => {
   // Handle error, e.g. by reporting to Sentry.
 });
 
-await init([path.join(__dirname, 'migrations')], 'prairielearn');
+await init({
+  directories: [path.join(__dirname, 'migrations')],
+  project: 'prairielearn',
+});
 
 startBatchedMigrations({
   workDurationMs: 60_000,

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-export { init } from './migrations/index.js';
+export { getPendingMigrations, init, type PendingMigration } from './migrations/index.js';
 
 export {
   type BatchedMigrationRow,

--- a/packages/migrations/src/load-migrations.test.ts
+++ b/packages/migrations/src/load-migrations.test.ts
@@ -40,6 +40,27 @@ describe('load-migrations', () => {
         },
       );
     });
+
+    it('ignores non-migration artifacts', async () => {
+      await withMigrationFiles(
+        ['20220101010101_testing.sql', '20220101010101_testing.sql.map', 'README.md', 'notes.txt'],
+        async (tmpDir) => {
+          const migrations = await readAndValidateMigrationsFromDirectory(tmpDir, [
+            '.sql',
+            '.js',
+            '.ts',
+            '.mjs',
+          ]);
+          assert.deepEqual(migrations, [
+            {
+              directory: tmpDir,
+              filename: '20220101010101_testing.sql',
+              timestamp: '20220101010101',
+            },
+          ]);
+        },
+      );
+    });
   });
 
   describe('sortMigrationFiles', () => {

--- a/packages/migrations/src/migrations/index.ts
+++ b/packages/migrations/src/migrations/index.ts
@@ -1,1 +1,1 @@
-export { init } from './migrations.js';
+export { getPendingMigrations, init, type PendingMigration } from './migrations.js';

--- a/packages/migrations/src/migrations/migrations.sql
+++ b/packages/migrations/src/migrations/migrations.sql
@@ -28,15 +28,20 @@ ADD COLUMN IF NOT EXISTS timestamp text;
 CREATE UNIQUE INDEX IF NOT EXISTS migrations_project_timestamp_key ON migrations (timestamp, project);
 
 -- BLOCK get_migrations
+-- Migrations always live in public. Do not let the caller's search path select another table.
 SELECT
   id,
   filename,
   index,
   timestamp
 FROM
-  migrations
+  public.migrations
 WHERE
   project = $project;
+
+-- BLOCK migrations_table_exists
+SELECT
+  to_regclass('public.migrations') IS NOT NULL AS exists;
 
 -- BLOCK insert_migration
 INSERT INTO

--- a/packages/migrations/src/migrations/migrations.test.sql
+++ b/packages/migrations/src/migrations/migrations.test.sql
@@ -1,0 +1,3 @@
+-- BLOCK get_migrations_table
+SELECT
+  to_regclass('public.migrations')::text AS name;

--- a/packages/migrations/src/migrations/migrations.test.ts
+++ b/packages/migrations/src/migrations/migrations.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 import { z } from 'zod';
 
-import { loadSqlEquiv, makePostgresTestUtils, queryRow } from '@prairielearn/postgres';
+import { loadSqlEquiv, makePostgresTestUtils, queryRow, queryScalar } from '@prairielearn/postgres';
 
 import { getMigrationsToExecute, getPendingMigrations, initWithLock } from './migrations.js';
 
@@ -167,11 +167,8 @@ describe('migrations', () => {
         },
       ]);
 
-      const migrationsTable = await queryRow(
-        sql.get_migrations_table,
-        z.object({ name: z.string().nullable() }),
-      );
-      assert.isNull(migrationsTable.name);
+      const migrationsTable = await queryScalar(sql.get_migrations_table, z.string().nullable());
+      assert.isNull(migrationsTable);
     });
 
     it('runs both SQL and JavaScript migrations', async () => {

--- a/packages/migrations/src/migrations/migrations.test.ts
+++ b/packages/migrations/src/migrations/migrations.test.ts
@@ -3,9 +3,11 @@ import path from 'node:path';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 import { z } from 'zod';
 
-import { makePostgresTestUtils, queryRow } from '@prairielearn/postgres';
+import { loadSqlEquiv, makePostgresTestUtils, queryRow } from '@prairielearn/postgres';
 
-import { getMigrationsToExecute, initWithLock } from './migrations.js';
+import { getMigrationsToExecute, getPendingMigrations, initWithLock } from './migrations.js';
+
+const sql = loadSqlEquiv(import.meta.filename);
 
 describe('migrations', () => {
   describe('getMigrationsToExecute', () => {
@@ -147,6 +149,31 @@ describe('migrations', () => {
       await postgresTestUtils.dropDatabase();
     });
 
+    it('reports all migrations without modifying a fresh database', async () => {
+      const migrationDir = path.join(import.meta.dirname, 'fixtures');
+      const pendingMigrations = await getPendingMigrations({
+        directories: [migrationDir],
+        project: 'prairielearn_migrations',
+      });
+
+      assert.deepEqual(pendingMigrations, [
+        {
+          filename: '20230407210409_create_users.sql',
+          timestamp: '20230407210409',
+        },
+        {
+          filename: '20230407210430_insert_user.ts',
+          timestamp: '20230407210430',
+        },
+      ]);
+
+      const migrationsTable = await queryRow(
+        sql.get_migrations_table,
+        z.object({ name: z.string().nullable() }),
+      );
+      assert.isNull(migrationsTable.name);
+    });
+
     it('runs both SQL and JavaScript migrations', async () => {
       const migrationDir = path.join(import.meta.dirname, 'fixtures');
       await initWithLock({ directories: [migrationDir], project: 'prairielearn_migrations' });
@@ -155,6 +182,21 @@ describe('migrations', () => {
       // in the database.
       const users = await queryRow('SELECT * FROM users', {}, z.object({ name: z.string() }));
       assert.equal(users.name, 'Test User');
+
+      assert.deepEqual(
+        await getPendingMigrations({
+          directories: [migrationDir],
+          project: 'prairielearn_migrations',
+        }),
+        [],
+      );
+      assert.lengthOf(
+        await getPendingMigrations({
+          directories: [migrationDir],
+          project: 'prairietest',
+        }),
+        2,
+      );
     });
   });
 });

--- a/packages/migrations/src/migrations/migrations.ts
+++ b/packages/migrations/src/migrations/migrations.ts
@@ -16,6 +16,7 @@ import {
 } from '../load-migrations.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.filename);
+const MIGRATION_EXTENSIONS = ['.sql', '.js', '.ts', '.mjs'];
 
 const MigrationRowSchema = z.object({
   id: z.coerce.string(),
@@ -31,6 +32,34 @@ interface InitOptions {
     beforeTimestamp?: string | null;
     inclusiveBefore?: boolean;
   };
+}
+
+export interface PendingMigration {
+  filename: string;
+  timestamp: string;
+}
+
+export async function getPendingMigrations({
+  directories,
+  project,
+}: {
+  directories: string[];
+  project: string;
+}): Promise<PendingMigration[]> {
+  const migrationFiles = await readAndValidateMigrationsFromDirectories(
+    directories,
+    MIGRATION_EXTENSIONS,
+  );
+  const migrationsTableExists = await sqldb.queryScalar(sql.migrations_table_exists, z.boolean());
+  const appliedMigrations = migrationsTableExists
+    ? await sqldb.queryRows(sql.get_migrations, { project }, MigrationRowSchema)
+    : [];
+
+  assertMigrationsHaveTimestamps(appliedMigrations);
+
+  return getMigrationsToExecute(sortMigrationFiles(migrationFiles), {
+    excludeMigrations: appliedMigrations,
+  }).map(({ filename, timestamp }) => ({ filename, timestamp }));
 }
 
 export async function init({ directories, project, migrationFilters = {} }: InitOptions) {
@@ -95,6 +124,23 @@ export function getMigrationsToExecute(
   );
 }
 
+function assertMigrationsHaveTimestamps(
+  migrations: { filename: string; timestamp: string | null }[],
+) {
+  const migrationsMissingTimestamps = migrations.filter((migration) => !migration.timestamp);
+  if (migrationsMissingTimestamps.length > 0) {
+    throw new Error(
+      [
+        'The following migrations are missing timestamps:',
+        migrationsMissingTimestamps.map((migration) => `  ${migration.filename}`),
+        // This revision was the most recent commit to `master` before the
+        // code handling indexes was removed.
+        'You must deploy revision 1aa43c7348fa24cf636413d720d06a2fa9e38ef2 first.',
+      ].join('\n'),
+    );
+  }
+}
+
 export async function initWithLock({ directories, project, migrationFilters = {} }: InitOptions) {
   const resolvedMigrationFilters = {
     beforeTimestamp: null,
@@ -139,28 +185,15 @@ export async function initWithLock({ directories, project, migrationFilters = {}
     }
 
     let allMigrations = await sqldb.queryRows(sql.get_migrations, { project }, MigrationRowSchema);
-    const migrationFiles = await readAndValidateMigrationsFromDirectories(directories, [
-      '.sql',
-      '.js',
-      '.ts',
-      '.mjs',
-    ]);
+    const migrationFiles = await readAndValidateMigrationsFromDirectories(
+      directories,
+      MIGRATION_EXTENSIONS,
+    );
 
     // Validation: if we not all previously-executed migrations have timestamps,
     // prompt the user to deploy an earlier version that includes both indexes
     // and timestamps.
-    const migrationsMissingTimestamps = allMigrations.filter((m) => !m.timestamp);
-    if (migrationsMissingTimestamps.length > 0) {
-      throw new Error(
-        [
-          'The following migrations are missing timestamps:',
-          migrationsMissingTimestamps.map((m) => `  ${m.filename}`),
-          // This revision was the most recent commit to `master` before the
-          // code handling indexes was removed.
-          'You must deploy revision 1aa43c7348fa24cf636413d720d06a2fa9e38ef2 first.',
-        ].join('\n'),
-      );
-    }
+    assertMigrationsHaveTimestamps(allMigrations);
 
     // Refetch the list of migrations from the database.
     allMigrations = await sqldb.queryRows(sql.get_migrations, { project }, MigrationRowSchema);


### PR DESCRIPTION
# Description

Add a read-only `getPendingMigrations()` API to `@prairielearn/migrations` so applications can inspect migration state with their own configured database connection. The API preserves project namespaces, ignores non-migration artifacts, and reports every discovered migration when the migrations table does not exist yet.

PrairieLearn now exposes `--list-pending-migrations`, which loads the normal application configuration, connects with the configured PostgreSQL credentials, and writes a JSON result as the final line of stdout without running migrations or initializing the rest of the server.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Codex was used for the majority of the implementation.

# Testing

- Added package tests covering fresh databases, project namespace isolation, and filtering non-migration artifacts.
- Ran the built PrairieLearn inspection command against a local database and confirmed that it emitted the expected JSON response.
