### PR TITLE
Restore human-readable console logs

### DIFF
--- a/.changeset/deprecate-format-error-stack-safe.md
+++ b/.changeset/deprecate-format-error-stack-safe.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/error': patch
+---
+
+Deprecate `formatErrorStackSafe` in favor of structured error logging.

--- a/.changeset/friendly-console-logs.md
+++ b/.changeset/friendly-console-logs.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/logger': patch
+---
+
+Format console logs for readability while preserving JSON file logs.

--- a/apps/prairielearn/src/api/v1/error.ts
+++ b/apps/prairielearn/src/api/v1/error.ts
@@ -1,17 +1,14 @@
 import type { ErrorRequestHandler } from 'express';
 import status from 'http-status';
-import jsonStringifySafe from 'json-stringify-safe';
 
-import { formatErrorStackSafe } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 
 export default (function (err, req, res, _next) {
   const statusCode = err.status || 500;
   logger[statusCode >= 500 ? 'error' : 'verbose']('API Error', {
-    msg: err.message,
+    err,
     status: statusCode,
-    stack: formatErrorStackSafe(err),
-    data: jsonStringifySafe(err.data),
+    url: req.originalUrl,
     response_id: res.locals.response_id,
   });
   res.status(statusCode).send({

--- a/apps/prairielearn/src/lib/trpc.ts
+++ b/apps/prairielearn/src/lib/trpc.ts
@@ -3,7 +3,6 @@ import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import { sampleSize } from 'es-toolkit';
 import type { Request } from 'express';
 
-import { formatErrorStackSafe } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 import * as Sentry from '@prairielearn/sentry';
 
@@ -41,13 +40,10 @@ export function handleTrpcError(opts: {
   }
 
   logger[code >= 500 ? 'error' : 'verbose']('tRPC error', {
-    msg: opts.error.message,
+    err: opts.error,
     id: error_id,
     status: code,
-    code: opts.error.code,
-    stack: formatErrorStackSafe(opts.error),
     url: opts.req.originalUrl,
-    referrer: opts.req.get('Referrer') ?? null,
     response_id: opts.req.res?.locals.response_id ?? null,
   });
 }

--- a/apps/prairielearn/src/pages/error/error.ts
+++ b/apps/prairielearn/src/pages/error/error.ts
@@ -1,7 +1,6 @@
 import type { ErrorRequestHandler } from 'express';
-import jsonStringifySafe from 'json-stringify-safe';
 
-import { AugmentedError, formatErrorStackSafe } from '@prairielearn/error';
+import { AugmentedError } from '@prairielearn/error';
 import { logger } from '@prairielearn/logger';
 
 import { config } from '../../lib/config.js';
@@ -49,13 +48,8 @@ export default (function (err, req, res, _next) {
   const referrer = req.get('Referrer') || null;
 
   logger[err.status >= 500 ? 'error' : 'verbose']('Error page', {
-    msg: err.message,
+    err,
     id: errorId,
-    status: err.status,
-    // Use the "safe" version when logging so that we don't error out while
-    // trying to log the actual error.
-    stack: formatErrorStackSafe(err),
-    data: jsonStringifySafe(err.data),
     url: req.url,
     referrer,
     response_id: res.locals.response_id,

--- a/apps/prairielearn/src/pages/error/error.ts
+++ b/apps/prairielearn/src/pages/error/error.ts
@@ -50,7 +50,7 @@ export default (function (err, req, res, _next) {
   logger[err.status >= 500 ? 'error' : 'verbose']('Error page', {
     err,
     id: errorId,
-    url: req.url,
+    url: req.originalUrl,
     referrer,
     response_id: res.locals.response_id,
   });

--- a/packages/error/src/format.ts
+++ b/packages/error/src/format.ts
@@ -42,6 +42,8 @@ export function formatErrorStack(err: any, depth = 0, prefix = ''): string {
  * of an unexpected error object. We'll use the original function if it works,
  * but if it fails for any reason, we'll just return the plain stack, whatever
  * it might be.
+ *
+ * @deprecated Pass errors directly to `@prairielearn/logger` instead.
  */
 export function formatErrorStackSafe(err: any): string {
   try {

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,6 +1,6 @@
 # `@prairielearn/logger`
 
-Provides a shared [Pino](https://getpino.io/) logger with JSON output.
+Provides a shared [Pino](https://getpino.io/) logger with human-readable console output and JSON file output.
 
 ## Usage
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -16,7 +16,8 @@
     "dev": "tsgo --watch --preserveWatchOutput"
   },
   "dependencies": {
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 
 import pino, { type Logger as PinoLogger } from 'pino';
+import pretty from 'pino-pretty';
 
 type LogLevel = 'debug' | 'verbose' | 'info' | 'warn' | 'error';
 
@@ -22,7 +23,15 @@ assert(
   "`verbose` must be between Pino's `debug` and `info` levels",
 );
 
-const output = pino.multistream<LogLevel>([{ level: 'info', stream: process.stdout }], {
+const consoleOutput = pretty({
+  messageKey: 'message',
+  singleLine: true,
+  timestampKey: 'timestamp',
+  translateTime: 'SYS:HH:MM:ss.l',
+});
+
+// Keep stdout readable; file destinations added below still receive Pino's JSON records.
+const output = pino.multistream<LogLevel>([{ level: 'info', stream: consoleOutput }], {
   levels: { verbose: VERBOSE_LEVEL },
 });
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -25,7 +25,6 @@ assert(
 
 const consoleOutput = pretty({
   messageKey: 'message',
-  singleLine: true,
   timestampKey: 'timestamp',
   translateTime: 'SYS:HH:MM:ss.l',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2076,6 +2076,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
     devDependencies:
       '@prairielearn/tsconfig':
         specifier: workspace:^
@@ -6546,6 +6549,9 @@ packages:
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -6879,6 +6885,9 @@ packages:
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debounce@3.0.0:
     resolution: {integrity: sha512-64byRbF0/AirwbuHqB3/ZpMG9/nckDa6ZA0yd6UnaQNwbbemCOwvz2sL5sjXLHhZHADyiwLm0M5qMhltUUx+TA==}
@@ -7415,6 +7424,9 @@ packages:
     resolution: {integrity: sha512-QE0+DRlpwSutYEy27uSqD/cW98B83aS7hn4MWk1vhfMUum9pvB/9GxOirM0RfHxKOg9nF1AWXPW4LUiczLaLyg==}
     engines: {node: '>=8.0.0'}
 
+  fast-copy@4.0.4:
+    resolution: {integrity: sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -7437,6 +7449,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -7763,6 +7778,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -8106,6 +8124,10 @@ packages:
 
   jose@6.2.8:
     resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   jquery-ui-dist@1.13.3:
     resolution: {integrity: sha512-qeTR3SOSQ0jgxaNXSFU6+JtxdzNUSJKgp8LCzVrVKntM25+2YBJW1Ea8B2AwjmmSHfPLy2dSlZxJQN06OfVFhg==}
@@ -9181,6 +9203,10 @@ packages:
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
@@ -9705,6 +9731,9 @@ packages:
 
   search-string@4.1.0:
     resolution: {integrity: sha512-a5Yun2HzluDFSe/fWSO5HGWGJ3wXhh31st128oCjlPoF8+Ugs0I5Ok/Pz+27EqEUKqg56O6xu/pw0NM440nMUA==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   select@1.1.2:
     resolution: {integrity: sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==}
@@ -14551,6 +14580,8 @@ snapshots:
 
   colord@2.9.3: {}
 
+  colorette@2.0.20: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
@@ -14877,6 +14908,8 @@ snapshots:
       - '@noble/hashes'
 
   date-fns@4.4.0: {}
+
+  dateformat@4.6.3: {}
 
   debounce@3.0.0: {}
 
@@ -15598,6 +15631,8 @@ snapshots:
 
   fabric@4.6.0-browser: {}
 
+  fast-copy@4.0.4: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -15617,6 +15652,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -15985,6 +16022,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  help-me@5.0.0: {}
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -16299,6 +16338,8 @@ snapshots:
   jju@1.4.0: {}
 
   jose@6.2.8: {}
+
+  joycon@3.1.1: {}
 
   jquery-ui-dist@1.13.3:
     dependencies:
@@ -17623,6 +17664,22 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.4
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
   pino-std-serializers@7.1.0: {}
 
   pino@10.3.1:
@@ -18223,6 +18280,8 @@ snapshots:
   scheduler@0.27.0: {}
 
   search-string@4.1.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   select@1.1.2: {}
 


### PR DESCRIPTION
# Description

Restore human-readable console output after #15502 changed it to raw JSON. Console records now flow through `pino-pretty`, while file destinations continue receiving the existing newline-delimited JSON used by log processing and rotation.

<img width="1120" height="328" alt="Screenshot 2026-08-14 at 09 04 08" src="https://github.com/user-attachments/assets/51f40cdf-f12f-4362-b408-23ae4dfe02ac" />

Structured metadata remains visible in the console, and errors retain their stack traces and nested causes. This also updates the logger documentation and adds the required package changeset.

- [x] I have disclosed the level of AI assistance used: the majority of the implementation was completed with AI assistance.

# Testing

Manually emitted representative startup messages, structured request metadata, and an error with a nested cause. Confirmed that stdout was human-readable while the corresponding file records retained their existing JSON structure.
