### PR TITLE
Add experimental local agent MCP server

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -72,6 +72,10 @@ module.exports = {
           '.(spec|test).(js|jsx|mjs|cjs|ts|tsx|ls|coffee|litcoffee|coffee.md)$',
           'src/tests/',
           'src/ee/tests/',
+          // The agent MCP server is a local development tool. Its SDK is
+          // deliberately a devDependency so it never ships to production.
+          'src/mcp/',
+          'src/mcp-server[.]ts$',
           '[.]d[.]ts$',
           'test-utils[.]ts$',
         ],

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -12,6 +12,10 @@
     "dev:bun": "bun --watch src/server.ts",
     "dev:no-watch": "tsx --tsconfig src/tsconfig.json src/server.ts",
     "dev:vite": "vite --port 3000 --host",
+    "mcp": "tsx --tsconfig src/tsconfig.json src/mcp-server.ts",
+    "mcp:create-scratch-course": "tsx --tsconfig src/tsconfig.json src/mcp/scripts/create-scratch-course.ts",
+    "mcp:loop-test": "tsx --tsconfig src/tsconfig.json src/mcp/scripts/loop-test.ts",
+    "mcp:smoke-test": "tsx --tsconfig src/tsconfig.json src/mcp/scripts/smoke-test.ts",
     "start": "node dist/server.js",
     "start-executor": "node dist/executor.js",
     "test": "vitest run --coverage",
@@ -265,6 +269,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@playwright/test": "^1.62.1",
     "@prairielearn/express-list-endpoints": "workspace:^",
     "@prairielearn/tsconfig": "workspace:^",

--- a/apps/prairielearn/src/lib/question-testing.sql
+++ b/apps/prairielearn/src/lib/question-testing.sql
@@ -5,3 +5,15 @@ FROM
   issues AS i
 WHERE
   i.variant_id = $variant_id;
+
+-- BLOCK select_issues_for_variant
+SELECT
+  i.student_message,
+  i.instructor_message,
+  i.system_data #>> '{courseErrData,outputBoth}' AS output
+FROM
+  issues AS i
+WHERE
+  i.variant_id = $variant_id
+ORDER BY
+  i.id;

--- a/apps/prairielearn/src/lib/question-testing.test.ts
+++ b/apps/prairielearn/src/lib/question-testing.test.ts
@@ -1,0 +1,54 @@
+import { assert, describe, it } from 'vitest';
+
+import { buildVariantSeed } from './question-testing.js';
+
+describe('buildVariantSeed', () => {
+  /**
+   * Seeds reach Python through `Number.parseInt(seed, 36)`, so the properties
+   * that matter are about the parsed number, not the string.
+   */
+  function numericSeeds(prefix: string, count: number) {
+    return Array.from({ length: count }, (_, iter) =>
+      Number.parseInt(buildVariantSeed(prefix, iter), 36),
+    );
+  }
+
+  const PREFIXES = ['smoke', 'loop-broken', 'loopgood', '---', '', 'Loop-Broken!', 'abcdefghij'];
+
+  it('round-trips exactly through parseInt', () => {
+    for (const prefix of PREFIXES) {
+      for (let iter = 0; iter < 20; iter++) {
+        const seed = buildVariantSeed(prefix, iter);
+        assert.equal(Number.parseInt(seed, 36).toString(36), seed);
+      }
+    }
+  });
+
+  it('produces distinct numeric seeds for each iteration', () => {
+    for (const prefix of PREFIXES) {
+      const seeds = numericSeeds(prefix, 300);
+      assert.equal(new Set(seeds).size, seeds.length, `collision for prefix "${prefix}"`);
+    }
+  });
+
+  it('stays within the range numpy accepts for a seed', () => {
+    // `np.random.seed` throws outside [0, 2**32 - 1], which kills the worker.
+    for (const prefix of PREFIXES) {
+      for (const seed of numericSeeds(prefix, 300)) {
+        assert.isTrue(Number.isInteger(seed) && seed >= 0 && seed <= 2 ** 32 - 1, `${seed}`);
+      }
+    }
+  });
+
+  it('only emits base-36 characters', () => {
+    assert.match(buildVariantSeed('Loop-Broken!', 41), /^[0-9a-z]+$/);
+  });
+
+  it('is deterministic', () => {
+    assert.equal(buildVariantSeed('loop-broken', 7), buildVariantSeed('loop-broken', 7));
+  });
+
+  it('distinguishes different prefixes', () => {
+    assert.notEqual(buildVariantSeed('alpha', 0), buildVariantSeed('beta', 0));
+  });
+});

--- a/apps/prairielearn/src/lib/question-testing.ts
+++ b/apps/prairielearn/src/lib/question-testing.ts
@@ -21,7 +21,7 @@ import { gradeVariant, saveSubmission } from './grading.js';
 import { writeCourseIssues } from './issues.js';
 import { getAndRenderVariant } from './question-render.js';
 import { ensureVariant, getQuestionCourse } from './question-variant.js';
-import { type ServerJob, createServerJob } from './server-jobs.js';
+import { type ServerJobLogger, createServerJob } from './server-jobs.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
 
