### PR TITLE
Use request validation helpers across routes

### DIFF
--- a/.changeset/parse-json-strings.md
+++ b/.changeset/parse-json-strings.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/zod': patch
+---
+
+Add a composable schema for parsing JSON strings.

--- a/.changeset/validate-postgres-ids.md
+++ b/.changeset/validate-postgres-ids.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/zod': patch
+---
+
+Validate that PostgreSQL IDs are positive scalar values within the `BIGINT` range, and add helpers for parsing request query parameters and bodies with consistent HTTP 400 errors.

--- a/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
+++ b/apps/prairielearn/src/ee/auth/lti13/lti13Auth.ts
@@ -10,6 +10,7 @@ import { cache } from '@prairielearn/cache';
 import { HttpStatusError } from '@prairielearn/error';
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 import { assertNever } from '@prairielearn/utils';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import * as authnLib from '../../../lib/authn.js';
 import { clearCookie, setCookie } from '../../../lib/cookie.js';
@@ -168,7 +169,7 @@ const OIDCAuthResponseSchema = z.union([
 router.post(
   '/callback',
   asyncHandler(async (req, res) => {
-    const authResponse = OIDCAuthResponseSchema.parse(req.body);
+    const authResponse = parseRequestBody(req, OIDCAuthResponseSchema);
 
     if ('error' in authResponse) {
       // e.g. launch_no_longer_valid

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { CourseSchema } from '../../../lib/db-types.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
@@ -58,8 +59,9 @@ router.post(
     );
 
     if (req.body.__action === 'update_enrollment_limits') {
-      const body = z
-        .object({
+      const body = parseRequestBody(
+        req,
+        z.object({
           __action: z.literal('update_enrollment_limits'),
           yearly_enrollment_limit: z.union([
             z.literal('').transform(() => null),
@@ -69,8 +71,8 @@ router.post(
             z.literal('').transform(() => null),
             z.coerce.number().int(),
           ]),
-        })
-        .parse(req.body);
+        }),
+      );
       await runInTransactionAsync(async () => {
         const updatedCourse = await queryRow(
           sql.update_enrollment_limits,

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.tsx
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.tsx
@@ -3,7 +3,7 @@ import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import { Hydrate } from '@prairielearn/react/server';
-import { ArrayFromCheckboxSchema } from '@prairielearn/zod';
+import { ArrayFromCheckboxSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../../components/PageLayout.js';
 import { getSupportedAuthenticationProviders } from '../../../lib/authn-providers.js';
@@ -32,12 +32,13 @@ router.post(
       supportedAuthenticationProviders.map((p) => p.id),
     );
 
-    const body = z
-      .object({
+    const body = parseRequestBody(
+      req,
+      z.object({
         default_authn_provider_id: z.string().transform((s) => (s === '' ? null : s)),
         enabled_authn_provider_ids: ArrayFromCheckboxSchema,
-      })
-      .parse(req.body);
+      }),
+    );
 
     const enabledProviders = body.enabled_authn_provider_ids.filter((id) =>
       supportedAuthenticationProviderIds.has(id),

--- a/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
+++ b/apps/prairielearn/src/ee/pages/studentCourseInstanceUpgrade/studentCourseInstanceUpgrade.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import { runInTransactionAsync } from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { EnrollmentPage } from '../../../components/EnrollmentPage.js';
 import { hasRole } from '../../../lib/authz-data-lib.js';
@@ -160,7 +161,7 @@ router.post(
         throw new error.HttpStatusError(403, getEligibilityErrorMessage(enrollmentInfo.reason));
       }
 
-      const body = UpgradeBodySchema.parse(req.body);
+      const body = parseRequestBody(req, UpgradeBodySchema);
 
       if (!body.terms_agreement) {
         throw new error.HttpStatusError(400, 'You must agree to the terms and conditions.');

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -164,8 +164,8 @@ router.post(
     if (req.body.__action === 'add_feature_grant') {
       const feature = validateFeature(req.params.feature);
 
-      const params = parseRequestBody(req, AddFeatureGrantModalParamsSchema);
-      const { institution, course, course_instance, user } = await getEntitiesFromParams(params);
+      const body = parseRequestBody(req, AddFeatureGrantModalParamsSchema);
+      const { institution, course, course_instance, user } = await getEntitiesFromParams(body);
 
       const context = features.validateContext({
         institution_id: institution?.id ?? null,
@@ -174,7 +174,7 @@ router.post(
         user_id: user?.id ?? null,
       });
 
-      if (params.enabled) {
+      if (body.enabled) {
         await features.enable(feature, context);
       } else {
         await features.disable(feature, context);

--- a/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
+++ b/apps/prairielearn/src/pages/administratorFeatures/administratorFeatures.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { execute, loadSqlEquiv, queryRows } from '@prairielearn/postgres';
-import { IdSchema } from '@prairielearn/zod';
+import { IdSchema, parseRequestBody, parseRequestQuery } from '@prairielearn/zod';
 
 import { config } from '../../lib/config.js';
 import {
@@ -139,7 +139,7 @@ router.get(
   typedAsyncHandler<'plain'>(async (req, res) => {
     const feature = validateFeature(req.params.feature);
 
-    const query = AddFeatureGrantModalParamsSchema.parse(req.query);
+    const query = parseRequestQuery(req, AddFeatureGrantModalParamsSchema);
     const { institutions, institution, courses, course, course_instances, course_instance } =
       await getEntitiesFromParams(query);
 
@@ -164,7 +164,7 @@ router.post(
     if (req.body.__action === 'add_feature_grant') {
       const feature = validateFeature(req.params.feature);
 
-      const params = AddFeatureGrantModalParamsSchema.parse(req.body);
+      const params = parseRequestBody(req, AddFeatureGrantModalParamsSchema);
       const { institution, course, course_instance, user } = await getEntitiesFromParams(params);
 
       const context = features.validateContext({

--- a/apps/prairielearn/src/pages/authLogin/authLogin.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+import { IdSchema, parseRequestBody, parseRequestQuery } from '@prairielearn/zod';
 
 import * as authLib from '../../lib/authn.js';
 import { config } from '../../lib/config.js';
@@ -28,17 +29,20 @@ const InstitutionSupportedProvidersSchema = z.object({
   name: AuthnProviderSchema.shape.name,
   is_default: z.boolean(),
 });
-const ServiceSchema = z.string().nullable();
-const InstitutionIdSchema = z.string().nullable();
+const LoginQuerySchema = z.object({
+  institution_id: IdSchema.optional(),
+  service: z.string().nullable().catch(null),
+  unsupported_provider: z.literal('true').optional().catch(undefined),
+});
 
 router.get(
   '/',
   asyncHandler(async (req, res, _next) => {
-    const service = ServiceSchema.parse(req.query.service ?? null);
+    const query = parseRequestQuery(req, LoginQuerySchema);
 
     // If an `institution_id` query parameter is provided, we'll only show the
     // login options for that institution.
-    const institutionId = InstitutionIdSchema.parse(req.query.institution_id ?? null);
+    const institutionId = query.institution_id ?? null;
     if (institutionId) {
       // Look up the supported providers for this institution.
       const supportedProviders = await queryRows(
@@ -49,10 +53,10 @@ router.get(
 
       res.send(
         AuthLoginInstitution({
-          showUnsupportedMessage: req.query.unsupported_provider === 'true',
+          showUnsupportedMessage: query.unsupported_provider === 'true',
           institutionId,
           supportedProviders,
-          service,
+          service: query.service,
           resLocals: res.locals,
         }),
       );
@@ -96,11 +100,17 @@ router.get(
       })
       .filter((provider): provider is InstitutionAuthnProvider => provider !== null);
 
-    res.send(AuthLogin({ service, institutionAuthnProviders, resLocals: res.locals }));
+    res.send(
+      AuthLogin({
+        service: query.service,
+        institutionAuthnProviders,
+        resLocals: res.locals,
+      }),
+    );
   }),
 );
 
-const DevLoginParamsSchema = z.object({
+const DevLoginBodySchema = z.object({
   uid: z.string().min(1),
   name: z.string().min(1),
   uin: z.string().nullable().optional().default(null),
@@ -115,7 +125,7 @@ router.post(
     }
 
     if (req.body.__action === 'dev_login') {
-      const body = DevLoginParamsSchema.parse(req.body);
+      const body = parseRequestBody(req, DevLoginBodySchema);
 
       const authnParams = {
         uid: body.uid,

--- a/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
+++ b/apps/prairielearn/src/pages/course_instance/lookup/lookupByEnrollmentCode.ts
@@ -3,6 +3,7 @@ import asyncHandler from 'express-async-handler';
 import z from 'zod';
 
 import { HttpStatusError } from '@prairielearn/error';
+import { parseRequestQuery } from '@prairielearn/zod';
 
 import { hasRole } from '../../../lib/authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
@@ -27,7 +28,10 @@ router.get(
     }
 
     // Parse and validate the code parameter
-    const { code, course_instance_id: courseInstanceIdToCheck } = LookupCodeSchema.parse(req.query);
+    const { code, course_instance_id: courseInstanceIdToCheck } = parseRequestQuery(
+      req,
+      LookupCodeSchema,
+    );
 
     // Look up the course instance by enrollment code
     const courseInstanceId = await selectOptionalCourseInstanceIdByEnrollmentCode({

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -6,6 +6,7 @@ import { flash } from '@prairielearn/flash';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { assertNever } from '@prairielearn/utils';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
@@ -190,7 +191,7 @@ router.post(
         course_instance_id: z.string().min(1),
       }),
     ]);
-    const body = BodySchema.parse(req.body);
+    const body = parseRequestBody(req, BodySchema);
 
     if (body.__action === 'dismiss_news_alert') {
       await markNewsItemsAsReadForUser(res.locals.authn_user);

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/instanceQuestion.ts
@@ -7,7 +7,7 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
-import { DateFromISOString, IdSchema } from '@prairielearn/zod';
+import { DateFromISOString, IdSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { AIGradingExplanation, AIGradingPrompt } from '../../../components/QuestionContainer.js';
 import { getAvailableAiGradingProviders } from '../../../ee/lib/ai-grading/ai-grading-credentials.js';
@@ -476,7 +476,7 @@ const PostBodySchema = z.union([
 router.post(
   '/',
   asyncHandler(async (req, res) => {
-    const body = PostBodySchema.parse(req.body);
+    const body = parseRequestBody(req, PostBodySchema);
     if (body.__action === 'next_instance_question') {
       if (!res.locals.authz_data.has_course_instance_permission_view) {
         throw new error.HttpStatusError(403, 'Access denied (must be a student data viewer)');

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.tsx
@@ -6,7 +6,7 @@ import { HttpStatusError } from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { Hydrate } from '@prairielearn/react/server';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
-import { parseRequestBody } from '@prairielearn/zod';
+import { JsonFromStringSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { selectAssessmentQuestions } from '../../lib/assessment-question.js';
@@ -37,16 +37,7 @@ import { buildHierarchicalAssessment } from './utils/questions.js';
 
 const router = Router();
 
-const SaveQuestionsZonesSchema = z
-  .string()
-  .transform((str) => {
-    try {
-      return JSON.parse(str);
-    } catch {
-      throw new Error('Invalid JSON in zones field');
-    }
-  })
-  .pipe(z.array(ZoneAssessmentJsonSchema));
+const SaveQuestionsZonesSchema = JsonFromStringSchema.pipe(z.array(ZoneAssessmentJsonSchema));
 
 const SaveQuestionsSchema = z.object({
   __action: z.literal('save_questions'),

--- a/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentQuestions/instructorAssessmentQuestions.tsx
@@ -6,6 +6,7 @@ import { HttpStatusError } from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { Hydrate } from '@prairielearn/react/server';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { selectAssessmentQuestions } from '../../lib/assessment-question.js';
@@ -208,7 +209,7 @@ router.post(
         throw new HttpStatusError(403, 'Access denied (must be course editor)');
       }
 
-      const body = SaveQuestionsSchema.parse(req.body);
+      const body = parseRequestBody(req, SaveQuestionsSchema);
 
       const assessmentPath = getAssessmentInfoJsonPath(res.locals);
 

--- a/apps/prairielearn/src/pages/instructorCopyPublicCourseInstance/instructorCopyPublicCourseInstance.ts
+++ b/apps/prairielearn/src/pages/instructorCopyPublicCourseInstance/instructorCopyPublicCourseInstance.ts
@@ -3,7 +3,11 @@ import asyncHandler from 'express-async-handler';
 import z from 'zod';
 
 import * as error from '@prairielearn/error';
-import { BooleanFromCheckboxSchema, DatetimeLocalStringSchema } from '@prairielearn/zod';
+import {
+  BooleanFromCheckboxSchema,
+  DatetimeLocalStringSchema,
+  parseRequestBody,
+} from '@prairielearn/zod';
 
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { copyCourseInstanceBetweenCourses } from '../../lib/copy-content.js';
@@ -28,15 +32,16 @@ router.post(
       course_instance_id,
       self_enrollment_enabled,
       self_enrollment_use_enrollment_code,
-    } = z
-      .object({
+    } = parseRequestBody(
+      req,
+      z.object({
         start_date: z.union([z.literal(''), DatetimeLocalStringSchema]),
         end_date: z.union([z.literal(''), DatetimeLocalStringSchema]),
         course_instance_id: z.string(),
         self_enrollment_enabled: BooleanFromCheckboxSchema,
         self_enrollment_use_enrollment_code: BooleanFromCheckboxSchema,
-      })
-      .parse(req.body);
+      }),
+    );
 
     // The ID of the course instance we are copying
     const fromCourseInstance = await selectOptionalCourseInstanceById(course_instance_id);

--- a/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminInstances/instructorCourseAdminInstances.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import * as sqldb from '@prairielearn/postgres';
 import { Hydrate } from '@prairielearn/react/server';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
@@ -122,8 +123,9 @@ router.post(
         self_enrollment_enabled,
         self_enrollment_use_enrollment_code,
         course_instance_permission,
-      } = z
-        .object({
+      } = parseRequestBody(
+        req,
+        z.object({
           short_name: z.string().trim(),
           long_name: z.string().trim(),
           start_date: z.string(),
@@ -131,8 +133,8 @@ router.post(
           self_enrollment_enabled: z.boolean().optional(),
           self_enrollment_use_enrollment_code: z.boolean().optional(),
           course_instance_permission: EnumCourseInstanceRoleSchema.optional().default('None'),
-        })
-        .parse(req.body);
+        }),
+      );
 
       if (!short_name) {
         throw new error.HttpStatusError(400, 'Short name is required');

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.tsx
@@ -9,6 +9,7 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 import { Hydrate } from '@prairielearn/react/server';
 import { run } from '@prairielearn/run';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
@@ -92,15 +93,16 @@ router.post(
         await fs.readFile(path.join(res.locals.course.path, 'infoCourse.json'), 'utf8'),
       );
 
-      const body = z
-        .object({
+      const body = parseRequestBody(
+        req,
+        z.object({
           __action: z.literal('save_assessment_sets'),
           orig_hash: z.string(),
           assessment_sets: z
             .string()
             .transform((s) => z.array(InstructorCourseAdminSetFormRowSchema).parse(JSON.parse(s))),
-        })
-        .parse(req.body);
+        }),
+      );
 
       const origHash = body.orig_hash;
       const resolveAssessmentSets = body.assessment_sets

--- a/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminSets/instructorCourseAdminSets.tsx
@@ -9,7 +9,7 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 import { Hydrate } from '@prairielearn/react/server';
 import { run } from '@prairielearn/run';
-import { parseRequestBody } from '@prairielearn/zod';
+import { JsonFromStringSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
@@ -98,9 +98,9 @@ router.post(
         z.object({
           __action: z.literal('save_assessment_sets'),
           orig_hash: z.string(),
-          assessment_sets: z
-            .string()
-            .transform((s) => z.array(InstructorCourseAdminSetFormRowSchema).parse(JSON.parse(s))),
+          assessment_sets: JsonFromStringSchema.pipe(
+            z.array(InstructorCourseAdminSetFormRowSchema),
+          ),
         }),
       );
 

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { Hydrate } from '@prairielearn/react/server';
-import { parseRequestBody } from '@prairielearn/zod';
+import { JsonFromStringSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { TagsTopicsTable } from '../../components/TagsTopicsTable.js';
@@ -91,18 +91,16 @@ router.post(
         req,
         z.object({
           orig_hash: z.string(),
-          data: z.string().transform((s) =>
-            z
-              .array(
-                TagSchema.pick({
-                  name: true,
-                  color: true,
-                  description: true,
-                  json_comment: true,
-                  implicit: true,
-                }),
-              )
-              .parse(JSON.parse(s)),
+          data: JsonFromStringSchema.pipe(
+            z.array(
+              TagSchema.pick({
+                name: true,
+                color: true,
+                description: true,
+                json_comment: true,
+                implicit: true,
+              }),
+            ),
           ),
         }),
       );

--- a/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTags/instructorCourseAdminTags.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { Hydrate } from '@prairielearn/react/server';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { TagsTopicsTable } from '../../components/TagsTopicsTable.js';
@@ -86,8 +87,9 @@ router.post(
         await fs.readFile(path.join(res.locals.course.path, 'infoCourse.json'), 'utf8'),
       );
 
-      const body = z
-        .object({
+      const body = parseRequestBody(
+        req,
+        z.object({
           orig_hash: z.string(),
           data: z.string().transform((s) =>
             z
@@ -102,8 +104,8 @@ router.post(
               )
               .parse(JSON.parse(s)),
           ),
-        })
-        .parse(req.body);
+        }),
+      );
 
       const origHash = body.orig_hash;
       const resolveTags = body.data

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.tsx
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { Hydrate } from '@prairielearn/react/server';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { TagsTopicsTable } from '../../components/TagsTopicsTable.js';
@@ -87,8 +88,9 @@ router.post(
         await fs.readFile(path.join(res.locals.course.path, 'infoCourse.json'), 'utf8'),
       );
 
-      const body = z
-        .object({
+      const body = parseRequestBody(
+        req,
+        z.object({
           orig_hash: z.string(),
           data: z.string().transform((s) =>
             z
@@ -103,8 +105,8 @@ router.post(
               )
               .parse(JSON.parse(s)),
           ),
-        })
-        .parse(req.body);
+        }),
+      );
 
       const origHash = body.orig_hash;
       const resolveTopics = body.data

--- a/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminTopics/instructorCourseAdminTopics.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { Hydrate } from '@prairielearn/react/server';
-import { parseRequestBody } from '@prairielearn/zod';
+import { JsonFromStringSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { TagsTopicsTable } from '../../components/TagsTopicsTable.js';
@@ -92,18 +92,16 @@ router.post(
         req,
         z.object({
           orig_hash: z.string(),
-          data: z.string().transform((s) =>
-            z
-              .array(
-                TopicSchema.pick({
-                  name: true,
-                  color: true,
-                  description: true,
-                  json_comment: true,
-                  implicit: true,
-                }),
-              )
-              .parse(JSON.parse(s)),
+          data: JsonFromStringSchema.pipe(
+            z.array(
+              TopicSchema.pick({
+                name: true,
+                color: true,
+                description: true,
+                json_comment: true,
+                implicit: true,
+              }),
+            ),
           ),
         }),
       );

--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/instructorInstanceAdminPublishing.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/instructorInstanceAdminPublishing.tsx
@@ -8,7 +8,7 @@ import * as error from '@prairielearn/error';
 import { flash } from '@prairielearn/flash';
 import { loadSqlEquiv, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
 import { Hydrate } from '@prairielearn/react/server';
-import { DatetimeLocalStringSchema } from '@prairielearn/zod';
+import { DatetimeLocalStringSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { type AuthzData, assertHasRole } from '../../lib/authz-data-lib.js';
@@ -267,12 +267,13 @@ router.post(
         await fs.readFile(infoCourseInstancePath, 'utf8'),
       );
 
-      const parsedBody = z
-        .object({
+      const parsedBody = parseRequestBody(
+        req,
+        z.object({
           start_date: z.union([z.literal(''), DatetimeLocalStringSchema]),
           end_date: z.union([z.literal(''), DatetimeLocalStringSchema]),
-        })
-        .parse(req.body);
+        }),
+      );
 
       // Update the publishing settings
       const resolvedPublishing = {

--- a/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/instructorInstanceAdminPublishing.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminPublishing/instructorInstanceAdminPublishing.tsx
@@ -267,7 +267,7 @@ router.post(
         await fs.readFile(infoCourseInstancePath, 'utf8'),
       );
 
-      const parsedBody = parseRequestBody(
+      const body = parseRequestBody(
         req,
         z.object({
           start_date: z.union([z.literal(''), DatetimeLocalStringSchema]),
@@ -279,12 +279,12 @@ router.post(
       const resolvedPublishing = {
         startDate: propertyValueWithDefault(
           courseInstanceInfo.publishing?.startDate,
-          parsedBody.start_date,
+          body.start_date,
           (v: string) => v === '',
         ),
         endDate: propertyValueWithDefault(
           courseInstanceInfo.publishing?.endDate,
-          parsedBody.end_date,
+          body.end_date,
           (v: string) => v === '',
         ),
       };
@@ -363,11 +363,7 @@ router.post(
           EmailsSchema,
         ),
       });
-      const addExtensionBodyResult = AddExtensionSchema.safeParse(req.body);
-      if (!addExtensionBodyResult.success) {
-        throw new error.HttpStatusError(400, 'Invalid request body');
-      }
-      const body = addExtensionBodyResult.data;
+      const body = parseRequestBody(req, AddExtensionSchema);
 
       const enrollments = (
         await selectUsersAndEnrollmentsByUidsInCourseInstance({
@@ -406,15 +402,12 @@ router.post(
       res.sendStatus(204);
       return;
     } else if (req.body.__action === 'delete_extension') {
-      const deleteExtensionBodyResult = z
-        .object({
+      const body = parseRequestBody(
+        req,
+        z.object({
           extension_id: z.string().trim().min(1),
-        })
-        .safeParse(req.body);
-      if (!deleteExtensionBodyResult.success) {
-        throw new error.HttpStatusError(400, 'Invalid request body');
-      }
-      const body = deleteExtensionBodyResult.data;
+        }),
+      );
 
       const extension = await selectPublishingExtensionById({
         id: body.extension_id,

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -10,6 +10,7 @@ import { flash } from '@prairielearn/flash';
 import * as sqldb from '@prairielearn/postgres';
 import { Hydrate } from '@prairielearn/react/server';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
+import { parseRequestBody } from '@prairielearn/zod';
 
 import { DeleteCourseInstanceModal } from '../../components/DeleteCourseInstanceModal.js';
 import { PageLayout } from '../../components/PageLayout.js';
@@ -207,8 +208,9 @@ router.post(
         course_instance_permission,
         access_control_strategy,
         clear_incompatible,
-      } = z
-        .object({
+      } = parseRequestBody(
+        req,
+        z.object({
           short_name: z.string().trim(),
           long_name: z.string().trim(),
           start_date: z.string(),
@@ -218,8 +220,8 @@ router.post(
           course_instance_permission: EnumCourseInstanceRoleSchema.optional().default('None'),
           access_control_strategy: z.enum(['migrate', 'keep', 'clear']).optional().default('clear'),
           clear_incompatible: z.boolean().optional().default(false),
-        })
-        .parse(req.body);
+        }),
+      );
 
       if (!short_name) {
         throw new error.HttpStatusError(400, 'Short name is required');
@@ -363,7 +365,7 @@ router.post(
         await fs.readFile(infoCourseInstancePath, 'utf8'),
       );
 
-      const parsedBody = SettingsFormBodySchema.parse(req.body);
+      const parsedBody = parseRequestBody(req, SettingsFormBodySchema);
 
       courseInstanceInfo.longName = parsedBody.long_name;
       courseInstanceInfo.timezone = propertyValueWithDefault(

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -365,17 +365,17 @@ router.post(
         await fs.readFile(infoCourseInstancePath, 'utf8'),
       );
 
-      const parsedBody = parseRequestBody(req, SettingsFormBodySchema);
+      const body = parseRequestBody(req, SettingsFormBodySchema);
 
-      courseInstanceInfo.longName = parsedBody.long_name;
+      courseInstanceInfo.longName = body.long_name;
       courseInstanceInfo.timezone = propertyValueWithDefault(
         courseInstanceInfo.timezone,
-        parsedBody.display_timezone,
+        body.display_timezone,
         course.display_timezone,
       );
       courseInstanceInfo.groupAssessmentsBy = propertyValueWithDefault(
         courseInstanceInfo.groupAssessmentsBy,
-        parsedBody.group_assessments_by,
+        body.group_assessments_by,
         'Set',
       );
       // dates from 'datetime-local' inputs are in the format 'YYYY-MM-DDTHH:MM', and we need them to include seconds.
@@ -386,27 +386,27 @@ router.post(
 
       const selfEnrollmentEnabled = propertyValueWithDefault(
         courseInstanceInfo.selfEnrollment?.enabled,
-        parsedBody.self_enrollment_enabled,
+        body.self_enrollment_enabled,
         true,
       );
       const selfEnrollmentUseEnrollmentCode = propertyValueWithDefault(
         courseInstanceInfo.selfEnrollment?.useEnrollmentCode,
-        parsedBody.self_enrollment_use_enrollment_code,
+        body.self_enrollment_use_enrollment_code,
         false,
       );
       const selfEnrollmentRestrictToInstitution = propertyValueWithDefault(
         courseInstanceInfo.selfEnrollment?.restrictToInstitution,
-        parsedBody.self_enrollment_restrict_to_institution,
+        body.self_enrollment_restrict_to_institution,
         true,
       );
 
       const selfEnrollmentBeforeDate = propertyValueWithDefault(
         parseDateTime(courseInstanceInfo.selfEnrollment?.beforeDate ?? ''),
         // We'll only serialize the value if self-enrollment is enabled.
-        parsedBody.self_enrollment_enabled &&
-          parsedBody.self_enrollment_enabled_before_date_enabled &&
-          parsedBody.self_enrollment_enabled_before_date
-          ? parseDateTime(parsedBody.self_enrollment_enabled_before_date)
+        body.self_enrollment_enabled &&
+          body.self_enrollment_enabled_before_date_enabled &&
+          body.self_enrollment_enabled_before_date
+          ? parseDateTime(body.self_enrollment_enabled_before_date)
           : undefined,
         undefined,
       );
@@ -436,7 +436,7 @@ router.post(
         courseInstanceInfo.selfEnrollment = undefined;
       }
       if (res.locals.question_sharing_enabled) {
-        if (parsedBody.share_source_publicly && !courseInstance.share_source_publicly) {
+        if (body.share_source_publicly && !courseInstance.share_source_publicly) {
           await assertCourseInstanceCanBeSharedPublicly({
             course_instance_id: courseInstance.id,
           });
@@ -447,7 +447,7 @@ router.post(
         // field may be a disabled checkbox whose current value must be preserved.
         courseInstanceInfo.shareSourcePublicly = propertyValueWithDefault(
           courseInstanceInfo.shareSourcePublicly,
-          parsedBody.share_source_publicly ?? false,
+          body.share_source_publicly ?? false,
           false,
         );
       }

--- a/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorQuestionSettings/instructorQuestionSettings.tsx
@@ -14,6 +14,7 @@ import {
   ArrayFromStringOrArraySchema,
   BooleanFromCheckboxSchema,
   IntegerFromStringOrEmptySchema,
+  parseRequestBody,
 } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
@@ -178,8 +179,9 @@ router.post(
       }
       req.body.preferences = preferencesArray.filter(Boolean);
 
-      const body = z
-        .object({
+      const body = parseRequestBody(
+        req,
+        z.object({
           orig_hash: z.string(),
           qid: z.string(),
           title: z.string(),
@@ -247,8 +249,8 @@ router.post(
           share_publicly: BooleanFromCheckboxSchema,
           share_source_publicly: BooleanFromCheckboxSchema,
           sharing_sets: ArrayFromStringOrArraySchema.optional(),
-        })
-        .parse(req.body);
+        }),
+      );
 
       const shortNameValidation = validateShortName(body.qid, res.locals.question.qid ?? undefined);
       if (!shortNameValidation.valid) {

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.tsx
@@ -9,7 +9,7 @@ import { callScalar } from '@prairielearn/postgres';
 import { Hydrate } from '@prairielearn/react/server';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 import { assertNever } from '@prairielearn/utils';
-import { UniqueUidsFromStringSchema } from '@prairielearn/zod';
+import { UniqueUidsFromStringSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { InsufficientCoursePermissionsCardPage } from '../../components/InsufficientCoursePermissionsCard.js';
 import { PageLayout } from '../../components/PageLayout.js';
@@ -249,7 +249,7 @@ router.post(
       throw new HttpStatusError(400, 'Modern publishing is not enabled for this course instance');
     }
 
-    const body = BodySchema.parse(req.body);
+    const body = parseRequestBody(req, BodySchema);
 
     switch (body.__action) {
       case 'invite_uids': {

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -379,7 +379,7 @@ describe('Access control save via tRPC', { concurrent: false }, () => {
     const [existingEnrollmentRule] = await selectAccessControlRules(assessment, ['enrollment']);
     assert.isOk(existingEnrollmentRule);
     const enrollmentId = existingEnrollmentRule.enrollments?.[0]?.enrollmentId;
-    assert.isDefined(enrollmentId);
+    assert(typeof enrollmentId === 'string');
 
     await expect(
       client.accessControl.saveAllRules.mutate({

--- a/apps/prairielearn/src/tests/accessControlSave.test.ts
+++ b/apps/prairielearn/src/tests/accessControlSave.test.ts
@@ -379,7 +379,7 @@ describe('Access control save via tRPC', { concurrent: false }, () => {
     const [existingEnrollmentRule] = await selectAccessControlRules(assessment, ['enrollment']);
     assert.isOk(existingEnrollmentRule);
     const enrollmentId = existingEnrollmentRule.enrollments?.[0]?.enrollmentId;
-    assert.isString(enrollmentId);
+    assert.isDefined(enrollmentId);
 
     await expect(
       client.accessControl.saveAllRules.mutate({

--- a/apps/prairielearn/src/tests/lti13Auth.test.ts
+++ b/apps/prairielearn/src/tests/lti13Auth.test.ts
@@ -219,7 +219,7 @@ describe('LTI 1.3 authentication', { concurrent: false }, () => {
     assert.ok(redirectUri);
     assert.ok(nonce);
 
-    // Missing state parameter should error
+    // Missing state parameter should return a bad request
     await withoutLogging(async () => {
       const finishBadLoginResponse = await fetchWithCookies(redirectUri, {
         method: 'POST',
@@ -229,7 +229,7 @@ describe('LTI 1.3 authentication', { concurrent: false }, () => {
         }),
         redirect: 'manual',
       });
-      assert.equal(finishBadLoginResponse.status, 500);
+      assert.equal(finishBadLoginResponse.status, 400);
     });
   });
 

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run --coverage"
   },
   "dependencies": {
+    "@prairielearn/error": "workspace:^",
     "postgres-interval": "^4.1.0",
     "zod": "^4.4.3"
   },

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   IdSchema,
   IntegerFromStringOrEmptySchema,
   IntervalSchema,
+  JsonFromStringSchema,
   UniqueUidsFromStringSchema,
 } from './index.js';
 
@@ -180,6 +181,18 @@ describe('IntegerFromStringOrEmptySchema', () => {
 
   it('rejects a decimal string', () => {
     const result = IntegerFromStringOrEmptySchema.safeParse('123.45');
+    assert.isFalse(result.success);
+  });
+});
+
+describe('JsonFromStringSchema', () => {
+  it('parses JSON strings', () => {
+    const result = JsonFromStringSchema.parse('{"name":"Alice"}');
+    assert.deepEqual(result, { name: 'Alice' });
+  });
+
+  it('rejects malformed JSON', () => {
+    const result = JsonFromStringSchema.safeParse('{');
     assert.isFalse(result.success);
   });
 });

--- a/packages/zod/src/index.test.ts
+++ b/packages/zod/src/index.test.ts
@@ -37,6 +37,16 @@ describe('IdSchema', () => {
     assert.equal(id, '123');
   });
 
+  it('parses a numeric id', () => {
+    const id = IdSchema.parse(123);
+    assert.equal(id, '123');
+  });
+
+  it('parses the largest PostgreSQL id', () => {
+    const id = IdSchema.parse('9223372036854775807');
+    assert.equal(id, '9223372036854775807');
+  });
+
   it('parses a nullable id', () => {
     const id = IdSchema.nullable().parse(null);
     assert.equal(id, null);
@@ -52,8 +62,23 @@ describe('IdSchema', () => {
     assert.isFalse(result.success);
   });
 
+  it('rejects a zero ID', () => {
+    const result = IdSchema.safeParse('0');
+    assert.isFalse(result.success);
+  });
+
   it('rejects a non-numeric ID', () => {
     const result = IdSchema.safeParse('abc');
+    assert.isFalse(result.success);
+  });
+
+  it('rejects a non-scalar ID', () => {
+    const result = IdSchema.safeParse(['1']);
+    assert.isFalse(result.success);
+  });
+
+  it('rejects an ID outside the PostgreSQL range', () => {
+    const result = IdSchema.safeParse('9223372036854775808');
     assert.isFalse(result.success);
   });
 });

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,6 +1,8 @@
 import parsePostgresInterval from 'postgres-interval';
 import { type ZodType, z } from 'zod';
 
+export { parseRequestBody, parseRequestQuery } from './request-validation.js';
+
 const INTERVAL_MS_PER_SECOND = 1000;
 const INTERVAL_MS_PER_MINUTE = 60 * INTERVAL_MS_PER_SECOND;
 const INTERVAL_MS_PER_HOUR = 60 * INTERVAL_MS_PER_MINUTE;
@@ -48,12 +50,21 @@ export const BooleanFromCheckboxSchema = required(
  * `to_jsonb()`). This schema coerces the ID to a string to ensure consistent
  * handling.
  *
- * The `refine` step is important to ensure that the thing we've coerced to a
- * string is actually a number. If it's not, we want to fail quickly.
+ * The `refine` step ensures that the value is a positive integer in the range
+ * supported by PostgreSQL's `BIGINT` type.
  */
-export const IdSchema = z.coerce
-  .string()
-  .refine((val) => /^\d+$/.test(val), { message: 'ID is not a non-negative integer' });
+export const IdSchema = z
+  .union([z.string(), z.number(), z.bigint()])
+  .transform(String)
+  .refine(
+    (value) => {
+      if (!/^\d+$/.test(value)) return false;
+
+      const id = BigInt(value);
+      return id > 0n && id <= 2n ** 63n - 1n;
+    },
+    { message: 'ID is not a valid PostgreSQL ID' },
+  );
 
 /**
  * A Zod schema for the objects produced by the `postgres-interval` library.

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -178,6 +178,19 @@ export const IntegerFromStringOrEmptySchema = z.preprocess(
 );
 
 /**
+ * A Zod schema that parses a JSON string. Use `.pipe()` to validate the parsed
+ * value with another schema.
+ */
+export const JsonFromStringSchema = z.string().transform((value, ctx): unknown => {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    ctx.addIssue({ code: 'custom', message: 'Invalid JSON' });
+    return z.NEVER;
+  }
+});
+
+/**
  * A Zod schema for an array of string values from either a string or an array of
  * strings.
  */

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -54,11 +54,7 @@ export const BooleanFromCheckboxSchema = required(
  * supported by PostgreSQL's `BIGINT` type.
  */
 export const IdSchema = z
-  .unknown()
-  .refine(
-    (value) => typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint',
-    { message: 'ID is not a valid PostgreSQL ID' },
-  )
+  .union([z.string(), z.number(), z.bigint()])
   .transform(String)
   .refine(
     (value) => {

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -54,7 +54,11 @@ export const BooleanFromCheckboxSchema = required(
  * supported by PostgreSQL's `BIGINT` type.
  */
 export const IdSchema = z
-  .union([z.string(), z.number(), z.bigint()])
+  .unknown()
+  .refine(
+    (value) => typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint',
+    { message: 'ID is not a valid PostgreSQL ID' },
+  )
   .transform(String)
   .refine(
     (value) => {

--- a/packages/zod/src/request-validation.test.ts
+++ b/packages/zod/src/request-validation.test.ts
@@ -1,0 +1,39 @@
+import { assert, describe, it } from 'vitest';
+import { z } from 'zod';
+
+import { HttpStatusError } from '@prairielearn/error';
+
+import { parseRequestBody, parseRequestQuery } from './index.js';
+
+describe('request validation', () => {
+  it('parses and transforms query parameters', () => {
+    const result = parseRequestQuery(
+      { query: { page: '2' } },
+      z.object({ page: z.coerce.number().int() }),
+    );
+
+    assert.deepEqual(result, { page: 2 });
+  });
+
+  it('throws a 400 error for invalid query parameters', () => {
+    const error = assert.throws(() =>
+      parseRequestQuery({ query: { page: 'invalid' } }, z.object({ page: z.coerce.number() })),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'Invalid query parameters');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+
+  it('throws a 400 error for an invalid request body', () => {
+    const error = assert.throws(() =>
+      parseRequestBody({ body: { name: 1 } }, z.object({ name: z.string() })),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'Invalid request body');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+});

--- a/packages/zod/src/request-validation.ts
+++ b/packages/zod/src/request-validation.ts
@@ -1,0 +1,36 @@
+import { type ZodType, type output } from 'zod';
+
+import { HttpStatusError } from '@prairielearn/error';
+
+const REQUEST_VALIDATION_ERROR_MESSAGES = {
+  body: 'Invalid request body',
+  query: 'Invalid query parameters',
+} as const;
+
+function parseRequestData<Schema extends ZodType>(
+  source: keyof typeof REQUEST_VALIDATION_ERROR_MESSAGES,
+  data: unknown,
+  schema: Schema,
+): output<Schema> {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    throw new HttpStatusError(400, REQUEST_VALIDATION_ERROR_MESSAGES[source], {
+      cause: result.error,
+    });
+  }
+  return result.data;
+}
+
+export function parseRequestQuery<Schema extends ZodType>(
+  req: { query: unknown },
+  schema: Schema,
+): output<Schema> {
+  return parseRequestData('query', req.query, schema);
+}
+
+export function parseRequestBody<Schema extends ZodType>(
+  req: { body: unknown },
+  schema: Schema,
+): output<Schema> {
+  return parseRequestData('body', req.body, schema);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2846,6 +2846,9 @@ importers:
 
   packages/zod:
     dependencies:
+      '@prairielearn/error':
+        specifier: workspace:^
+        version: link:../error
       postgres-interval:
         specifier: ^4.1.0
         version: 4.1.0


### PR DESCRIPTION
# Description

Builds on #15571.

This converts every existing Zod call that parses an entire `req.body` or `req.query` object to the shared `parseRequestBody` and `parseRequestQuery` helpers, so invalid request payloads consistently produce HTTP 400 responses. Field-level parsing, combined-source parsing, and `safeParse` form-validation flows are intentionally unchanged because they have different error-handling semantics.

- [x] I have disclosed the level of AI assistance used (majority of implementation).

# Testing

No new tests; this is a mechanical call-site conversion that retains each route's existing schema and successful parsing behavior.
