### PR TITLE
Update example PDF upload questions to allow any file name

### DIFF
--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -181,7 +181,7 @@
           );
           if (regexMatch) {
             this.addWarningMessage(
-              `A file with pattern <strong>${escapeFileName(regexMatch[1])}</strong> is already provided with a different file name. To replace it with <strong>${escapeFileName(file.name)}</strong>, delete the existing file first and then upload the new file.`,
+              `A file with pattern <strong>${escapeFileName(regexMatch[1])}</strong> is already provided. To replace it with <strong>${escapeFileName(file.name)}</strong>, delete the existing file first and then upload the new file.`,
             );
           } else {
             this.addWarningMessage(

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -175,9 +175,19 @@
         const acceptedFileName = this.findAcceptedFileName(fileNameLowerCase);
 
         if (acceptedFileName === null) {
-          this.addWarningMessage(
-            `<strong>${escapeFileName(file.name)}</strong> did not match any accepted file for this question.`,
+          // If the file matches a required regex, we show a different message, as the user may be attempting to replace an existing file with a different name.
+          const regexMatch = this.requiredFilesRegex.find((f) =>
+            new RegExp(f[0], 'i').test(fileNameLowerCase),
           );
+          if (regexMatch) {
+            this.addWarningMessage(
+              `A file with pattern <strong>${escapeFileName(regexMatch[1])}</strong> is already provided with a different file name. To replace it with <strong>${escapeFileName(file.name)}</strong>, delete the existing file first and then upload the new file.`,
+            );
+          } else {
+            this.addWarningMessage(
+              `<strong>${escapeFileName(file.name)}</strong> did not match any accepted file for this question.`,
+            );
+          }
           continue;
         }
 

--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -35,6 +35,8 @@
       // Checks whether a file name is acceptable
       // If yes, it returns the canonical name of the file, if not, it returns null
       // Note the priority order: first, fill required file names, then required patterns, then optional names, then optional patterns
+      // We finish by checking if an existing file already matches the name.
+      // This allows a file pattern already covered to be replaced with another file with the same name, presuming the file is acceptable if already submitted.
       this.findAcceptedFileName = (fileName) => {
         if (this.requiredFilesLowerCase.includes(fileName)) {
           return this.requiredFiles[this.requiredFilesLowerCase.indexOf(fileName)];
@@ -48,6 +50,8 @@
         if (this.optionalFilesRegex.some((f) => new RegExp(f[0], 'i').test(fileName))) {
           return fileName;
         }
+        const existingFile = this.files.find((f) => f.name.toLowerCase() === fileName);
+        if (existingFile) return existingFile.name;
         return null;
       };
 

--- a/exampleCourse/questions/demo/fileDownloadUpload/question.html
+++ b/exampleCourse/questions/demo/fileDownloadUpload/question.html
@@ -6,10 +6,10 @@
 
   <p>Open the file <pl-file-download file-name="Prompt.pdf" directory="clientFilesQuestion"></pl-file-download> which contains the problem statement.</p>
 
-  <p>Construct your solution, scan it, save the file as <strong>ProblemSolution.pdf</strong>, and upload the file below.
+  <p>Construct your solution, scan it, save the file as a PDF file, and upload the file below.
      Your solution will be later manually graded by a course staff. </p>
 
-  <pl-file-upload file-names="ProblemSolution.pdf"></pl-file-upload>
+  <pl-file-upload file-patterns="*.pdf"></pl-file-upload>
 
 
 </pl-question-panel>

--- a/exampleCourse/questions/template/file-upload/fixed/question.html
+++ b/exampleCourse/questions/template/file-upload/fixed/question.html
@@ -3,7 +3,7 @@
   <p>Prove that the square root of 2 is irrational.</p>
 </pl-question-panel>
 
-<pl-file-upload file-names="proof.pdf"></pl-file-upload>
+<pl-file-upload file-patterns="*.pdf"></pl-file-upload>
 
 <pl-submission-panel>
   <pl-file-preview></pl-file-preview>


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

#10317 introduced support for pl-file-upload elements with flexible file names. This allows questions to give students flexibility in the name of the file they upload. This is particularly useful in non-code uploads, like PDFs, since there is no expectation that the file have a particular name for most common reasons.

This PR changes two example course questions that expect a PDF upload for submission, so that they accept any PDF file as input. This is done to encourage instructors to accept any file name when using these questions as templates.

The PR also updates the error message shown if a user uploads a new file name for the same required pattern. Currently the message is a generic "did not match any accepted file", which can be confusing in the particular case where there is a match but the pattern is already covered. This is changed to a more targeted message for this particular case. This is not a problem for file names (since they are replaced) or for optional file patterns (since these patterns accept multiple uploads).

It also accepts replacing pattern-based files that already exists with another file with the same name. These are already supported for non-pattern names or for optional patterns.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: IDE auto-complete.

# Testing

Tested locally, these questions now accept PDF files with any name. The warning now also provides a targeted message in the changed questions if a PDF with a different name is provided, and the original error message for non-PDF uploads.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
