### PR TITLE
Limit issue search by UID based on user permissions

### DIFF
--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
@@ -526,7 +526,9 @@ function FilterHelpModal() {
                     <td>
                       Shows all issues that were reported by a user with a UID like <code>UID</code>
                       . For example, <code>user:student@example.com</code> shows all issues that
-                      were reported by <code>student@example.com</code>.
+                      were reported by <code>student@example.com</code>. This will only include
+                      issues where the user information is not hidden due to insufficient
+                      permissions.
                     </td>
                   </tr>
                 </tbody>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
@@ -526,9 +526,9 @@ function FilterHelpModal() {
                     <td>
                       Shows all issues that were reported by a user with a UID like <code>UID</code>
                       . For example, <code>user:student@example.com</code> shows all issues that
-                      were reported by <code>student@example.com</code>. This will only include
-                      issues where the user information is not hidden due to insufficient
-                      permissions.
+                      were reported by <code>student@example.com</code>. Searching by UID will only
+                      include issues in course instances where you have permission to see student
+                      data.
                     </td>
                   </tr>
                 </tbody>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -78,16 +78,36 @@ WITH
         OR a.tid NOT ILIKE ANY ($filter_not_assessments::text[])
       )
       AND (
-        $filter_course_instance_ids::bigint[] IS NULL
+        -- We only filter by course instance if the user filter has been set,
+        -- since in that case we don't want to enable search by information the
+        -- user does not have access to.
+        (
+          $filter_users::text[] IS NULL
+          AND $filter_not_users::text[] IS NULL
+        )
         -- We don't use = ANY because we may have nulls in the array, and = ANY does not match nulls.
         OR array_position(
-          $filter_course_instance_ids::bigint[],
+          $course_instances_show_user_info::bigint[],
           i.course_instance_id::bigint
         ) IS NOT NULL
       )
       AND (
         $filter_query_text::text IS NULL
-        OR to_tsvector(concat_ws(' ', q.qid, u.uid, i.student_message)) @@ plainto_tsquery($filter_query_text::text)
+        OR to_tsvector(
+          concat_ws(
+            ' ',
+            q.qid,
+            -- The UID is only included in the search if the current user has
+            -- permission to view student data.
+            CASE
+              WHEN array_position(
+                $course_instances_show_user_info::bigint[],
+                i.course_instance_id::bigint
+              ) IS NOT NULL THEN u.uid
+            END,
+            i.student_message
+          )
+        ) @@ plainto_tsquery($filter_query_text::text)
       )
   )
 SELECT

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -78,6 +78,14 @@ WITH
         OR a.tid NOT ILIKE ANY ($filter_not_assessments::text[])
       )
       AND (
+        $filter_course_instance_ids::bigint[] IS NULL
+        -- We don't use = ANY because we may have nulls in the array, and = ANY does not match nulls.
+        OR array_position(
+          $filter_course_instance_ids::bigint[],
+          i.course_instance_id::bigint
+        ) IS NOT NULL
+      )
+      AND (
         $filter_query_text::text IS NULL
         OR to_tsvector(concat_ws(' ', q.qid, u.uid, i.student_message)) @@ plainto_tsquery($filter_query_text::text)
       )

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -85,14 +85,6 @@ function parseRawQuery(str: string) {
         }
         break;
       case 'user':
-        // The filter by user applies even if the current user does not have
-        // permission to view the user data. Ideally we would not allow
-        // filtering by user in this case, but we still want to allow
-        // instructors to filter by user within the context of their own course
-        // instance, even if they do not have permission to view the user data
-        // in other course instances. While this is not ideal, it is a
-        // reasonable compromise. Future implementations may refine this
-        // further.
         if (!option.negated) {
           filters.filter_users = filters.filter_users || [];
           filters.filter_users.push(formatForLikeClause(option.value));

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -158,27 +158,11 @@ router.get(
     });
     const linkableCourseInstanceIds = new Set(course_instances.map((ci) => ci.id));
 
-    // There are three situations in which the issue need not be anonymized:
+    // There are three situations in which the issue need not be anonymized.
     //
