### PR TITLE
Bump typescript-cp, remove rimraf override

### DIFF
--- a/.changeset/yummy-hotels-peel.md
+++ b/.changeset/yummy-hotels-peel.md
@@ -1,0 +1,8 @@
+---
+'@prairielearn/encrypted-storage': patch
+'@prairielearn/migrations': patch
+'@prairielearn/postgres-tools': patch
+'@prairielearn/ui': patch
+---
+
+Update dependency on typescript-cp

--- a/apps/grader-host/package.json
+++ b/apps/grader-host/package.json
@@ -52,7 +52,7 @@
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.10",
     "tsx": "^4.23.5",
-    "typescript-cp": "^0.1.10",
+    "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"
   }
 }

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -324,7 +324,7 @@
     "get-port": "^7.2.0",
     "jsdom": "^29.1.1",
     "tsx": "^4.23.5",
-    "typescript-cp": "^0.1.10",
+    "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"
   }
 }

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -55,7 +55,7 @@
     "@vitest/coverage-v8": "^4.1.10",
     "fast-glob": "^3.3.3",
     "tsx": "^4.23.5",
-    "typescript-cp": "^0.1.10",
+    "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/encrypted-storage/package.json
+++ b/packages/encrypted-storage/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^24.13.3",
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.10",
-    "typescript-cp": "^0.1.10",
+    "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -32,7 +32,7 @@
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.10",
     "tmp-promise": "^3.0.3",
-    "typescript-cp": "^0.1.10",
+    "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/postgres-tools/package.json
+++ b/packages/postgres-tools/package.json
@@ -35,6 +35,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.13.3",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.10"
+    "typescript-cp": "^0.1.11"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,7 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^24.13.3",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.10",
+    "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/workspace-utils/package.json
+++ b/packages/workspace-utils/package.json
@@ -30,6 +30,6 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^24.13.3",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.10"
+    "typescript-cp": "^0.1.11"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,7 +215,6 @@ overrides:
   linkinator>marked: ^18
   markdownlint-cli2>smol-toml: ^1
   notebookjs>jsdom: '*'
-  typescript-cp>rimraf: ^6.1.3
 
 importers:
 
@@ -440,8 +439,8 @@ importers:
         specifier: ^4.23.5
         version: 4.23.5
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -1350,8 +1349,8 @@ importers:
         specifier: ^4.23.5
         version: 4.23.5
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -1477,8 +1476,8 @@ importers:
         specifier: ^4.23.5
         version: 4.23.5
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -1816,8 +1815,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -2188,8 +2187,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -2439,8 +2438,8 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
 
   packages/question-conversion:
     dependencies:
@@ -2759,8 +2758,8 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -2864,8 +2863,8 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
       typescript-cp:
-        specifier: ^0.1.10
-        version: 0.1.10(typescript@6.0.3)
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
 
   packages/zod:
     dependencies:
@@ -10228,8 +10227,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-cp@0.1.10:
-    resolution: {integrity: sha512-5hAVy1WlFzYHAqhfFkB1zpDe1us4NWgjggXGglH79v2SRCiUj22c05HAi3L3SbjwcktOr1EM49Fus69pVelEFg==}
+  typescript-cp@0.1.11:
+    resolution: {integrity: sha512-LF7Mp0qMuYweByCBdxuDSB/HfPPJfWBRA5GHYjwnMFjiMz/kSrBn6vN/bu1WcInJKczs9eOINGeIcEYagVmKsg==}
+    engines: {node: '>= 20', pnpm: '11'}
     hasBin: true
     peerDependencies:
       typescript: '>=4.2.3'
@@ -18851,7 +18851,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-cp@0.1.10(typescript@6.0.3):
+  typescript-cp@0.1.11(typescript@6.0.3):
     dependencies:
       chokidar: 3.6.0
       commander: 10.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,6 @@ overrides:
   'linkinator>marked': ^18
   'markdownlint-cli2>smol-toml': ^1
   'notebookjs>jsdom': '*'
-  'typescript-cp>rimraf': ^6.1.3 # https://github.com/body-builder/typescript-cp/issues/22
 
 # Delay newly published npm packages for 3 days.
 minimumReleaseAge: 4320
@@ -43,20 +42,4 @@ supportedArchitectures:
     - gnu
 
 minimumReleaseAgeExclude:
-  - '@aws-sdk/core@3.977.6'
-  # Changesets v3 was explicitly adopted on its release day.
-  - '@changesets/apply-release-plan@8.0.0'
-  - '@changesets/assemble-release-plan@7.0.0'
-  - '@changesets/changelog-git@1.0.0'
-  - '@changesets/cli@3.0.0'
-  - '@changesets/config@4.0.0'
-  - '@changesets/errors@1.0.0'
-  - '@changesets/format@0.1.1'
-  - '@changesets/get-dependents-graph@3.0.0'
-  - '@changesets/git@4.0.0'
-  - '@changesets/parse@1.0.0'
-  - '@changesets/pre@3.0.0'
-  - '@changesets/read@1.0.0'
-  - '@changesets/should-skip-package@1.0.0'
-  - '@changesets/types@7.0.0'
-  - '@changesets/write@1.0.0'
+  - 'typescript-cp@0.1.11'


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

As of https://github.com/body-builder/typescript-cp/issues/22 and version 0.1.11, typescript-cp no longer depends on the vulnerable version of glob. Bumping to catch the new version. No other relevant changes in the package.

Also opportunistically remove packages that no longer need cooldown overrides.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

`make build` works as expected. CI should also take care of the rest.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
