### PR TITLE
Add skill for references to node assets in elements

### DIFF
--- a/.agents/skills/element-runtime-assets/SKILL.md
+++ b/.agents/skills/element-runtime-assets/SKILL.md
@@ -20,7 +20,7 @@ In practice, this means:
 Use these two concepts carefully:
 
 - `dependencies` are for assets that are part of the element's baseline runtime and should be loaded up front. These assets typically create global variables or otherwise register themselves with the browser runtime so that the element's code can use them immediately. They are loaded using `<script src="...">` or `<link rel="stylesheet" href="...">` tags in the page header. Element code can assume that these assets are available immediately after the page loads, and may reference its resources using global variables.
-- `dynamicDependencies` are for optional or on-demand loading. They are useful when a feature, data payload, or interaction path is only needed after some user action or condition is met. They may also be used as ESM modules that are imported by the element's code at runtime, though still browser-loadable as standalone assets. They are loaded using import maps, and may be imported with `import` or `await import()` in the element's code. The element's code should not assume that it is available until it has been explicitly loaded.
+- `dynamicDependencies` are for optional or on-demand loading. They are useful when a feature, data payload, or interaction path is only needed after some user action or condition is met. They may also be used as ESM modules that are imported by the element's code at runtime, though still browser-loadable as standalone assets. Their import-map entries map module specifiers to asset URLs. The browser fetches a dynamic dependency when the element executes `import()`. Use static `import` only when the element script is loaded as an ES module. The element's code should not assume that it is available until it has been explicitly loaded.
 
 ## Workflow
 

--- a/.agents/skills/element-runtime-assets/SKILL.md
+++ b/.agents/skills/element-runtime-assets/SKILL.md
@@ -15,6 +15,13 @@ In practice, this means:
 - Verify that the served asset can be loaded directly by the app's asset pipeline.
 - If the asset needs more module resolution than the current import-map flow provides, choose a different asset or bundle it first.
 
+## Distinguishing dependencies from dynamicDependencies
+
+Use these two concepts carefully:
+
+- `dependencies` are for assets that are part of the element's baseline runtime and should be loaded up front. These assets typically create global variables or otherwise register themselves with the browser runtime so that the element's code can use them immediately. They are loaded using `<script src="...">` or `<link rel="stylesheet" href="...">` tags in the page header. Element code can assume that these assets are available immediately after the page loads, and may reference its resources using global variables.
+- `dynamicDependencies` are for optional or on-demand loading. They are useful when a feature, data payload, or interaction path is only needed after some user action or condition is met. They may also be used as ESM modules that are imported by the element's code at runtime, though still browser-loadable as standalone assets. They are loaded using import maps, and may be imported with `import` or `await import()` in the element's code. The element's code should not assume that it is available until it has been explicitly loaded.
+
 ## Workflow
 
 1. Create or update the element's controller, template, CSS, JavaScript, and `info.json` together.

--- a/.agents/skills/element-runtime-assets/SKILL.md
+++ b/.agents/skills/element-runtime-assets/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: element-runtime-assets
+description: Use when creating a new PrairieLearn element or changing an element's runtime dependencies, scripts, styles, or bundled assets.
+---
+
+Use this when adding a new element under `apps/prairielearn/elements/` or when changing how an element loads JavaScript, CSS, or other runtime assets.
+
+## Core requirement
+
+Any file referenced from an element's `dependencies` or `dynamicDependencies` must be browser-loadable as a standalone asset. It must be bundled or otherwise self-contained so it does not rely on extra `import`/`require` resolution from the browser runtime.
+
+In practice, this means:
+
+- Prefer a real bundled artifact over a package entry point that still pulls in additional modules.
+- Verify that the served asset can be loaded directly by the app's asset pipeline.
+- If the asset needs more module resolution than the current import-map flow provides, choose a different asset or bundle it first.
+
+## Workflow
+
+1. Create or update the element's controller, template, CSS, JavaScript, and `info.json` together.
+2. Keep the runtime asset wiring in `info.json` aligned with the actual files that are shipped and loadable in the browser.
+3. Update the element docs and example-course questions when author-facing behavior changes.
+4. Verify the asset path in the browser or via the app's asset-serving checks before calling the change complete.
+
+## Typical files
+
+- `apps/prairielearn/elements/<tag>/info.json`
+- `apps/prairielearn/elements/<tag>/<tag>.py`
+- `apps/prairielearn/elements/<tag>/<tag>.js`
+- `apps/prairielearn/elements/<tag>/<tag>.mustache`
+- `docs/elements/<tag>.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,8 @@ When modifying or reviewing element controllers — especially adding fields to 
 
 When changing or reviewing an element's accepted/generated HTML attribute contract, see the [`element-validation` skill](./.agents/skills/element-validation/SKILL.md) to keep schema modules, legacy AI validation, Python render-time checks, and element docs aligned.
 
+When creating a new element or changing an element's runtime dependencies, scripts, styles, or bundled assets, see the [`element-runtime-assets` skill](./.agents/skills/element-runtime-assets/SKILL.md) for the requirement that those assets be browser-loadable as standalone bundles.
+
 ### Testing
 
 - For Python tests, use `uv run pytest path/to/testfile.py` from the root directory.

--- a/docs/devElements.md
+++ b/docs/devElements.md
@@ -124,6 +124,10 @@ All functions above have equivalents in [question code](question/server.md) (i.e
 
 It's likely that your element will depend on certain client-side assets, such as scripts or stylesheets. To keep clean separation of HTML, CSS, and JS, you can place those dependencies in other files. If you depend on libraries like `lodash` or `d3`, you can also link to node modules containing these libraries. PrairieLearn will compile a list of all dependencies needed by all elements on a page, deduplicate the dependencies, and ensure they are loaded on the page.
 
+!!! warning
+
+    Files referenced from an element's `dependencies` or `dynamicDependencies` must be browser-loadable as standalone assets. They must be bundled or otherwise self-contained, and should not rely on additional `import`/`require` resolution from the browser runtime.
+
 Dependencies are listed in your element's `info.json`. You can configure them for your element as follows:
 
 ```json title="info.json"


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

A recent session with AI took a lot of time to end up reaching nowhere. The main issue had to do with understanding how element code handles dependencies. This PR adds a new skill and updates the docs to clarify how these dependencies are used, with a focus on self-contained resources.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

N/A.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
