### PR TITLE
Configure esbuild to target ES2022

### DIFF
--- a/.changeset/cuddly-kings-wash.md
+++ b/.changeset/cuddly-kings-wash.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/compiled-assets': patch
+---
+
+Migrate esbuild target to es2022

--- a/packages/compiled-assets/src/index.ts
+++ b/packages/compiled-assets/src/index.ts
@@ -90,7 +90,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
 
     esbuildContext = await esbuild.context({
       entryPoints: sourcePaths,
-      target: 'es2017',
+      target: 'es2022',
       format: 'iife',
       sourcemap: 'inline',
       bundle: true,
@@ -124,7 +124,7 @@ export async function init(newOptions: Partial<CompiledAssetsOptions>): Promise<
 
     splitEsbuildContext = await esbuild.context({
       entryPoints: splitSourcePaths,
-      target: 'es2017',
+      target: 'es2022',
       format: 'esm',
       sourcemap: 'inline',
       bundle: true,
@@ -304,7 +304,7 @@ async function buildAssets(sourceDirectory: string, buildDirectory: string): Pro
   const files = [...scriptFiles, ...styleFiles];
   const buildResult = await esbuild.build({
     entryPoints: files,
-    target: 'es2017',
+    target: 'es2022',
     format: 'iife',
     sourcemap: 'linked',
     bundle: true,
@@ -331,7 +331,7 @@ async function buildAssets(sourceDirectory: string, buildDirectory: string): Pro
   );
   const esmBundleBuildResult = await esbuild.build({
     entryPoints: scriptBundleFiles,
-    target: 'es2017',
+    target: 'es2022',
     format: 'esm',
     sourcemap: 'linked',
     bundle: true,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

As discussed on Slack. This matches the tsconfig settings already in place. This is required to handle the new use of bigint in the zod package, introduced in #15571.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Building and starting the server was causing a warning on master. This warning no longer shows up in this branch.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