-    //  1) The issue is not associated with a course instance. The only way
-    //     for a user to generate an issue that is not associated with a
-    //     course instance is if they are an instructor. In this case, the
-    //     user data is other instructors, so we only need to check that the
-    //     effective user has course preview access, which is required to view
-    //     the question preview in the first place.
-    //
-    //  2) We are accessing this page through a course instance, the issue is
-    //     associated with the same course instance, and the user has student
-    //     data view access.
-    //
-    //  3) We are not accessing this page through the course instance
-    //     associated to the issue (i.e., we are accessing it through the
-    //     course or through a different course instance), and the user has
-    //     student data view access in the course instance associated to the
-    //     issue. This is distinguished from situation 2 above to ensure
-    //     effective user roles are taken into account.
-    //
-    // Otherwise, all issues must be anonymized.
+    // 1. For issues associated with a course instance other than the one
+    //    through which we are accessing this page, we check if the user has
+    //    student data view access in that course instance.
     const courseInstancesShowUserInfo: (string | null)[] = course_instances
       .filter(
         (ci) =>
@@ -186,11 +170,23 @@ router.get(
           ci.has_course_instance_permission_view,
       )
       .map((ci) => ci.id);
-    if (res.locals.course_instance && 'course_instance_role' in res.locals.authz_data) {
-      if (res.locals.authz_data.has_course_instance_permission_view) {
-        courseInstancesShowUserInfo.push(res.locals.course_instance.id);
-      }
+    // 2. For issues associated with the course instance through which we are
+    //    accessing this page: we use the permissions from authz_data. This is
+    //    distinguished from situation 1 above to ensure effective user roles
+    //    are taken into account.
+    if (
+      res.locals.course_instance &&
+      'has_course_instance_permission_view' in res.locals.authz_data &&
+      res.locals.authz_data.has_course_instance_permission_view
+    ) {
+      courseInstancesShowUserInfo.push(res.locals.course_instance.id);
     }
+    // 3. For issues not associated with a course instance: the only way for a
+    //    user to generate an issue that is not associated with a course
+    //    instance is if they are an instructor. In this case, the user data is
+    //    other instructors, so we only need to check that the effective user
+    //    has course preview access, which is required to view the question
+    //    preview in the first place.
     if (authzData.has_course_permission_preview) {
       courseInstancesShowUserInfo.push(null);
     }

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -35,7 +35,7 @@ function formatForLikeClause(str: string) {
     .replaceAll('*', '%');
 }
 
-function parseRawQuery(str: string, courseInstancesShowUserInfo: (string | null)[]) {
+function parseRawQuery(str: string) {
   const parsedQuery = SearchString.parse(str);
   const filters = {
     filter_is_open: null as boolean | null,
@@ -49,7 +49,6 @@ function parseRawQuery(str: string, courseInstancesShowUserInfo: (string | null)
     filter_not_users: null as string[] | null,
     filter_assessments: null as string[] | null,
     filter_not_assessments: null as string[] | null,
-    filter_course_instance_ids: null as (string | null)[] | null,
   };
 
   const queryText = parsedQuery.getAllText();
@@ -85,9 +84,6 @@ function parseRawQuery(str: string, courseInstancesShowUserInfo: (string | null)
         }
         break;
       case 'user':
-        // If the issues are filtered by user, we need to filter out any issues
-        // where the user information is hidden due to insufficient permissions.
-        filters.filter_course_instance_ids = courseInstancesShowUserInfo;
         if (!option.negated) {
           filters.filter_users = filters.filter_users || [];
           filters.filter_users.push(formatForLikeClause(option.value));
@@ -192,11 +188,17 @@ router.get(
     }
 
     const queryPageNumber = Number(req.query.page);
-    const filters = parseRawQuery(filterQuery, courseInstancesShowUserInfo);
+    const filters = parseRawQuery(filterQuery);
     const offset = Number.isInteger(queryPageNumber) ? (queryPageNumber - 1) * PAGE_SIZE : 0;
     const issueRows = await queryRows(
       sql.select_issues,
-      { course_id: course.id, offset, limit: PAGE_SIZE, ...filters },
+      {
+        course_id: course.id,
+        offset,
+        limit: PAGE_SIZE,
+        course_instances_show_user_info: courseInstancesShowUserInfo,
+        ...filters,
+      },
       IssueRowSchema,
     );
     // If the offset is not zero and there are no returned issues, this

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -181,7 +181,7 @@ router.get(
     });
     const linkableCourseInstanceIds = new Set(course_instances.map((ci) => ci.id));
 
-    const issues = issueRows.map((row) => ({
+    let issues = issueRows.map((row) => ({
       ...row,
 
       // Each issue is associated with a question variant. If an issue is also
@@ -237,7 +237,12 @@ router.get(
       }),
     }));
 
-    const openFilteredIssuesCount = issueRows.reduce((acc, row) => (row.open ? acc + 1 : acc), 0);
+    if (filters.filter_users?.length || filters.filter_not_users?.length) {
+      // If the issues are filtered by user, we do not list any issues where user information is hidden.
+      issues = issues.filter((row) => row.showUser);
+    }
+
+    const openFilteredIssuesCount = issues.reduce((acc, row) => (row.open ? acc + 1 : acc), 0);
 
     res.send(
       PageLayout({

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -11,7 +11,6 @@ import {
   queryScalar,
   queryScalars,
 } from '@prairielearn/postgres';
-import { run } from '@prairielearn/run';
 import { IdSchema } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
@@ -50,6 +49,9 @@ function parseRawQuery(str: string) {
     filter_not_users: null as string[] | null,
     filter_assessments: null as string[] | null,
     filter_not_assessments: null as string[] | null,
+    // Used to filter course instances where the student has student data
+    // permission if user filter is in use.
+    filter_course_instance_ids: null as (string | null)[] | null,
   };
 
   const queryText = parsedQuery.getAllText();
@@ -148,8 +150,58 @@ router.get(
       z.number(),
     );
 
-    const queryPageNumber = Number(req.query.page);
+    // Compute the IDs of the course instances to which the effective user has access.
+    const course_instances = await selectCourseInstancesWithStaffAccess({
+      course,
+      authzData,
+    });
+    const linkableCourseInstanceIds = new Set(course_instances.map((ci) => ci.id));
+
+    // There are three situations in which the issue need not be anonymized:
+    //
+    //  1) The issue is not associated with a course instance. The only way
+    //     for a user to generate an issue that is not associated with a
+    //     course instance is if they are an instructor. In this case, the
+    //     user data is other instructors, so we only need to check that the
+    //     effective user has course preview access, which is required to view
+    //     the question preview in the first place.
+    //
+    //  2) We are accessing this page through a course instance, the issue is
+    //     associated with the same course instance, and the user has student
+    //     data view access.
+    //
+    //  3) We are not accessing this page through the course instance
+    //     associated to the issue (i.e., we are accessing it through the
+    //     course or through a different course instance), and the user has
+    //     student data view access in the course instance associated to the
+    //     issue. This is distinguished from situation 2 above to ensure
+    //     effective user roles are taken into account.
+    //
+    // Otherwise, all issues must be anonymized.
+    const courseInstancesShowUserInfo: (string | null)[] = course_instances
+      .filter(
+        (ci) =>
+          !(res.locals.course_instance && idsEqual(res.locals.course_instance.id, ci.id)) &&
+          ci.has_course_instance_permission_view,
+      )
+      .map((ci) => ci.id);
+    if (res.locals.course_instance && 'course_instance_role' in res.locals.authz_data) {
+      if (res.locals.authz_data.has_course_instance_permission_view) {
+        courseInstancesShowUserInfo.push(res.locals.course_instance.id);
+      }
+    }
+    if (authzData.has_course_permission_preview) {
+      courseInstancesShowUserInfo.push(null);
+    }
+
     const filters = parseRawQuery(filterQuery);
+    if (filters.filter_users?.length || filters.filter_not_users?.length) {
+      // If the issues are filtered by user, we need to filter out any issues
+      // where the user information is hidden due to insufficient permissions.
+      filters.filter_course_instance_ids = courseInstancesShowUserInfo;
+    }
+
+    const queryPageNumber = Number(req.query.page);
     const offset = Number.isInteger(queryPageNumber) ? (queryPageNumber - 1) * PAGE_SIZE : 0;
     const issueRows = await queryRows(
       sql.select_issues,
@@ -165,15 +217,7 @@ router.get(
       return;
     }
 
-    // Compute the IDs of the course instances to which the effective user has access.
-
-    const course_instances = await selectCourseInstancesWithStaffAccess({
-      course,
-      authzData,
-    });
-    const linkableCourseInstanceIds = new Set(course_instances.map((ci) => ci.id));
-
-    let issues = issueRows.map((row) => ({
+    const issues = issueRows.map((row) => ({
       ...row,
 
       // Each issue is associated with a question variant. If an issue is also
@@ -186,53 +230,8 @@ router.get(
       hideAssessmentLink:
         row.course_instance_id != null && !linkableCourseInstanceIds.has(row.course_instance_id),
 
-      // There are three situations in which the issue need not be anonymized:
-      //
-      //  1) The issue is not associated with a course instance. The only way
-      //     for a user to generate an issue that is not associated with a
-      //     course instance is if they are an instructor. In this case, the
-      //     user data is other instructors, so we only need to check that the
-      //     effective user has course preview access, which is required to view
-      //     the question preview in the first place.
-      //
-      //  2) We are accessing this page through a course instance, the issue is
-      //     associated with the same course instance, and the user has student
-      //     data view access.
-      //
-      //  3) We are not accessing this page through the course instance
-      //     associated to the issue (i.e., we are accessing it through the
-      //     course or through a different course instance), and the user has
-      //     student data view access in the course instance associated to the
-      //     issue. This is distinguished from situation 2 above to ensure
-      //     effective user roles are taken into account.
-      //
-      // Otherwise, all issues must be anonymized.
-      showUser: run(() => {
-        if (row.course_instance_id == null) {
-          return authzData.has_course_permission_preview;
-        }
-
-        // Use request-scoped authorization for the current course instance so
-        // that effective-user role overrides are respected. The model results
-        // below reflect stored roles instead.
-        if (
-          res.locals.course_instance &&
-          'course_instance_role' in res.locals.authz_data &&
-          idsEqual(res.locals.course_instance.id, row.course_instance_id)
-        ) {
-          return res.locals.authz_data.has_course_instance_permission_view;
-        }
-
-        return course_instances.some(
-          (ci) => ci.id === row.course_instance_id && ci.has_course_instance_permission_view,
-        );
-      }),
+      showUser: courseInstancesShowUserInfo.includes(row.course_instance_id),
     }));
-
-    if (filters.filter_users?.length || filters.filter_not_users?.length) {
-      // If the issues are filtered by user, we do not list any issues where user information is hidden.
-      issues = issues.filter((row) => row.showUser);
-    }
 
     const openFilteredIssuesCount = issues.reduce((acc, row) => (row.open ? acc + 1 : acc), 0);
 

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -189,7 +189,9 @@ router.get(
 
     const queryPageNumber = Number(req.query.page);
     const filters = parseRawQuery(filterQuery);
-    const offset = Number.isInteger(queryPageNumber) ? (queryPageNumber - 1) * PAGE_SIZE : 0;
+    const offset = Number.isInteger(queryPageNumber)
+      ? Math.max(0, (queryPageNumber - 1) * PAGE_SIZE)
+      : 0;
     const issueRows = await queryRows(
       sql.select_issues,
       {

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -35,7 +35,7 @@ function formatForLikeClause(str: string) {
     .replaceAll('*', '%');
 }
 
-function parseRawQuery(str: string) {
+function parseRawQuery(str: string, courseInstancesShowUserInfo: (string | null)[]) {
   const parsedQuery = SearchString.parse(str);
   const filters = {
     filter_is_open: null as boolean | null,
@@ -49,8 +49,6 @@ function parseRawQuery(str: string) {
     filter_not_users: null as string[] | null,
     filter_assessments: null as string[] | null,
     filter_not_assessments: null as string[] | null,
-    // Used to filter course instances where the student has student data
-    // permission if user filter is in use.
     filter_course_instance_ids: null as (string | null)[] | null,
   };
 
@@ -87,6 +85,9 @@ function parseRawQuery(str: string) {
         }
         break;
       case 'user':
+        // If the issues are filtered by user, we need to filter out any issues
+        // where the user information is hidden due to insufficient permissions.
+        filters.filter_course_instance_ids = courseInstancesShowUserInfo;
         if (!option.negated) {
           filters.filter_users = filters.filter_users || [];
           filters.filter_users.push(formatForLikeClause(option.value));
@@ -194,14 +195,8 @@ router.get(
       courseInstancesShowUserInfo.push(null);
     }
 
-    const filters = parseRawQuery(filterQuery);
-    if (filters.filter_users?.length || filters.filter_not_users?.length) {
-      // If the issues are filtered by user, we need to filter out any issues
-      // where the user information is hidden due to insufficient permissions.
-      filters.filter_course_instance_ids = courseInstancesShowUserInfo;
-    }
-
     const queryPageNumber = Number(req.query.page);
+    const filters = parseRawQuery(filterQuery, courseInstancesShowUserInfo);
     const offset = Number.isInteger(queryPageNumber) ? (queryPageNumber - 1) * PAGE_SIZE : 0;
     const issueRows = await queryRows(
       sql.select_issues,
@@ -233,7 +228,7 @@ router.get(
       showUser: courseInstancesShowUserInfo.includes(row.course_instance_id),
     }));
 
-    const openFilteredIssuesCount = issues.reduce((acc, row) => (row.open ? acc + 1 : acc), 0);
+    const openFilteredIssuesCount = issueRows.reduce((acc, row) => (row.open ? acc + 1 : acc), 0);
 
     res.send(
       PageLayout({


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Resolves #15598. When a search by user is performed (either positive or negative), issues where the current user does not have permission to read user information are not included in the search result.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: occasional auto-complete only.

# Testing

Tested locally with users with limited permission. Given that there are no current tests that check for issue information based on permissions I haven't added any CI tests, but I can add if desirable.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
