### PR TITLE
Clear stale release date errors after mode changes

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessmentAccess/components/fields/ReleaseDateField.tsx
@@ -108,16 +108,16 @@ export function DefaultReleaseDateField({ displayTimezone }: { displayTimezone: 
     name: 'defaultRule.release.date',
   });
 
-  // Re-run the validator when dateControlEnabled changes so the
-  // "required" error appears/disappears immediately on toggle.
-  useEffect(() => {
-    void trigger('defaultRule.release.date');
-  }, [dateControlEnabled, trigger]);
-
   const { field: releasedField } = useController<
     AccessControlFormData,
     'defaultRule.release.released'
   >({ name: 'defaultRule.release.released' });
+
+  // Re-validate the release date when date control or the release mode changes
+  // because errors for both settings are stored on the date field.
+  useEffect(() => {
+    void trigger('defaultRule.release.date');
+  }, [dateControlEnabled, releasedField.value, trigger]);
 
   return (
     <div>
@@ -142,6 +142,7 @@ export function OverrideReleaseDateField({
   index: number;
   displayTimezone: string;
 }) {
+  const { trigger } = useFormContext<AccessControlFormData>();
   const defaultRuleValue = useWatch<AccessControlFormData, 'defaultRule.release.date'>({
     name: 'defaultRule.release.date',
   });
@@ -159,6 +160,12 @@ export function OverrideReleaseDateField({
   >({
     name: `overrides.${index}.release.released`,
   });
+
+  // Re-validate the release date when the release mode changes because the
+  // cross-field error is stored on the date field.
+  useEffect(() => {
+    void trigger(`overrides.${index}.release.date`);
+  }, [index, releasedField.value, trigger]);
 
   const { isOverridden, addOverride, removeOverride } = useOverrideField(index, 'release');
 

--- a/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/accessControl.spec.ts
@@ -183,6 +183,29 @@ test.describe('Access control UI', () => {
     await expect(panel.getByText('Exam UUID is required')).toBeVisible();
   });
 
+  test('clears a release date error when the release mode resolves it', async ({
+    page,
+    courseInstance,
+  }) => {
+    const assessment = await selectAssessmentByTid({
+      course_instance_id: courseInstance.id,
+      tid: ASSESSMENT_TID,
+    });
+    await navigateToAccessPage(page, courseInstance.id, assessment.id);
+
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+
+    const panel = getDetailPanel(page);
+    await panel.getByLabel('Scheduled for release').check();
+    await panel.getByLabel('Release date').fill('2000-01-01T00:00');
+
+    const errorMessage = 'Release date must be in the future when scheduled for release.';
+    await expect(panel.getByText(errorMessage)).toBeVisible();
+
+    await panel.getByLabel('Released').check();
+    await expect(panel.getByText(errorMessage)).toBeHidden();
+  });
+
   test('can switch after-due-date submissions from partial credit to practice', async ({
     page,
     courseInstance,


### PR DESCRIPTION
# Description

Fix stale release-date validation errors after switching between "Released" and "Scheduled for release." The release-state validator attaches its error to `release.date`, but changing the radio button only revalidated `release.released`, so React Hook Form kept the old sibling error. Revalidate the date field whenever the release mode changes for both default and override rules.

Add a focused browser regression test that creates an invalid scheduled release date, switches the rule to "Released," and verifies the error disappears.

- [x] I have disclosed the level of AI assistance used: the majority of the implementation was AI-assisted.

# Testing

- Added and ran focused Playwright regression coverage that reproduces a past scheduled release date, switches the mode to "Released," and verifies the stale error disappears.
