### PR TITLE
Fix database encryption startup order

### DIFF
--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -2461,6 +2461,16 @@ if (shouldStartServer) {
       });
     }
 
+    if ('database-encryption' in argv) {
+      const mode = argv['database-encryption'];
+      if (mode !== 'check' && mode !== 'rotate') {
+        throw new Error('--database-encryption must be either "check" or "rotate"');
+      }
+      const result = await runDatabaseEncryptionOperation({ mode });
+      logger.info(`Database encryption ${mode} complete`, result);
+      process.exit(0);
+    }
+
     // We create and activate a random DB schema name
     // (https://www.postgresql.org/docs/current/ddl-schemas.html)
     // after we have run the migrations but before we create
@@ -2492,16 +2502,6 @@ if (shouldStartServer) {
 
     await sqldb.setRandomSearchSchemaAsync(schemaPrefix);
     await sprocs.init();
-
-    if ('database-encryption' in argv) {
-      const mode = argv['database-encryption'];
-      if (mode !== 'check' && mode !== 'rotate') {
-        throw new Error('--database-encryption must be either "check" or "rotate"');
-      }
-      const result = await runDatabaseEncryptionOperation({ mode });
-      logger.info(`Database encryption ${mode} complete`, result);
-      process.exit(0);
-    }
 
     if (argv['migrate-and-exit']) {
       logger.info('option --migrate-and-exit passed, running DB setup and exiting');


### PR DESCRIPTION
# Description

Move the normal entrypoint's `--database-encryption check|rotate` operation to run after the default PostgreSQL pool, named-lock pool, and configured migrations are initialized, but before random search-schema creation and sproc initialization. This prevents the one-off command from creating a timestamped runtime schema while preserving its existing operation, key handling, logging, and exit behavior.

This intentionally preserves PrairieLearn's existing behavior when `--database-encryption` is combined with other exit flags; the coordinated fix is scoped to the standalone database-encryption lifecycle.

- [x] I have disclosed the level of AI assistance used: Codex implemented the change and prepared this PR.

# Testing

No tests were run, per the coordinated scope for this ordering-only block move. The final diff was inspected to confirm that the existing database-encryption block moved unchanged, and `git diff --check` passed.
