### PR TITLE
Fix LTI 1.3 roster context handling

### DIFF
--- a/apps/prairielearn/src/ee/lib/lti13-course-instance.ts
+++ b/apps/prairielearn/src/ee/lib/lti13-course-instance.ts
@@ -1,0 +1,7 @@
+import type { Lti13CourseInstance } from '../../lib/db-types.js';
+
+export function getLti13CourseDisplayName(
+  course: Pick<Lti13CourseInstance, 'context_id' | 'context_label' | 'context_title'>,
+): string {
+  return course.context_label || course.context_title || course.context_id;
+}

--- a/apps/prairielearn/src/ee/lib/lti13-memberships.test.ts
+++ b/apps/prairielearn/src/ee/lib/lti13-memberships.test.ts
@@ -185,13 +185,10 @@ describe('Lti13MembershipIndex', () => {
 
   test('rejects a duplicate UIN across roster pages', () => {
     const user = makeUser('duplicate-uin', { uin: 'matching-uin' });
-    const memberships = parseContextMemberships(
-      [
-        makePage([makeMember({ sub: 'first-sub', uin: user.uin ?? undefined })]),
-        makePage([makeMember({ sub: 'second-sub', uin: user.uin ?? undefined })]),
-      ],
-      'expected-context',
-    );
+    const memberships = parseContextMemberships([
+      makePage([makeMember({ sub: 'first-sub', uin: user.uin ?? undefined })]),
+      makePage([makeMember({ sub: 'second-sub', uin: user.uin ?? undefined })]),
+    ]);
 
     expect(makeIndex(memberships).lookup(user)).toBeNull();
   });
@@ -216,19 +213,16 @@ describe('Lti13MembershipIndex', () => {
   test('rejects a duplicate sub across roster pages', () => {
     const uinUser = makeUser('duplicate-sub-uin', { uin: 'first-uin' });
     const emailUser = makeUser('duplicate-sub-email');
-    const memberships = parseContextMemberships(
-      [
-        makePage([
-          makeMember({
-            sub: 'duplicate-sub',
-            uin: uinUser.uin ?? undefined,
-            email: emailUser.email ?? undefined,
-          }),
-        ]),
-        makePage([makeMember({ sub: 'duplicate-sub', uin: 'second-uin' })]),
-      ],
-      'expected-context',
-    );
+    const memberships = parseContextMemberships([
+      makePage([
+        makeMember({
+          sub: 'duplicate-sub',
+          uin: uinUser.uin ?? undefined,
+          email: emailUser.email ?? undefined,
+        }),
+      ]),
+      makePage([makeMember({ sub: 'duplicate-sub', uin: 'second-uin' })]),
+    ]);
 
     expect(makeIndex(memberships).lookup(uinUser)).toBeNull();
     expect(makeIndex(memberships, null).lookup(emailUser)).toBeNull();
@@ -330,7 +324,7 @@ describe('analyzeRosterMemberUin', () => {
 });
 
 describe('parseContextMemberships', () => {
-  test('returns members from pages for the expected context', () => {
+  test('returns members from pages', () => {
     const members = [makeMember({ sub: 'first' }), makeMember({ sub: 'second' })];
     const pages = members.map((member) => ({
       id: 'roster',
@@ -338,7 +332,7 @@ describe('parseContextMemberships', () => {
       members: [member],
     }));
 
-    expect(parseContextMemberships(pages, 'expected-context')).toHaveLength(2);
+    expect(parseContextMemberships(pages)).toHaveLength(2);
   });
 
   test('normalizes an uppercase status', () => {
@@ -350,24 +344,10 @@ describe('parseContextMemberships', () => {
       },
     ];
 
-    expect(parseContextMemberships(pages, 'expected-context')[0].status).toBe('Active');
-  });
-
-  test('rejects a page for a different context', () => {
-    const pages = [
-      {
-        id: 'roster',
-        context: { id: 'different-context' },
-        members: [makeMember({ sub: 'sub' })],
-      },
-    ];
-
-    expect(() => parseContextMemberships(pages, 'expected-context')).toThrow(
-      'does not match expected context',
-    );
+    expect(parseContextMemberships(pages)[0].status).toBe('Active');
   });
 
   test('treats an omitted members field as empty', () => {
-    expect(parseContextMemberships([makePage()], 'expected-context')).toEqual([]);
+    expect(parseContextMemberships([makePage()])).toEqual([]);
   });
 });

--- a/apps/prairielearn/src/ee/lib/lti13-memberships.ts
+++ b/apps/prairielearn/src/ee/lib/lti13-memberships.ts
@@ -58,23 +58,11 @@ const ContextMembershipContainerSchema = z.object({
 });
 
 /**
- * Parses paginated NRPS responses and verifies that every page belongs to the
- * course context that supplied the memberships URL.
+ * Parses paginated NRPS responses from the URL supplied by the LTI launch.
+ * The NRPS specification does not require its context ID to match the launch context claim.
  */
-export function parseContextMemberships(
-  pages: unknown[],
-  expectedContextId: string,
-): ContextMembership[] {
+export function parseContextMemberships(pages: unknown[]): ContextMembership[] {
   const containers = ContextMembershipContainerSchema.array().parse(pages);
-
-  for (const container of containers) {
-    if (container.context.id !== expectedContextId) {
-      throw new Error(
-        `LTI roster context ${container.context.id} does not match expected context ${expectedContextId}`,
-      );
-    }
-  }
-
   return containers.flatMap((container) => container.members);
 }
 

--- a/apps/prairielearn/src/ee/lib/lti13.ts
+++ b/apps/prairielearn/src/ee/lib/lti13.ts
@@ -33,6 +33,7 @@ import { selectOptionalUserByUin } from '../../models/user.js';
 import { selectOptionalUserByLti13Sub } from '../models/lti13-user.js';
 import { selectLti13Instance } from '../models/lti13Instance.js';
 
+import { getLti13CourseDisplayName } from './lti13-course-instance.js';
 import {
   Lti13MembershipIndex,
   RosterMemberSchema,
@@ -477,7 +478,7 @@ async function getLineitem(instance: Lti13CombinedInstance, lineitem_id_url: str
 
 export async function syncLineitems(instance: Lti13CombinedInstance, job: ServerJob) {
   job.info(
-    `Polling for external assignments from ${instance.lti13_instance.name} ${instance.lti13_course_instance.context_label}`,
+    `Polling for external assignments from ${instance.lti13_instance.name} ${getLti13CourseDisplayName(instance.lti13_course_instance)}`,
   );
   const lineitems = await getLineitems(instance);
   job.info(`Found ${lineitems.length} assignments.`);
@@ -534,7 +535,7 @@ export async function createAndLinkLineitem(
   };
 
   job.info(
-    `Creating assignment for ${assessment.label} in ${instance.lti13_instance.name} ${instance.lti13_course_instance.context_label}`,
+    `Creating assignment for ${assessment.label} in ${instance.lti13_instance.name} ${getLti13CourseDisplayName(instance.lti13_course_instance)}`,
   );
 
   const token = await getAccessToken(instance.lti13_instance.id);
@@ -823,7 +824,7 @@ async function loadLti13MembershipIndex(
   const url = getLti13RosterUrl(instance, lti13_course_instance.resource_link_id);
   const rawRosterPages = await fetchLti13RosterPages(instance, url);
 
-  const memberships = parseContextMemberships(rawRosterPages, lti13_course_instance.context_id);
+  const memberships = parseContextMemberships(rawRosterPages);
 
   return new Lti13MembershipIndex(memberships, {
     institution_id: lti13_instance.institution_id,
@@ -845,6 +846,8 @@ export async function updateLti13Scores({
   instance: Lti13CombinedInstance;
   job: ServerJob;
 }) {
+  const lti13CourseName = getLti13CourseDisplayName(instance.lti13_course_instance);
+
   // Get the assessment metadata
   const assessment = await queryRow(
     sql.select_assessment_for_lti13_scores,
@@ -861,7 +864,7 @@ export async function updateLti13Scores({
 
   job.info(
     `Working on assessment ${assessment.title} (${assessment.tid}) in ` +
-      `${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
+      `${instance.lti13_instance.name} course ${lti13CourseName}`,
   );
 
   const assessment_instances = await queryRows(
@@ -902,7 +905,7 @@ export async function updateLti13Scores({
       job.info(
         `Not sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.` +
           ` Course staff ${user.uid} is excluded from grade passback` +
-          ` in ${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
+          ` in ${instance.lti13_instance.name} course ${lti13CourseName}`,
       );
       counts.not_sent++;
       continue;
@@ -915,7 +918,7 @@ export async function updateLti13Scores({
       job.info(
         `Not sending grade ${assessment_instance.score_perc.toFixed(2)}% for ${user.uid}.` +
           ` Could not find student ${user.uid}` +
-          ` in ${instance.lti13_instance.name} course ${instance.lti13_course_instance.context_label}`,
+          ` in ${instance.lti13_instance.name} course ${lti13CourseName}`,
       );
       counts.not_sent++;
       continue;
@@ -966,9 +969,7 @@ export async function updateLti13Scores({
   job.info(`${counts.error} score${counts.error === 1 ? '' : 's'} not sent due to errors.`);
   if (counts.error > 0 && counts.success === 0) {
     job.warn('\tNo scores successfully sent and errors are present.');
-    job.warn(
-      `\tIs the ${instance.lti13_instance.name} ${instance.lti13_course_instance.context_label} course published?`,
-    );
+    job.warn(`\tIs the ${instance.lti13_instance.name} ${lti13CourseName} course published?`);
   }
   job.info(`${counts.not_sent} score${counts.not_sent === 1 ? '' : 's'} skipped (not sent).`);
 }
@@ -992,7 +993,7 @@ export async function inspectRoster({
   const url = getLti13RosterUrl(instance, rlid);
 
   job.info(
-    `Fetching roster for ${lti13_instance.name}: ${lti13_course_instance.context_label ?? '(no context label)'}`,
+    `Fetching roster for ${lti13_instance.name}: ${getLti13CourseDisplayName(lti13_course_instance)}`,
   );
   job.info(`NRPS URL: ${url}`);
   if (rlid) {

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionLti13/administratorInstitutionLti13.html.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../lib/db-types.js';
 import { LTI13_ROSTER_SYNC_CONFIRMATION_FIELDS } from '../../../lib/institution-identity.js';
 import type { ResLocalsForPage } from '../../../lib/res-locals.js';
+import { getLti13CourseDisplayName } from '../../lib/lti13-course-instance.js';
 
 import { type LTI13InstancePlatforms } from './administratorInstitutionLti13.types.js';
 
@@ -636,7 +637,7 @@ function RosterInspectorForm({
           >
             ${courseLabel}
           </a>
-          <span class="text-muted fw-normal">(${lci.context_label ?? 'no context label'})</span>
+          <span class="text-muted fw-normal">(${getLti13CourseDisplayName(lci)})</span>
         </h6>
         ${lci.context_memberships_url === null
           ? html`

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -12,6 +12,7 @@ import {
   type Lti13Instance,
 } from '../../../lib/db-types.js';
 import type { ResLocalsForPage } from '../../../lib/res-locals.js';
+import { getLti13CourseDisplayName } from '../../lib/lti13-course-instance.js';
 import { type Lineitems, type Lti13CombinedInstance } from '../../lib/lti13.js';
 
 export const AssessmentRowSchema = AssessmentSchema.extend({
@@ -102,7 +103,7 @@ export function InstructorInstanceAdminLti13({
   assessments: AssessmentRow[];
   lineitems: Lti13Assessment[];
 }): string {
-  const lms_name = `${instance.lti13_instance.name}: ${instance.lti13_course_instance.context_label}`;
+  const lms_name = `${instance.lti13_instance.name}: ${getLti13CourseDisplayName(instance.lti13_course_instance)}`;
 
   return PageLayout({
     resLocals,
@@ -133,7 +134,8 @@ export function InstructorInstanceAdminLti13({
                   data-bs-boundary="window"
                 >
                   <span class="d-inline-block text-wrap w-100">
-                    ${instance.lti13_instance.name}: ${instance.lti13_course_instance.context_label}
+                    ${instance.lti13_instance.name}:
+                    ${getLti13CourseDisplayName(instance.lti13_course_instance)}
                   </span>
                 </button>
                 <div class="dropdown-menu">
@@ -152,7 +154,8 @@ export function InstructorInstanceAdminLti13({
                           ? 'true'
                           : ''}"
                       >
-                        ${i.lti13_instance.name}: ${i.lti13_course_instance.context_label}
+                        ${i.lti13_instance.name}:
+                        ${getLti13CourseDisplayName(i.lti13_course_instance)}
                       </a>
                     `;
                   })}
@@ -200,7 +203,7 @@ export function InstructorInstanceAdminLti13({
                   onclick="return confirm('Are you sure you want to remove this connection?');"
                 >
                   Remove LTI 1.3 connection with ${instance.lti13_instance.name}:
-                  ${instance.lti13_course_instance.context_label}
+                  ${getLti13CourseDisplayName(instance.lti13_course_instance)}
                 </button>
               </form>
             </div>

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.html.ts
@@ -25,6 +25,10 @@ export const AssessmentRowSchema = AssessmentSchema.extend({
 });
 type AssessmentRow = z.infer<typeof AssessmentRowSchema>;
 
+function getLti13ConnectionDisplayName(instance: Lti13CombinedInstance): string {
+  return `${instance.lti13_instance.name}: ${getLti13CourseDisplayName(instance.lti13_course_instance)}`;
+}
+
 export function InstructorInstanceAdminLti13NoInstances({
   resLocals,
   lti13_instances,
@@ -103,7 +107,7 @@ export function InstructorInstanceAdminLti13({
   assessments: AssessmentRow[];
   lineitems: Lti13Assessment[];
 }): string {
-  const lms_name = `${instance.lti13_instance.name}: ${getLti13CourseDisplayName(instance.lti13_course_instance)}`;
+  const lmsConnectionName = getLti13ConnectionDisplayName(instance);
 
   return PageLayout({
     resLocals,
@@ -133,10 +137,7 @@ export function InstructorInstanceAdminLti13({
                   aria-expanded="false"
                   data-bs-boundary="window"
                 >
-                  <span class="d-inline-block text-wrap w-100">
-                    ${instance.lti13_instance.name}:
-                    ${getLti13CourseDisplayName(instance.lti13_course_instance)}
-                  </span>
+                  <span class="d-inline-block text-wrap w-100">${lmsConnectionName}</span>
                 </button>
                 <div class="dropdown-menu">
                   ${instances.map((i) => {
@@ -154,8 +155,7 @@ export function InstructorInstanceAdminLti13({
                           ? 'true'
                           : ''}"
                       >
-                        ${i.lti13_instance.name}:
-                        ${getLti13CourseDisplayName(i.lti13_course_instance)}
+                        ${getLti13ConnectionDisplayName(i)}
                       </a>
                     `;
                   })}
@@ -178,7 +178,7 @@ export function InstructorInstanceAdminLti13({
               instance.lti13_course_instance.lineitems_url
                 ? LinkedAssessments({
                     resLocals,
-                    lms_name,
+                    lmsConnectionName,
                     assessments,
                     lineitems,
                     hasMultipleLmsCourses: instances.length > 1,
@@ -216,13 +216,13 @@ export function InstructorInstanceAdminLti13({
 
 function LinkedAssessments({
   resLocals,
-  lms_name,
+  lmsConnectionName,
   assessments,
   lineitems,
   hasMultipleLmsCourses,
 }: {
   resLocals: ResLocalsForPage<'course-instance'>;
-  lms_name: string;
+  lmsConnectionName: string;
   assessments: AssessmentRow[];
   lineitems: Lti13Assessment[];
   hasMultipleLmsCourses: boolean;
@@ -249,7 +249,7 @@ function LinkedAssessments({
               <form method="POST">
                 <input type="hidden" name="__action" value="poll_lti13_assessments" />
                 <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-                ${lms_name} Assignment
+                ${lmsConnectionName} Assignment
                 <button class="btn btn-success btn-xs">Sync metadata</button>
               </form>
             </th>
@@ -293,7 +293,7 @@ function LinkedAssessments({
                           value="bulk_create_assessments"
                           onclick="return confirm('Are you sure?');"
                         >
-                          Create and link assignments in ${lms_name}
+                          Create and link assignments in ${lmsConnectionName}
                         </button>
                         that aren't already linked.
                         <br />
@@ -346,7 +346,7 @@ function LinkedAssessments({
                     <td>
                       ${Modal({
                         body: html`
-                          <p>Which ${lms_name} assignment should we link?</p>
+                          <p>Which ${lmsConnectionName} assignment should we link?</p>
                           <form method="POST">
                             <input
                               type="hidden"
@@ -375,7 +375,7 @@ function LinkedAssessments({
                               hx-target="next .line-items-inputs"
                               onclick="this.querySelector('.refresh-button').classList.remove('d-none');"
                             >
-                              Pick from existing ${lms_name} assignments
+                              Pick from existing ${lmsConnectionName} assignments
                               <span class="refresh-button d-none"
                                 ><i class="fa fa-refresh"></i
                               ></span>
@@ -391,7 +391,7 @@ function LinkedAssessments({
                           Close
                         </button>`,
                         id: `assignment-${row.id}`,
-                        title: `Configure ${row.title} in ${lms_name}`,
+                        title: `Configure ${row.title} in ${lmsConnectionName}`,
                       })}
 
                       <form method="POST">

--- a/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.ts
+++ b/apps/prairielearn/src/ee/pages/instructorInstanceAdminLti13/instructorInstanceAdminLti13.ts
@@ -26,6 +26,7 @@ import { createServerJob } from '../../../lib/server-jobs.js';
 import { getCanonicalHost } from '../../../lib/url.js';
 import { createAuthzMiddleware } from '../../../middlewares/authzHelper.js';
 import { insertAuditLog } from '../../../models/audit-log.js';
+import { getLti13CourseDisplayName } from '../../lib/lti13-course-instance.js';
 import {
   Lti13CombinedInstanceSchema,
   createAndLinkLineitem,
@@ -351,7 +352,7 @@ router.post(
             errorCount++;
             job.error(
               `Error sending grades to ${targetInstance.lti13_instance.name} course ` +
-                `${targetInstance.lti13_course_instance.context_label}:\n` +
+                `${getLti13CourseDisplayName(targetInstance.lti13_course_instance)}:\n` +
                 error.formatErrorStack(err),
             );
           }


### PR DESCRIPTION
# Description

LTI grade passback currently rejects a Names and Role Provisioning Services (NRPS) response when its `context.id` differs from the `context.id` in the launch. Coursera exposes this mismatch in practice: a launch may use a composite context such as `ondemand~course-id!~session-id`, while the corresponding roster uses `session~session-id`. The membership URL still identifies the correct roster, but PrairieLearn rejects it before attempting grade passback.

That equality check is not required by the specifications. [LTI Core 1.3](https://www.imsglobal.org/spec/lti/v1p3#context-claim) defines the launch context ID as an identifier scoped to the deployment. [NRPS 2.0](https://www.imsglobal.org/spec/lti-nrps/v2p0) separately requires the membership container to include a context ID and says the membership service URL matches the launch context, but it does not require the two ID strings to be identical. This change therefore continues to validate every NRPS response against the membership-container schema but no longer compares its context ID with the launch claim. Pagination remains restricted to the original URL's origin so the bearer token cannot be forwarded elsewhere.

The launch `context.label` and `context.title` fields are both optional. Platforms commonly use a course code or short name for `label` and a full course or section name for `title`, but captured launches also omit them, send an empty label, or use an opaque platform key. Course names in LTI logs and administration pages now use `label || title || id`, preserving the existing short-label preference while avoiding `course null` when the label is absent.

- [x] I have disclosed the level of AI assistance used (the majority of the investigation, implementation, and PR drafting used Codex).

# Testing

The existing NRPS membership parsing and indexing test suite passes after removing the unsupported context-ID rejection. It continues to cover response schema parsing, pagination flattening, status normalization, and duplicate identity handling. This has not been tested against a live Coursera course.