@@ -151,6 +151,43 @@ interface TestQuestionResults {
 
 export const TEST_TYPES = ['correct', 'incorrect', 'invalid'] as const;
 export type TestType = (typeof TEST_TYPES)[number];
+
+/**
+ * Upper bound on a variant seed's numeric value. `zygote.py` passes the seed to
+ * `np.random.seed()`, which rejects anything outside `[0, 2**32 - 1]`; exceeding
+ * it kills the Python worker rather than producing a useful error.
+ */
+const MAX_VARIANT_SEED = 2 ** 32 - 1;
+
+/** 32-bit FNV-1a. Deterministic across processes, unlike `Math.random`. */
+function hash32(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    // `Math.imul` keeps the multiply in 32-bit range.
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Builds a deterministic variant seed for a test iteration.
+ *
+ * Two constraints make this less obvious than it looks. Seeds reach Python via
+ * `Number.parseInt(variant_seed, 36)`, so any character outside `[0-9a-z]`
+ * terminates the parse — meaning a naive `${prefix}-${iteration}` collapses every
+ * iteration onto the same numeric seed and silently reduces a multi-variant run
+ * to repeated tests of one variant. And the parsed value must stay within
+ * {@link MAX_VARIANT_SEED} or the Python worker dies.
+ *
+ * So we hash the prefix into a 32-bit value, offset it by the iteration, and
+ * render the result in base 36. That round-trips exactly through `parseInt`,
+ * varies per iteration, and is always in range.
+ */
+export function buildVariantSeed(prefix: string, iteration: number): string {
+  const seed = (hash32(prefix) + iteration) % (MAX_VARIANT_SEED + 1);
+  return seed.toString(36);
+}
 
 export function questionSupportsTesting(question: Question): boolean {
   return questionServers.getModule(question.type).test != null;
@@ -508,8 +545,8 @@ async function runTest({
   authn_user_id,
   variant_seed,
 }: {
-  /** The server job to run within. */
-  logger: ServerJob;
+  /** Receives progress output. A `ServerJob` satisfies this. */
+  logger: ServerJobLogger;
   /** Whether to display test data details. */
   showDetails: boolean;
   /** The question for the variant. */
@@ -526,7 +563,7 @@ async function runTest({
   authn_user_id: string;
   /** Optional seed for the variant. */
   variant_seed?: string;
-}): Promise<{ success: boolean; stats: TestResultStats }> {
+}): Promise<{ success: boolean; stats: TestResultStats; variant: Variant; issueCount: number }> {
   logger.verbose('Testing ' + question.qid);
   const { variant, expectedTestData, submission, stats } = await testQuestion({
     question,
@@ -585,7 +622,106 @@ async function runTest({
     logger.verbose('Success: no issues during test');
   }
 
-  return { success: issueCount === 0, stats };
+  return { success: issueCount === 0, stats, variant, issueCount };
+}
+
+/** A single test iteration, as returned by {@link runQuestionTests}. */
+export interface QuestionTestResult {
+  testType: TestType;
+  /** The seed used, so a failure can be reproduced exactly. */
+  variantSeed: string;
+  success: boolean;
+  /** Generated parameters for this variant. */
+  params: Record<string, any> | null;
+  /** The correct answer for this variant. */
+  trueAnswer: Record<string, any> | null;
+  /** Set when the question's code raised during generate, render, or grade. */
+  brokenAt: Date | null;
+  issues: {
+    studentMessage: string | null;
+    instructorMessage: string | null;
+    /** Combined stdout/stderr from the failing Python code, when available. */
+    output: string | null;
+  }[];
+  durations: TestResultStats;
+}
+
+/**
+ * Runs a question's test cycle and returns structured results, rather than
+ * writing them to a server job's log. Intended for programmatic callers that
+ * need to act on the outcome — see `src/mcp/tools/test-question.ts`.
+ *
+ * Like {@link startTestQuestion}, this runs each of `correct`, `incorrect`, and
+ * `invalid` `count` times, and inserts issues into the `issues` table.
+ */
+export async function runQuestionTests({
+  question,
+  course,
+  course_instance = null,
+  count,
+  user_id,
+  authn_user_id,
+  variantSeedPrefix,
+  logger = { error() {}, warn() {}, info() {}, verbose() {} },
+}: {
+  question: Question;
+  course: Course;
+  course_instance?: CourseInstance | null;
+  /** Number of iterations of each test type. */
+  count: number;
+  user_id: string;
+  authn_user_id: string;
+  /** Makes seeds deterministic as `{prefix}-{iteration}`. */
+  variantSeedPrefix?: string;
+  logger?: ServerJobLogger;
+}): Promise<QuestionTestResult[]> {
+  const results: QuestionTestResult[] = [];
+
+  for (const iter of range(count * TEST_TYPES.length)) {
+    const test_type = TEST_TYPES[iter % TEST_TYPES.length];
+    const variant_seed = variantSeedPrefix ? buildVariantSeed(variantSeedPrefix, iter) : undefined;
+
+    const { success, stats, variant } = await runTest({
+      logger,
+      showDetails: false,
+      question,
+      course_instance,
+      course,
+      test_type,
+      user_id,
+      authn_user_id,
+      variant_seed,
+    });
+
+    const issues = success
+      ? []
+      : await sqldb.queryRows(
+          sql.select_issues_for_variant,
+          { variant_id: variant.id },
+          z.object({
+            student_message: z.string().nullable(),
+            instructor_message: z.string().nullable(),
+            output: z.string().nullable(),
+          }),
+        );
+
+    results.push({
+      testType: test_type,
+      variantSeed: variant.variant_seed,
+      success,
+      params: variant.params,
+      trueAnswer: variant.true_answer,
+      brokenAt: variant.broken_at,
+      issues: issues.map((issue) => ({
+        studentMessage: issue.student_message,
+        instructorMessage: issue.instructor_message,
+        output: issue.output,
+      })),
+      durations: stats,
+    });
+  }
+
+  return results;
 }
 
 /**
@@ -618,9 +754,9 @@ export async function startTestQuestion({
   /** The currently authenticated user. */
   authn_user_id: string;
   /**
-   * Optional prefix for variant seeds. When provided, seeds will be generated
-   * deterministically as `{prefix}-{iteration}` for each test iteration. This
-   * ensures reproducible tests while still testing different variants.
+   * Optional prefix for variant seeds. When provided, each test iteration gets a
+   * deterministic seed derived from the prefix via {@link buildVariantSeed}, so
+   * runs are reproducible while still exercising different variants.
    */
   variantSeedPrefix?: string;
 }): Promise<string> {
@@ -641,7 +777,9 @@ export async function startTestQuestion({
       const type = TEST_TYPES[iter % TEST_TYPES.length];
       const testIterationIndex = Math.floor(iter / TEST_TYPES.length) + 1;
       // Generate a deterministic seed if a prefix was provided, otherwise let the system generate a random one
-      const variant_seed = variantSeedPrefix ? `${variantSeedPrefix}-${iter}` : undefined;
+      const variant_seed = variantSeedPrefix
+        ? buildVariantSeed(variantSeedPrefix, iter)
+        : undefined;
       job.verbose(`Test ${testIterationIndex}, type ${type}`);
       const result = await runTest({
         logger: job,

--- a/apps/prairielearn/src/mcp-server.ts
+++ b/apps/prairielearn/src/mcp-server.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+//
+// Experimental MCP server exposing PrairieLearn to an external agent harness.
+//
+// LOCAL DEVELOPMENT ONLY. This server performs no authorization checks and is
+// scoped to a single course by command-line argument. It refuses to start
+// outside a local development environment — see `assertLocalOnly` in
+// `mcp/context.ts`.
+//
+// Usage:
+//   tsx src/mcp-server.ts --course-id 2 [--user-uid dev@example.com] [--config path]
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import minimist from 'minimist';
+
+import { config } from './lib/config.js';
+import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from './lib/paths.js';
+import {
+  McpSafetyError,
+  initPrairieLearn,
+  resolveCourse,
+  shutdownPrairieLearn,
+} from './mcp/context.js';
+import { createMcpServer } from './mcp/server.js';
+import { selectOrInsertUserByUid } from './models/user.js';
+
+// `pnpm run <script> -- --flag` forwards the `--` separator into our argv, and
+// minimist would otherwise treat every flag after it as a positional argument.
+const argv = minimist(process.argv.slice(2).filter((arg) => arg !== '--'));
+
+const USAGE = `
+Usage: mcp-server --course-id <id> [options]
+
+Options:
+  --course-id <id>    Required. The course this server operates on.
+  --user-uid <uid>    User to act as. Default: dev@example.com
+  --config <path>     Config file path. Defaults to the standard locations.
+  -h, --help          Show this message.
+`.trim();
+
+async function main() {
+  if ('h' in argv || 'help' in argv) {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  const courseId = argv['course-id'];
+  if (!courseId) {
+    throw new McpSafetyError('--course-id is required.\n\n' + USAGE);
+  }
+
+  const configPaths =
+    'config' in argv
+      ? [argv.config]
+      : [
+          path.join(os.homedir(), '.config', 'prairielearn', 'config.json'),
+          path.join(REPOSITORY_ROOT_PATH, 'config.json'),
+          path.join(APP_ROOT_PATH, 'config.json'),
+        ];
+
+  await initPrairieLearn(configPaths);
+
+  const course = await resolveCourse(String(courseId));
+  const user = await selectOrInsertUserByUid(argv['user-uid'] ?? 'dev@example.com');
+
+  // stdout is the MCP transport, so all diagnostics go to stderr.
+  process.stderr.write(
+    'PrairieLearn MCP server ready\n' +
+      `  course:   ${course.short_name ?? course.id} (id ${course.id})\n` +
+      `  path:     ${course.path}\n` +
+      `  user:     ${user.uid}\n` +
+      `  database: ${config.postgresqlUser}@${config.postgresqlHost}/${config.postgresqlDatabase}\n`,
+  );
+
+  const server = createMcpServer({
+    course,
+    userId: user.id,
+    authnUserId: user.id,
+  });
+
+  await server.connect(new StdioServerTransport());
+
+  const shutdown = async () => {
+    await server.close().catch(() => {});
+    await shutdownPrairieLearn().catch(() => {});
+    process.exit(0);
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}
+
+main().catch((err) => {
+  if (err instanceof McpSafetyError) {
+    process.stderr.write(`\nRefusing to start: ${err.message}\n`);
+  } else {
+    process.stderr.write(`\n${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`);
+  }
+  process.exit(1);
+});

--- a/apps/prairielearn/src/mcp/README.md
+++ b/apps/prairielearn/src/mcp/README.md
@@ -1,0 +1,93 @@
+# Agent MCP server (experimental)
+
+An [MCP](https://modelcontextprotocol.io) server that exposes PrairieLearn to an
+external agent harness such as Claude Code. It is a **local development tool**:
+it performs no authorization checks and refuses to start against anything that
+doesn't look like a developer's own machine.
+
+The premise is that a harness already has excellent file tools, and course
+content is just files in a git repository. So this server only provides what a
+harness _can't_ do on its own: reach PrairieLearn's database, sync pipeline, and
+question rendering engine.
+
+## Tools
+
+| Tool                | Purpose                                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `sync_course`       | Applies file edits by syncing disk → database. Returns schema errors, dangling QID references, duplicate UUIDs, undeclared topics/tags. |
+| `list_entities`     | Lists questions, course instances, or assessments with both database IDs and repo paths. Bridges `qid` (files) to `question_id` (data). |
+| `test_question`     | Renders a question across random variants, submitting correct/incorrect/invalid answers. Failures include the reproducing seed.         |
+| `query_course_data` | Read-only SQL over student work, statistics, and issues. Single `SELECT`/`WITH`, 1000-row cap, 15s timeout.                             |
+| `get_job_output`    | Reads a job sequence's output.                                                                                                          |
+
+The agent's working loop is **edit files → `sync_course` → `test_question` →
+repeat**. The primer served as the server's MCP `instructions` (see
+`instructions.ts`) explains the repo layout, where PrairieLearn's own docs live,
+and the SQL joins that are wrong in non-obvious ways.
+
+## Safety
+
+This server has no permission model, so the guards are environmental:
+
+- Refuses to start when `NODE_ENV=production`.
+- Refuses to start when `config.devMode` is false.
+- Refuses to connect to any Postgres host other than localhost.
+- Refuses to operate on the example course or a deleted course.
+- `query_course_data` runs in a `READ ONLY` transaction with a statement
+  timeout, and rejects anything that isn't a single `SELECT`/`WITH`.
+- The scratch-course script refuses to create a course inside the PrairieLearn
+  repository, so agent edits can't dirty PrairieLearn's own working tree.
+
+The MCP SDK is a **devDependency**, so it never enters the production dependency
+tree.
+
+## Setup
+
+Requires a local Postgres and Redis, plus the Python environment
+(`make python-deps`).
+
+```sh
+# 1. Create a scratch course outside the repository, seeded from testCourse.
+pnpm --filter @prairielearn/prairielearn mcp:create-scratch-course
+# -> prints the course id, e.g. 1
+
+# 2. Verify the tools work end to end.
+pnpm --filter @prairielearn/prairielearn mcp:smoke-test -- --course-id 1
+pnpm --filter @prairielearn/prairielearn mcp:loop-test -- --course-id 1
+```
+
+Then register the server with your harness. For Claude Code, add to
+`.mcp.json` or `~/.claude.json` — the course id is machine-specific, so this
+is deliberately not committed:
+
+```json
+{
+  "mcpServers": {
+    "prairielearn": {
+      "type": "stdio",
+      "command": "pnpm",
+      "args": ["--filter", "@prairielearn/prairielearn", "mcp", "--", "--course-id", "1"],
+      "cwd": "/absolute/path/to/PrairieLearn"
+    }
+  }
+}
+```
+
+If you use Conductor, the database name comes from `CONDUCTOR_WORKSPACE_NAME`,
+so pass that through in `env` alongside `CONDUCTOR_PORT`.
+
+## Flags
+
+```
+--course-id <id>    Required. The course to operate on.
+--user-uid <uid>    User to act as. Default: dev@example.com
+--config <path>     Config file path. Defaults to the standard locations.
+```
+
+## Not implemented
+
+There are no tools for grades, enrollment, staff, rubrics, or LMS integration,
+and no authorization layer. Content writes go through the harness's own file
+tools rather than PrairieLearn's `Editor` classes, which means this does not
+exercise the production git path (commit, push, conflict retry, sharing
+validation).

--- a/apps/prairielearn/src/mcp/context.ts
+++ b/apps/prairielearn/src/mcp/context.ts
@@ -1,0 +1,176 @@
+// Boot sequence and safety guards for the experimental agent MCP server.
+//
+// This server is a local development tool. It exposes PrairieLearn's database,
+// sync pipeline, and question rendering engine to an external agent harness
+// with NO authorization checks. The guards in `assertLocalOnly` are the only
+// thing standing between that and a production database, so they refuse to run
+// anywhere that doesn't look unambiguously like a developer's machine.
+
+import { cache } from '@prairielearn/cache';
+import * as namedLocks from '@prairielearn/named-locks';
+import * as sqldb from '@prairielearn/postgres';
+
+import * as assets from '../lib/assets.js';
+import * as codeCaller from '../lib/code-caller/index.js';
+import { config, loadConfig } from '../lib/config.js';
+import { type Course } from '../lib/db-types.js';
+import * as load from '../lib/load.js';
+import { selectCourseById } from '../models/course.js';
+import * as freeformServer from '../question-servers/freeform.js';
+import * as sprocs from '../sprocs/index.js';
+
+/** Hosts that we're willing to believe are a developer's own machine. */
+const ALLOWED_POSTGRES_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'postgres']);
+
+/**
+ * Search schema prefix for this process's stored procedures. The process ID is
+ * part of the prefix so that concurrent MCP servers — a harness usually spawns
+ * one automatically while a developer runs another by hand — don't drop each
+ * other's schemas and leave the surviving process unable to call any sproc.
+ */
+const SCHEMA_PREFIX = `pl_mcp_${process.pid}`;
+
+export class McpSafetyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'McpSafetyError';
+  }
+}
+
+/**
+ * Refuses to continue if the process environment claims production. Runs before
+ * the config is even loaded, so this is the first thing that can stop us.
+ */
+function assertNotProductionEnv() {
+  if (process.env.NODE_ENV === 'production') {
+    throw new McpSafetyError('NODE_ENV is "production". The agent MCP server is local-only.');
+  }
+}
+
+/**
+ * Refuses to continue unless the loaded config points at a local development
+ * database. Called after the config loads and before any connection is opened.
+ */
+function assertLocalOnly() {
+  assertNotProductionEnv();
+
+  if (!config.devMode) {
+    throw new McpSafetyError('config.devMode is false. The agent MCP server is local-only.');
+  }
+
+  if (!ALLOWED_POSTGRES_HOSTS.has(config.postgresqlHost)) {
+    throw new McpSafetyError(
+      `Refusing to connect to Postgres host "${config.postgresqlHost}". ` +
+        `The agent MCP server only runs against ${Array.from(ALLOWED_POSTGRES_HOSTS).join(', ')}.`,
+    );
+  }
+}
+
+export interface McpContext {
+  /** The single course this server is scoped to. */
+  course: Course;
+  /** Effective and authenticated user for rendering and test submissions. */
+  userId: string;
+  authnUserId: string;
+}
+
+let initialized = false;
+
+/**
+ * Initializes the subset of PrairieLearn that the tools need: config, database,
+ * named locks, the Python worker pool, the element cache, and the freeform
+ * question server. Mirrors the relevant portion of `server.ts`.
+ */
+export async function initPrairieLearn(configPaths: string[]) {
+  if (initialized) return;
+
+  // Checked before the config loads so that a production environment fails with
+  // our message rather than a config validation error.
+  assertNotProductionEnv();
+
+  await loadConfig(configPaths);
+
+  // Must happen after the config is loaded and before we touch the database.
+  assertLocalOnly();
+
+  const pgConfig = {
+    user: config.postgresqlUser,
+    database: config.postgresqlDatabase,
+    host: config.postgresqlHost,
+    password: config.postgresqlPassword ?? undefined,
+    max: config.postgresqlPoolSize,
+    idleTimeoutMillis: config.postgresqlIdleTimeoutMillis,
+    ssl: config.postgresqlSsl,
+    errorOnUnusedParameters: config.devMode,
+  };
+
+  const idleErrorHandler = (err: Error) => {
+    console.error('Postgres idle client error', err);
+  };
+
+  await sqldb.initAsync(pgConfig, idleErrorHandler);
+  await namedLocks.init(pgConfig, idleErrorHandler, {
+    renewIntervalMs: config.namedLocksRenewIntervalMs,
+  });
+
+  // PrairieLearn keeps stored procedures in a per-process schema so that
+  // servers can be upgraded independently (see `server.ts`). Sync and question
+  // rendering both call sprocs, so this process needs its own copy. We clear
+  // schemas left behind by an earlier crashed run of this same process ID
+  // first, so repeated runs don't accumulate them; this is safe because
+  // `assertLocalOnly` has already run.
+  await sqldb.clearSchemasStartingWith(SCHEMA_PREFIX);
+  await sqldb.setRandomSearchSchemaAsync(SCHEMA_PREFIX);
+  await sprocs.init();
+
+  // The load estimators are read by the code caller, so they have to exist
+  // before we initialize the worker pool.
+  load.initEstimator('python', 1, false);
+  load.initEstimator('python_worker_active', 1);
+  load.initEstimator('python_worker_idle', 1, false);
+  load.initEstimator('python_callback_waiting', 1);
+
+  await codeCaller.init({ lazyWorkers: true });
+  // Rendering a question resolves asset URLs, which requires the asset
+  // manifest to be loaded even though nothing here serves HTTP.
+  await assets.init();
+  await cache.init({
+    type: config.cacheType,
+    keyPrefix: config.cacheKeyPrefix,
+    redisUrl: config.redisUrl,
+  });
+  await freeformServer.init();
+
+  initialized = true;
+}
+
+export async function shutdownPrairieLearn() {
+  if (!initialized) return;
+  // Drop this process's sproc schema so schemas don't accumulate across runs.
+  await sqldb.clearSchemasStartingWith(SCHEMA_PREFIX).catch(() => {});
+  await codeCaller.finish();
+  await cache.close();
+  await namedLocks.close();
+  await sqldb.closeAsync();
+  initialized = false;
+}
+
+/**
+ * Resolves the course this server is scoped to, and refuses courses that must
+ * never be modified by an agent.
+ */
+export async function resolveCourse(courseId: string): Promise<Course> {
+  const course = await selectCourseById(courseId);
+
+  if (course.example_course) {
+    throw new McpSafetyError(
+      `Course ${courseId} is the example course, which cannot be modified. Use a scratch course.`,
+    );
+  }
+
+  if (course.deleted_at !== null) {
+    throw new McpSafetyError(`Course ${courseId} is deleted.`);
+  }
+
+  return course;
+}

--- a/apps/prairielearn/src/mcp/instructions.ts
+++ b/apps/prairielearn/src/mcp/instructions.ts
@@ -1,0 +1,118 @@
+import { type Course } from '../lib/db-types.js';
+
+/**
+ * Served as the MCP server's `instructions`, so the harness loads it before the
+ * agent's first turn. This is the primer: it tells the agent where things are,
+ * what the edit/verify loop is, and which SQL joins are wrong in non-obvious
+ * ways. It matters as much as the tools do.
+ */
+export function buildInstructions(course: Course): string {
+  return `
+You are working on a PrairieLearn course as an instructor would.
+
+# This course
+
+- Title: ${course.title ?? '(untitled)'} (${course.short_name ?? 'no short name'})
+- Course ID: ${course.id}  (use this in SQL; files use "qid" instead)
+- Repository root on disk: ${course.path}
+- Timezone: ${course.display_timezone}
+
+Edit files under the repository root with your own file tools. Use the tools this
+server provides for anything that needs PrairieLearn's database, sync pipeline,
+or question rendering engine.
+
+# The loop
+
+1. Edit files (question.html, server.py, info.json, infoAssessment.json, ...)
+2. Call \`sync_course\` — this validates and applies your edits. It reports JSON
+   schema errors, dangling QID references, duplicate UUIDs, and undeclared
+   topics or tags. Nothing you write exists to PrairieLearn until you sync.
+3. Call \`test_question\` — renders the question across many random variants and
+   submits correct, incorrect, and invalid answers to each.
+4. Fix what failed and repeat. Every failure includes the variant seed; pass the
+   same \`seedPrefix\` to reproduce it exactly.
+
+Do not skip step 3. A question that syncs cleanly can still be broken for a
+subset of random variants, and that is the most common defect in practice.
+
+# Repository layout
+
+    infoCourse.json                                    course config: topics, tags,
+                                                       assessment sets and modules
+    questions/<qid>/info.json                          question metadata
+    questions/<qid>/question.html                      question template (Mustache)
+    questions/<qid>/server.py                          randomization and grading
+    questions/<qid>/clientFilesQuestion/               files served to the browser
+    questions/<qid>/tests/                             external grader files
+    courseInstances/<ci>/infoCourseInstance.json       one term: publishing,
+                                                       self-enrollment, student labels
+    courseInstances/<ci>/assessments/<tid>/infoAssessment.json
+                                                       zones, points, access control,
+                                                       group work
+    serverFilesCourse/                                 shared Python modules
+    elements/                                          course-specific elements
+
+Note that a question's \`qid\` is its path under \`questions/\`, so it may contain
+slashes (e.g. \`topic/subtopic/my-question\`).
+
+# PrairieLearn's own documentation is on disk — read it
+
+Relative to the PrairieLearn repository root (not the course root):
+
+    docs/elements/<element-name>.md    reference for each of the ~44 elements
+    docs/question/                     question authoring, server.py, templates
+    docs/assessment/configuration.md   every infoAssessment.json option
+    docs/assessment/accessControl.md   access control and override precedence
+    docs/course/index.md               infoCourse.json
+    docs/courseInstance/index.md       infoCourseInstance.json
+    exampleCourse/questions/           ~190 working example questions
+    apps/prairielearn/src/schemas/schemas/*.json   JSON schemas for every info file
+
+Read \`docs/elements/<name>.md\` before using an element you are unsure about, and
+copy from \`exampleCourse/questions/\` rather than inventing patterns.
+
+# Writing SQL for query_course_data
+
+Read-only. A single SELECT or WITH statement. Results are capped at 1000 rows.
+
+Useful tables: \`questions\`, \`assessments\`, \`assessment_questions\` (per-question
+statistics), \`variants\` (\`params\` holds the exact values a student saw),
+\`submissions\` (\`submitted_answer\`, \`partial_scores\`, \`format_errors\`),
+\`instance_questions\` (\`submission_score_array\`, \`number_attempts\`),
+\`assessment_instances\`, \`issues\` (runtime errors, with the failing seed in
+\`course_data\` and the Python traceback at
+\`system_data #>> '{courseErrData,outputBoth}'\`).
+
+These joins are wrong in ways that produce plausible but incorrect numbers.
+Get them right:
+
+- **Group work** puts the identity in one of two columns. Use
+  \`COALESCE(ai.user_id, -ai.team_id)\` as the per-student key, negating team IDs
+  so they cannot collide with user IDs.
+- **Soft deletes** exist on courses, course instances, assessments, and
+  questions. Always filter \`deleted_at IS NULL\`.
+- **Staff test submissions** pollute statistics. Exclude them with
+  \`users_get_displayed_role(user_id, course_instance_id)\`.
+- **Multi-instance assessments** need \`ai.include_in_statistics\`, and a
+  \`row_number() OVER (PARTITION BY user ORDER BY score_perc DESC) = 1\` window if
+  you want each student's best attempt.
+- **Scope to this course.** Join through to \`course_id = ${course.id}\`; the
+  database contains other courses.
+- Report the row count alongside any aggregate. A pattern in 12 submissions is
+  not a finding.
+
+\`assessment_questions\` already stores computed psychometrics — \`discrimination\`
+(an item-total correlation scaled 0-100), \`mean_question_score\`,
+\`quintile_question_scores\`, and submission histograms. Negative discrimination
+means strong students did worse on that question, which is almost always a bug
+or an ambiguous prompt. Read the question's source before explaining why.
+
+# Constraints
+
+- This server is scoped to one course and has no authorization checks. It is a
+  local development tool.
+- \`query_course_data\` cannot write. Use file edits plus \`sync_course\` to change
+  course content.
+- There are no tools for grades, enrollment, staff, or rubrics yet.
+`.trim();
+}

--- a/apps/prairielearn/src/mcp/scripts/create-scratch-course.ts
+++ b/apps/prairielearn/src/mcp/scripts/create-scratch-course.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+//
+// Creates a scratch course for the agent to work on, seeded from `testCourse`.
+//
+// The course is copied OUTSIDE the PrairieLearn repository so that agent edits
+// can never dirty PrairieLearn's own working tree. Local development only.
+//
+// Usage:
+//   tsx src/mcp/scripts/create-scratch-course.ts [--dest <path>] [--short-name QA]
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import fs from 'fs-extra';
+import minimist from 'minimist';
+
+import { config } from '../../lib/config.js';
+import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH, TEST_COURSE_PATH } from '../../lib/paths.js';
+import { insertCourse, selectOptionalCourseByPath } from '../../models/course.js';
+import { selectOrInsertUserByUid } from '../../models/user.js';
+import { syncDiskToSql } from '../../sync/syncFromDisk.js';
+import { initPrairieLearn, shutdownPrairieLearn } from '../context.js';
+
+// `pnpm run <script> -- --flag` forwards the `--` separator into our argv, and
+// minimist would otherwise treat every flag after it as a positional argument.
+const argv = minimist(process.argv.slice(2).filter((arg) => arg !== '--'));
+
+async function main() {
+  const configPaths = [
+    path.join(os.homedir(), '.config', 'prairielearn', 'config.json'),
+    path.join(REPOSITORY_ROOT_PATH, 'config.json'),
+    path.join(APP_ROOT_PATH, 'config.json'),
+  ];
+
+  await initPrairieLearn(configPaths);
+
+  const dest: string = argv.dest ?? path.join(os.homedir(), 'pl-agent-scratch', 'course');
+  const shortName: string = argv['short-name'] ?? 'AGENT';
+
+  if (dest.startsWith(REPOSITORY_ROOT_PATH)) {
+    throw new Error(
+      `Refusing to create a scratch course inside the PrairieLearn repository (${dest}). ` +
+        "Agent edits must not touch PrairieLearn's own working tree.",
+    );
+  }
+
+  if (!(await fs.pathExists(dest))) {
+    console.log(`Copying ${TEST_COURSE_PATH} -> ${dest}`);
+    await fs.copy(TEST_COURSE_PATH, dest);
+
+    // The seed course's UUIDs are already claimed by `testCourse` if it's been
+    // synced, so give the copy fresh ones for the course and its instances.
+    const infoPath = path.join(dest, 'infoCourse.json');
+    const info = await fs.readJson(infoPath);
+    info.uuid = crypto.randomUUID();
+    info.name = shortName;
+    info.title = 'Agent Scratch Course';
+    await fs.writeJson(infoPath, info, { spaces: 4 });
+  } else {
+    console.log(`Reusing existing directory ${dest}`);
+  }
+
+  // Normally created by the server's `insertDevUser` on boot; this script may
+  // run against a freshly migrated database where that hasn't happened yet.
+  const user = await selectOrInsertUserByUid(argv['user-uid'] ?? 'dev@example.com');
+
+  let course = await selectOptionalCourseByPath(dest);
+  if (!course) {
+    course = await insertCourse({
+      institution_id: '1',
+      short_name: shortName,
+      title: 'Agent Scratch Course',
+      display_timezone: 'America/Chicago',
+      path: dest,
+      repository: null,
+      branch: 'master',
+      authn_user_id: user.id,
+    });
+
+    console.log(`Inserted course id ${course.id}`);
+  } else {
+    console.log(`Course already exists with id ${course.id}`);
+  }
+
+  const logger = {
+    error: (msg: string) => console.error(msg),
+    warn: (msg: string) => console.warn(msg),
+    info: (msg: string) => console.log(msg),
+    verbose: () => {},
+  };
+
+  const result = await syncDiskToSql(course, logger);
+
+  console.log(`\nSync status: ${result.status}`);
+
+  console.log(
+    '\nScratch course ready.\n' +
+      `  id:       ${course.id}\n` +
+      `  path:     ${course.path}\n` +
+      `  database: ${config.postgresqlDatabase}\n\n` +
+      'Start the MCP server with:\n' +
+      `  tsx src/mcp-server.ts --course-id ${course.id}\n`,
+  );
+}
+
+main()
+  .then(() => shutdownPrairieLearn())
+  .then(() => process.exit(0))
+  .catch(async (err) => {
+    console.error(err);
+    await shutdownPrairieLearn().catch(() => {});
+    process.exit(1);
+  });

--- a/apps/prairielearn/src/mcp/scripts/loop-test.ts
+++ b/apps/prairielearn/src/mcp/scripts/loop-test.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+//
+// Exercises the edit -> sync -> test loop the way an agent would, including the
+// cases that motivated the tool design:
+//
+//   1. A brand-new question is authored on disk, synced, and verified.
+//   2. A seed-dependent bug is planted; the test cycle must catch it and report
+//      the exact failing seed.
+//   3. The bug is fixed and re-verified with the same seeds.
+//   4. A malformed info.json must surface as a sync error, not a silent failure.
+//
+// Local development only. Operates on the scratch course, outside the repo.
+
+import * as path from 'node:path';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import fs from 'fs-extra';
+import minimist from 'minimist';
+
+import { APP_ROOT_PATH, REPOSITORY_ROOT_PATH } from '../../lib/paths.js';
+
+// `pnpm run <script> -- --flag` forwards the `--` separator into our argv, and
+// minimist would otherwise treat every flag after it as a positional argument.
+const argv = minimist(process.argv.slice(2).filter((arg) => arg !== '--'));
+const courseId = String(argv['course-id'] ?? '1');
+const coursePath: string =
+  argv['course-path'] ?? path.join(process.env.HOME ?? '', 'pl-agent-scratch', 'course');
+
+const QID = 'agent-loop-test';
+
+let failures = 0;
+
+function check(name: string, condition: boolean, detail?: unknown) {
+  if (condition) {
+    console.log(`  PASS  ${name}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${name}`);
+    if (detail !== undefined) console.log(`        ${JSON.stringify(detail).slice(0, 500)}`);
+  }
+}
+
+function parse(result: any): any {
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== 'string') throw new Error('Tool returned no text content');
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+// Built by concatenation because the LaTeX delimiters sit directly against
+// Mustache braces, which reads as JS interpolation inside a template literal.
+const QUESTION_HTML = [
+  '<pl-question-panel>',
+  '  <p>What is $' + '{{params.a}} + {{params.b}}$?</p>',
+  '</pl-question-panel>',
+  '',
+  '<pl-integer-input answers-name="c" label="$c =$"></pl-integer-input>',
+  '',
+].join('\n');
+
+const INFO_JSON = {
+  uuid: 'f1e2d3c4-b5a6-4789-9abc-def012345678',
+  title: 'Agent loop test',
+  topic: 'Algebra',
+  tags: ['test'],
+  type: 'v3',
+};
+
+/** Correct implementation. */
+const SERVER_PY_GOOD = `import random
+
+
+def generate(data):
+    a = random.randint(1, 10)
+    b = random.randint(1, 10)
+    data["params"]["a"] = a
+    data["params"]["b"] = b
+    data["correct_answers"]["c"] = a + b
+`;
+
+/**
+ * Raises only when \`a\` happens to be 7. This is the class of bug that a single
+ * "New variant" click almost always misses.
+ */
+const SERVER_PY_BROKEN = `import random
+
+
+def generate(data):
+    a = random.randint(1, 10)
+    b = random.randint(1, 10)
+    if a == 7:
+        raise ValueError("seed-dependent failure: a == 7")
+    data["params"]["a"] = a
+    data["params"]["b"] = b
+    data["correct_answers"]["c"] = a + b
+`;
+
+async function writeQuestion(serverPy: string) {
+  const dir = path.join(coursePath, 'questions', QID);
+  await fs.ensureDir(dir);
+  await fs.writeJson(path.join(dir, 'info.json'), INFO_JSON, { spaces: 4 });
+  await fs.writeFile(path.join(dir, 'question.html'), QUESTION_HTML);
+  await fs.writeFile(path.join(dir, 'server.py'), serverPy);
+}
+
+async function main() {
+  if (coursePath.startsWith(REPOSITORY_ROOT_PATH)) {
+    throw new Error(`Refusing to write into the PrairieLearn repository: ${coursePath}`);
+  }
+
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: [
+      'tsx',
+      '--tsconfig',
+      path.join(APP_ROOT_PATH, 'src/tsconfig.json'),
+      path.join(APP_ROOT_PATH, 'src/mcp-server.ts'),
+      '--course-id',
+      courseId,
+    ],
+    cwd: APP_ROOT_PATH,
+    env: process.env as Record<string, string>,
+    stderr: 'pipe',
+  });
+
+  const client = new Client({ name: 'loop-test', version: '0.1.0' });
+  transport.stderr?.on('data', () => {});
+  await client.connect(transport);
+
+  // Rendering dozens of variants comfortably exceeds the SDK's 60s default.
+  const TIMEOUT = { timeout: 600_000 };
+
+  const callSync = async () =>
+    parse(await client.callTool({ name: 'sync_course', arguments: {} }, undefined, TIMEOUT));
+  const callTest = async (count: number, seedPrefix: string) =>
+    parse(
+      await client.callTool(
+        { name: 'test_question', arguments: { qid: QID, count, seedPrefix } },
+        undefined,
+        TIMEOUT,
+      ),
+    );
+
+  try {
+    console.log('\n== 1. author a new question, sync, verify ==');
+    await writeQuestion(SERVER_PY_GOOD);
+    const sync1 = await callSync();
+    check('sync succeeds', sync1?.status === 'complete' && !sync1?.hadJsonErrors, sync1?.problems);
+
+    const listed = parse(
+      await client.callTool({ name: 'list_entities', arguments: { scope: 'questions' } }),
+    );
+    check(
+      'new question appears in list_entities',
+      listed.some((q: any) => q.qid === QID),
+    );
+
+    const good = await callTest(4, 'loop-good');
+    check('new question passes its tests', good?.passed === true, good?.failures);
+
+    console.log('\n== 2. plant a seed-dependent bug ==');
+    await writeQuestion(SERVER_PY_BROKEN);
+    const sync2 = await callSync();
+    check('broken version still syncs (bug is runtime, not schema)', sync2?.status === 'complete');
+
+    // 12 iterations of each type over a 1-10 range makes hitting a == 7 nearly certain.
+    const broken = await callTest(12, 'loop-broken');
+    check('test cycle catches the seed-dependent bug', broken?.passed === false, broken?.summary);
+
+    const failure = broken?.failures?.[0];
+    check('failure reports the exact seed', typeof failure?.variantSeed === 'string', failure);
+    check(
+      'failure includes the Python traceback',
+      typeof failure?.issues?.[0]?.output === 'string' &&
+        failure.issues[0].output.includes('seed-dependent failure'),
+      failure?.issues?.[0]?.output?.slice(0, 200),
+    );
+
+    console.log('\n== 3. reproduce deterministically with the same seed prefix ==');
+    const rerun = await callTest(12, 'loop-broken');
+    check(
+      'same seeds reproduce the same failure count',
+      rerun?.summary?.failed === broken?.summary?.failed,
+      {
+        first: broken?.summary,
+        second: rerun?.summary,
+      },
+    );
+
+    console.log('\n== 4. fix and re-verify ==');
+    await writeQuestion(SERVER_PY_GOOD);
+    await callSync();
+    const fixed = await callTest(12, 'loop-broken');
+    check(
+      'fixed question passes on the previously failing seeds',
+      fixed?.passed === true,
+      fixed?.failures,
+    );
+
+    console.log('\n== 5. malformed info.json surfaces as a sync error ==');
+    await fs.writeJson(
+      path.join(coursePath, 'questions', QID, 'info.json'),
+      { uuid: INFO_JSON.uuid, title: 'Broken', type: 'v3', topic: 'Algebra', bogusProperty: true },
+      { spaces: 4 },
+    );
+    const sync3 = await callSync();
+    check('sync reports the schema problem', (sync3?.problems?.length ?? 0) > 0, sync3?.problems);
+    const problem = sync3?.problems?.find((p: any) => p.identifier === QID);
+    check('problem is attributed to the right question', !!problem, sync3?.problems);
+  } finally {
+    // Leave the scratch course clean for the next run.
+    await fs.remove(path.join(coursePath, 'questions', QID));
+    await callSync().catch(() => {});
+    await client.close();
+  }
+
+  console.log(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}\n`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/prairielearn/src/mcp/scripts/smoke-test.ts
+++ b/apps/prairielearn/src/mcp/scripts/smoke-test.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+//
+// Drives the MCP server over stdio the way a real client does, exercising every
+// tool and asserting on the results. Local development only.
+//
+// Usage:
+//   tsx src/mcp/scripts/smoke-test.ts --course-id 1
+
+import * as path from 'node:path';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import minimist from 'minimist';
+
+import { APP_ROOT_PATH } from '../../lib/paths.js';
+
+// `pnpm run <script> -- --flag` forwards the `--` separator into our argv, and
+// minimist would otherwise treat every flag after it as a positional argument.
+const argv = minimist(process.argv.slice(2).filter((arg) => arg !== '--'));
+const courseId = String(argv['course-id'] ?? '1');
+
+let failures = 0;
+
+function check(name: string, condition: boolean, detail?: unknown) {
+  if (condition) {
+    console.log(`  PASS  ${name}`);
+  } else {
+    failures += 1;
+    console.log(`  FAIL  ${name}`);
+    if (detail !== undefined) console.log(`        ${JSON.stringify(detail).slice(0, 400)}`);
+  }
+}
+
+/** Unwraps the JSON text content our tools return. */
+function parse(result: any): any {
+  const text = result?.content?.[0]?.text;
+  if (typeof text !== 'string') throw new Error('Tool returned no text content');
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function main() {
+  const transport = new StdioClientTransport({
+    command: 'npx',
+    args: [
+      'tsx',
+      '--tsconfig',
+      path.join(APP_ROOT_PATH, 'src/tsconfig.json'),
+      path.join(APP_ROOT_PATH, 'src/mcp-server.ts'),
+      '--course-id',
+      courseId,
+    ],
+    cwd: APP_ROOT_PATH,
+    env: process.env as Record<string, string>,
+    stderr: 'pipe',
+  });
+
+  const client = new Client({ name: 'smoke-test', version: '0.1.0' });
+
+  transport.stderr?.on('data', (chunk: Buffer) => {
+    process.stderr.write(`[server] ${chunk.toString()}`);
+  });
+
+  await client.connect(transport);
+
+  console.log('\n== handshake ==');
+  const { tools } = await client.listTools();
+  const toolNames = tools.map((tool) => tool.name).sort();
+  console.log(`  tools: ${toolNames.join(', ')}`);
+  check(
+    'all five tools registered',
+    ['get_job_output', 'list_entities', 'query_course_data', 'sync_course', 'test_question'].every(
+      (name) => toolNames.includes(name),
+    ),
+    toolNames,
+  );
+  check(
+    'instructions include the course path',
+    (client.getInstructions() ?? '').includes('pl-agent-scratch'),
+  );
+
+  console.log('\n== list_entities ==');
+  const questions = parse(
+    await client.callTool({ name: 'list_entities', arguments: { scope: 'questions' } }),
+  );
+  check('returns questions', Array.isArray(questions) && questions.length > 0, {
+    count: questions?.length,
+  });
+  const sample = questions.find((q: any) => q.qid === 'addNumbers') ?? questions[0];
+  check(
+    'question has id, qid and path',
+    !!sample?.question_id && !!sample?.qid && !!sample?.path,
+    sample,
+  );
+  check('path is repo-relative', sample?.path?.startsWith('questions/'), sample?.path);
+
+  const assessments = parse(
+    await client.callTool({ name: 'list_entities', arguments: { scope: 'assessments' } }),
+  );
+  check('returns assessments', Array.isArray(assessments) && assessments.length > 0, {
+    count: assessments?.length,
+  });
+
+  console.log('\n== query_course_data ==');
+  const counts = parse(
+    await client.callTool({
+      name: 'query_course_data',
+      arguments: {
+        query: `SELECT count(*)::int AS n FROM questions WHERE course_id = ${courseId} AND deleted_at IS NULL`,
+      },
+    }),
+  );
+  check('SELECT returns rows', counts?.rows?.[0]?.n > 0, counts);
+  check(
+    'reports columns',
+    Array.isArray(counts?.columns) && counts.columns.includes('n'),
+    counts?.columns,
+  );
+
+  const rejectedWrite = await client.callTool({
+    name: 'query_course_data',
+    arguments: { query: "UPDATE questions SET title = 'nope'" },
+  });
+  check('rejects UPDATE', rejectedWrite.isError === true, rejectedWrite);
+
+  const rejectedMulti = await client.callTool({
+    name: 'query_course_data',
+    arguments: { query: 'SELECT 1; SELECT 2' },
+  });
+  check('rejects multiple statements', rejectedMulti.isError === true, rejectedMulti);
+
+  const rejectedDdl = await client.callTool({
+    name: 'query_course_data',
+    arguments: { query: 'WITH x AS (SELECT 1) SELECT * FROM x; DROP TABLE users' },
+  });
+  check('rejects trailing DDL', rejectedDdl.isError === true, rejectedDdl);
+
+  const literalDollar = parse(
+    await client.callTool({
+      name: 'query_course_data',
+      arguments: { query: "SELECT 'costs $5 or $name' AS s" },
+    }),
+  );
+  check(
+    'does not mangle $ in string literals',
+    literalDollar?.rows?.[0]?.s === 'costs $5 or $name',
+    literalDollar,
+  );
+
+  console.log('\n== sync_course ==');
+  const sync = parse(await client.callTool({ name: 'sync_course', arguments: {} }));
+  check('sync completes', sync?.status === 'complete', { status: sync?.status });
+  check('no JSON errors on a clean course', sync?.hadJsonErrors === false, sync?.problems);
+
+  console.log('\n== test_question ==');
+  const good = parse(
+    await client.callTool({
+      name: 'test_question',
+      arguments: { qid: 'addNumbers', count: 2, seedPrefix: 'smoke' },
+    }),
+  );
+  check('known-good question passes', good?.passed === true, good?.failures ?? good);
+  check('reports 6 runs (2 x 3 test types)', good?.summary?.total === 6, good?.summary);
+
+  const missing = await client.callTool({
+    name: 'test_question',
+    arguments: { qid: 'does-not-exist', count: 1 },
+  });
+  check('unknown qid returns an error', missing.isError === true, missing);
+
+  // `brokenGeneration` raises in `server.py`'s generate(). This is the signal
+  // the issue-triage workflow depends on: a reproducible seed plus a traceback.
+  const broken = parse(
+    await client.callTool({
+      name: 'test_question',
+      arguments: { qid: 'brokenGeneration', count: 1, seedPrefix: 'smoke-broken' },
+    }),
+  );
+  check('detects a broken question', broken?.passed === false, broken?.summary);
+  check(
+    'failure includes a variant seed',
+    !!broken?.failures?.[0]?.variantSeed,
+    broken?.failures?.[0],
+  );
+  check(
+    'failure includes the Python traceback',
+    typeof broken?.failures?.[0]?.issues?.[0]?.output === 'string' &&
+      broken.failures[0].issues[0].output.length > 0,
+    broken?.failures?.[0]?.issues?.[0],
+  );
+
+  console.log('\n== get_job_output ==');
+  const jobIds = parse(
+    await client.callTool({
+      name: 'query_course_data',
+      arguments: {
+        query: `SELECT id FROM job_sequences WHERE course_id = ${courseId} ORDER BY id DESC LIMIT 1`,
+      },
+    }),
+  );
+  if (jobIds?.rows?.length) {
+    const job = parse(
+      await client.callTool({
+        name: 'get_job_output',
+        arguments: { jobSequenceId: String(jobIds.rows[0].id) },
+      }),
+    );
+    check('reads job sequence', !!job?.jobSequenceId && Array.isArray(job?.jobs), job);
+  } else {
+    console.log('  SKIP  no job sequences in this course yet');
+  }
+
+  await client.close();
+
+  console.log(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}\n`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/prairielearn/src/mcp/server.ts
+++ b/apps/prairielearn/src/mcp/server.ts
@@ -1,0 +1,165 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { type McpContext } from './context.js';
+import { buildInstructions } from './instructions.js';
+import { getJobOutput } from './tools/get-job-output.js';
+import { ENTITY_SCOPES, listEntities } from './tools/list-entities.js';
+import { queryCourseData } from './tools/query-course-data.js';
+import { syncCourse } from './tools/sync-course.js';
+import { testQuestionTool } from './tools/test-question.js';
+
+/** Serializes a tool result as the JSON text content MCP clients expect. */
+function json(value: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };
+}
+
+function errorText(err: unknown) {
+  return {
+    content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }],
+    isError: true,
+  };
+}
+
+export function createMcpServer(ctx: McpContext): McpServer {
+  const server = new McpServer(
+    { name: 'prairielearn', version: '0.1.0' },
+    { instructions: buildInstructions(ctx.course) },
+  );
+
+  server.registerTool(
+    'sync_course',
+    {
+      title: 'Sync course',
+      description:
+        'Applies your file edits to PrairieLearn by syncing the course from disk to the ' +
+        'database, and returns any errors. Call this after every batch of edits — nothing ' +
+        'you write to disk takes effect until you do. Reports JSON schema violations, ' +
+        'dangling QID references, duplicate UUIDs, and undeclared topics or tags.',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        return json(await syncCourse(ctx.course));
+      } catch (err) {
+        return errorText(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'list_entities',
+    {
+      title: 'List course entities',
+      description:
+        'Lists questions, course instances, or assessments with both their database IDs ' +
+        'and their paths on disk. Use this to map between a file you edited (addressed by ' +
+        'qid or tid) and the rows describing it in the database (addressed by numeric ID).',
+      inputSchema: {
+        scope: z.enum(ENTITY_SCOPES).describe('Which kind of entity to list.'),
+      },
+    },
+    async ({ scope }) => {
+      try {
+        return json(await listEntities({ course: ctx.course, scope }));
+      } catch (err) {
+        return errorText(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'test_question',
+    {
+      title: 'Test question',
+      description:
+        'Renders a question across random variants and submits correct, incorrect, and ' +
+        'invalid answers to each, returning failures with the variant seed that produced ' +
+        'them. Run this on every question you create or modify — a question can sync ' +
+        'cleanly and still be broken for some random variants. The question must be ' +
+        'synced first.',
+      inputSchema: {
+        qid: z
+          .string()
+          .describe('Question ID — its path under questions/, e.g. "topic/my-question".'),
+        count: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .default(5)
+          .describe(
+            'Iterations of each test type (correct, incorrect, invalid). 5 is a good ' +
+              'default; use 25+ to hunt for seed-dependent bugs.',
+          ),
+        seedPrefix: z
+          .string()
+          .optional()
+          .describe(
+            'Makes variant seeds deterministic as "{prefix}-{n}". Pass the same prefix ' +
+              'again to reproduce a specific failure.',
+          ),
+      },
+    },
+    async ({ qid, count, seedPrefix }) => {
+      try {
+        return json(
+          await testQuestionTool({
+            course: ctx.course,
+            qid,
+            count,
+            seedPrefix,
+            userId: ctx.userId,
+            authnUserId: ctx.authnUserId,
+          }),
+        );
+      } catch (err) {
+        return errorText(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'query_course_data',
+    {
+      title: 'Query course data',
+      description:
+        'Runs a read-only SQL query against the PrairieLearn database: student ' +
+        'submissions, question statistics, issues, gradebook. A single SELECT or WITH ' +
+        "statement, capped at 1000 rows. See this server's instructions for the joins " +
+        'that are easy to get wrong (group work, soft deletes, staff submissions).',
+      inputSchema: {
+        query: z.string().describe('A single read-only SQL statement.'),
+      },
+    },
+    async ({ query }) => {
+      try {
+        return json(await queryCourseData(query));
+      } catch (err) {
+        return errorText(err);
+      }
+    },
+  );
+
+  server.registerTool(
+    'get_job_output',
+    {
+      title: 'Get job output',
+      description:
+        'Reads the output of a PrairieLearn job sequence. Long-running operations run as ' +
+        'job sequences; use this to inspect one you did not run inline.',
+      inputSchema: {
+        jobSequenceId: z.string().describe('The job sequence ID.'),
+      },
+    },
+    async ({ jobSequenceId }) => {
+      try {
+        return json(await getJobOutput({ course: ctx.course, jobSequenceId }));
+      } catch (err) {
+        return errorText(err);
+      }
+    },
+  );
+
+  return server;
+}

--- a/apps/prairielearn/src/mcp/tools/get-job-output.ts
+++ b/apps/prairielearn/src/mcp/tools/get-job-output.ts
@@ -1,0 +1,49 @@
+import { type Course } from '../../lib/db-types.js';
+import { getJobSequence } from '../../lib/server-jobs.js';
+
+export interface JobOutputResult {
+  jobSequenceId: string;
+  type: string | null;
+  description: string | null;
+  status: string | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  jobs: {
+    status: string | null;
+    description: string | null;
+    errorMessage: string | null;
+    output: string | null;
+  }[];
+}
+
+/**
+ * Reads the output of a job sequence. Long-running PrairieLearn operations
+ * (syncs, regrades, question tests started through the UI) run as job sequences,
+ * so this is how the agent inspects work it didn't run inline.
+ *
+ * Scoped to the current course, so it can't read another course's job output.
+ */
+export async function getJobOutput({
+  course,
+  jobSequenceId,
+}: {
+  course: Course;
+  jobSequenceId: string;
+}): Promise<JobOutputResult> {
+  const jobSequence = await getJobSequence(jobSequenceId, course.id);
+
+  return {
+    jobSequenceId: jobSequence.id,
+    type: jobSequence.type,
+    description: jobSequence.description,
+    status: jobSequence.status,
+    startedAt: jobSequence.start_date,
+    finishedAt: jobSequence.finish_date,
+    jobs: jobSequence.jobs.map((job) => ({
+      status: job.status,
+      description: job.description,
+      errorMessage: job.error_message,
+      output: job.output,
+    })),
+  };
+}

--- a/apps/prairielearn/src/mcp/tools/list-entities.sql
+++ b/apps/prairielearn/src/mcp/tools/list-entities.sql
@@ -1,0 +1,81 @@
+-- BLOCK select_questions
+SELECT
+  q.id AS question_id,
+  q.qid,
+  q.title,
+  top.name AS topic,
+  COALESCE(
+    (
+      SELECT
+        ARRAY_AGG(
+          t.name
+          ORDER BY
+            t.name
+        )
+      FROM
+        question_tags AS qt
+        JOIN tags AS t ON (t.id = qt.tag_id)
+      WHERE
+        qt.question_id = q.id
+    ),
+    ARRAY[]::text[]
+  ) AS tags,
+  q.grading_method::text AS grading_method,
+  q.draft
+FROM
+  questions AS q
+  LEFT JOIN topics AS top ON (top.id = q.topic_id)
+WHERE
+  q.course_id = $course_id
+  AND q.deleted_at IS NULL
+ORDER BY
+  q.qid;
+
+-- BLOCK select_course_instances
+SELECT
+  ci.id AS course_instance_id,
+  ci.short_name,
+  ci.long_name,
+  (
+    SELECT
+      COUNT(*)::int
+    FROM
+      assessments AS a
+    WHERE
+      a.course_instance_id = ci.id
+      AND a.deleted_at IS NULL
+  ) AS assessment_count
+FROM
+  course_instances AS ci
+WHERE
+  ci.course_id = $course_id
+  AND ci.deleted_at IS NULL
+ORDER BY
+  ci.short_name;
+
+-- BLOCK select_assessments
+SELECT
+  a.id AS assessment_id,
+  a.tid,
+  a.title,
+  a.type::text AS type,
+  ci.short_name AS course_instance_short_name,
+  (
+    SELECT
+      COUNT(*)::int
+    FROM
+      assessment_questions AS aq
+    WHERE
+      aq.assessment_id = a.id
+      AND aq.deleted_at IS NULL
+  ) AS question_count
+FROM
+  assessments AS a
+  JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+WHERE
+  ci.course_id = $course_id
+  AND a.deleted_at IS NULL
+  AND ci.deleted_at IS NULL
+ORDER BY
+  ci.short_name,
+  a.tid;

--- a/apps/prairielearn/src/mcp/tools/list-entities.ts
+++ b/apps/prairielearn/src/mcp/tools/list-entities.ts
@@ -1,0 +1,91 @@
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import * as sqldb from '@prairielearn/postgres';
+
+import { type Course } from '../../lib/db-types.js';
+
+const sql = sqldb.loadSqlEquiv(import.meta.url);
+
+export const ENTITY_SCOPES = ['questions', 'course_instances', 'assessments'] as const;
+export type EntityScope = (typeof ENTITY_SCOPES)[number];
+
+const QuestionRowSchema = z.object({
+  question_id: z.string(),
+  qid: z.string().nullable(),
+  title: z.string().nullable(),
+  topic: z.string().nullable(),
+  tags: z.array(z.string()),
+  grading_method: z.string(),
+  draft: z.boolean(),
+});
+
+const CourseInstanceRowSchema = z.object({
+  course_instance_id: z.string(),
+  short_name: z.string(),
+  long_name: z.string().nullable(),
+  assessment_count: z.number(),
+});
+
+const AssessmentRowSchema = z.object({
+  assessment_id: z.string(),
+  tid: z.string().nullable(),
+  title: z.string().nullable(),
+  type: z.string(),
+  course_instance_short_name: z.string(),
+  question_count: z.number(),
+});
+
+/**
+ * Lists course entities with both their database IDs and their paths on disk.
+ *
+ * This is the bridge between the agent's two halves: it edits files addressed
+ * by `qid`/`tid`, but student data is keyed by `question_id` and
+ * `assessment_question_id`. Without this mapping it can't connect a question it
+ * just wrote to the rows describing how students did on it.
+ */
+export async function listEntities({
+  course,
+  scope,
+}: {
+  course: Course;
+  scope: EntityScope;
+}): Promise<unknown> {
+  if (scope === 'questions') {
+    const rows = await sqldb.queryRows(
+      sql.select_questions,
+      { course_id: course.id },
+      QuestionRowSchema,
+    );
+    return rows.map((row) => ({
+      ...row,
+      // Questions live at `questions/<qid>/` relative to the course root.
+      path: row.qid ? path.join('questions', row.qid) : null,
+    }));
+  }
+
+  if (scope === 'course_instances') {
+    const rows = await sqldb.queryRows(
+      sql.select_course_instances,
+      { course_id: course.id },
+      CourseInstanceRowSchema,
+    );
+    return rows.map((row) => ({
+      ...row,
+      path: path.join('courseInstances', row.short_name),
+    }));
+  }
+
+  const rows = await sqldb.queryRows(
+    sql.select_assessments,
+    { course_id: course.id },
+    AssessmentRowSchema,
+  );
+  return rows.map((row) => ({
+    ...row,
+    path: row.tid
+      ? path.join('courseInstances', row.course_instance_short_name, 'assessments', row.tid)
+      : null,
+  }));
+}

--- a/apps/prairielearn/src/mcp/tools/query-course-data.ts
+++ b/apps/prairielearn/src/mcp/tools/query-course-data.ts
@@ -1,0 +1,116 @@
+// Read-only SQL access for the agent.
+//
+// This is deliberately a single general-purpose tool rather than dozens of
+// typed accessors: the set of questions an instructor might ask about their
+// course is unbounded, and PrairieLearn already stores the answers. Safety comes
+// from the transaction, not from a restricted verb list.
+
+import * as sqldb from '@prairielearn/postgres';
+
+const MAX_ROWS = 1000;
+const STATEMENT_TIMEOUT_MS = 15_000;
+
+/**
+ * Statements that would mutate data. Checked as a cheap second guard; the real
+ * protection is the read-only transaction, which the database enforces.
+ */
+const FORBIDDEN_KEYWORDS = [
+  'insert',
+  'update',
+  'delete',
+  'truncate',
+  'drop',
+  'alter',
+  'create',
+  'grant',
+  'revoke',
+  'copy',
+  'vacuum',
+  'reindex',
+  'refresh',
+  'call',
+  'do',
+  'set',
+  'reset',
+  'listen',
+  'notify',
+];
+
+/** Strips string literals, dollar-quoted blocks, and comments before scanning. */
+function stripLiteralsAndComments(sql: string): string {
+  return sql
+    .replaceAll(/\$\w*\$[\s\S]*?\$\w*\$/g, ' ')
+    .replaceAll(/'(?:''|[^'])*'/g, ' ')
+    .replaceAll(/"(?:""|[^"])*"/g, ' ')
+    .replaceAll(/--[^\n]*/g, ' ')
+    .replaceAll(/\/\*[\s\S]*?\*\//g, ' ');
+}
+
+class QueryRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'QueryRejectedError';
+  }
+}
+
+function assertQueryIsReadOnly(query: string) {
+  const scannable = stripLiteralsAndComments(query);
+  const normalized = scannable.trim().toLowerCase();
+
+  if (normalized.length === 0) {
+    throw new QueryRejectedError('Query is empty.');
+  }
+
+  if (!/^(select|with)\b/.test(normalized)) {
+    throw new QueryRejectedError('Only SELECT and WITH queries are allowed.');
+  }
+
+  // Reject multiple statements. A trailing semicolon is fine.
+  const withoutTrailingSemicolon = normalized.replace(/;\s*$/, '');
+  if (withoutTrailingSemicolon.includes(';')) {
+    throw new QueryRejectedError('Only a single statement is allowed.');
+  }
+
+  for (const keyword of FORBIDDEN_KEYWORDS) {
+    if (new RegExp(`\\b${keyword}\\b`).test(withoutTrailingSemicolon)) {
+      throw new QueryRejectedError(`Query contains forbidden keyword "${keyword}".`);
+    }
+  }
+}
+
+export interface QueryCourseDataResult {
+  rowCount: number;
+  /** True when results were cut off at {@link MAX_ROWS}. */
+  truncated: boolean;
+  columns: string[];
+  rows: Record<string, any>[];
+}
+
+/**
+ * Runs a single read-only query inside a read-only transaction with a statement
+ * timeout. Row count is capped so a careless `SELECT *` can't exhaust memory.
+ *
+ * The query runs on the raw client rather than through `queryAsync` so that
+ * PrairieLearn's named-parameter interpolation doesn't rewrite `$` characters
+ * in agent-authored SQL.
+ */
+export async function queryCourseData(query: string): Promise<QueryCourseDataResult> {
+  assertQueryIsReadOnly(query);
+
+  return await sqldb.runInTransactionAsync(async (client) => {
+    // Enforced by Postgres for the duration of this transaction, so it holds
+    // even if the keyword scan above is fooled.
+    await client.query('SET TRANSACTION READ ONLY');
+    await client.query(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`);
+
+    const result = await client.query(query);
+    const rows = result.rows.slice(0, MAX_ROWS);
+
+    return {
+      rowCount: result.rows.length,
+      truncated: result.rows.length > MAX_ROWS,
+      columns: result.fields.map((field) => field.name),
+      rows,
+    };
+  });
+}

--- a/apps/prairielearn/src/mcp/tools/sync-course.sql
+++ b/apps/prairielearn/src/mcp/tools/sync-course.sql
@@ -1,0 +1,72 @@
+-- BLOCK select_sync_problems
+(
+  SELECT
+    'course' AS entity,
+    c.short_name AS identifier,
+    c.sync_errors AS errors,
+    c.sync_warnings AS warnings
+  FROM
+    courses AS c
+  WHERE
+    c.id = $course_id
+    AND (
+      COALESCE(c.sync_errors, '') != ''
+      OR COALESCE(c.sync_warnings, '') != ''
+    )
+)
+UNION ALL
+(
+  SELECT
+    'course_instance' AS entity,
+    ci.short_name AS identifier,
+    ci.sync_errors AS errors,
+    ci.sync_warnings AS warnings
+  FROM
+    course_instances AS ci
+  WHERE
+    ci.course_id = $course_id
+    AND ci.deleted_at IS NULL
+    AND (
+      COALESCE(ci.sync_errors, '') != ''
+      OR COALESCE(ci.sync_warnings, '') != ''
+    )
+)
+UNION ALL
+(
+  SELECT
+    'assessment' AS entity,
+    (ci.short_name || '/' || a.tid) AS identifier,
+    a.sync_errors AS errors,
+    a.sync_warnings AS warnings
+  FROM
+    assessments AS a
+    JOIN course_instances AS ci ON (ci.id = a.course_instance_id)
+  WHERE
+    ci.course_id = $course_id
+    AND a.deleted_at IS NULL
+    AND ci.deleted_at IS NULL
+    AND (
+      COALESCE(a.sync_errors, '') != ''
+      OR COALESCE(a.sync_warnings, '') != ''
+    )
+)
+UNION ALL
+(
+  SELECT
+    'question' AS entity,
+    q.qid AS identifier,
+    q.sync_errors AS errors,
+    q.sync_warnings AS warnings
+  FROM
+    questions AS q
+  WHERE
+    q.course_id = $course_id
+    AND q.deleted_at IS NULL
+    AND (
+      COALESCE(q.sync_errors, '') != ''
+      OR COALESCE(q.sync_warnings, '') != ''
+    )
+)
+ORDER BY
+  entity,
+  identifier;

--- a/apps/prairielearn/src/mcp/tools/sync-course.ts
+++ b/apps/prairielearn/src/mcp/tools/sync-course.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import * as sqldb from '@prairielearn/postgres';
+
+import { type Course } from '../../lib/db-types.js';
+import { type ServerJobLogger } from '../../lib/server-jobs.js';
+import { syncDiskToSql } from '../../sync/syncFromDisk.js';
+
+const sql = sqldb.loadSqlEquiv(import.meta.url);
+
+const SyncProblemSchema = z.object({
+  entity: z.string(),
+  identifier: z.string().nullable(),
+  errors: z.string().nullable(),
+  warnings: z.string().nullable(),
+});
+
+export interface SyncCourseResult {
+  status: 'complete' | 'sharing_error';
+  hadJsonErrors: boolean;
+  hadJsonErrorsOrWarnings: boolean;
+  /** Per-entity sync errors and warnings, read back after the sync. */
+  problems: {
+    entity: string;
+    identifier: string | null;
+    errors: string | null;
+    warnings: string | null;
+  }[];
+  log: string[];
+}
+
+/**
+ * Syncs the course from disk into the database and returns any errors.
+ *
+ * This is the agent's commit point: it edits files with its own filesystem
+ * tools, then calls this to validate and apply them. Sync errors are the
+ * feedback signal for JSON schema violations, dangling QID references,
+ * duplicate UUIDs, and undeclared topics or tags.
+ */
+export async function syncCourse(course: Course): Promise<SyncCourseResult> {
+  const log: string[] = [];
+  const logger: ServerJobLogger = {
+    error: (msg) => log.push(msg),
+    warn: (msg) => log.push(msg),
+    info: (msg) => log.push(msg),
+    // `verbose` output is per-entity timing noise; it isn't useful to the agent.
+    verbose: () => {},
+  };
+
+  const result = await syncDiskToSql(course, logger);
+
+  // `syncDiskToSql` reports only whether errors occurred. The messages
+  // themselves are written to `sync_errors`/`sync_warnings` columns on each
+  // entity, so we read them back to tell the agent what to fix.
+  const problems = await sqldb.queryRows(
+    sql.select_sync_problems,
+    { course_id: course.id },
+    SyncProblemSchema,
+  );
+
+  return {
+    status: result.status,
+    hadJsonErrors: result.status === 'complete' ? result.hadJsonErrors : true,
+    hadJsonErrorsOrWarnings: result.status === 'complete' ? result.hadJsonErrorsOrWarnings : true,
+    problems,
+    log,
+  };
+}

--- a/apps/prairielearn/src/mcp/tools/test-question.ts
+++ b/apps/prairielearn/src/mcp/tools/test-question.ts
@@ -1,0 +1,123 @@
+import { type Course } from '../../lib/db-types.js';
+import {
+  type QuestionTestResult,
+  questionSupportsTesting,
+  runQuestionTests,
+} from '../../lib/question-testing.js';
+import { selectQuestionByQid } from '../../models/question.js';
+
+/** A variant that rendered without error but looks suspicious anyway. */
+interface Warning {
+  variantSeed: string;
+  message: string;
+}
+
+/**
+ * Flags variants that "work" but are probably wrong. These are the failures that
+ * a pass/fail test cycle misses entirely: an answer that collides with a
+ * distractor, an unrendered Mustache tag, a degenerate zero answer.
+ */
+function findWarnings(results: QuestionTestResult[]): Warning[] {
+  const warnings: Warning[] = [];
+
+  for (const result of results) {
+    // Only inspect the `correct` runs — the others deliberately submit bad data.
+    if (result.testType !== 'correct' || !result.success) continue;
+
+    const answers = Object.entries(result.trueAnswer ?? {});
+
+    for (const [name, value] of answers) {
+      if (value === 0 || value === '0') {
+        warnings.push({
+          variantSeed: result.variantSeed,
+          message: `Correct answer "${name}" is zero, which is often a degenerate variant.`,
+        });
+      }
+    }
+
+    // A correct answer that also appears among the generated parameters is
+    // usually a distractor collision.
+    const paramValues = Object.entries(result.params ?? {});
+    for (const [answerName, answerValue] of answers) {
+      if (answerValue == null || typeof answerValue === 'object') continue;
+      for (const [paramName, paramValue] of paramValues) {
+        if (paramValue == null || typeof paramValue === 'object') continue;
+        if (String(paramValue) !== String(answerValue)) continue;
+        // Params that the question intentionally derives from the answer are
+        // common, so only flag names that look like alternatives.
+        if (!/distract|option|choice|wrong|incorrect/i.test(paramName)) continue;
+        warnings.push({
+          variantSeed: result.variantSeed,
+          message: `Parameter "${paramName}" equals correct answer "${answerName}" (${String(answerValue)}).`,
+        });
+      }
+    }
+  }
+
+  return warnings;
+}
+
+export interface TestQuestionResult {
+  qid: string;
+  questionId: string;
+  passed: boolean;
+  summary: { total: number; passed: number; failed: number };
+  /** Only the failures, so the agent isn't handed a wall of successes. */
+  failures: QuestionTestResult[];
+  warnings: Warning[];
+}
+
+/**
+ * Renders a question across many random variants and submits correct, incorrect,
+ * and invalid answers to each, returning structured results.
+ *
+ * Failures include the variant seed, so the agent can reproduce any one of them
+ * deterministically by calling this again with the same `seedPrefix`.
+ */
+export async function testQuestionTool({
+  course,
+  qid,
+  count,
+  seedPrefix,
+  userId,
+  authnUserId,
+}: {
+  course: Course;
+  qid: string;
+  count: number;
+  seedPrefix?: string;
+  userId: string;
+  authnUserId: string;
+}): Promise<TestQuestionResult> {
+  const question = await selectQuestionByQid({ course_id: course.id, qid });
+
+  if (!questionSupportsTesting(question)) {
+    throw new Error(
+      `Question "${qid}" does not support automated testing (only v3 "Freeform" questions do).`,
+    );
+  }
+
+  const results = await runQuestionTests({
+    question,
+    course,
+    count,
+    user_id: userId,
+    authn_user_id: authnUserId,
+    variantSeedPrefix: seedPrefix,
+  });
+
+  const failures = results.filter((result) => !result.success);
+
+  return {
+    qid,
+    questionId: question.id,
+    passed: failures.length === 0,
+    summary: {
+      total: results.length,
+      passed: results.length - failures.length,
+      failed: failures.length,
+    },
+    failures,
+    warnings: findWarnings(results),
+  };
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -175,7 +175,12 @@ export default [
     },
   },
   {
-    files: ['apps/prairielearn/src/tests/**/*', 'scripts/**/*', 'contrib/**/*'],
+    files: [
+      'apps/prairielearn/src/tests/**/*',
+      'apps/prairielearn/src/mcp/scripts/**/*',
+      'scripts/**/*',
+      'contrib/**/*',
+    ],
     rules: {
       'no-console': 'off',
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1174,6 +1174,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(supports-color@7.2.0)(zod@4.4.3)
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -3720,6 +3723,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@html-eslint/core@0.61.0':
     resolution: {integrity: sha512-/dcMywhcO7+CvyV5oUGUkh4641ZyeJyncQas+Ulq7z9fXorTstMrApIzIUdV9TNgkwZZ97Rd8/8XbXkxgoJo6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3999,6 +4008,16 @@ packages:
 
   '@mathjax/mathjax-newcm-font@4.1.3':
     resolution: {integrity: sha512-gzAB3dFHilHX1l5x2xUqRL+1jDQt3Fyza1DkEMVXWC4E8SvsGdlgEza47HYi2WhVcgfkvf4zgUGzuhbq3Pjlew==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.2.2':
     resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
@@ -6026,6 +6045,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@zip.js/zip.js@2.8.34':
     resolution: {integrity: sha512-+6a3lyqq69rpseLbvDPiVIWsZ/HdTGAAD6afFtug6ECPDGttb2dHnPC6cJgdPofYkzL9OvXizegq+DQVfL2rnA==}
@@ -6041,6 +6061,10 @@ packages:
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
   ace-builds@1.44.0:
@@ -6089,6 +6113,14 @@ packages:
     resolution: {integrity: sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==}
     peerDependencies:
       ajv: ^8.0.1
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-i18n@4.2.0:
     resolution: {integrity: sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==}
@@ -6316,6 +6348,10 @@ packages:
   body-parser@1.20.6:
     resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -6619,6 +6655,10 @@ packages:
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -7395,6 +7435,10 @@ packages:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -7409,12 +7453,22 @@ packages:
   express-async-handler@1.2.0:
     resolution: {integrity: sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w==}
 
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express-static-gzip@2.2.0:
     resolution: {integrity: sha512-4ZQ0pHX0CAauxmzry2/8XFLM6aZA4NBvg9QezSlsEO1zLnl7vMFa48/WIcjzdfOiEUS4S1npPPKP2NHHYAp6qg==}
 
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -7548,6 +7602,10 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -7593,6 +7651,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -7796,6 +7858,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hono@4.13.2:
+    resolution: {integrity: sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==}
+    engines: {node: '>=16.9.0'}
+
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
 
@@ -7914,6 +7980,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
   identifier-regex@1.1.0:
     resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
     engines: {node: '>=18'}
@@ -7986,6 +8056,10 @@ packages:
   ioredis@6.0.0:
     resolution: {integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==}
     engines: {node: '>=20.0.0'}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -8066,6 +8140,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -8197,6 +8274,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -8603,6 +8683,10 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
@@ -8617,6 +8701,10 @@ packages:
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -8727,9 +8815,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -8837,6 +8933,10 @@ packages:
 
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
@@ -9133,6 +9233,9 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -9466,6 +9569,10 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
   react-aria-components@1.20.0:
     resolution: {integrity: sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==}
     peerDependencies:
@@ -9663,6 +9770,10 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rss-parser@3.13.0:
     resolution: {integrity: sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==}
 
@@ -9765,6 +9876,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@13.0.1:
     resolution: {integrity: sha512-bBZaRwLH9PN5HbLCjPId4dP5bNGEtumcErgOX952IsvOhVPrm3/AeK1y0UHA/QaPG701eg0yEnOKsCOC6X/kaA==}
     engines: {node: '>=20'}
@@ -9776,6 +9891,10 @@ packages:
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
@@ -10261,6 +10380,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -10760,6 +10883,11 @@ packages:
   zip-stream@7.0.5:
     resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
     engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -11872,6 +12000,10 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
+  '@hono/node-server@2.1.1(hono@4.13.2)':
+    dependencies:
+      hono: 4.13.2
+
   '@html-eslint/core@0.61.0':
     dependencies:
       '@html-eslint/types': 0.61.0
@@ -12114,6 +12246,28 @@ snapshots:
       yaml: 2.9.0
 
   '@mathjax/mathjax-newcm-font@4.1.3': {}
+
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.2)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1(supports-color@7.2.0)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
+      hono: 4.13.2
+      jose: 6.2.8
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -14100,6 +14254,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   ace-builds@1.44.0: {}
 
   ace-code@1.44.0: {}
@@ -14137,6 +14296,10 @@ snapshots:
 
   ajv-errors@3.0.0(ajv@8.20.0):
     dependencies:
+      ajv: 8.20.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
       ajv: 8.20.0
 
   ajv-i18n@4.2.0(ajv@8.20.0):
@@ -14346,6 +14509,20 @@ snapshots:
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.3.0(supports-color@7.2.0):
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@7.2.0)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -14643,6 +14820,8 @@ snapshots:
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
+
+  content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
 
@@ -15567,6 +15746,10 @@ snapshots:
 
   eventsource-parser@3.1.0: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -15587,6 +15770,14 @@ snapshots:
   exponential-backoff@3.1.3: {}
 
   express-async-handler@1.2.0: {}
+
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      express: 5.2.1(supports-color@7.2.0)
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   express-static-gzip@2.2.0(supports-color@7.2.0):
     dependencies:
@@ -15627,6 +15818,39 @@ snapshots:
       statuses: 2.0.2
       type-is: 1.6.18
       utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1(supports-color@7.2.0):
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0(supports-color@7.2.0)
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@7.2.0)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1(supports-color@7.2.0)
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      router: 2.2.0(supports-color@7.2.0)
+      send: 1.2.1(supports-color@7.2.0)
+      serve-static: 2.2.1(supports-color@7.2.0)
+      statuses: 2.0.2
+      type-is: 2.1.0
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15774,6 +15998,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up-simple@1.0.1: {}
 
   find-up@5.0.0:
@@ -15816,6 +16051,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -16046,6 +16283,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hono@4.13.2: {}
+
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
@@ -16174,6 +16413,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   identifier-regex@1.1.0:
     dependencies:
       reserved-identifiers: 1.2.0
@@ -16237,6 +16480,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -16306,6 +16551,8 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -16422,6 +16669,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -16957,6 +17206,8 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.1: {}
+
   memorystream@0.3.1: {}
 
   meow@13.2.0: {}
@@ -16964,6 +17215,8 @@ snapshots:
   meow@14.1.0: {}
 
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -17189,9 +17442,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -17282,6 +17541,8 @@ snapshots:
       randexp: 0.4.6
 
   negotiator@0.6.3: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -17611,6 +17872,8 @@ snapshots:
   path-to-regexp@0.1.13: {}
 
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -17972,6 +18235,13 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
   react-aria-components@1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@internationalized/date': 3.12.3
@@ -18225,6 +18495,16 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  router@2.2.0(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rss-parser@3.13.0:
     dependencies:
       entities: 2.2.0
@@ -18329,6 +18609,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1(supports-color@7.2.0):
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@13.0.1:
     dependencies:
       non-error: 0.1.0
@@ -18348,6 +18644,15 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1(supports-color@7.2.0):
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18924,6 +19229,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
+
   typedarray@0.0.6: {}
 
   typescript-cp@0.1.11(typescript@6.0.3):
@@ -19358,6 +19669,10 @@ snapshots:
       compress-commons: 7.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Description

Adds a deliberately local-only MCP proof of concept for a course-authoring agent harness. The harness retains its native file tools; the server exposes the PrairieLearn capabilities it cannot provide directly: course sync, course/entity lookup, structured question testing, read-only course-data queries, and job-output retrieval.

The server rejects production and non-local database configurations, scopes each process to one course, and provides a scratch-course plus smoke/loop-test workflow. Structured test output includes reproducible variant seeds.

AI assistance: implementation review and PR preparation by Codex; the implementation originated in the local worktree.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

## Testing

- Added focused coverage for deterministic, Python-compatible variant seeds.
- End-to-end MCP smoke and loop tests require a local scratch course plus Postgres, Redis, and the Python environment; they are documented but were not run for this PR.