### PR TITLE
Remove irrelevant Dockerfile check skip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# check=skip=CopyIgnoredFile
-# TODO: remove once the following issue is fixed:
-# https://github.com/moby/buildkit/issues/6512
-
 FROM amazonlinux:2023
 ARG CACHEBUST=2026-07-15-14-34-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,5 +51,5 @@ RUN chmod +x /PrairieLearn/scripts/init.sh \
     && git config --global user.name "Dev User" \
     && git config --global safe.directory '*'
 
-HEALTHCHECK CMD curl --fail http://localhost:3000/pl/webhooks/ping || exit 1
+HEALTHCHECK CMD ["curl", "--fail", "http://localhost:3000/pl/webhooks/ping"]
 CMD [ "/PrairieLearn/scripts/init.sh" ]

--- a/workspaces/rstudio/Dockerfile
+++ b/workspaces/rstudio/Dockerfile
@@ -156,6 +156,7 @@ ENV USER=rstudio
 # Judging from some discussion online, the PASSWORD variable may be necessary
 # due to a bug in RStudio Server's DISABLE_AUTH mode.
 ENV DISABLE_AUTH=true
+# hadolint ignore=DL3064
 ENV PASSWORD=placeholder
 # This tells s6 to use alternative, writable locations if the paths it
 # expects to write to are read-only.


### PR DESCRIPTION
# Description

See https://github.com/moby/buildkit/issues/6512, this should no longer be necessary.

# Testing

`make lint-docker` is happy.