### PR TITLE
Validate institution IDs on the login page

### DIFF
--- a/apps/prairielearn/src/pages/authLogin/authLogin.ts
+++ b/apps/prairielearn/src/pages/authLogin/authLogin.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
 
 import * as authLib from '../../lib/authn.js';
 import { config } from '../../lib/config.js';
@@ -29,7 +30,7 @@ const InstitutionSupportedProvidersSchema = z.object({
   is_default: z.boolean(),
 });
 const ServiceSchema = z.string().nullable();
-const InstitutionIdSchema = z.string().nullable();
+const InstitutionIdSchema = IdSchema.nullable();
 
 router.get(
   '/',
@@ -38,7 +39,11 @@ router.get(
 
     // If an `institution_id` query parameter is provided, we'll only show the
     // login options for that institution.
-    const institutionId = InstitutionIdSchema.parse(req.query.institution_id ?? null);
+    const institutionIdResult = InstitutionIdSchema.safeParse(req.query.institution_id ?? null);
+    if (!institutionIdResult.success) {
+      throw new error.HttpStatusError(400, 'Invalid institution_id');
+    }
+    const institutionId = institutionIdResult.data;
     if (institutionId) {
       // Look up the supported providers for this institution.
       const supportedProviders = await queryRows(

--- a/apps/prairielearn/src/tests/authLogin.test.ts
+++ b/apps/prairielearn/src/tests/authLogin.test.ts
@@ -1,0 +1,28 @@
+import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+
+import { config } from '../lib/config.js';
+
+import * as helperServer from './helperServer.js';
+
+const siteUrl = `http://localhost:${config.serverPort}`;
+
+describe('GET /pl/login', { timeout: 20_000 }, () => {
+  beforeAll(helperServer.before());
+
+  afterAll(helperServer.after);
+
+  it('renders the login page for a valid institution ID', async () => {
+    const response = await fetch(`${siteUrl}/pl/login?institution_id=1`);
+
+    assert.equal(response.status, 200);
+  });
+
+  it('rejects a malformed institution ID', async () => {
+    const url = new URL('/pl/login', siteUrl);
+    url.searchParams.set('institution_id', "' UNION SELECT 1--");
+
+    const response = await fetch(url);
+
+    assert.equal(response.status, 400);
+  });
+});


### PR DESCRIPTION
# Description

Validate the optional `institution_id` login-page query parameter with the canonical `IdSchema` before querying supported authentication providers. Malformed values now produce an explicit HTTP 400 response.

Previously, arbitrary strings reached a parameterized PostgreSQL comparison against a `bigint` institution ID. PostgreSQL safely rejected malformed values during type coercion, but those failures surfaced as application HTTP 500 responses and generated unnecessary error-monitoring noise. The bound parameter was treated as data; this change does not address an exploitable SQL injection.

- [x] I have disclosed the level of AI assistance used (Codex implemented the change and regression coverage under user direction).

# Testing

Added a `helperServer` integration regression for `GET /pl/login` that verifies a valid institution ID returns 200 and an injection-like, non-numeric value returns 400.