### PR TITLE
Add upcoming instances filter to staff table

### DIFF
--- a/.changeset/fix-column-manager-dropdown.md
+++ b/.changeset/fix-column-manager-dropdown.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': patch
+---
+
+Avoid closing the column manager before an adjacent dropdown is activated.

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -881,17 +881,27 @@ function StaffTableInner({
   const { columnFilters, onColumnFiltersChange, onResetColumnFilters } =
     useColumnFilters(filterRegistry);
 
-  const activeCourseInstanceIds = useMemo(() => {
+  const { activeCourseInstanceIds, upcomingCourseInstanceIds } = useMemo(() => {
     const now = new Date();
-    return new Set(
-      courseInstances
-        .filter((ci) => {
-          const hasStarted = !ci.start_date || ci.start_date <= now;
-          const hasNotEnded = !ci.end_date || ci.end_date >= now;
-          return hasStarted && hasNotEnded;
-        })
-        .map((ci) => ci.id),
-    );
+    const activeIds = new Set<string>();
+    const upcomingIds = new Set<string>();
+
+    for (const courseInstance of courseInstances) {
+      const hasStarted = !courseInstance.start_date || courseInstance.start_date <= now;
+      const hasNotEnded = !courseInstance.end_date || courseInstance.end_date >= now;
+      const isUndated = !courseInstance.start_date && !courseInstance.end_date;
+
+      if (!isUndated && hasStarted && hasNotEnded) {
+        activeIds.add(courseInstance.id);
+      } else if (hasNotEnded && (!hasStarted || isUndated)) {
+        upcomingIds.add(courseInstance.id);
+      }
+    }
+
+    return {
+      activeCourseInstanceIds: activeIds,
+      upcomingCourseInstanceIds: upcomingIds,
+    };
   }, [courseInstances]);
 
   const allColumnIds = useMemo(
@@ -1126,12 +1136,15 @@ function StaffTableInner({
       'Active instances': Object.fromEntries(
         courseInstances.map((ci) => [`ci_${ci.id}`, activeCourseInstanceIds.has(ci.id)]),
       ),
+      'Upcoming instances': Object.fromEntries(
+        courseInstances.map((ci) => [`ci_${ci.id}`, upcomingCourseInstanceIds.has(ci.id)]),
+      ),
       'All instances': Object.fromEntries(courseInstances.map((ci) => [`ci_${ci.id}`, true])),
     }),
-    [courseInstances, activeCourseInstanceIds],
+    [courseInstances, activeCourseInstanceIds, upcomingCourseInstanceIds],
   );
 
-  const selectedViewPreset = useMemo(() => {
+  const selectedInstancePreset = useMemo(() => {
     for (const [name, preset] of Object.entries(instanceVisibilityPresets)) {
       const matches = Object.entries(preset).every(
         ([colId, visible]) => (columnVisibility[colId] ?? true) === visible,
@@ -1141,30 +1154,30 @@ function StaffTableInner({
     return null;
   }, [instanceVisibilityPresets, columnVisibility]);
 
-  const handleViewPresetSelect = (presetName: string) => {
+  const handleInstancePresetSelect = (presetName: string) => {
     const preset = instanceVisibilityPresets[presetName as keyof typeof instanceVisibilityPresets];
     void setColumnVisibility((prev) => ({ ...prev, ...preset }));
   };
 
   const allInstancesAreActive = activeCourseInstanceIds.size === courseInstances.length;
 
-  const viewPresetDropdown =
+  const instancePresetDropdown =
     courseInstances.length > 0 && !allInstancesAreActive ? (
       <Dropdown as={ButtonGroup}>
         <Dropdown.Toggle variant="tanstack-table">
           <i className="bi bi-funnel me-2" aria-hidden="true" />
-          View: {selectedViewPreset ?? 'Custom'}
+          {selectedInstancePreset ?? 'Custom'}
         </Dropdown.Toggle>
         <Dropdown.Menu>
           {Object.keys(instanceVisibilityPresets).map((name) => {
-            const isSelected = selectedViewPreset === name;
+            const isSelected = selectedInstancePreset === name;
             return (
               <Dropdown.Item
                 key={name}
                 as="button"
                 type="button"
                 active={isSelected}
-                onClick={() => handleViewPresetSelect(name)}
+                onClick={() => handleInstancePresetSelect(name)}
               >
                 <i
                   className={`bi ${isSelected ? 'bi-check-circle-fill' : 'bi-circle'} me-2`}
@@ -1174,7 +1187,7 @@ function StaffTableInner({
               </Dropdown.Item>
             );
           })}
-          {selectedViewPreset === null && (
+          {selectedInstancePreset === null && (
             <Dropdown.Item as="button" type="button" active disabled>
               <i className="bi bi-check-circle-fill me-2" aria-hidden="true" />
               Custom
@@ -1196,7 +1209,7 @@ function StaffTableInner({
           globalFilter={{ placeholder: 'Search by UID or name...' }}
           tableOptions={{ filters, rowHeight: 72 }}
           headerButtons={headerButtons}
-          columnManager={{ buttons: viewPresetDropdown }}
+          columnManager={{ buttons: instancePresetDropdown }}
           statusContent={statusContent}
           onResetColumnFilters={onResetColumnFilters}
         />

--- a/packages/ui/src/components/ColumnManager.tsx
+++ b/packages/ui/src/components/ColumnManager.tsx
@@ -1,6 +1,6 @@
 import { type Column, type Table } from '@tanstack/react-table';
 import clsx from 'clsx';
-import { type ReactNode, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Dropdown from 'react-bootstrap/Dropdown';
 
@@ -179,7 +179,6 @@ export function ColumnManager<RowDataModel>({
 }: ColumnManagerProps<RowDataModel>) {
   const [activeElementId, setActiveElementId] = useState<string | null>(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
   const handleTogglePin = (columnId: string) => {
     const currentLeft = table.getState().columnPinning.left ?? [];
     const isPinned = currentLeft.includes(columnId);
@@ -281,17 +280,9 @@ export function ColumnManager<RowDataModel>({
 
   return (
     <Dropdown
-      ref={menuRef}
       autoClose="outside"
       show={dropdownOpen}
       onToggle={(isOpen, _meta) => setDropdownOpen(isOpen)}
-      onBlur={(e: React.FocusEvent) => {
-        // Since we aren't using role="menu", we need to manually close the dropdown when focus leaves.
-        // `relatedTarget` is the element gaining focus.
-        if (menuRef.current && !menuRef.current.contains(e.relatedTarget)) {
-          setDropdownOpen(false);
-        }
-      }}
     >
       <Dropdown.Toggle
         // We assume that this component will only appear once per page. If that changes,
@@ -301,16 +292,7 @@ export function ColumnManager<RowDataModel>({
       >
         <i className="bi bi-view-list me-2" aria-hidden="true" /> View{' '}
       </Dropdown.Toggle>
-      <Dropdown.Menu
-        style={{ maxHeight: '60vh', overflowY: 'auto' }}
-        onMouseDown={(e: React.MouseEvent) => {
-          // Prevent mousedown from moving focus away from the toggle button.
-          // Without this, clicking non-focusable elements like label text causes
-          // a blur with relatedTarget=null, which closes the dropdown before the
-          // click event can fire and toggle the checkbox.
-          e.preventDefault();
-        }}
-      >
+      <Dropdown.Menu style={{ maxHeight: '60vh', overflowY: 'auto' }}>
         {topContent && (
           <>
             {topContent}


### PR DESCRIPTION
# Description

Course staff can now choose an **Upcoming instances** preset that shows future and undated development instances while excluding active and ended instances. The **Active instances** preset now excludes undated development instances, keeping the two focused views distinct.

<img width="1142" height="318" alt="Screenshot 2026-08-14 at 15 30 57" src="https://github.com/user-attachments/assets/5c85ecef-aae0-4a63-9ff7-eae8947ba47d" />

The instance selector now uses its filter icon and selected preset as the label, avoiding a second control labeled "View" next to the column manager.

Switching between the column manager and instance selector now works consistently in either direction. The column manager previously closed on blur during the adjacent control's mousedown, which could consume the first click; React-Bootstrap already provides the required outside-click and keyboard dismissal behavior.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Manually verified on the course staff page that the Active, Upcoming, and All presets show the expected instance columns; switching between both dropdowns works with one click in either direction; menu labels remain interactive; and outside click, Escape, Tab, and Shift+Tab dismiss the column manager correctly.
