### PR TITLE
Validate institution IDs at the login boundary

### DIFF
--- a/.changeset/validate-postgres-ids.md
+++ b/.changeset/validate-postgres-ids.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/zod': patch
+---
+
+Validate that PostgreSQL IDs are positive scalar values within the `BIGINT` range, and add helpers for parsing request query parameters and bodies with consistent HTTP 400 errors.

--- a/apps/prairielearn/src/pages/authLogin/authLogin.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+import { IdSchema, parseRequestBody, parseRequestQuery } from '@prairielearn/zod';
 
 import * as authLib from '../../lib/authn.js';
 import { config } from '../../lib/config.js';
@@ -28,17 +29,20 @@ const InstitutionSupportedProvidersSchema = z.object({
   name: AuthnProviderSchema.shape.name,
   is_default: z.boolean(),
 });
-const ServiceSchema = z.string().nullable();
-const InstitutionIdSchema = z.string().nullable();
+const LoginQuerySchema = z.object({
+  institution_id: IdSchema.optional(),
+  service: z.string().nullable().catch(null),
+  unsupported_provider: z.literal('true').optional().catch(undefined),
+});
 
 router.get(
   '/',
   asyncHandler(async (req, res, _next) => {
-    const service = ServiceSchema.parse(req.query.service ?? null);
+    const query = parseRequestQuery(req, LoginQuerySchema);
 
     // If an `institution_id` query parameter is provided, we'll only show the
     // login options for that institution.
-    const institutionId = InstitutionIdSchema.parse(req.query.institution_id ?? null);
+    const institutionId = query.institution_id ?? null;
     if (institutionId) {
       // Look up the supported providers for this institution.
       const supportedProviders = await queryRows(
@@ -49,10 +53,10 @@ router.get(
 
       res.send(
         AuthLoginInstitution({
-          showUnsupportedMessage: req.query.unsupported_provider === 'true',
+          showUnsupportedMessage: query.unsupported_provider === 'true',
           institutionId,
           supportedProviders,
-          service,
+          service: query.service,
           resLocals: res.locals,
         }),
       );
@@ -96,11 +100,17 @@ router.get(
       })
       .filter((provider): provider is InstitutionAuthnProvider => provider !== null);
 
-    res.send(AuthLogin({ service, institutionAuthnProviders, resLocals: res.locals }));
+    res.send(
+      AuthLogin({
+        service: query.service,
+        institutionAuthnProviders,
+        resLocals: res.locals,
+      }),
+    );
   }),
 );
 
-const DevLoginParamsSchema = z.object({
+const DevLoginBodySchema = z.object({
   uid: z.string().min(1),
   name: z.string().min(1),
   uin: z.string().nullable().optional().default(null),
@@ -115,7 +125,7 @@ router.post(
     }
 
     if (req.body.__action === 'dev_login') {
-      const body = DevLoginParamsSchema.parse(req.body);
+      const body = parseRequestBody(req, DevLoginBodySchema);
 
       const authnParams = {
         uid: body.uid,

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -379,7 +379,7 @@ describe('Access control save via tRPC', { concurrent: false }, () => {
     const [existingEnrollmentRule] = await selectAccessControlRules(assessment, ['enrollment']);
     assert.isOk(existingEnrollmentRule);
     const enrollmentId = existingEnrollmentRule.enrollments?.[0]?.enrollmentId;
-    assert.isDefined(enrollmentId);
+    assert(typeof enrollmentId === 'string');
 
     await expect(
       client.accessControl.saveAllRules.mutate({

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -379,7 +379,7 @@ describe('Access control save via tRPC', { concurrent: false }, () => {
     const [existingEnrollmentRule] = await selectAccessControlRules(assessment, ['enrollment']);
     assert.isOk(existingEnrollmentRule);
     const enrollmentId = existingEnrollmentRule.enrollments?.[0]?.enrollmentId;
-    assert.isString(enrollmentId);
+    assert.isDefined(enrollmentId);
 
     await expect(
       client.accessControl.saveAllRules.mutate({

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@prairielearn/error": "workspace:^",
     "postgres-interval": "^4.1.0",
     "zod": "^4.4.3"
   },

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -37,6 +37,16 @@ describe('IdSchema', () => {
     assert.equal(id, '123');
   });
 
+  it('parses a numeric id', () => {
+    const id = IdSchema.parse(123);
+    assert.equal(id, '123');
+  });
+
+  it('parses the largest PostgreSQL id', () => {
+    const id = IdSchema.parse('9223372036854775807');
+    assert.equal(id, '9223372036854775807');
+  });
+
   it('parses a nullable id', () => {
     const id = IdSchema.nullable().parse(null);
     assert.equal(id, null);
@@ -52,8 +62,23 @@ describe('IdSchema', () => {
     assert.isFalse(result.success);
   });
 
+  it('rejects a zero ID', () => {
+    const result = IdSchema.safeParse('0');
+    assert.isFalse(result.success);
+  });
+
   it('rejects a non-numeric ID', () => {
     const result = IdSchema.safeParse('abc');
+    assert.isFalse(result.success);
+  });
+
+  it('rejects a non-scalar ID', () => {
+    const result = IdSchema.safeParse(['1']);
+    assert.isFalse(result.success);
+  });
+
+  it('rejects an ID outside the PostgreSQL range', () => {
+    const result = IdSchema.safeParse('9223372036854775808');
     assert.isFalse(result.success);
   });
 });

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,6 +1,8 @@
 import parsePostgresInterval from 'postgres-interval';
 import { type ZodType, z } from 'zod';
 
+export { parseRequestBody, parseRequestQuery } from './request-validation.js';
+
 const INTERVAL_MS_PER_SECOND = 1000;
 const INTERVAL_MS_PER_MINUTE = 60 * INTERVAL_MS_PER_SECOND;
 const INTERVAL_MS_PER_HOUR = 60 * INTERVAL_MS_PER_MINUTE;
@@ -48,12 +50,21 @@ export const BooleanFromCheckboxSchema = required(
  * `to_jsonb()`). This schema coerces the ID to a string to ensure consistent
  * handling.
  *
- * The `refine` step is important to ensure that the thing we've coerced to a
- * string is actually a number. If it's not, we want to fail quickly.
+ * The `refine` step ensures that the value is a positive integer in the range
+ * supported by PostgreSQL's `BIGINT` type.
  */
-export const IdSchema = z.coerce
-  .string()
-  .refine((val) => /^\d+$/.test(val), { message: 'ID is not a non-negative integer' });
+export const IdSchema = z
+  .union([z.string(), z.number(), z.bigint()])
+  .transform(String)
+  .refine(
+    (value) => {
+      if (!/^\d+$/.test(value)) return false;
+
+      const id = BigInt(value);
+      return id > 0n && id <= 2n ** 63n - 1n;
+    },
+    { message: 'ID is not a valid PostgreSQL ID' },
+  );
 
 /**
  * A Zod schema for the objects produced by the `postgres-interval` library.

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -54,11 +54,7 @@ export const BooleanFromCheckboxSchema = required(
  * supported by PostgreSQL's `BIGINT` type.
  */
 export const IdSchema = z
-  .unknown()
-  .refine(
-    (value) => typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint',
-    { message: 'ID is not a valid PostgreSQL ID' },
-  )
+  .union([z.string(), z.number(), z.bigint()])
   .transform(String)
   .refine(
     (value) => {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -54,7 +54,11 @@ export const BooleanFromCheckboxSchema = required(
  * supported by PostgreSQL's `BIGINT` type.
  */
 export const IdSchema = z
-  .union([z.string(), z.number(), z.bigint()])
+  .unknown()
+  .refine(
+    (value) => typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint',
+    { message: 'ID is not a valid PostgreSQL ID' },
+  )
   .transform(String)
   .refine(
     (value) => {

--- a/packages/zod/src/request-validation.test.ts
+++ b/packages/zod/src/request-validation.test.ts
@@ -1,0 +1,39 @@
+import { assert, describe, it } from 'vitest';
+import { z } from 'zod';
+
+import { HttpStatusError } from '@prairielearn/error';
+
+import { parseRequestBody, parseRequestQuery } from './index.js';
+
+describe('request validation', () => {
+  it('parses and transforms query parameters', () => {
+    const result = parseRequestQuery(
+      { query: { page: '2' } },
+      z.object({ page: z.coerce.number().int() }),
+    );
+
+    assert.deepEqual(result, { page: 2 });
+  });
+
+  it('throws a 400 error for invalid query parameters', () => {
+    const error = assert.throws(() =>
+      parseRequestQuery({ query: { page: 'invalid' } }, z.object({ page: z.coerce.number() })),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'Invalid query parameters');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+
+  it('throws a 400 error for an invalid request body', () => {
+    const error = assert.throws(() =>
+      parseRequestBody({ body: { name: 1 } }, z.object({ name: z.string() })),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'Invalid request body');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+});

--- a/packages/zod/src/request-validation.ts
+++ b/packages/zod/src/request-validation.ts
@@ -1,0 +1,36 @@
+import { type ZodType, type output } from 'zod';
+
+import { HttpStatusError } from '@prairielearn/error';
+
+const REQUEST_VALIDATION_ERROR_MESSAGES = {
+  body: 'Invalid request body',
+  query: 'Invalid query parameters',
+} as const;
+
+function parseRequestData<Schema extends ZodType>(
+  source: keyof typeof REQUEST_VALIDATION_ERROR_MESSAGES,
+  data: unknown,
+  schema: Schema,
+): output<Schema> {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw new HttpStatusError(400, REQUEST_VALIDATION_ERROR_MESSAGES[source], {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+export function parseRequestQuery<Schema extends ZodType>(
+  req: { query: unknown },
+  schema: Schema,
+): output<Schema> {
+  return parseRequestData('query', req.query, schema);
+}
+
+export function parseRequestBody<Schema extends ZodType>(
+  req: { body: unknown },
+  schema: Schema,
+): output<Schema> {
+  return parseRequestData('body', req.body, schema);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2846,6 +2846,9 @@ importers:
 
   packages/zod:
     dependencies:
+      '@prairielearn/error':
+        specifier: workspace:^
+        version: link:../error
       postgres-interval:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
# Description

SQL-injection scanners send malformed `institution_id` values to the public `/pl/login` route. The value is safely bound, but PostgreSQL rejects it as a `BIGINT` and PrairieLearn responds with HTTP 500, which triggers load-balancer error-rate alerts.

This change strengthens the shared `IdSchema` to accept only positive scalar values within PostgreSQL's signed `BIGINT` range, adds framework-neutral helpers for translating request query/body Zod validation failures into HTTP 400 errors, and uses them at the login boundary. Malformed cosmetic login parameters continue to fall back instead of halting the login experience.

- [x] I have disclosed the level of AI assistance used (majority of implementation).

# Testing

Added focused unit coverage for PostgreSQL ID boundaries and for translating invalid query parameters and request bodies into HTTP 400 errors.
