### PR TITLE
Fix `pl-symbolic-input` proliferating emptyset bug

### DIFF
--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
@@ -604,7 +604,13 @@
     mf.addEventListener('focus', updateKeyboardLayout);
     mf.addEventListener('selection-change', updateKeyboardLayout);
 
+    const initialLatex = $('#symbolic-input-latex-' + name).val();
+
     setUpSymbolicInputMacros(mf);
+
+    if (typeof initialLatex === 'string') {
+      mf.value = initialLatex;
+    }
 
     // Disable auto-complete suggestions for macros
     mf.popoverPolicy = 'off';

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -20,7 +20,7 @@
                 name="{{name}}-latex"
                 id="symbolic-input-latex-{{name}}"
                 type="hidden"
-                value=""
+                value="{{raw_submitted_answer_latex}}"
             />
             <math-field
                 id="symbolic-input-{{name}}"
@@ -35,7 +35,6 @@
                 {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
                 {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
                 >
-                {{#raw_submitted_answer_latex}}{{raw_submitted_answer_latex}}{{/raw_submitted_answer_latex}}
             </math-field>
         {{/formula_editor}}
         {{^formula_editor}}

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -1,95 +1,138 @@
 {{#question}}
-{{#inline}}
-<span class="d-inline-block ms-2">
-{{/inline}}
-<span class="input-group pl-symbolic-input {{#formula_editor}}w-100{{/formula_editor}}">
-    {{#label}}
+{{#inline}}<span class="d-inline-block ms-2">{{/inline}}
+    <span class="input-group pl-symbolic-input {{#formula_editor}}w-100{{/formula_editor}}">
+        {{#label}}
         <span class="input-group-text" id="pl-symbolic-input-{{uuid}}-label">{{{label}}}</span>
-    {{/label}}
-    {{#formula_editor}}
+        {{/label}}
+        {{#formula_editor}}
         <script>
-            $(function () {
-              window.PLSymbolicInput("{{name}}");
+            $(function() {
+                window.PLSymbolicInput("{{name}}");
             });
         </script>
-        <input name="{{name}}" id="symbolic-input-sub-{{name}}" type="hidden" value="" />
-        <input
-            name="{{name}}-latex"
-            id="symbolic-input-latex-{{name}}"
-            type="hidden"
-            value="{{raw_submitted_answer_latex}}"
-        />
-        <math-field
-            id="symbolic-input-{{name}}"
-            class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid no-validation-icon{{/parse_error}}{{^formula_editor_buttons}} no-buttons{{/formula_editor_buttons}}"
-            {{#parse_error}}aria-invalid="true"{{/parse_error}}
-            {{^editable}}contentEditable="false"{{/editable}}
-            data-placeholder-text="{{placeholder}}"
-            custom-functions="{{custom_functions}}"
-            {{#log_as_ln}}log-as-ln="log-as-ln"{{/log_as_ln}}
-            {{#imaginary_unit}}imaginary-unit="{{imaginary_unit}}"{{/imaginary_unit}}
-            {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
-            {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
-            {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
-        ></math-field>
-    {{/formula_editor}}
-    {{^formula_editor}}
-        <input
-            name="{{name}}"
-            type="text"
-            autocomplete="off"
-            autocorrect="off"
-            class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid{{/parse_error}}"
-            {{#parse_error}}aria-invalid="true"{{/parse_error}}
-            size="{{size}}"
-            {{^editable}}disabled{{/editable}}
-            {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
-            placeholder="{{placeholder}}"
-            {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
-            {{#aria_label}}aria-label="{{aria_label}}"{{/aria_label}}
-            {{^aria_label}}{{#label}}aria-labelledby="pl-symbolic-input-{{uuid}}-label"{{/label}}{{/aria_label}}
-        />
-    {{/formula_editor}}
-    {{#suffix}}
+            <input
+                name="{{name}}"
+                id="symbolic-input-sub-{{name}}"
+                type="hidden"
+                value=""
+            />
+            <input
+                name="{{name}}-latex"
+                id="symbolic-input-latex-{{name}}"
+                type="hidden"
+                value=""
+            />
+            <math-field
+                id="symbolic-input-{{name}}"
+                class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid no-validation-icon{{/parse_error}}{{^formula_editor_buttons}} no-buttons{{/formula_editor_buttons}}"
+                {{#parse_error}}aria-invalid="true"{{/parse_error}}
+                {{^editable}}contentEditable="false"{{/editable}}
+                data-placeholder-text = "{{placeholder}}"
+                custom-functions="{{custom_functions}}"
+                {{#log_as_ln}}log-as-ln="log-as-ln"{{/log_as_ln}}
+                {{#imaginary_unit}}imaginary-unit="{{imaginary_unit}}"{{/imaginary_unit}}
+                {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
+                {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
+                {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
+                >
+                {{#raw_submitted_answer_latex}}{{raw_submitted_answer_latex}}{{/raw_submitted_answer_latex}}
+            </math-field>
+        {{/formula_editor}}
+        {{^formula_editor}}
+            <input
+                name="{{name}}"
+                type="text"
+                autocomplete="off"
+                autocorrect="off"
+                class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid{{/parse_error}}"
+                {{#parse_error}}aria-invalid="true"{{/parse_error}}
+                size="{{size}}"
+                {{^editable}}disabled{{/editable}}
+                {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
+                placeholder="{{placeholder}}"
+                {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
+                {{#aria_label}}aria-label="{{aria_label}}"{{/aria_label}}
+                {{^aria_label}}{{#label}}aria-labelledby="pl-symbolic-input-{{uuid}}-label"{{/label}}{{/aria_label}}
+            />
+        {{/formula_editor}}
+        {{#suffix}}
         <span class="input-group-text" id="pl-symbolic-input-{{uuid}}-suffix">{{suffix}}</span>
-    {{/suffix}}
-    {{#show_info}}
-        <button
-            type="button"
-            class="btn btn-light border d-flex align-items-center"
-            data-bs-toggle="popover"
-            data-bs-html="true"
-            title="Symbolic"
-            data-bs-content="{{info}}"
-            data-bs-placement="auto"
-        >
+        {{/suffix}}
+        {{#show_info}}
+        <button type="button" class="btn btn-light border d-flex align-items-center" data-bs-toggle="popover" data-bs-html="true" title="Symbolic" data-bs-content="{{info}}" data-bs-placement="auto">
             <i class="fas fa-question-circle" aria-hidden="true"></i>
         </button>
-    {{/show_info}}
-    {{#correct}}
-        <span class="input-group-text">
-            <span class="badge text-bg-success">
-                <i class="fas fa-check" aria-hidden="true"></i> 100%
+        {{/show_info}}
+        {{#correct}}
+            <span class="input-group-text">
+                <span class="badge text-bg-success"><i class="fas fa-check" aria-hidden="true"></i> 100%</span>
             </span>
-        </span>
-    {{/correct}}
-    {{#partial}}
-        <span class="input-group-text">
-            <span class="badge text-bg-warning">
-                <i class="far fa-circle" aria-hidden="true"></i> {{partial}}%
+        {{/correct}}
+        {{#partial}}
+            <span class="input-group-text">
+                <span class="badge text-bg-warning"><i class="far fa-circle" aria-hidden="true"></i> {{partial}}%</span>
             </span>
-        </span>
-    {{/partial}}
-    {{#incorrect}}
-        <span class="input-group-text">
+        {{/partial}}
+        {{#incorrect}}
+            <span class="input-group-text">
+                <span class="badge text-bg-danger"><i class="fas fa-times" aria-hidden="true"></i> 0%</span>
+            </span>
+        {{/incorrect}}
+    </span>
+    {{#parse_error}}
+        <span class="invalid-feedback d-block">
             <span class="badge text-bg-danger">
-                <i class="fas fa-times" aria-hidden="true"></i> 0%
+                Invalid
+                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
             </span>
+            <a
+                class="link-primary"
+                tabindex="0"
+                role="button"
+                data-bs-placement="auto"
+                data-bs-toggle="popover"
+                data-bs-html="true"
+                title="Format error"
+                data-bs-content="{{parse_error}}"
+            >
+                More info…
+            </a>
         </span>
-    {{/incorrect}}
-</span>
+    {{/parse_error}}
+{{#inline}}</span>{{/inline}}
+{{/question}}
+
+
+{{#submission}}
+{{#block}}<div>{{/block}}{{#inline}}<span class="d-inline-block">{{/inline}}
+{{#error}}
+
+<span>
+
 {{#parse_error}}
-    <span class="invalid-feedback d-block">
+    {{#label}}<span>{{{label}}}</span>{{/label}}
+    {{#formula_editor}}
+        <script>
+            $(function() {
+                window.PLSymbolicInputParseError("{{uuid}}");
+            });
+        </script>
+        {{#raw_submitted_answer_latex}}
+            <math-field
+                id="symbolic-input-parse-error-{{uuid}}"
+                read-only
+                custom-functions="{{custom_functions}}"
+                {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
+                {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
+                class="read-only"
+            >{{raw_submitted_answer_latex}}</math-field>
+        {{/raw_submitted_answer_latex}}
+    {{/formula_editor}}
+    {{^formula_editor}}
+        {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
+    {{/formula_editor}}
+    {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
+    <span class="small" style="white-space: nowrap">
         <span class="badge text-bg-danger">
             Invalid <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
         </span>
@@ -103,113 +146,54 @@
             title="Format error"
             data-bs-content="{{parse_error}}"
         >
-            More info…
+           More info…
         </a>
     </span>
 {{/parse_error}}
-{{#inline}}
-</span>
-{{/inline}}
-{{/question}}
-
-{{#submission}}
-{{#block}}
-<div>
-{{/block}}
-{{#inline}}
-<span class="d-inline-block">
-{{/inline}}
-{{#error}}
-    <span>
-        {{#parse_error}}
-            {{#label}}<span>{{{label}}}</span>{{/label}}
-            {{#formula_editor}}
-                <script>
-                    $(function () {
-                      window.PLSymbolicInputParseError("{{uuid}}");
-                    });
-                </script>
-                {{#raw_submitted_answer_latex}}
-                    <math-field
-                        id="symbolic-input-parse-error-{{uuid}}"
-                        read-only
-                        custom-functions="{{custom_functions}}"
-                        {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
-                        {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
-                        class="read-only"
-                    >
-                        {{raw_submitted_answer_latex}}
-                    </math-field>
-                {{/raw_submitted_answer_latex}}
-            {{/formula_editor}}
-            {{^formula_editor}}
-                {{#raw_submitted_answer}}
-                    <code class="user-output-invalid">{{raw_submitted_answer}}</code>
-                {{/raw_submitted_answer}}
-            {{/formula_editor}}
-            {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-            <span class="small" style="white-space: nowrap">
-                <span class="badge text-bg-danger">
-                    Invalid <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-                </span>
-                <a
-                    class="link-primary"
-                    tabindex="0"
-                    role="button"
-                    data-bs-placement="auto"
-                    data-bs-toggle="popover"
-                    data-bs-html="true"
-                    title="Format error"
-                    data-bs-content="{{parse_error}}"
-                >
-                    More info…
-                </a>
-            </span>
-        {{/parse_error}}
-        {{#missing_input}}
-            {{#label}}<span>{{{label}}}</span>{{/label}}
-            <span class="small" style="white-space: nowrap">
-                <span class="badge text-bg-dark border">
-                    Missing input <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-                </span>
-                <a
-                    class="link-primary"
-                    tabindex="0"
-                    role="button"
-                    data-bs-placement="auto"
-                    data-bs-toggle="popover"
-                    data-bs-html="true"
-                    title="Missing input"
-                    data-bs-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."
-                >
-                    More info…
-                </a>
-            </span>
-            {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-        {{/missing_input}}
+{{#missing_input}}
+    {{#label}}<span>{{{label}}}</span>{{/label}}
+    <span class="small" style="white-space: nowrap">
+        <span class="badge text-bg-dark border">
+            Missing input
+            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+        </span>
+        <a
+            class="link-primary"
+            tabindex="0"
+            role="button"
+            data-bs-placement="auto"
+            data-bs-toggle="popover"
+            data-bs-html="true"
+            title="Missing input"
+            data-bs-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."
+        >
+           More info…
+        </a>
     </span>
+    {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
+{{/missing_input}}
+
+</span>
+
 {{/error}}
 {{^error}}
-    {{#label}}<span>{{{label}}}</span>{{/label}} ${{a_sub}}$ {{#raw_submitted_answer_latex}}
+{{#label}}<span>{{{label}}}</span>{{/label}}
+${{a_sub}}$
+{{#raw_submitted_answer_latex}}
     <script>
-    $(function() {
-    window.PLSymbolicInputPopover("{{uuid}}");
-    });
+        $(function() {
+            window.PLSymbolicInputPopover("{{uuid}}");
+        });
     </script>
-    {{/raw_submitted_answer_latex}}
-    {{! Show submitted answer submission was parsed from }}
-    <button
-        type="button"
-        id="pl-symbolic-input-{{uuid}}-button"
-        class="ms-1 btn btn-sm btn-secondary small border"
-        data-bs-placement="auto"
-        data-bs-toggle="popover"
-        data-bs-html="true"
-        title="Original Input"
-        {{^raw_submitted_answer_latex}}
+{{/raw_submitted_answer_latex}}
+{{! Show submitted answer submission was parsed from }}
+<button type="button" id="pl-symbolic-input-{{uuid}}-button" class="ms-1 btn btn-sm btn-secondary small border"
+    data-bs-placement="auto" data-bs-toggle="popover" data-bs-html="true"
+    title="Original Input"
+    {{^raw_submitted_answer_latex}}
     data-bs-content="Parsed from <samp class=&#34;user-output&#34;>{{raw_submitted_answer}}</samp>"
     {{/raw_submitted_answer_latex}}
-        {{#raw_submitted_answer_latex}}
+    {{#raw_submitted_answer_latex}}
     data-bs-content='Parsed from
         <math-field
             read-only
@@ -222,99 +206,52 @@
             {{raw_submitted_answer_latex}}
         </math-field>'
     {{/raw_submitted_answer_latex}}
-    >
-        <i class="fas fa-question-circle" aria-hidden="true"></i>
-    </button>
+>
+    <i class="fas fa-question-circle" aria-hidden="true"></i>
+</button>
 
-    {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
+{{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 
-    {{#correct}}
-        <span class="badge text-bg-success">
-            <i class="fas fa-check" aria-hidden="true"></i> 100%
-        </span>
-    {{/correct}}
-    {{#partial}}
-        <span class="badge text-bg-warning">
-            <i class="far fa-circle" aria-hidden="true"></i> {{partial}}%
-        </span>
-    {{/partial}}
-    {{#incorrect}}
-        <span class="badge text-bg-danger">
-            <i class="fas fa-times" aria-hidden="true"></i> 0%
-        </span>
-    {{/incorrect}}
+{{#correct}}<span class="badge text-bg-success"><i class="fas fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
+{{#partial}}<span class="badge text-bg-warning"><i class="far fa-circle" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
+{{#incorrect}}<span class="badge text-bg-danger"><i class="fas fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
 {{/error}}
-{{#inline}}
-</span>
-{{/inline}}
-{{#block}}
-</div>
-{{/block}}
+{{#inline}}</span>{{/inline}}{{#block}}</div>{{/block}}
 {{/submission}}
 
 {{#answer}}
-{{#block}}
-<div>
-{{/block}}
-{{#inline}}
-<span class="d-inline-block">
-{{/inline}}
-{{#label}}<span>{{{label}}}</span>{{/label}} ${{a_tru}}$
+{{#block}}<div>{{/block}}{{#inline}}<span class="d-inline-block">{{/inline}}
+{{#label}}<span>{{{label}}}</span>{{/label}}
+${{a_tru}}$
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-{{#inline}}
-</span>
-{{/inline}}
-{{#block}}
-</div>
-{{/block}}
+{{#inline}}</span>{{/inline}}{{#block}}</div>{{/block}}
 {{/answer}}
 
 {{#format}}
-    <p>
-        <strong>General format information:</strong><br>
-        Your answer must be a symbolic expression. All numbers must be rational - so,
-        <code>1/2</code> instead of <code>0.5</code>.
-        {{^allow_complex}}Complex numbers are not allowed.{{/allow_complex}}
-        {{#allow_sets}}
-            Intervals and sets may be used, e.g. <code>[0, +oo)</code> or
-            <code>{ 0, pi/2, 3pi/2, 2pi }</code>. Sets and intervals have unions (<code>U</code>)
-            and intersections (<code>&amp;</code>), e.g.
-            <code>({1, 3} U (2, 4]) &amp; {0, 2, 4}</code>.
-        {{/allow_sets}}
-    </p>
-    {{! From https://stackoverflow.com/a/14417521/2923069 }}
-    {{#variables.0}}
-        <p>
-            <strong>Allowable variables:</strong>
-            <br>
-            {{#variables}}
-                <code>{{.}}</code>
-                &nbsp;
-            {{/variables}}
-        </p>
-    {{/variables.0}}
-    {{#constants.0}}
-        <p>
-            <strong>Allowable constants:</strong>
-            <br>
-            {{#constants}}
-                <code>{{.}}</code>
-                &nbsp;
-            {{/constants}}
-        </p>
-    {{/constants.0}}
-    {{#operators.0}}
-        <p>
-            <strong>Allowable operators:</strong>
-            <br>
-            {{#operators}}
-                <code>{{.}}</code>
-                &nbsp;
-            {{/operators}}
-        </p>
-    {{/operators.0}}
+<p><strong>General format information:</strong><br>Your answer must be a symbolic expression. All numbers must be rational - so, <code>1/2</code> instead of <code>0.5</code>.
+{{^allow_complex}}Complex numbers are not allowed.{{/allow_complex}}
+{{#allow_sets}}Intervals and sets may be used, e.g. <code>[0, +oo)</code> or <code>{ 0, pi/2, 3pi/2, 2pi }</code>. Sets and intervals have unions (<code>U</code>) and intersections (<code>&amp;</code>), e.g. <code>({1, 3} U (2, 4]) &amp; {0, 2, 4}</code>.{{/allow_sets}}</p>
+{{! From https://stackoverflow.com/a/14417521/2923069 }}
+{{#variables.0}}
+<p>
+    <strong>Allowable variables:</strong><br>
+    {{#variables}} <code>{{.}}</code> &nbsp; {{/variables}}
+</p>
+{{/variables.0}}
+{{#constants.0}}
+<p>
+    <strong>Allowable constants:</strong><br>
+    {{#constants}} <code>{{.}}</code> &nbsp; {{/constants}}
+</p>
+{{/constants.0}}
+{{#operators.0}}
+<p>
+    <strong>Allowable operators:</strong><br>
+    {{#operators}} <code>{{.}}</code> &nbsp; {{/operators}}
+</p>
+{{/operators.0}}
 
-    <p>Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p>
+<p>Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p>
 {{/format}}
 
 {{#format_error}}

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.mustache
@@ -1,138 +1,95 @@
 {{#question}}
-{{#inline}}<span class="d-inline-block ms-2">{{/inline}}
-    <span class="input-group pl-symbolic-input {{#formula_editor}}w-100{{/formula_editor}}">
-        {{#label}}
+{{#inline}}
+<span class="d-inline-block ms-2">
+{{/inline}}
+<span class="input-group pl-symbolic-input {{#formula_editor}}w-100{{/formula_editor}}">
+    {{#label}}
         <span class="input-group-text" id="pl-symbolic-input-{{uuid}}-label">{{{label}}}</span>
-        {{/label}}
-        {{#formula_editor}}
-        <script>
-            $(function() {
-                window.PLSymbolicInput("{{name}}");
-            });
-        </script>
-            <input
-                name="{{name}}"
-                id="symbolic-input-sub-{{name}}"
-                type="hidden"
-                value=""
-            />
-            <input
-                name="{{name}}-latex"
-                id="symbolic-input-latex-{{name}}"
-                type="hidden"
-                value=""
-            />
-            <math-field
-                id="symbolic-input-{{name}}"
-                class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid no-validation-icon{{/parse_error}}{{^formula_editor_buttons}} no-buttons{{/formula_editor_buttons}}"
-                {{#parse_error}}aria-invalid="true"{{/parse_error}}
-                {{^editable}}contentEditable="false"{{/editable}}
-                data-placeholder-text = "{{placeholder}}"
-                custom-functions="{{custom_functions}}"
-                {{#log_as_ln}}log-as-ln="log-as-ln"{{/log_as_ln}}
-                {{#imaginary_unit}}imaginary-unit="{{imaginary_unit}}"{{/imaginary_unit}}
-                {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
-                {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
-                {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
-                >
-                {{#raw_submitted_answer_latex}}{{raw_submitted_answer_latex}}{{/raw_submitted_answer_latex}}
-            </math-field>
-        {{/formula_editor}}
-        {{^formula_editor}}
-            <input
-                name="{{name}}"
-                type="text"
-                autocomplete="off"
-                autocorrect="off"
-                class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid{{/parse_error}}"
-                {{#parse_error}}aria-invalid="true"{{/parse_error}}
-                size="{{size}}"
-                {{^editable}}disabled{{/editable}}
-                {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
-                placeholder="{{placeholder}}"
-                {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
-                {{#aria_label}}aria-label="{{aria_label}}"{{/aria_label}}
-                {{^aria_label}}{{#label}}aria-labelledby="pl-symbolic-input-{{uuid}}-label"{{/label}}{{/aria_label}}
-            />
-        {{/formula_editor}}
-        {{#suffix}}
-        <span class="input-group-text" id="pl-symbolic-input-{{uuid}}-suffix">{{suffix}}</span>
-        {{/suffix}}
-        {{#show_info}}
-        <button type="button" class="btn btn-light border d-flex align-items-center" data-bs-toggle="popover" data-bs-html="true" title="Symbolic" data-bs-content="{{info}}" data-bs-placement="auto">
-            <i class="fas fa-question-circle" aria-hidden="true"></i>
-        </button>
-        {{/show_info}}
-        {{#correct}}
-            <span class="input-group-text">
-                <span class="badge text-bg-success"><i class="fas fa-check" aria-hidden="true"></i> 100%</span>
-            </span>
-        {{/correct}}
-        {{#partial}}
-            <span class="input-group-text">
-                <span class="badge text-bg-warning"><i class="far fa-circle" aria-hidden="true"></i> {{partial}}%</span>
-            </span>
-        {{/partial}}
-        {{#incorrect}}
-            <span class="input-group-text">
-                <span class="badge text-bg-danger"><i class="fas fa-times" aria-hidden="true"></i> 0%</span>
-            </span>
-        {{/incorrect}}
-    </span>
-    {{#parse_error}}
-        <span class="invalid-feedback d-block">
-            <span class="badge text-bg-danger">
-                Invalid
-                <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-            </span>
-            <a
-                class="link-primary"
-                tabindex="0"
-                role="button"
-                data-bs-placement="auto"
-                data-bs-toggle="popover"
-                data-bs-html="true"
-                title="Format error"
-                data-bs-content="{{parse_error}}"
-            >
-                More info…
-            </a>
-        </span>
-    {{/parse_error}}
-{{#inline}}</span>{{/inline}}
-{{/question}}
-
-
-{{#submission}}
-{{#block}}<div>{{/block}}{{#inline}}<span class="d-inline-block">{{/inline}}
-{{#error}}
-
-<span>
-
-{{#parse_error}}
-    {{#label}}<span>{{{label}}}</span>{{/label}}
+    {{/label}}
     {{#formula_editor}}
         <script>
-            $(function() {
-                window.PLSymbolicInputParseError("{{uuid}}");
+            $(function () {
+              window.PLSymbolicInput("{{name}}");
             });
         </script>
-        {{#raw_submitted_answer_latex}}
-            <math-field
-                id="symbolic-input-parse-error-{{uuid}}"
-                read-only
-                custom-functions="{{custom_functions}}"
-                {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
-                {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
-                class="read-only"
-            >{{raw_submitted_answer_latex}}</math-field>
-        {{/raw_submitted_answer_latex}}
+        <input name="{{name}}" id="symbolic-input-sub-{{name}}" type="hidden" value="" />
+        <input
+            name="{{name}}-latex"
+            id="symbolic-input-latex-{{name}}"
+            type="hidden"
+            value="{{raw_submitted_answer_latex}}"
+        />
+        <math-field
+            id="symbolic-input-{{name}}"
+            class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid no-validation-icon{{/parse_error}}{{^formula_editor_buttons}} no-buttons{{/formula_editor_buttons}}"
+            {{#parse_error}}aria-invalid="true"{{/parse_error}}
+            {{^editable}}contentEditable="false"{{/editable}}
+            data-placeholder-text="{{placeholder}}"
+            custom-functions="{{custom_functions}}"
+            {{#log_as_ln}}log-as-ln="log-as-ln"{{/log_as_ln}}
+            {{#imaginary_unit}}imaginary-unit="{{imaginary_unit}}"{{/imaginary_unit}}
+            {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
+            {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
+            {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
+        ></math-field>
     {{/formula_editor}}
     {{^formula_editor}}
-        {{#raw_submitted_answer}}<code class="user-output-invalid">{{raw_submitted_answer}}</code>{{/raw_submitted_answer}}
+        <input
+            name="{{name}}"
+            type="text"
+            autocomplete="off"
+            autocorrect="off"
+            class="form-control pl-symbolic-input-input {{#parse_error}}has-validation is-invalid{{/parse_error}}"
+            {{#parse_error}}aria-invalid="true"{{/parse_error}}
+            size="{{size}}"
+            {{^editable}}disabled{{/editable}}
+            {{#raw_submitted_answer}}value="{{raw_submitted_answer}}"{{/raw_submitted_answer}}
+            placeholder="{{placeholder}}"
+            {{#suffix}}aria-describedby="pl-symbolic-input-{{uuid}}-suffix"{{/suffix}}
+            {{#aria_label}}aria-label="{{aria_label}}"{{/aria_label}}
+            {{^aria_label}}{{#label}}aria-labelledby="pl-symbolic-input-{{uuid}}-label"{{/label}}{{/aria_label}}
+        />
     {{/formula_editor}}
-    {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-    <span class="small" style="white-space: nowrap">
+    {{#suffix}}
+        <span class="input-group-text" id="pl-symbolic-input-{{uuid}}-suffix">{{suffix}}</span>
+    {{/suffix}}
+    {{#show_info}}
+        <button
+            type="button"
+            class="btn btn-light border d-flex align-items-center"
+            data-bs-toggle="popover"
+            data-bs-html="true"
+            title="Symbolic"
+            data-bs-content="{{info}}"
+            data-bs-placement="auto"
+        >
+            <i class="fas fa-question-circle" aria-hidden="true"></i>
+        </button>
+    {{/show_info}}
+    {{#correct}}
+        <span class="input-group-text">
+            <span class="badge text-bg-success">
+                <i class="fas fa-check" aria-hidden="true"></i> 100%
+            </span>
+        </span>
+    {{/correct}}
+    {{#partial}}
+        <span class="input-group-text">
+            <span class="badge text-bg-warning">
+                <i class="far fa-circle" aria-hidden="true"></i> {{partial}}%
+            </span>
+        </span>
+    {{/partial}}
+    {{#incorrect}}
+        <span class="input-group-text">
+            <span class="badge text-bg-danger">
+                <i class="fas fa-times" aria-hidden="true"></i> 0%
+            </span>
+        </span>
+    {{/incorrect}}
+</span>
+{{#parse_error}}
+    <span class="invalid-feedback d-block">
         <span class="badge text-bg-danger">
             Invalid <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
         </span>
@@ -146,54 +103,113 @@
             title="Format error"
             data-bs-content="{{parse_error}}"
         >
-           More info…
+            More info…
         </a>
     </span>
 {{/parse_error}}
-{{#missing_input}}
-    {{#label}}<span>{{{label}}}</span>{{/label}}
-    <span class="small" style="white-space: nowrap">
-        <span class="badge text-bg-dark border">
-            Missing input
-            <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-        </span>
-        <a
-            class="link-primary"
-            tabindex="0"
-            role="button"
-            data-bs-placement="auto"
-            data-bs-toggle="popover"
-            data-bs-html="true"
-            title="Missing input"
-            data-bs-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."
-        >
-           More info…
-        </a>
-    </span>
-    {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-{{/missing_input}}
-
+{{#inline}}
 </span>
+{{/inline}}
+{{/question}}
 
+{{#submission}}
+{{#block}}
+<div>
+{{/block}}
+{{#inline}}
+<span class="d-inline-block">
+{{/inline}}
+{{#error}}
+    <span>
+        {{#parse_error}}
+            {{#label}}<span>{{{label}}}</span>{{/label}}
+            {{#formula_editor}}
+                <script>
+                    $(function () {
+                      window.PLSymbolicInputParseError("{{uuid}}");
+                    });
+                </script>
+                {{#raw_submitted_answer_latex}}
+                    <math-field
+                        id="symbolic-input-parse-error-{{uuid}}"
+                        read-only
+                        custom-functions="{{custom_functions}}"
+                        {{#allow_trig}}allow-trig="allow-trig"{{/allow_trig}}
+                        {{#allow_sets}}allow-sets="allow-sets"{{/allow_sets}}
+                        class="read-only"
+                    >
+                        {{raw_submitted_answer_latex}}
+                    </math-field>
+                {{/raw_submitted_answer_latex}}
+            {{/formula_editor}}
+            {{^formula_editor}}
+                {{#raw_submitted_answer}}
+                    <code class="user-output-invalid">{{raw_submitted_answer}}</code>
+                {{/raw_submitted_answer}}
+            {{/formula_editor}}
+            {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
+            <span class="small" style="white-space: nowrap">
+                <span class="badge text-bg-danger">
+                    Invalid <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                </span>
+                <a
+                    class="link-primary"
+                    tabindex="0"
+                    role="button"
+                    data-bs-placement="auto"
+                    data-bs-toggle="popover"
+                    data-bs-html="true"
+                    title="Format error"
+                    data-bs-content="{{parse_error}}"
+                >
+                    More info…
+                </a>
+            </span>
+        {{/parse_error}}
+        {{#missing_input}}
+            {{#label}}<span>{{{label}}}</span>{{/label}}
+            <span class="small" style="white-space: nowrap">
+                <span class="badge text-bg-dark border">
+                    Missing input <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
+                </span>
+                <a
+                    class="link-primary"
+                    tabindex="0"
+                    role="button"
+                    data-bs-placement="auto"
+                    data-bs-toggle="popover"
+                    data-bs-html="true"
+                    title="Missing input"
+                    data-bs-content="There is no submitted value for this field.  This may have happened because the question was changed by course staff after the answer was submitted."
+                >
+                    More info…
+                </a>
+            </span>
+            {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
+        {{/missing_input}}
+    </span>
 {{/error}}
 {{^error}}
-{{#label}}<span>{{{label}}}</span>{{/label}}
-${{a_sub}}$
-{{#raw_submitted_answer_latex}}
+    {{#label}}<span>{{{label}}}</span>{{/label}} ${{a_sub}}$ {{#raw_submitted_answer_latex}}
     <script>
-        $(function() {
-            window.PLSymbolicInputPopover("{{uuid}}");
-        });
+    $(function() {
+    window.PLSymbolicInputPopover("{{uuid}}");
+    });
     </script>
-{{/raw_submitted_answer_latex}}
-{{! Show submitted answer submission was parsed from }}
-<button type="button" id="pl-symbolic-input-{{uuid}}-button" class="ms-1 btn btn-sm btn-secondary small border"
-    data-bs-placement="auto" data-bs-toggle="popover" data-bs-html="true"
-    title="Original Input"
-    {{^raw_submitted_answer_latex}}
+    {{/raw_submitted_answer_latex}}
+    {{! Show submitted answer submission was parsed from }}
+    <button
+        type="button"
+        id="pl-symbolic-input-{{uuid}}-button"
+        class="ms-1 btn btn-sm btn-secondary small border"
+        data-bs-placement="auto"
+        data-bs-toggle="popover"
+        data-bs-html="true"
+        title="Original Input"
+        {{^raw_submitted_answer_latex}}
     data-bs-content="Parsed from <samp class=&#34;user-output&#34;>{{raw_submitted_answer}}</samp>"
     {{/raw_submitted_answer_latex}}
-    {{#raw_submitted_answer_latex}}
+        {{#raw_submitted_answer_latex}}
     data-bs-content='Parsed from
         <math-field
             read-only
@@ -206,52 +222,99 @@ ${{a_sub}}$
             {{raw_submitted_answer_latex}}
         </math-field>'
     {{/raw_submitted_answer_latex}}
->
-    <i class="fas fa-question-circle" aria-hidden="true"></i>
-</button>
+    >
+        <i class="fas fa-question-circle" aria-hidden="true"></i>
+    </button>
 
-{{#suffix}}<span>{{suffix}}</span>{{/suffix}}
+    {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
 
-{{#correct}}<span class="badge text-bg-success"><i class="fas fa-check" aria-hidden="true"></i> 100%</span>{{/correct}}
-{{#partial}}<span class="badge text-bg-warning"><i class="far fa-circle" aria-hidden="true"></i> {{partial}}%</span>{{/partial}}
-{{#incorrect}}<span class="badge text-bg-danger"><i class="fas fa-times" aria-hidden="true"></i> 0%</span>{{/incorrect}}
+    {{#correct}}
+        <span class="badge text-bg-success">
+            <i class="fas fa-check" aria-hidden="true"></i> 100%
+        </span>
+    {{/correct}}
+    {{#partial}}
+        <span class="badge text-bg-warning">
+            <i class="far fa-circle" aria-hidden="true"></i> {{partial}}%
+        </span>
+    {{/partial}}
+    {{#incorrect}}
+        <span class="badge text-bg-danger">
+            <i class="fas fa-times" aria-hidden="true"></i> 0%
+        </span>
+    {{/incorrect}}
 {{/error}}
-{{#inline}}</span>{{/inline}}{{#block}}</div>{{/block}}
+{{#inline}}
+</span>
+{{/inline}}
+{{#block}}
+</div>
+{{/block}}
 {{/submission}}
 
 {{#answer}}
-{{#block}}<div>{{/block}}{{#inline}}<span class="d-inline-block">{{/inline}}
-{{#label}}<span>{{{label}}}</span>{{/label}}
-${{a_tru}}$
+{{#block}}
+<div>
+{{/block}}
+{{#inline}}
+<span class="d-inline-block">
+{{/inline}}
+{{#label}}<span>{{{label}}}</span>{{/label}} ${{a_tru}}$
 {{#suffix}}<span>{{suffix}}</span>{{/suffix}}
-{{#inline}}</span>{{/inline}}{{#block}}</div>{{/block}}
+{{#inline}}
+</span>
+{{/inline}}
+{{#block}}
+</div>
+{{/block}}
 {{/answer}}
 
 {{#format}}
-<p><strong>General format information:</strong><br>Your answer must be a symbolic expression. All numbers must be rational - so, <code>1/2</code> instead of <code>0.5</code>.
-{{^allow_complex}}Complex numbers are not allowed.{{/allow_complex}}
-{{#allow_sets}}Intervals and sets may be used, e.g. <code>[0, +oo)</code> or <code>{ 0, pi/2, 3pi/2, 2pi }</code>. Sets and intervals have unions (<code>U</code>) and intersections (<code>&amp;</code>), e.g. <code>({1, 3} U (2, 4]) &amp; {0, 2, 4}</code>.{{/allow_sets}}</p>
-{{! From https://stackoverflow.com/a/14417521/2923069 }}
-{{#variables.0}}
-<p>
-    <strong>Allowable variables:</strong><br>
-    {{#variables}} <code>{{.}}</code> &nbsp; {{/variables}}
-</p>
-{{/variables.0}}
-{{#constants.0}}
-<p>
-    <strong>Allowable constants:</strong><br>
-    {{#constants}} <code>{{.}}</code> &nbsp; {{/constants}}
-</p>
-{{/constants.0}}
-{{#operators.0}}
-<p>
-    <strong>Allowable operators:</strong><br>
-    {{#operators}} <code>{{.}}</code> &nbsp; {{/operators}}
-</p>
-{{/operators.0}}
+    <p>
+        <strong>General format information:</strong><br>
+        Your answer must be a symbolic expression. All numbers must be rational - so,
+        <code>1/2</code> instead of <code>0.5</code>.
+        {{^allow_complex}}Complex numbers are not allowed.{{/allow_complex}}
+        {{#allow_sets}}
+            Intervals and sets may be used, e.g. <code>[0, +oo)</code> or
+            <code>{ 0, pi/2, 3pi/2, 2pi }</code>. Sets and intervals have unions (<code>U</code>)
+            and intersections (<code>&amp;</code>), e.g.
+            <code>({1, 3} U (2, 4]) &amp; {0, 2, 4}</code>.
+        {{/allow_sets}}
+    </p>
+    {{! From https://stackoverflow.com/a/14417521/2923069 }}
+    {{#variables.0}}
+        <p>
+            <strong>Allowable variables:</strong>
+            <br>
+            {{#variables}}
+                <code>{{.}}</code>
+                &nbsp;
+            {{/variables}}
+        </p>
+    {{/variables.0}}
+    {{#constants.0}}
+        <p>
+            <strong>Allowable constants:</strong>
+            <br>
+            {{#constants}}
+                <code>{{.}}</code>
+                &nbsp;
+            {{/constants}}
+        </p>
+    {{/constants.0}}
+    {{#operators.0}}
+        <p>
+            <strong>Allowable operators:</strong>
+            <br>
+            {{#operators}}
+                <code>{{.}}</code>
+                &nbsp;
+            {{/operators}}
+        </p>
+    {{/operators.0}}
 
-<p>Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p>
+    <p>Note that either <code>^</code> or <code>**</code> can be used for exponentiation.</p>
 {{/format}}
 
 {{#format_error}}

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input_test.py
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input_test.py
@@ -6,6 +6,7 @@ from typing import Any
 import prairielearn.sympy_utils as psu
 import pytest
 import sympy
+from lxml import html
 
 symbolic_input = importlib.import_module("pl-symbolic-input")
 
@@ -309,6 +310,39 @@ def test_formula_editor_initial_value_respects_display_log_as_ln(
 
     assert "\\ln{\\left(x \\right)}" in rendered
     assert "\\log{\\left(x \\right)}" not in rendered
+
+
+# Resolves issue where submitting "{}" returns populated with "{}{}"
+@pytest.mark.parametrize(
+    ("raw_submitted_answers", "attributes", "expected_latex"),
+    [
+        ({"test-latex": "\\emptyset"}, [], "\\emptyset"),
+        ({"test-latex": "x+1"}, [], "x+1"),
+        ({}, ['initial-value="x + 1"'], "x + 1"),
+    ],
+)
+def test_formula_editor_initial_latex_is_stored_outside_math_field(
+    monkeypatch: pytest.MonkeyPatch,
+    raw_submitted_answers: dict[str, Any],
+    attributes: list[str],
+    expected_latex: str,
+) -> None:
+    monkeypatch.chdir(Path(__file__).parent)
+    element_html = build_element_html(
+        'variables="x"',
+        'formula-editor="true"',
+        *attributes,
+    )
+    data = make_question_data(raw_submitted_answers=raw_submitted_answers)
+
+    symbolic_input.prepare(element_html, data)
+    rendered = symbolic_input.render(element_html, data)
+    fragment = html.fragment_fromstring(rendered)
+
+    math_field = fragment.get_element_by_id("symbolic-input-test")
+    latex_input = fragment.get_element_by_id("symbolic-input-latex-test")
+    assert (math_field.text or "").strip() == ""
+    assert latex_input.get("value") == expected_latex
 
 
 @pytest.mark.parametrize(

--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input_test.py
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input_test.py
@@ -6,7 +6,6 @@ from typing import Any
 import prairielearn.sympy_utils as psu
 import pytest
 import sympy
-from lxml import html
 
 symbolic_input = importlib.import_module("pl-symbolic-input")
 
@@ -310,39 +309,6 @@ def test_formula_editor_initial_value_respects_display_log_as_ln(
 
     assert "\\ln{\\left(x \\right)}" in rendered
     assert "\\log{\\left(x \\right)}" not in rendered
-
-
-# Resolves issue where submitting "{}" returns populated with "{}{}"
-@pytest.mark.parametrize(
-    ("raw_submitted_answers", "attributes", "expected_latex"),
-    [
-        ({"test-latex": "\\emptyset"}, [], "\\emptyset"),
-        ({"test-latex": "x+1"}, [], "x+1"),
-        ({}, ['initial-value="x + 1"'], "x + 1"),
-    ],
-)
-def test_formula_editor_initial_latex_is_stored_outside_math_field(
-    monkeypatch: pytest.MonkeyPatch,
-    raw_submitted_answers: dict[str, Any],
-    attributes: list[str],
-    expected_latex: str,
-) -> None:
-    monkeypatch.chdir(Path(__file__).parent)
-    element_html = build_element_html(
-        'variables="x"',
-        'formula-editor="true"',
-        *attributes,
-    )
-    data = make_question_data(raw_submitted_answers=raw_submitted_answers)
-
-    symbolic_input.prepare(element_html, data)
-    rendered = symbolic_input.render(element_html, data)
-    fragment = html.fragment_fromstring(rendered)
-
-    math_field = fragment.get_element_by_id("symbolic-input-test")
-    latex_input = fragment.get_element_by_id("symbolic-input-latex-test")
-    assert (math_field.text or "").strip() == ""
-    assert latex_input.get("value") == expected_latex
 
 
 @pytest.mark.parametrize(

--- a/apps/prairielearn/src/tests/e2e/symbolicInput.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/symbolicInput.spec.ts
@@ -1,9 +1,5 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
-
 import { selectCourseByShortName } from '../../models/course.js';
 import { selectQuestionByQid } from '../../models/question.js';
-import { syncCourse } from '../helperCourse.js';
 
 import { expect, test } from './fixtures.js';
 
@@ -15,33 +11,9 @@ for (const { label, latex, plainText } of [
 ]) {
   test(`formula editor preserves a single empty set submitted as ${label}`, async ({
     page,
-    testCoursePath,
     courseInstance,
   }) => {
     const qid = 'symbolicInputEmptySet';
-    const questionPath = path.join(testCoursePath, 'questions', qid);
-    await fs.mkdir(questionPath, { recursive: true });
-    await fs.writeFile(
-      path.join(questionPath, 'info.json'),
-      JSON.stringify({
-        uuid: 'd98429d6-791d-4dbc-b9c0-9d1219ba4783',
-        title: 'Symbolic input empty set',
-        topic: 'Algebra',
-        tags: [],
-        type: 'v3',
-      }),
-    );
-    await fs.writeFile(
-      path.join(questionPath, 'question.html'),
-      `<pl-symbolic-input
-      answers-name="answer"
-      allow-sets="true"
-      formula-editor="true"
-      correct-answer="0"
-    ></pl-symbolic-input>`,
-    );
-    await syncCourse(testCoursePath);
-
     const course = await selectCourseByShortName('QA 101');
     const question = await selectQuestionByQid({ qid, course_id: course.id });
     await page.goto(

--- a/apps/prairielearn/src/tests/e2e/symbolicInput.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/symbolicInput.spec.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { selectCourseByShortName } from '../../models/course.js';
+import { selectQuestionByQid } from '../../models/question.js';
+import { syncCourse } from '../helperCourse.js';
+
+import { expect, test } from './fixtures.js';
+
+test.setTimeout(60_000);
+
+for (const { label, latex, plainText } of [
+  { label: 'empty-set symbol', latex: '\\emptyset', plainText: 'O/' },
+  { label: 'empty braces', latex: '\\{\\}', plainText: '{}' },
+]) {
+  test(`formula editor preserves a single empty set submitted as ${label}`, async ({
+    page,
+    testCoursePath,
+    courseInstance,
+  }) => {
+    const qid = 'symbolicInputEmptySet';
+    const questionPath = path.join(testCoursePath, 'questions', qid);
+    await fs.mkdir(questionPath, { recursive: true });
+    await fs.writeFile(
+      path.join(questionPath, 'info.json'),
+      JSON.stringify({
+        uuid: 'd98429d6-791d-4dbc-b9c0-9d1219ba4783',
+        title: 'Symbolic input empty set',
+        topic: 'Algebra',
+        tags: [],
+        type: 'v3',
+      }),
+    );
+    await fs.writeFile(
+      path.join(questionPath, 'question.html'),
+      `<pl-symbolic-input
+      answers-name="answer"
+      allow-sets="true"
+      formula-editor="true"
+      correct-answer="0"
+    ></pl-symbolic-input>`,
+    );
+    await syncCourse(testCoursePath);
+
+    const course = await selectCourseByShortName('QA 101');
+    const question = await selectQuestionByQid({ qid, course_id: course.id });
+    await page.goto(
+      `/pl/course_instance/${courseInstance.id}/instructor/question/${question.id}/preview`,
+    );
+
+    const mathField = page.locator('math-field').first();
+    await mathField.evaluate((element, value) => {
+      const field = element as HTMLElement & { value: string };
+      field.value = value;
+      field.dispatchEvent(new Event('input', { bubbles: true }));
+    }, latex);
+
+    await expect(page.locator('input[name="answer"]')).toHaveValue(plainText);
+    const submittedLatex = await page.locator('input[name="answer-latex"]').inputValue();
+
+    await page.getByRole('button', { name: /Save & Grade/ }).click();
+
+    await expect(mathField).toBeVisible();
+    await expect
+      .poll(() =>
+        mathField.evaluate((element) =>
+          (element as HTMLElement & { getValue(format: string): string }).getValue('latex'),
+        ),
+      )
+      .toBe(submittedLatex);
+    await expect(page.locator('input[name="answer-latex"]')).toHaveValue(submittedLatex);
+  });
+}

--- a/testCourse/questions/symbolicInputEmptySet/info.json
+++ b/testCourse/questions/symbolicInputEmptySet/info.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "d98429d6-791d-4dbc-b9c0-9d1219ba4783",
+  "title": "Symbolic input empty set",
+  "topic": "Algebra",
+  "tags": [],
+  "type": "v3"
+}

--- a/testCourse/questions/symbolicInputEmptySet/question.html
+++ b/testCourse/questions/symbolicInputEmptySet/question.html
@@ -1,0 +1,10 @@
+<pl-question-panel>
+  <p>Enter an empty set using the symbolic input formula editor.</p>
+</pl-question-panel>
+
+<pl-symbolic-input
+  answers-name="answer"
+  allow-sets="true"
+  formula-editor="true"
+  correct-answer="0"
+></pl-symbolic-input>

--- a/testCourse/questions/symbolicInputEmptySet/question.html
+++ b/testCourse/questions/symbolicInputEmptySet/question.html
@@ -6,5 +6,5 @@
   answers-name="answer"
   allow-sets="true"
   formula-editor="true"
-  correct-answer="0"
+  correct-answer="{}"
 ></pl-symbolic-input>


### PR DESCRIPTION
# Description

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

There was a bug where hitting "Save + Grade" on a `pl-symbolic-input[formula-editor][allow-sets][value="{}"]` would return a webpage with `value="{}{}"` for each instance of `{}`. This causes emptysets to proliferate and answers to be un-submissible without fixing the new copies.

The workaround required populating the `math-field` value from `input#symbolic-input-latex-XXX` after rendering instead of directly filling the value as the inner HTML of `math-field` in mustache. I'll be honest, I'm not sure why this makes a difference, but the tests validate the results.

The entirety of this PR was drafted by Codex.

- [X] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).


# Testing

There are two new sets of tests:

- The first is a python check that makes sure that data is interpolated directly inside the math-field element.
- The second is a new pair of e2e tests for checking that round-trip emptyset submissions don't proliferate.
