### PR TITLE
Recommend built-in Canvas content importer

### DIFF
--- a/contrib/question_converters/canvas/README.md
+++ b/contrib/question_converters/canvas/README.md
@@ -1,5 +1,9 @@
 # Canvas conversion tool
 
+!!! warning "Legacy tool"
+
+    PrairieLearn now has a built-in [content importer](https://docs.prairielearn.com/importingContent/) for Canvas and other learning management systems. We recommend using the built-in importer instead of this legacy converter. It accepts QTI exports in `.zip` or `.imscc` format directly within PrairieLearn and does not require a Canvas API token.
+
 ## Converting Canvas assessments to PrairieLearn
 
 This directory contains scripts that use the Canvas API to import course assessments into


### PR DESCRIPTION
# Description

Adds a prominent warning to the legacy Canvas converter documentation that recommends PrairieLearn's built-in content importer, links to its documentation, and explains that it accepts Canvas QTI exports without requiring an API token.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex authored the documentation change and PR description under maintainer direction.

# Testing

Not run (documentation-only change).
