### PR TITLE
Prune stale TanStack row selections

### DIFF
--- a/.changeset/prune-table-row-selection.md
+++ b/.changeset/prune-table-row-selection.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/ui': minor
+---
+
+Add a hook for pruning row selections when table data changes

--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -31,6 +31,7 @@ import {
   parseAsSortingState,
   useColumnFilters,
   useColumnVisibilityQueryState,
+  usePruneRowSelection,
   useShiftClickCheckbox,
 } from '@prairielearn/ui';
 
@@ -1058,6 +1059,8 @@ function StaffTableInner({
       enableHiding: false,
     },
   });
+
+  usePruneRowSelection(table);
 
   const selectedUsers = table.getFilteredSelectedRowModel().rows.map((row) => row.original);
   const displayedCount = table.getRowModel().rows.length;

--- a/packages/ui/src/hooks/use-prune-row-selection.test.ts
+++ b/packages/ui/src/hooks/use-prune-row-selection.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { pruneRowSelection } from './use-prune-row-selection.js';
+
+describe('pruneRowSelection', () => {
+  it('removes selections for rows that are no longer present', () => {
+    expect(pruneRowSelection({ first: true, second: true }, new Set(['second']))).toEqual({
+      second: true,
+    });
+  });
+});

--- a/packages/ui/src/hooks/use-prune-row-selection.ts
+++ b/packages/ui/src/hooks/use-prune-row-selection.ts
@@ -1,0 +1,28 @@
+import type { RowSelectionState, Table } from '@tanstack/react-table';
+import { useEffect } from 'react';
+
+export function pruneRowSelection(
+  selection: RowSelectionState,
+  validRowIds: Set<string>,
+): RowSelectionState {
+  const retainedEntries = Object.entries(selection).filter(([id]) => validRowIds.has(id));
+  return retainedEntries.length === Object.keys(selection).length
+    ? selection
+    : Object.fromEntries(retainedEntries);
+}
+
+/**
+ * Removes selected row IDs that are no longer present in the table's core data.
+ * This is opt-in because tables with server-side pagination may intentionally retain off-page selections.
+ */
+export function usePruneRowSelection<TData>(table: Table<TData>) {
+  const data = table.options.data;
+
+  useEffect(() => {
+    const validRowIds = new Set(table.getCoreRowModel().flatRows.map((row) => row.id));
+
+    // TanStack Table retains selected row IDs after data changes, so synchronize selection with the core rows.
+    // eslint-disable-next-line react-you-might-not-need-an-effect/no-pass-data-to-parent
+    table.setRowSelection((selection) => pruneRowSelection(selection, validRowIds));
+  }, [data, table]);
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -42,6 +42,7 @@ export {
 } from './components/nuqs.js';
 export { useColumnVisibilityQueryState } from './hooks/use-column-visibility-query-state.js';
 export { useColumnFilters, type ColumnFilterEntry } from './hooks/use-column-filters.js';
+export { usePruneRowSelection } from './hooks/use-prune-row-selection.js';
 
 export { SplitPane, type SplitPaneProps } from './components/SplitPane.js';
 export {


### PR DESCRIPTION
# Description

TanStack Table retains controlled row-selection IDs when backing data changes. On the course staff page, deleting a selected user and later adding that user back therefore caused the row to reappear selected.

Add an opt-in `usePruneRowSelection` hook to `@prairielearn/ui` that synchronizes selection with the table's core rows when its data changes, and use it on the course staff table. The hook uses the core row model so filtering does not clear valid hidden selections, and remains opt-in so server-paginated tables can intentionally retain off-page selections.

- [x] I used AI assistance for the majority of the implementation.

# Testing

- Added focused unit coverage for pruning selected row IDs that are absent from the current table data.
- Manually tested in a browser: start with one user, select them, delete them, add them back. After this change, they are no longer selected after being added back.
