### PR TITLE
Add Zod helpers for parsing Express requests

### DIFF
--- a/.agents/skills/express-request-validation/SKILL.md
+++ b/.agents/skills/express-request-validation/SKILL.md
@@ -36,7 +36,7 @@ const PostRequestSchemas = {
 
 router.post(
   '/',
-  typedAsyncHandler(async (req, res) => {
+  typedAsyncHandler<'plain'>(async (req, res) => {
     const { params, body } = parseRequest(req, PostRequestSchemas);
     await updateCourse(params.course_id, body.name);
     res.redirect(req.originalUrl);

--- a/.agents/skills/express-request-validation/SKILL.md
+++ b/.agents/skills/express-request-validation/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: express-request-validation
+description: Conventions for validating PrairieLearn Express request parameters, query strings, bodies, and `__action` forms with Zod.
+---
+
+## Request boundaries
+
+- Define request schemas at module scope unless they genuinely depend on request-time values. Prefer a static structural schema followed by a semantic check over constructing a schema per request.
+- Parse every request source a handler consumes before database queries or other work. After parsing, use only the parsed values; do not read the corresponding `req.params`, `req.query`, or `req.body` values again.
+- Use `parseRequest` when validating multiple sources together. Use `parseRequestParams`, `parseRequestQuery`, or `parseRequestBody` when validating only one source.
+- Express cannot verify that a params schema matches the router path. Check the parent mount path as well as the local route and ensure every `ParamsSchema` key matches an actual `:parameter`.
+
+## Schema naming
+
+- Name schemas at the boundary where they are consumed: `PostBodySchema` for `parseRequestBody` and `PostRequestSchemas` for `parseRequest` in a POST handler.
+- Inline a source schema inside `PostRequestSchemas` when it is used only there. Extract `ParamsSchema`, `QuerySchema`, or `PostBodySchema` when the same schema is reused by another handler, parser, inferred type, or composed schema.
+- The combined request schema object is plural because it contains schemas keyed by source.
+- If a file has multiple handlers that would make these names ambiguous, add a concise operation prefix, such as `CreatePostBodySchema` or `ArchivePostRequestSchemas`.
+- For a discriminated union, action-specific branch schemas may use names such as `InviteUidsBodySchema`, while the complete union remains `PostBodySchema`.
+
+## `__action` forms
+
+- Use `__action` only when one POST endpoint genuinely multiplexes multiple operations. A single-operation endpoint should use a plain body schema and a submit button without `name="__action"`.
+- Model a multi-operation body as a top-level `z.discriminatedUnion('__action', ...)`, parse it before dispatch, and switch on the parsed `body.__action`.
+- An unrecognized top-level `__action` discriminator is automatically reported as `unknown __action: <value>` by the request-validation helpers. Other body validation failures remain `Invalid request body`.
+
+## Example
+
+```ts
+const ParamsSchema = z.object({ course_id: IdSchema });
+const PostRequestSchemas = {
+  params: ParamsSchema,
+  body: z.object({ name: z.string().min(1) }),
+};
+
+router.post(
+  '/',
+  typedAsyncHandler(async (req, res) => {
+    const { params, body } = parseRequest(req, PostRequestSchemas);
+    await updateCourse(params.course_id, body.name);
+    res.redirect(req.originalUrl);
+  }),
+);
+```

--- a/.agents/skills/express-request-validation/SKILL.md
+++ b/.agents/skills/express-request-validation/SKILL.md
@@ -7,6 +7,7 @@ description: Conventions for validating PrairieLearn Express request parameters,
 
 - Define request schemas at module scope unless they genuinely depend on request-time values. Prefer a static structural schema followed by a semantic check over constructing a schema per request.
 - Parse every request source a handler consumes before database queries or other work. After parsing, use only the parsed values; do not read the corresponding `req.params`, `req.query`, or `req.body` values again.
+- Treat parsed request objects as boundary data, not as parameter bags. Pass explicit fields to database queries, model functions, and other downstream APIs instead of passing `params`, `query`, or `body` wholesale; this keeps each callsite's contract visible and avoids unused-parameter failures when request schemas grow.
 - Use `parseRequest` when validating multiple sources together. Use `parseRequestParams`, `parseRequestQuery`, or `parseRequestBody` when validating only one source.
 - Express cannot verify that a params schema matches the router path. Check the parent mount path as well as the local route and ensure every `ParamsSchema` key matches an actual `:parameter`.
 

--- a/.changeset/parse-request-path-params.md
+++ b/.changeset/parse-request-path-params.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/zod': minor
+---
+
+Add helpers for parsing and validating Express path parameters or multiple request data sources with Zod, and report unrecognized `__action` discriminators with an action-specific error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,7 @@ When working with assessment "groups" / "teams", see the [`groups-and-teams` ski
 
 - Use `tRPC + @trpc/tanstack-react-query` for new client/server communication. When interacting with existing REST APIs, use `@tanstack/react-query`. See the [`trpc` skill](./.agents/skills/trpc/SKILL.md) for conventions on authorization scopes, file structure, and client-side patterns.
 - Use `react-hook-form` for form handling.
+- Use the [`express-request-validation` skill](./.agents/skills/express-request-validation/SKILL.md) when validating Express request parameters, query strings, or bodies with Zod.
 - Prefer `extractPageContext(res.locals, ...)` over accessing `res.locals` properties directly in route handlers. This provides better type safety and ensures consistent access patterns.
 - Use `nuqs` for URL query state in hydrated components. Use `NuqsAdapter` from `@prairielearn/ui` and pass the search string from the router. See `pages/home/` for an example.
 

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.html.ts
@@ -114,14 +114,7 @@ export function AdministratorInstitutionCourse({
         </div>
 
         <input type="hidden" name="__csrf_token" value="${resLocals.__csrf_token}" />
-        <button
-          type="submit"
-          name="__action"
-          value="update_enrollment_limits"
-          class="btn btn-primary"
-        >
-          Save
-        </button>
+        <button type="submit" class="btn btn-primary">Save</button>
       </form>
 
       <h2 class="h4">Course instances</h2>

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
@@ -42,7 +42,14 @@ router.get(
     const params = parseRequestParams(req, ParamsSchema);
 
     const institution = await getInstitution(params.institution_id);
-    const course = await queryRow(sql.select_course, params, CourseSchema);
+    const course = await queryRow(
+      sql.select_course,
+      {
+        institution_id: params.institution_id,
+        course_id: params.course_id,
+      },
+      CourseSchema,
+    );
     const rows = await queryRows(
       sql.select_course_instances,
       { course_id: course.id },
@@ -63,7 +70,14 @@ router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
     const { params, body } = parseRequest(req, PostRequestSchemas);
-    const course = await queryRow(sql.select_course, params, CourseSchema);
+    const course = await queryRow(
+      sql.select_course,
+      {
+        institution_id: params.institution_id,
+        course_id: params.course_id,
+      },
+      CourseSchema,
+    );
 
     await runInTransactionAsync(async () => {
       const updatedCourse = await queryRow(

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
@@ -2,7 +2,12 @@ import { Router } from 'express';
 import { z } from 'zod';
 
 import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
-import { IdSchema, parseRequest, parseRequestParams } from '@prairielearn/zod';
+import {
+  IdSchema,
+  IntegerFromStringOrEmptySchema,
+  parseRequest,
+  parseRequestParams,
+} from '@prairielearn/zod';
 
 import { CourseSchema } from '../../../lib/db-types.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
@@ -25,14 +30,8 @@ const ParamsSchema = z.object({
 const PostRequestSchemas = {
   params: ParamsSchema,
   body: z.object({
-    yearly_enrollment_limit: z.union([
-      z.literal('').transform(() => null),
-      z.coerce.number().int(),
-    ]),
-    course_instance_enrollment_limit: z.union([
-      z.literal('').transform(() => null),
-      z.coerce.number().int(),
-    ]),
+    yearly_enrollment_limit: IntegerFromStringOrEmptySchema,
+    course_instance_enrollment_limit: IntegerFromStringOrEmptySchema,
   }),
 };
 

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
@@ -1,9 +1,8 @@
 import { Router } from 'express';
 import { z } from 'zod';
 
-import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
-import { IdSchema, parseRequest } from '@prairielearn/zod';
+import { IdSchema, parseRequest, parseRequestParams } from '@prairielearn/zod';
 
 import { CourseSchema } from '../../../lib/db-types.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
@@ -18,13 +17,14 @@ import {
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });
 
-const UpdateEnrollmentLimitsRequestSchemas = {
-  params: z.object({
-    institution_id: IdSchema,
-    course_id: IdSchema,
-  }),
+const ParamsSchema = z.object({
+  institution_id: IdSchema,
+  course_id: IdSchema,
+});
+
+const PostRequestSchemas = {
+  params: ParamsSchema,
   body: z.object({
-    __action: z.literal('update_enrollment_limits'),
     yearly_enrollment_limit: z.union([
       z.literal('').transform(() => null),
       z.coerce.number().int(),
@@ -39,15 +39,10 @@ const UpdateEnrollmentLimitsRequestSchemas = {
 router.get(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const institution = await getInstitution(req.params.institution_id);
-    const course = await queryRow(
-      sql.select_course,
-      {
-        institution_id: req.params.institution_id,
-        course_id: req.params.course_id,
-      },
-      CourseSchema,
-    );
+    const params = parseRequestParams(req, ParamsSchema);
+
+    const institution = await getInstitution(params.institution_id);
+    const course = await queryRow(sql.select_course, params, CourseSchema);
     const rows = await queryRows(
       sql.select_course_instances,
       { course_id: course.id },
@@ -67,36 +62,32 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    if (req.body.__action === 'update_enrollment_limits') {
-      const { params, body } = parseRequest(req, UpdateEnrollmentLimitsRequestSchemas);
-      const course = await queryRow(sql.select_course, params, CourseSchema);
+    const { params, body } = parseRequest(req, PostRequestSchemas);
+    const course = await queryRow(sql.select_course, params, CourseSchema);
 
-      await runInTransactionAsync(async () => {
-        const updatedCourse = await queryRow(
-          sql.update_enrollment_limits,
-          {
-            course_id: course.id,
-            yearly_enrollment_limit: body.yearly_enrollment_limit,
-            course_instance_enrollment_limit: body.course_instance_enrollment_limit,
-          },
-          CourseSchema,
-        );
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        await insertAuditLog({
-          authn_user_id: res.locals.authn_user.id,
-          table_name: 'courses',
-          action: 'update',
-          institution_id: params.institution_id,
-          course_id: params.course_id,
-          old_state: course,
-          new_state: updatedCourse,
-          row_id: params.course_id,
-        });
+    await runInTransactionAsync(async () => {
+      const updatedCourse = await queryRow(
+        sql.update_enrollment_limits,
+        {
+          course_id: course.id,
+          yearly_enrollment_limit: body.yearly_enrollment_limit,
+          course_instance_enrollment_limit: body.course_instance_enrollment_limit,
+        },
+        CourseSchema,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      await insertAuditLog({
+        authn_user_id: res.locals.authn_user.id,
+        table_name: 'courses',
+        action: 'update',
+        institution_id: params.institution_id,
+        course_id: params.course_id,
+        old_state: course,
+        new_state: updatedCourse,
+        row_id: params.course_id,
       });
-      res.redirect(req.originalUrl);
-    } else {
-      throw new error.HttpStatusError(400, `Unknown action: ${req.body.__action}`);
-    }
+    });
+    res.redirect(req.originalUrl);
   }),
 );
 

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionCourse/administratorInstitutionCourse.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import * as error from '@prairielearn/error';
 import { loadSqlEquiv, queryRow, queryRows, runInTransactionAsync } from '@prairielearn/postgres';
-import { parseRequestBody } from '@prairielearn/zod';
+import { IdSchema, parseRequest } from '@prairielearn/zod';
 
 import { CourseSchema } from '../../../lib/db-types.js';
 import { typedAsyncHandler } from '../../../lib/res-locals.js';
@@ -17,6 +17,24 @@ import {
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });
+
+const UpdateEnrollmentLimitsRequestSchemas = {
+  params: z.object({
+    institution_id: IdSchema,
+    course_id: IdSchema,
+  }),
+  body: z.object({
+    __action: z.literal('update_enrollment_limits'),
+    yearly_enrollment_limit: z.union([
+      z.literal('').transform(() => null),
+      z.coerce.number().int(),
+    ]),
+    course_instance_enrollment_limit: z.union([
+      z.literal('').transform(() => null),
+      z.coerce.number().int(),
+    ]),
+  }),
+};
 
 router.get(
   '/',
@@ -49,30 +67,10 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const course = await queryRow(
-      sql.select_course,
-      {
-        institution_id: req.params.institution_id,
-        course_id: req.params.course_id,
-      },
-      CourseSchema,
-    );
-
     if (req.body.__action === 'update_enrollment_limits') {
-      const body = parseRequestBody(
-        req,
-        z.object({
-          __action: z.literal('update_enrollment_limits'),
-          yearly_enrollment_limit: z.union([
-            z.literal('').transform(() => null),
-            z.coerce.number().int(),
-          ]),
-          course_instance_enrollment_limit: z.union([
-            z.literal('').transform(() => null),
-            z.coerce.number().int(),
-          ]),
-        }),
-      );
+      const { params, body } = parseRequest(req, UpdateEnrollmentLimitsRequestSchemas);
+      const course = await queryRow(sql.select_course, params, CourseSchema);
+
       await runInTransactionAsync(async () => {
         const updatedCourse = await queryRow(
           sql.update_enrollment_limits,
@@ -88,11 +86,11 @@ router.post(
           authn_user_id: res.locals.authn_user.id,
           table_name: 'courses',
           action: 'update',
-          institution_id: req.params.institution_id,
-          course_id: req.params.course_id,
+          institution_id: params.institution_id,
+          course_id: params.course_id,
           old_state: course,
           new_state: updatedCourse,
-          row_id: req.params.course_id,
+          row_id: params.course_id,
         });
       });
       res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.tsx
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.tsx
@@ -3,7 +3,12 @@ import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import { Hydrate } from '@prairielearn/react/server';
-import { ArrayFromCheckboxSchema, IdSchema, parseRequest } from '@prairielearn/zod';
+import {
+  ArrayFromCheckboxSchema,
+  IdSchema,
+  parseRequest,
+  parseRequestParams,
+} from '@prairielearn/zod';
 
 import { PageLayout } from '../../../components/PageLayout.js';
 import { getSupportedAuthenticationProviders } from '../../../lib/authn-providers.js';
@@ -24,8 +29,10 @@ import { AdministratorInstitutionSsoForm } from './components/AdministratorInsti
 
 const router = Router({ mergeParams: true });
 
-const UpdateInstitutionSsoRequestSchemas = {
-  params: z.object({ institution_id: IdSchema }),
+const ParamsSchema = z.object({ institution_id: IdSchema });
+
+const PostRequestSchemas = {
+  params: ParamsSchema,
   body: z.object({
     default_authn_provider_id: z.string().transform((s) => (s === '' ? null : s)),
     enabled_authn_provider_ids: ArrayFromCheckboxSchema,
@@ -35,12 +42,12 @@ const UpdateInstitutionSsoRequestSchemas = {
 router.post(
   '/',
   asyncHandler(async (req, res) => {
+    const { params, body } = parseRequest(req, PostRequestSchemas);
+
     const supportedAuthenticationProviders = await getSupportedAuthenticationProviders();
     const supportedAuthenticationProviderIds = new Set(
       supportedAuthenticationProviders.map((p) => p.id),
     );
-
-    const { params, body } = parseRequest(req, UpdateInstitutionSsoRequestSchemas);
 
     const enabledProviders = body.enabled_authn_provider_ids.filter((id) =>
       supportedAuthenticationProviderIds.has(id),
@@ -60,16 +67,16 @@ router.post(
 router.get(
   '/',
   asyncHandler(async (req, res) => {
+    const { institution_id } = parseRequestParams(req, ParamsSchema);
+
     const supportedAuthenticationProviders = await getSupportedAuthenticationProviders();
 
-    const institution = await getInstitution(req.params.institution_id);
-    const institutionSamlProvider = await getInstitutionSamlProvider(req.params.institution_id);
-    const institutionAuthenticationProviders = await getInstitutionAuthenticationProviders(
-      req.params.institution_id,
-    );
-    const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
-      req.params.institution_id,
-    );
+    const institution = await getInstitution(institution_id);
+    const institutionSamlProvider = await getInstitutionSamlProvider(institution_id);
+    const institutionAuthenticationProviders =
+      await getInstitutionAuthenticationProviders(institution_id);
+    const identityConfigurationStatus =
+      await selectInstitutionIdentityConfigurationStatus(institution_id);
 
     const pageContext = extractPageContext(res.locals, {
       pageType: 'plain',

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.tsx
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSso/administratorInstitutionSso.tsx
@@ -3,7 +3,7 @@ import asyncHandler from 'express-async-handler';
 import { z } from 'zod';
 
 import { Hydrate } from '@prairielearn/react/server';
-import { ArrayFromCheckboxSchema, parseRequestBody } from '@prairielearn/zod';
+import { ArrayFromCheckboxSchema, IdSchema, parseRequest } from '@prairielearn/zod';
 
 import { PageLayout } from '../../../components/PageLayout.js';
 import { getSupportedAuthenticationProviders } from '../../../lib/authn-providers.js';
@@ -24,6 +24,14 @@ import { AdministratorInstitutionSsoForm } from './components/AdministratorInsti
 
 const router = Router({ mergeParams: true });
 
+const UpdateInstitutionSsoRequestSchemas = {
+  params: z.object({ institution_id: IdSchema }),
+  body: z.object({
+    default_authn_provider_id: z.string().transform((s) => (s === '' ? null : s)),
+    enabled_authn_provider_ids: ArrayFromCheckboxSchema,
+  }),
+};
+
 router.post(
   '/',
   asyncHandler(async (req, res) => {
@@ -32,20 +40,14 @@ router.post(
       supportedAuthenticationProviders.map((p) => p.id),
     );
 
-    const body = parseRequestBody(
-      req,
-      z.object({
-        default_authn_provider_id: z.string().transform((s) => (s === '' ? null : s)),
-        enabled_authn_provider_ids: ArrayFromCheckboxSchema,
-      }),
-    );
+    const { params, body } = parseRequest(req, UpdateInstitutionSsoRequestSchemas);
 
     const enabledProviders = body.enabled_authn_provider_ids.filter((id) =>
       supportedAuthenticationProviderIds.has(id),
     );
 
     await updateInstitutionAuthnProviders({
-      institution_id: req.params.institution_id,
+      institution_id: params.institution_id,
       enabled_authn_provider_ids: enabledProviders,
       default_authn_provider_id: body.default_authn_provider_id,
       authn_user_id: res.locals.authn_user.id.toString(),

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -38,6 +38,14 @@ import { InstructorHomePageCourseSchema, StudentHomePageCourseSchema } from './h
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
 
+const PostBodySchema = z.discriminatedUnion('__action', [
+  z.object({ __action: z.literal('dismiss_news_alert') }),
+  z.object({
+    __action: z.enum(['accept_invitation', 'reject_invitation', 'unenroll']),
+    course_instance_id: z.string().min(1),
+  }),
+]);
+
 router.get(
   '/',
   typedAsyncHandler<'plain', { navPage: 'home' }>(async (req, res) => {
@@ -184,14 +192,7 @@ router.post(
       withAuthzData: false,
     });
 
-    const BodySchema = z.discriminatedUnion('__action', [
-      z.object({ __action: z.literal('dismiss_news_alert') }),
-      z.object({
-        __action: z.enum(['accept_invitation', 'reject_invitation', 'unenroll']),
-        course_instance_id: z.string().min(1),
-      }),
-    ]);
-    const body = parseRequestBody(req, BodySchema);
+    const body = parseRequestBody(req, PostBodySchema);
 
     if (body.__action === 'dismiss_news_alert') {
       await markNewsItemsAsReadForUser(res.locals.authn_user);

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -184,6 +184,8 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
+    const body = parseRequestBody(req, PostBodySchema);
+
     const {
       authn_user: { uid },
     } = extractPageContext(res.locals, {
@@ -191,8 +193,6 @@ router.post(
       accessType: 'student',
       withAuthzData: false,
     });
-
-    const body = parseRequestBody(req, PostBodySchema);
 
     if (body.__action === 'dismiss_news_alert') {
       await markNewsItemsAsReadForUser(res.locals.authn_user);

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -4,6 +4,33 @@ Useful Zod schemas.
 
 ## Usage
 
+### Express request validation
+
+Use `parseRequest` to validate any combination of Express path parameters, query parameters, and request body. Request schemas that do not depend on request-time values should be defined at module scope so their Zod instances are reused.
+
+```ts
+import { z } from 'zod';
+
+import { IdSchema, parseRequest } from '@prairielearn/zod';
+
+const PostRequestSchemas = {
+  params: z.object({ course_id: IdSchema }),
+  body: z.discriminatedUnion('__action', [
+    z.object({
+      __action: z.literal('rename'),
+      name: z.string().min(1),
+    }),
+    z.object({ __action: z.literal('delete') }),
+  ]),
+};
+
+const { params, body } = parseRequest(req, PostRequestSchemas);
+```
+
+Validation failures throw a `400` `HttpStatusError` with a source-specific message. An unrecognized discriminator in a top-level `z.discriminatedUnion('__action', ...)` body schema is reported as `unknown __action: <value>`; other body failures are reported as `Invalid request body`.
+
+Use `parseRequestParams`, `parseRequestQuery`, or `parseRequestBody` when validating a single request data source.
+
 ### `BooleanFromCheckboxSchema`
 
 ```ts

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,7 +1,12 @@
 import parsePostgresInterval from 'postgres-interval';
 import { type ZodType, z } from 'zod';
 
-export { parseRequestBody, parseRequestQuery } from './request-validation.js';
+export {
+  parseRequest,
+  parseRequestBody,
+  parseRequestParams,
+  parseRequestQuery,
+} from './request-validation.js';
 
 const INTERVAL_MS_PER_SECOND = 1000;
 const INTERVAL_MS_PER_MINUTE = 60 * INTERVAL_MS_PER_SECOND;

--- a/packages/zod/src/request-validation.test.ts
+++ b/packages/zod/src/request-validation.test.ts
@@ -1,11 +1,53 @@
-import { assert, describe, it } from 'vitest';
+import { assert, describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod';
 
 import { HttpStatusError } from '@prairielearn/error';
 
-import { parseRequestBody, parseRequestQuery } from './index.js';
+import { parseRequest, parseRequestBody, parseRequestParams, parseRequestQuery } from './index.js';
 
 describe('request validation', () => {
+  it('parses request data by source', () => {
+    const result = parseRequest(
+      {
+        params: { course_id: '123' },
+        query: { page: '2' },
+        body: { enabled: 'true' },
+      },
+      {
+        params: z.object({ course_id: z.coerce.number().int() }),
+        query: z.object({ page: z.coerce.number().int() }),
+        body: z.object({
+          enabled: z.enum(['true', 'false']).transform((value) => value === 'true'),
+        }),
+      },
+    );
+
+    expectTypeOf(result).toEqualTypeOf<{
+      params: { course_id: number };
+      query: { page: number };
+      body: { enabled: boolean };
+    }>();
+    assert.deepEqual(result, {
+      params: { course_id: 123 },
+      query: { page: 2 },
+      body: { enabled: true },
+    });
+  });
+
+  it('preserves source-specific errors when parsing request data', () => {
+    const error = assert.throws(() =>
+      parseRequest(
+        { params: {}, query: {}, body: { name: 1 } },
+        { body: z.object({ name: z.string() }) },
+      ),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'Invalid request body');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+
   it('parses and transforms query parameters', () => {
     const result = parseRequestQuery(
       { query: { page: '2' } },
@@ -26,6 +68,29 @@ describe('request validation', () => {
     assert.instanceOf(error.cause, z.ZodError);
   });
 
+  it('parses and transforms path parameters', () => {
+    const result = parseRequestParams(
+      { params: { course_id: '123' } },
+      z.object({ course_id: z.coerce.number().int() }),
+    );
+
+    assert.deepEqual(result, { course_id: 123 });
+  });
+
+  it('throws a 400 error for invalid path parameters', () => {
+    const error = assert.throws(() =>
+      parseRequestParams(
+        { params: { course_id: 'invalid' } },
+        z.object({ course_id: z.coerce.number() }),
+      ),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'Invalid path parameters');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+
   it('throws a 400 error for an invalid request body', () => {
     const error = assert.throws(() =>
       parseRequestBody({ body: { name: 1 } }, z.object({ name: z.string() })),
@@ -34,6 +99,23 @@ describe('request validation', () => {
     assert.instanceOf(error, HttpStatusError);
     assert.equal(error.status, 400);
     assert.equal(error.message, 'Invalid request body');
+    assert.instanceOf(error.cause, z.ZodError);
+  });
+
+  it('throws an action-specific error for an unrecognized __action', () => {
+    const error = assert.throws(() =>
+      parseRequestBody(
+        { body: { __action: 'archive' } },
+        z.discriminatedUnion('__action', [
+          z.object({ __action: z.literal('create') }),
+          z.object({ __action: z.literal('update') }),
+        ]),
+      ),
+    );
+
+    assert.instanceOf(error, HttpStatusError);
+    assert.equal(error.status, 400);
+    assert.equal(error.message, 'unknown __action: archive');
     assert.instanceOf(error.cause, z.ZodError);
   });
 });

--- a/packages/zod/src/request-validation.ts
+++ b/packages/zod/src/request-validation.ts
@@ -28,8 +28,7 @@ function getRequestValidationErrorMessage(
       if (
         issue.code === 'invalid_union' &&
         issue.discriminator === '__action' &&
-        issue.path.length === 1 &&
-        issue.path[0] === issue.discriminator
+        issue.path.length === 1
       ) {
         const value =
           typeof data === 'object' && data !== null

--- a/packages/zod/src/request-validation.ts
+++ b/packages/zod/src/request-validation.ts
@@ -1,26 +1,85 @@
-import { type ZodType, type output } from 'zod';
+import { type ZodError, type ZodType, type output } from 'zod';
 
 import { HttpStatusError } from '@prairielearn/error';
 
 const REQUEST_VALIDATION_ERROR_MESSAGES = {
   body: 'Invalid request body',
+  params: 'Invalid path parameters',
   query: 'Invalid query parameters',
 } as const;
 
+type RequestSource = keyof typeof REQUEST_VALIDATION_ERROR_MESSAGES;
+type RequestSchemas = Partial<Record<RequestSource, ZodType>>;
+type ParsedRequest<Schemas extends RequestSchemas> = {
+  [Source in keyof Schemas]: output<Extract<Schemas[Source], ZodType>>;
+};
+type ExactRequestSchemas<Schemas extends RequestSchemas> = Schemas &
+  Record<Exclude<keyof Schemas, RequestSource>, never>;
+
+function getRequestValidationErrorMessage(
+  source: RequestSource,
+  data: unknown,
+  error: ZodError,
+): string {
+  if (source === 'body') {
+    for (const issue of error.issues) {
+      // Keep PrairieLearn's established `unknown __action` response while leaving
+      // other body validation failures generic.
+      if (
+        issue.code === 'invalid_union' &&
+        issue.discriminator === '__action' &&
+        issue.path.length === 1 &&
+        issue.path[0] === issue.discriminator
+      ) {
+        const value =
+          typeof data === 'object' && data !== null
+            ? Reflect.get(data, issue.discriminator)
+            : undefined;
+        return `unknown ${issue.discriminator}: ${String(value)}`;
+      }
+    }
+  }
+
+  return REQUEST_VALIDATION_ERROR_MESSAGES[source];
+}
+
 function parseRequestData<Schema extends ZodType>(
-  source: keyof typeof REQUEST_VALIDATION_ERROR_MESSAGES,
+  source: RequestSource,
   data: unknown,
   schema: Schema,
 ): output<Schema> {
   const result = schema.safeParse(data);
   if (!result.success) {
-    throw new HttpStatusError(400, REQUEST_VALIDATION_ERROR_MESSAGES[source], {
+    throw new HttpStatusError(400, getRequestValidationErrorMessage(source, data, result.error), {
       cause: result.error,
     });
   }
   return result.data;
 }
 
+/**
+ * Parses each request data source for which a schema is provided.
+ *
+ * An unrecognized discriminator in a top-level `__action` body union is reported
+ * as `unknown __action: <value>`.
+ */
+export function parseRequest<Schemas extends RequestSchemas>(
+  req: Record<RequestSource, unknown>,
+  schemas: ExactRequestSchemas<Schemas>,
+): ParsedRequest<Schemas> {
+  const result: Partial<Record<RequestSource, unknown>> = {};
+
+  for (const source of ['params', 'query', 'body'] as const) {
+    const schema = schemas[source];
+    if (schema !== undefined) {
+      result[source] = parseRequestData(source, req[source], schema);
+    }
+  }
+
+  return result as ParsedRequest<Schemas>;
+}
+
+/** Parses and validates an Express request's query parameters. */
 export function parseRequestQuery<Schema extends ZodType>(
   req: { query: unknown },
   schema: Schema,
@@ -28,6 +87,20 @@ export function parseRequestQuery<Schema extends ZodType>(
   return parseRequestData('query', req.query, schema);
 }
 
+/** Parses and validates an Express request's path parameters. */
+export function parseRequestParams<Schema extends ZodType>(
+  req: { params: unknown },
+  schema: Schema,
+): output<Schema> {
+  return parseRequestData('params', req.params, schema);
+}
+
+/**
+ * Parses and validates an Express request body.
+ *
+ * An unrecognized discriminator in a top-level `__action` union is reported as
+ * `unknown __action: <value>`.
+ */
 export function parseRequestBody<Schema extends ZodType>(
   req: { body: unknown },
   schema: Schema,


### PR DESCRIPTION
# Description

Add `parseRequestParams` and `parseRequest` to `@prairielearn/zod` so Express handlers can validate path parameters alongside query parameters and request bodies while preserving each schema's inferred output type.

Validation failures now produce source-specific `400` errors and retain the original `ZodError` as the cause. A top-level discriminated union on `__action` preserves PrairieLearn's established `unknown __action: <value>` error for unrecognized actions.

Update two institution administration routes to validate their path parameters and bodies together, and define static request schemas at module scope so their Zod instances are reused. The home page's existing action schema is also moved to module scope.

Document the request-validation helpers and include a changeset for the public package.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: The majority of the implementation and PR description were produced with Codex, with iterative design direction and review from the author.

# Testing

- Added focused unit coverage for combined request-source parsing, transformed path parameters, source-specific validation errors, and unrecognized `__action` discriminators.
