### PR TITLE
Use structured error logging in remaining call sites

### DIFF
--- a/apps/prairielearn/src/cron/index.ts
+++ b/apps/prairielearn/src/cron/index.ts
@@ -286,12 +286,7 @@ async function runJobs(jobsList: CronJob[]) {
           span.setStatus({ code: SpanStatusCode.OK });
         } catch (err: any) {
           debug(`runJobs(): error running ${job.name}: ${err}`);
-          logger.error(`cron: ${job.name} failure: ` + String(err), {
-            message: err.message,
-            stack: err.stack,
-            data: JSON.stringify(err.data),
-            cronUuid,
-          });
+          logger.error(`cron: ${job.name} failure`, { err, cronUuid });
 
           Sentry.captureException(err, {
             tags: {

--- a/apps/prairielearn/src/lib/require-frontend.ts
+++ b/apps/prairielearn/src/lib/require-frontend.ts
@@ -20,17 +20,7 @@ requirejs.config({
 });
 
 requirejs.onError = function (err: Error) {
-  const data = {
-    errorMsg: err.toString(),
-    stack: err.stack,
-  };
-  for (const e in err) {
-    if (Object.prototype.hasOwnProperty.call(err, e)) {
-      // @ts-expect-error This is legacy code.
-      data[e] = String(err[e]);
-    }
-  }
-  logger.error('requirejs load error', data);
+  logger.error('requirejs load error', err);
 };
 
 export default requirejs;

--- a/apps/prairielearn/src/middlewares/workspaceProxy.ts
+++ b/apps/prairielearn/src/middlewares/workspaceProxy.ts
@@ -121,7 +121,7 @@ export function makeWorkspaceProxyMiddleware(containerPathRegex: RegExp) {
         const newPath = '/' + pathSuffix;
         return newPath;
       } catch (err: any) {
-        logger.error(`Error in pathRewrite for path=${path}: ${err}`);
+        logger.error('Error in workspace path rewrite', { err, path });
         return path;
       }
     },
@@ -151,7 +151,7 @@ export function makeWorkspaceProxyMiddleware(containerPathRegex: RegExp) {
         stripSensitiveCookies(proxyReq);
       },
       error: (err, req, res) => {
-        logger.error(`Error proxying workspace request: ${err}`, {
+        logger.error('Error proxying workspace request', {
           err,
           url: req.url,
           originalUrl: req.originalUrl,


### PR DESCRIPTION
# Description

Pass the remaining PrairieLearn runtime errors to `@prairielearn/logger` as structured `err` values instead of flattening them into message, stack, and JSON strings.

This lets Pino preserve stack traces, nested causes, `AggregateError` members, and custom enumerable fields in both human-readable console output and JSON files. It also removes duplicated error text from workspace proxy messages while retaining path and request context.

This follows the structured-error behavior introduced in #15502 and applied to the main error handlers in #15609.

- [x] The majority of the implementation and review used AI assistance.

# Testing

No additional tests were added; these call sites use the structured-error behavior already owned and verified by `@prairielearn/logger`.
