### PR TITLE
Group Dependabot Docker updates across directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
     schedule:
       interval: monthly
     rebase-strategy: disabled
+    groups:
+      docker-images:
+        group-by: dependency-name
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
# Description

Group Dependabot's Docker version updates by dependency name across all configured Dockerfile directories. This allows a base image update such as `amazonlinux` to update every Dockerfile that references it in one pull request instead of opening a separate pull request for each directory.

- [x] This change was implemented with AI assistance (majority of implementation).

# Testing

Not tested against a live Dependabot run; this configuration-only change uses GitHub's documented `group-by: dependency-name` option.
