### PR TITLE
Add feature-flagged cloud course agent MVP

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -43,7 +43,7 @@ module.exports = {
       comment: "Depends on a module that cannot be found ('resolved to disk').",
       severity: 'error',
       from: {},
-      to: { couldNotResolve: true },
+      to: { couldNotResolve: true, pathNot: ['^cloudflare:'] },
     },
     {
       name: 'no-duplicate-dep-types',

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ __pycache__/
 
 ## Wrangler local state
 .wrangler
+.dev.vars
 apps/agent-worker/worker-configuration.d.ts
 
 ## Compiled files

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ __pycache__/
 ## Turborepo caches
 .turbo
 
+## Wrangler local state
+.wrangler
+apps/agent-worker/worker-configuration.d.ts
+
 ## Compiled files
 apps/*/dist
 apps/prairielearn/public/build

--- a/.knip.ts
+++ b/.knip.ts
@@ -189,6 +189,10 @@ const config: KnipConfig = {
     'apps/grader-host': {
       project: ['**/*.{ts,cts,mts,tsx}'],
     },
+    'apps/agent-worker': {
+      ignoreDependencies: ['cloudflare'],
+      project: ['**/*.{ts,cts,mts,tsx}'],
+    },
     'packages/*': {
       project: ['**/*.{ts,cts,mts,tsx}'],
     },

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,9 @@ apps/*/dist/
 apps/prairielearn/public/build/
 packages/*/dist/
 
+# Wrangler-generated Worker runtime declarations
+apps/agent-worker/worker-configuration.d.ts
+
 # Built assets
 apps/prairielearn/public/build/
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ dev-bun: python-deps
 	@pnpm dev-bun
 dev-workspace-host: start-support
 	@pnpm dev-workspace-host
+dev-agent-worker:
+	@pnpm dev-agent-worker
 dev-all:
 	@$(MAKE) -s -j2 dev dev-workspace-host
 
@@ -159,7 +161,7 @@ lint-markdown:
 lint-links:
 	@node scripts/validate-links.mjs
 lint-docker:
-	@hadolint ./graders/**/Dockerfile ./workspaces/**/Dockerfile ./images/**/Dockerfile Dockerfile
+	@hadolint ./apps/agent-worker/Dockerfile ./graders/**/Dockerfile ./workspaces/**/Dockerfile ./images/**/Dockerfile Dockerfile
 lint-shell:
 	@shellcheck -S warning $(shell find . -type f -name "*.sh" ! -path "./node_modules/*" ! -path "./.venv/*" ! -path "./testCourse/*")
 lint-sql:

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ dev-workspace-host: start-support
 	@pnpm dev-workspace-host
 dev-agent-worker:
 	@pnpm dev-agent-worker
+dev-agent: start-support python-deps
+	@pnpm dev-agent
 dev-all:
 	@$(MAKE) -s -j2 dev dev-workspace-host
 
@@ -85,6 +87,8 @@ start-s3rver:
 test-all: test-js test-python test-e2e
 
 test: test-js test-python
+test-agent: start-support python-deps
+	@pnpm test-agent
 test-js: start-support
 	@pnpm test
 test-prairielearn-docker-smoke-tests: start-support

--- a/apps/agent-worker/.dev.vars.example
+++ b/apps/agent-worker/.dev.vars.example
@@ -1,0 +1,12 @@
+# Copy this file to .dev.vars only when you need to override the account-free
+# deterministic defaults supplied by the package scripts.
+AGENT_WORKER_ENABLED=
+LOCAL_DEVELOPMENT=
+AGENT_CAPABILITY_SECRET=
+PRAIRIELEARN_ORIGIN=
+
+# Optional live-provider compatibility testing. These are never required by
+# make dev-agent or make test-agent.
+ANTHROPIC_API_KEY=
+GITHUB_READ_TOKEN=
+GITHUB_WRITE_TOKEN=

--- a/apps/agent-worker/Dockerfile
+++ b/apps/agent-worker/Dockerfile
@@ -3,5 +3,10 @@ FROM docker.io/cloudflare/sandbox:0.13.0-next.738.2
 WORKDIR /opt/prairielearn-agent
 COPY sandbox/package.json sandbox/package-lock.json /opt/prairielearn-agent/
 RUN npm ci --omit=dev
+COPY sandbox/*.mjs /opt/prairielearn-agent/
+RUN groupadd --system prairie-agent \
+  && useradd --system --gid prairie-agent --home-dir /nonexistent --shell /usr/sbin/nologin prairie-agent \
+  && git config --system --add safe.directory /workspace/course \
+  && chmod -R a-w /opt/prairielearn-agent
 
 WORKDIR /workspace

--- a/apps/agent-worker/Dockerfile
+++ b/apps/agent-worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.io/cloudflare/sandbox:0.13.0-next.738.2
+
+WORKDIR /opt/prairielearn-agent
+COPY sandbox/package.json sandbox/package-lock.json /opt/prairielearn-agent/
+RUN npm ci --omit=dev
+
+WORKDIR /workspace

--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -1,0 +1,36 @@
+# PrairieLearn agent worker
+
+This app is the Cloudflare Worker and Sandbox execution boundary for PrairieLearn's course-authoring agent. The current foundation slice provides:
+
+- a health endpoint that runs without starting a container;
+- a local-only smoke endpoint that runs a fixed command in a real Cloudflare Sandbox;
+- one Durable Object per conversation to serialize run-state transitions; and
+- an R2 checkpoint write/read during the smoke run.
+
+The smoke endpoint intentionally does not accept a command from the caller. Arbitrary agent commands will be introduced behind PrairieLearn-issued run authorization rather than an unauthenticated HTTP endpoint.
+
+## Local development
+
+Docker must be running. From the repository root:
+
+```sh
+pnpm dev-agent-worker
+```
+
+Wrangler builds the Sandbox image and persists local Durable Object and R2 state in `apps/agent-worker/.wrangler/state`.
+
+In another terminal, verify the Worker-only route:
+
+```sh
+curl --fail-with-body --silent --show-error http://localhost:8787/health
+```
+
+Then exercise the real Sandbox, Durable Object, and R2 bindings:
+
+```sh
+pnpm --filter @prairielearn/agent-worker test:smoke
+```
+
+The first Sandbox image build can take several minutes. A successful response includes `sandbox-ok`, the installed Node and Git versions, `claude-agent-sdk-ok`, and the R2 checkpoint key.
+
+The `LOCAL_DEVELOPMENT` binding gates this endpoint. Production configuration must omit it.

--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -1,36 +1,55 @@
 # PrairieLearn agent worker
 
-This app is the Cloudflare Worker and Sandbox execution boundary for PrairieLearn's course-authoring agent. The current foundation slice provides:
+This private Worker runs one serialized course-authoring conversation per Durable Object. Agent
+processes run in the pinned Cloudflare Sandbox image, use `/workspace/course`, mirror Claude sessions
+to immutable R2 parts, and checkpoint Git history as verified baseline/incremental bundles. No public
+endpoint accepts a command.
 
-- a health endpoint that runs without starting a container;
-- a local-only smoke endpoint that runs a fixed command in a real Cloudflare Sandbox;
-- one Durable Object per conversation to serialize run-state transitions; and
-- an R2 checkpoint write/read during the smoke run.
+The service is disabled unless both `AGENT_WORKER_ENABLED=true` and
+`AGENT_CAPABILITY_SECRET` are configured. PrairieLearn issues short-lived HS256 capabilities bound to
+the route purpose, prompt hash, run/conversation/course, callback origin, harness, repository, and
+allowed tools. Production also requires `PRAIRIELEARN_ORIGIN`; HTTP callback URLs are accepted only
+with `LOCAL_DEVELOPMENT=true`.
 
-The smoke endpoint intentionally does not accept a command from the caller. Arbitrary agent commands will be introduced behind PrairieLearn-issued run authorization rather than an unauthenticated HTTP endpoint.
+## API
 
-## Local development
+- `POST /v1/runs/start`
+- `GET /v1/runs/:run_id`
+- `POST /v1/runs/:run_id/cancel`
+- `POST /v1/runs/:run_id/publish`
+- `DELETE /v1/conversations/:conversation_id`
 
-Docker must be running. From the repository root:
+Publication uses a separate `purpose=publish` capability and a fresh model-free publisher sandbox.
+Its exact repository, branch, HEAD, operation ID, and capability JTI are verified before a temporary
+Git write handler is installed.
+
+## Local development and recovery smoke
+
+Docker must be running. Start the Worker from the repository root:
 
 ```sh
-pnpm dev-agent-worker
+pnpm --filter @prairielearn/agent-worker dev
 ```
 
-Wrangler builds the Sandbox image and persists local Durable Object and R2 state in `apps/agent-worker/.wrangler/state`.
-
-In another terminal, verify the Worker-only route:
+The dev script supplies the fixed local-only capability secret and persists Wrangler state in
+`.wrangler/state`. Run the first smoke phase:
 
 ```sh
-curl --fail-with-body --silent --show-error http://localhost:8787/health
+pnpm --filter @prairielearn/agent-worker test:smoke -- start /tmp/agent-smoke.json
 ```
 
-Then exercise the real Sandbox, Durable Object, and R2 bindings:
+After it completes, stop Wrangler, restart the same dev command (and therefore the same persisted
+DO/R2 directory), then run:
 
 ```sh
-pnpm --filter @prairielearn/agent-worker test:smoke
+pnpm --filter @prairielearn/agent-worker test:smoke -- resume /tmp/agent-smoke.json
 ```
 
-The first Sandbox image build can take several minutes. A successful response includes `sandbox-ok`, the installed Node and Git versions, `claude-agent-sdk-ok`, and the R2 checkpoint key.
+The phases cover signed start/status, concurrent-turn rejection, a real deterministic harness commit,
+Worker restart, sandbox destruction and R2 restore, publication and receipt replay, session resume,
+cancellation, deletion, and confirmation that the conversation R2 prefix is empty. `test:smoke`
+without a phase runs both halves without the explicit Worker restart.
 
-The `LOCAL_DEVELOPMENT` binding gates this endpoint. Production configuration must omit it.
+Production secrets are `AGENT_CAPABILITY_SECRET` and, when enabled, `ANTHROPIC_API_KEY`,
+`GITHUB_READ_TOKEN`, and `GITHUB_WRITE_TOKEN`. Deployable Wrangler configuration contains no secret
+values.

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -8,14 +8,16 @@
   },
   "scripts": {
     "build": "wrangler types && tsgo && tscp",
-    "dev": "wrangler dev --local --persist-to .wrangler/state --var LOCAL_DEVELOPMENT:true",
+    "dev": "wrangler dev --local --persist-to .wrangler/state --var LOCAL_DEVELOPMENT:true --var AGENT_WORKER_ENABLED:true --var AGENT_CAPABILITY_SECRET:local-agent-capability-secret-32-bytes",
     "test": "vitest run --coverage",
     "test:smoke": "node scripts/smoke.mjs",
     "test:unit": "vitest run",
     "types": "wrangler types"
   },
   "dependencies": {
-    "@cloudflare/sandbox": "0.13.0-next.738.2"
+    "@cloudflare/sandbox": "0.13.0-next.738.2",
+    "@prairielearn/agent-protocol": "workspace:^",
+    "jose": "^6.2.8"
   },
   "devDependencies": {
     "@prairielearn/tsconfig": "workspace:^",

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@prairielearn/agent-worker",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "scripts": {
+    "build": "wrangler types && tsgo && tscp",
+    "dev": "wrangler dev --local --persist-to .wrangler/state --var LOCAL_DEVELOPMENT:true",
+    "test": "vitest run --coverage",
+    "test:smoke": "node scripts/smoke.mjs",
+    "test:unit": "vitest run",
+    "types": "wrangler types"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "0.13.0-next.738.2"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "workspace:^",
+    "@types/node": "^24.13.3",
+    "@typescript/native-preview": "beta",
+    "@vitest/coverage-v8": "^4.1.10",
+    "typescript-cp": "^0.1.11",
+    "vitest": "^4.1.10",
+    "wrangler": "^4.120.0"
+  }
+}

--- a/apps/agent-worker/sandbox/harness.mjs
+++ b/apps/agent-worker/sandbox/harness.mjs
@@ -1,0 +1,228 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+import { HttpSessionStore } from './session-store.mjs';
+import { callPrairieLearnTool, createPrairieLearnMcpServer } from './tool-adapter.mjs';
+
+const coursePath = '/workspace/course';
+const eventsUrl = 'http://worker-events.internal/events';
+const configPath = process.argv[2];
+const execFileAsync = promisify(execFile);
+const authoringSystemPrompt = `You are the PrairieLearn course-authoring agent for one instructor-owned course repository.
+
+- Work only inside /workspace/course. Inspect and follow the repository's existing conventions.
+- You may use Bash for local analysis and scripts. Never push Git refs or attempt to obtain credentials.
+- Use the PrairieLearn MCP tools for course entities, instructor-visible data, job output, and question rendering instead of guessing server state.
+- Before calling render_question, stage and commit the complete question change. The render tool previews exactly one deterministic variant from that committed tree; fix reported issues, commit, and render again when needed.
+- Keep all intended changes committed. In the final response, summarize what changed, the checks or preview performed, and any unresolved issue. Publication is a separate instructor action.`;
+
+if (!configPath) throw new Error('Harness configuration path is required');
+const config = JSON.parse(await readFile(configPath, 'utf8'));
+const result =
+  config.harness === 'claude'
+    ? await runClaudeHarness(config)
+    : await runDeterministicHarness(config);
+process.stdout.write(`${JSON.stringify(result)}\n`);
+
+async function runDeterministicHarness(config) {
+  if (process.getuid?.() === 0) throw new Error('Agent harness must not run as root');
+  for (const name of ['ANTHROPIC_API_KEY', 'GITHUB_READ_TOKEN', 'GITHUB_WRITE_TOKEN']) {
+    if (process.env[name]) {
+      throw new Error(`${name} must not be present in the harness environment`);
+    }
+  }
+  try {
+    await access('/opt/prairielearn-agent/harness.mjs', fsConstants.W_OK);
+    throw new Error('Agent harness adapter files must be immutable');
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === 'Agent harness adapter files must be immutable'
+    ) {
+      throw error;
+    }
+  }
+  const store = new HttpSessionStore();
+  const sessionId = config.resume_session_id ?? randomUUID();
+  const projectKey = coursePath;
+  const userEntry = {
+    type: 'user',
+    uuid: randomUUID(),
+    timestamp: new Date().toISOString(),
+    message: { role: 'user', content: config.prompt },
+  };
+  const assistantText = `Deterministic response for: ${config.prompt}`;
+  const assistantEntry = {
+    type: 'assistant',
+    uuid: randomUUID(),
+    timestamp: new Date().toISOString(),
+    message: { role: 'assistant', content: assistantText },
+  };
+
+  await store.append({ projectKey, sessionId }, [userEntry]);
+  await store.append({ projectKey, sessionId }, [userEntry]);
+  await store.append({ projectKey, sessionId, subpath: 'subagents/agent-deterministic' }, [
+    {
+      type: 'agent_metadata',
+      uuid: randomUUID(),
+      timestamp: new Date().toISOString(),
+      parentAgentId: null,
+    },
+  ]);
+
+  const toolResults = {};
+  if (config.allowed_tools.includes('list_entities')) {
+    toolResults.list_entities = await callTool('list_entities', { scope: 'questions' });
+  }
+  if (config.allowed_tools.includes('read_course_file')) {
+    toolResults.read_course_file = await callTool('read_course_file', { path: 'README.md' });
+  }
+  if (config.local_development && config.allowed_tools.includes('query_course_data')) {
+    toolResults.query_course_data = await callTool('query_course_data', {
+      query: 'SELECT id, qid FROM questions ORDER BY id LIMIT 1',
+    });
+  }
+
+  if (config.prompt.includes('[wait-for-cancel]')) {
+    await new Promise((resolve) => setTimeout(resolve, 30_000));
+  }
+
+  const listedQid = firstQuestionId(toolResults.list_entities);
+  const qid = `agent-generated-${config.run_id.replaceAll(/[^A-Za-z0-9._-]/g, '-')}`;
+  const questionPath = `${coursePath}/questions/${qid}`;
+  await mkdir(questionPath, { recursive: true });
+  await writeFile(
+    `${questionPath}/question.html`,
+    '<pl-question-panel><p>Deterministic agent edit</p></pl-question-panel>\n',
+  );
+  await writeFile(
+    `${questionPath}/info.json`,
+    `${JSON.stringify({ title: 'Agent edit' }, null, 2)}\n`,
+  );
+  await writeFile(
+    `${questionPath}/server.py`,
+    'def generate(data):\n    data["params"]["agent"] = True\n',
+  );
+  await writeFile(
+    `${coursePath}/agent-output.txt`,
+    `${assistantText}\n${JSON.stringify(toolResults)}\n`,
+  );
+  await runGit(['add', 'agent-output.txt', `questions/${qid}`]);
+  await runGit(['commit', '--allow-empty', '-m', `Agent turn ${config.run_id}`]);
+  if (config.allowed_tools.includes('render_question')) {
+    toolResults.render_question = await callTool('render_question', { qid, variant_seed: '1' });
+    if (
+      toolResults.render_question?.result?.rendered !== true ||
+      toolResults.render_question?.result?.variant_seed !== '1'
+    ) {
+      throw new Error('Deterministic render_question did not return a rendered question');
+    }
+  }
+  await store.append({ projectKey, sessionId }, [assistantEntry]);
+  const loaded = await store.load({ projectKey, sessionId });
+  const subkeys = await store.listSubkeys({ projectKey, sessionId });
+  await emit([
+    { type: 'assistant_message_delta', data: { text: assistantText } },
+    { type: 'assistant_message', data: { text: assistantText } },
+  ]);
+
+  return {
+    session_id: sessionId,
+    transcript_entries: loaded?.length ?? 0,
+    listed_qid: listedQid,
+    rendered_qid: qid,
+    runtime_uid: process.getuid?.(),
+    adapter_immutable: true,
+    secret_env_absent: true,
+    subkeys,
+  };
+}
+
+async function callTool(name, input) {
+  const operationId = randomUUID();
+  return await callPrairieLearnTool(name, input, undefined, operationId);
+}
+
+function firstQuestionId(result) {
+  const entities = result?.result?.entities;
+  if (!Array.isArray(entities) || entities.length === 0) return undefined;
+  const entity = entities[0];
+  return typeof entity?.qid === 'string' ? entity.qid : undefined;
+}
+
+async function runClaudeHarness(config) {
+  const store = new HttpSessionStore();
+  const mcpServer = createPrairieLearnMcpServer(config.allowed_tools);
+  let sessionId = config.resume_session_id;
+  let finalResult;
+  let mirrorFailed = false;
+
+  const conversation = query({
+    prompt: config.prompt,
+    options: {
+      cwd: coursePath,
+      resume: config.resume_session_id,
+      sessionStore: store,
+      sessionStoreFlush: 'batched',
+      mcpServers: { prairielearn: mcpServer },
+      allowedTools: [
+        'Read',
+        'Write',
+        'Edit',
+        'Glob',
+        'Grep',
+        'Bash',
+        ...config.allowed_tools.map((name) => `mcp__prairielearn__${name}`),
+      ],
+      disallowedTools: ['WebFetch', 'WebSearch'],
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+      maxTurns: 20,
+      systemPrompt: authoringSystemPrompt,
+      env: {
+        ...process.env,
+        ANTHROPIC_API_KEY: 'worker-injected',
+        CLAUDE_CONFIG_DIR: '/tmp/prairielearn-claude',
+      },
+    },
+  });
+
+  for await (const message of conversation) {
+    if ('session_id' in message && message.session_id) sessionId = message.session_id;
+    if (message.type === 'system' && message.subtype === 'mirror_error') {
+      mirrorFailed = true;
+    } else if (message.type === 'assistant') {
+      await emit([{ type: 'assistant_message', data: { message: message.message } }]);
+    } else if (message.type === 'result') {
+      finalResult = message;
+    }
+  }
+
+  if (mirrorFailed) throw new Error('Claude transcript mirroring failed');
+  if (!sessionId) throw new Error('Claude harness did not return a session ID');
+  await runGit(['add', '--all']);
+  await runGit(['commit', '--allow-empty', '-m', `Agent turn ${config.run_id}`]);
+  return { session_id: sessionId, result: finalResult };
+}
+
+async function emit(events) {
+  const stableEvents = events.map((event) => ({
+    event_id: event.event_id ?? randomUUID(),
+    ...event,
+  }));
+  const response = await fetch(eventsUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ events: stableEvents }),
+  });
+  if (!response.ok) throw new Error(`Event forwarding failed: ${await response.text()}`);
+}
+
+async function runGit(args) {
+  await execFileAsync('git', ['-C', coursePath, ...args], { maxBuffer: 1_000_000 });
+}

--- a/apps/agent-worker/sandbox/package-lock.json
+++ b/apps/agent-worker/sandbox/package-lock.json
@@ -1,0 +1,1477 @@
+{
+  "name": "@prairielearn/agent-sandbox",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@prairielearn/agent-sandbox",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.233"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.233.tgz",
+      "integrity": "sha512-Dy+YqhggwtbezDy3Ap2pb1sK3bOqnI+sLNnsVjB3AUWvR0QlGnjjrjORXY03Y50I+B1eFRNEcYPAZKRYlCkSLQ==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.233"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.233.tgz",
+      "integrity": "sha512-4WDiBZgcrmvTDJjS8RNZwoxGgMz/0EpOM+sYa6EtyjwHTd6It1H/+k5zBckCmBajbgS5/ASCJqdwZzi7dwBl0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.233.tgz",
+      "integrity": "sha512-RaaEfNrbqSh77H5NdVF9cJQ0xhAUO92aOv71LSKSdAYModMeUvJN0k22Q7gvmx0TlmqJ+aVyCG8J8gVfgSL9mg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.233.tgz",
+      "integrity": "sha512-Az9HjQthYQqRjJCacBtDIAHX3TRGK9WlACNb/UOGAK3JndNzZMprM2mK/t6YmP2cRLJsGyorxL7HZmR9R9HYaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.233.tgz",
+      "integrity": "sha512-Z3uZdzt6xgJ3f4NIgO6lzBYSELULKSq6AL4OsNLBzuaEpVW0iYs1kUCaD9rcMlMrf3cV+Dk/GA/lTCGMgbucjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.233.tgz",
+      "integrity": "sha512-jpbhV+n9PnxLiyheQ/HjtHIg/E5/jVsk2Vdu132BSoL/3bsObSmMqKgsqoMutzwRZvtpqRs2RPVcjsC8G4A9Zw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.233.tgz",
+      "integrity": "sha512-kYBIAQCu2f1YITcGbpUN2jfrkAzs59TVAragAhE2z+GrkIcxcpZwmaRY6heMBtaSY8SuyrwgqbCW9hJALYFnEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.233.tgz",
+      "integrity": "sha512-aO2MaNdmQofyPLKszE4s+Ope/sLJPeI/ZlGdCcjYp7qhji2hgZ4bRWWsOrx5eKjz0gFK5CFFltILkFcNcxCsVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.233.tgz",
+      "integrity": "sha512-TcAYyWPXS5mREZGUksuCZsLIRQjbo/Vriur2PqIhAmgZ1oiqBZO27a90sX60EUczD7yV8wpwOVhVLhUxO0kAEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.120.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
+      "integrity": "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/apps/agent-worker/sandbox/package-lock.json
+++ b/apps/agent-worker/sandbox/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@prairielearn/agent-sandbox",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.233"
+        "@anthropic-ai/claude-agent-sdk": "0.3.233",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -144,7 +145,6 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
       "integrity": "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",
         "standardwebhooks": "^1.0.0"

--- a/apps/agent-worker/sandbox/package.json
+++ b/apps/agent-worker/sandbox/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.233"
+    "@anthropic-ai/claude-agent-sdk": "0.3.233",
+    "zod": "^4.4.3"
   }
 }

--- a/apps/agent-worker/sandbox/package.json
+++ b/apps/agent-worker/sandbox/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@prairielearn/agent-sandbox",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "0.3.233"
+  }
+}

--- a/apps/agent-worker/sandbox/session-store.mjs
+++ b/apps/agent-worker/sandbox/session-store.mjs
@@ -1,0 +1,33 @@
+const sessionStoreBaseUrl = 'http://session-store.internal';
+
+export class HttpSessionStore {
+  async append(key, entries) {
+    await request('/append', { key, entries });
+  }
+
+  async load(key) {
+    return (await request('/load', { key })).entries;
+  }
+
+  async listSessions(projectKey) {
+    return (await request('/list-sessions', { project_key: projectKey })).sessions;
+  }
+
+  async listSubkeys(key) {
+    return (await request('/list-subkeys', { key })).subkeys;
+  }
+
+  async delete(key) {
+    await request('/delete', { key });
+  }
+}
+
+async function request(path, body) {
+  const response = await fetch(`${sessionStoreBaseUrl}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) throw new Error(`Session store ${path} failed: ${await response.text()}`);
+  return await response.json();
+}

--- a/apps/agent-worker/sandbox/tool-adapter.mjs
+++ b/apps/agent-worker/sandbox/tool-adapter.mjs
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto';
+
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+
+const toolBaseUrl = 'http://prairielearn.internal/tools';
+
+export async function callPrairieLearnTool(
+  name,
+  input,
+  expectedRevision,
+  operationId = randomUUID(),
+) {
+  const response = await fetch(`${toolBaseUrl}/${name}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      operation_id: operationId,
+      input,
+      expected_revision: expectedRevision,
+    }),
+  });
+  if (!response.ok) throw new Error(`PrairieLearn tool ${name} failed: ${await response.text()}`);
+  return await response.json();
+}
+
+export function createPrairieLearnMcpServer(allowedTools) {
+  const tools = allowedTools.map((name) =>
+    tool(name, toolDefinitions[name].description, toolDefinitions[name].schema, async (input) => {
+      const result = await callPrairieLearnTool(name, input);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+      };
+    }),
+  );
+  return createSdkMcpServer({ name: 'prairielearn', version: '1.0.0', tools });
+}
+
+const toolDefinitions = {
+  list_entities: {
+    description: 'List PrairieLearn questions, course instances, or assessments in this course.',
+    schema: { scope: z.enum(['questions', 'course_instances', 'assessments']) },
+  },
+  read_course_file: {
+    description: 'Read one UTF-8 file using its course-relative path.',
+    schema: { path: z.string().min(1) },
+  },
+  query_course_data: {
+    description: 'Run one development-only read-only SELECT or WITH query against course data.',
+    schema: { query: z.string().min(1) },
+  },
+  render_question: {
+    description: 'Render a committed question from the sandbox for preview and validation.',
+    schema: { qid: z.string().min(1), variant_seed: z.string().optional() },
+  },
+  get_job_output: {
+    description: 'Read output for a PrairieLearn background job by sequence ID.',
+    schema: { job_sequence_id: z.string().min(1) },
+  },
+};

--- a/apps/agent-worker/scripts/smoke.mjs
+++ b/apps/agent-worker/scripts/smoke.mjs
@@ -1,38 +1,178 @@
 import assert from 'node:assert/strict';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+
+import { SignJWT } from 'jose';
 
 const baseUrl = process.env.AGENT_WORKER_URL ?? 'http://localhost:8787';
+const secret = process.env.AGENT_CAPABILITY_SECRET ?? 'local-agent-capability-secret-32-bytes';
+const args = process.argv.slice(2).filter((arg) => arg !== '--');
+const phase = args[0] ?? 'all';
+const statePath = args[1] ?? '/tmp/prairielearn-agent-smoke.json';
 
-const healthResponse = await fetch(`${baseUrl}/health`);
-assert.equal(healthResponse.status, 200);
-assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+assert.deepEqual(await json(await fetch(`${baseUrl}/health`)), { status: 'ok', enabled: true });
 
-const conversationId = `local-smoke-${randomUUID()}`;
-const attempts = await Promise.all([requestSmoke(conversationId), requestSmoke(conversationId)]);
-assert.deepEqual(attempts.map(({ response }) => response.status).sort(), [200, 409]);
+if (phase === 'start' || phase === 'all') await startPhase();
+if (phase === 'resume' || phase === 'all') await resumePhase();
 
-const { response: smokeResponse, result: smokeResult } = attempts.find(
-  ({ response }) => response.status === 200,
-);
-assert.equal(smokeResponse.status, 200, JSON.stringify(smokeResult));
-assert.equal(smokeResult.status, 'ok');
-assert.equal(smokeResult.conversation_id, conversationId);
-assert.equal(smokeResult.sandbox.exit_code, 0);
-assert.match(smokeResult.sandbox.stdout, /claude-agent-sdk-ok/);
-assert.match(smokeResult.sandbox.stdout, /sandbox-ok/);
-assert.match(
-  smokeResult.checkpoint_key,
-  new RegExp(`^conversations/${conversationId}/runs/.+/local-smoke\\.json$`),
-);
+async function startPhase() {
+  const state = {
+    conversation_id: `local-smoke-${randomUUID()}`,
+    course_id: 'deterministic-course',
+    run_id: `run-${randomUUID()}`,
+    prompt: 'Create and render one deterministic question',
+  };
+  const competing = {
+    ...state,
+    run_id: `run-${randomUUID()}`,
+    prompt: 'This concurrent turn must be rejected',
+  };
+  const [first, second] = await Promise.all([startRun(state), startRun(competing)]);
+  assert.deepEqual([first.status, second.status].sort(), [202, 409]);
+  const accepted = first.status === 202 ? state : competing;
+  const completed = await poll(accepted, 'completed');
+  assert.ok(completed.checkpoint_key);
+  await writeFile(statePath, `${JSON.stringify(accepted, null, 2)}\n`);
+  process.stdout.write(
+    `phase=start completed run ${accepted.run_id}; restart Wrangler with the same persisted state\n`,
+  );
+}
 
-process.stdout.write(`${JSON.stringify(smokeResult, null, 2)}\n`);
+async function resumePhase() {
+  const first = JSON.parse(await readFile(statePath, 'utf8'));
+  const firstControl = await token(first, 'control');
+  const checkpoint = await json(
+    await authorized(`/internal/local/runs/${first.run_id}/checkpoint`, firstControl),
+  );
+  const destroy = await authorized(
+    `/internal/local/conversations/${first.conversation_id}/destroy-sandbox`,
+    firstControl,
+    { method: 'POST' },
+  );
+  assert.equal(destroy.status, 204);
 
-async function requestSmoke(conversationId) {
-  const response = await fetch(`${baseUrl}/internal/local/smoke`, {
+  const publication = {
+    operation_id: `publish-${randomUUID()}`,
+    target: {
+      https_url: 'https://local.invalid/course.git',
+      branch: `pl-agent/${first.course_id}/${first.run_id}`,
+      head_sha: checkpoint.head_sha,
+    },
+  };
+  const publishToken = await token(first, 'publish', publication);
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const published = await authorized(`/v1/runs/${first.run_id}/publish`, publishToken, {
+      method: 'POST',
+      body: JSON.stringify(publication),
+    });
+    assert.equal(published.status, 200, await published.text());
+  }
+
+  const resumed = {
+    ...first,
+    run_id: `run-${randomUUID()}`,
+    prompt: 'Resume after Worker restart and sandbox destruction',
+  };
+  assert.equal((await startRun(resumed)).status, 202);
+  await poll(resumed, 'completed');
+
+  const cancelled = {
+    ...first,
+    run_id: `run-${randomUUID()}`,
+    prompt: '[wait-for-cancel] cancel this deterministic turn',
+  };
+  assert.equal((await startRun(cancelled)).status, 202);
+  const cancelToken = await token(cancelled, 'control');
+  const cancel = await authorized(`/v1/runs/${cancelled.run_id}/cancel`, cancelToken, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ conversation_id: conversationId }),
   });
+  assert.equal(cancel.status, 200, await cancel.text());
+  await poll(cancelled, 'cancelled');
 
-  return { response, result: await response.json() };
+  const deleteToken = await token(cancelled, 'delete');
+  const deleted = await authorized(`/v1/conversations/${first.conversation_id}`, deleteToken, {
+    method: 'DELETE',
+  });
+  assert.equal(deleted.status, 204, await deleted.text());
+  const count = await json(
+    await authorized(
+      `/internal/local/conversations/${first.conversation_id}/object-count`,
+      deleteToken,
+    ),
+  );
+  assert.equal(count.count, 0);
+  process.stdout.write(
+    `phase=resume recovered, published, cancelled, and deleted ${first.conversation_id}\n`,
+  );
+}
+
+async function startRun(run) {
+  return await authorized('/v1/runs/start', await token(run, 'run'), {
+    method: 'POST',
+    body: JSON.stringify({
+      ...run,
+      prairielearn_base_url: 'http://prairielearn-fixture.invalid',
+      harness: 'deterministic',
+    }),
+  });
+}
+
+async function poll(run, expected) {
+  const control = await token(run, 'control');
+  for (let attempt = 0; attempt < 180; attempt++) {
+    const response = await authorized(`/v1/runs/${run.run_id}`, control);
+    if (response.status === 200) {
+      const status = await json(response);
+      if (status.status === expected) return status;
+      if (status.status === 'failed') throw new Error(JSON.stringify(status));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Timed out waiting for ${run.run_id} to become ${expected}`);
+}
+
+async function token(run, purpose, publication) {
+  const now = Math.floor(Date.now() / 1_000);
+  const claims = {
+    sub: 'local-user',
+    jti: randomUUID(),
+    run_id: run.run_id,
+    conversation_id: run.conversation_id,
+    course_id: run.course_id,
+    authn_user_id: 'local-user',
+    user_id: 'local-user',
+    allowed_tools: [
+      'list_entities',
+      'read_course_file',
+      'query_course_data',
+      'render_question',
+      'get_job_output',
+    ],
+    purpose,
+    prompt_sha256: createHash('sha256').update(run.prompt).digest('hex'),
+    prairielearn_base_url: 'http://prairielearn-fixture.invalid',
+    harness: 'deterministic',
+    ...publication,
+  };
+  return await new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer('prairielearn')
+    .setAudience(['prairielearn-agent-worker', 'prairielearn-agent-api'])
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3_600)
+    .sign(new TextEncoder().encode(secret));
+}
+
+async function authorized(path, bearer, init = {}) {
+  const headers = new Headers(init.headers);
+  headers.set('authorization', `Bearer ${bearer}`);
+  if (init.body) headers.set('content-type', 'application/json');
+  return await fetch(`${baseUrl}${path}`, { ...init, headers });
+}
+
+async function json(response) {
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${await response.text()}`);
+  }
+  return await response.json();
 }

--- a/apps/agent-worker/scripts/smoke.mjs
+++ b/apps/agent-worker/scripts/smoke.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+
+const baseUrl = process.env.AGENT_WORKER_URL ?? 'http://localhost:8787';
+
+const healthResponse = await fetch(`${baseUrl}/health`);
+assert.equal(healthResponse.status, 200);
+assert.deepEqual(await healthResponse.json(), { status: 'ok' });
+
+const conversationId = `local-smoke-${randomUUID()}`;
+const attempts = await Promise.all([requestSmoke(conversationId), requestSmoke(conversationId)]);
+assert.deepEqual(attempts.map(({ response }) => response.status).sort(), [200, 409]);
+
+const { response: smokeResponse, result: smokeResult } = attempts.find(
+  ({ response }) => response.status === 200,
+);
+assert.equal(smokeResponse.status, 200, JSON.stringify(smokeResult));
+assert.equal(smokeResult.status, 'ok');
+assert.equal(smokeResult.conversation_id, conversationId);
+assert.equal(smokeResult.sandbox.exit_code, 0);
+assert.match(smokeResult.sandbox.stdout, /claude-agent-sdk-ok/);
+assert.match(smokeResult.sandbox.stdout, /sandbox-ok/);
+assert.match(
+  smokeResult.checkpoint_key,
+  new RegExp(`^conversations/${conversationId}/runs/.+/local-smoke\\.json$`),
+);
+
+process.stdout.write(`${JSON.stringify(smokeResult, null, 2)}\n`);
+
+async function requestSmoke(conversationId) {
+  const response = await fetch(`${baseUrl}/internal/local/smoke`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ conversation_id: conversationId }),
+  });
+
+  return { response, result: await response.json() };
+}

--- a/apps/agent-worker/src/agent-sandbox.ts
+++ b/apps/agent-worker/src/agent-sandbox.ts
@@ -1,0 +1,8 @@
+import { ContainerProxy, Sandbox } from '@cloudflare/sandbox';
+
+export { ContainerProxy };
+
+export class AgentSandbox extends Sandbox<Cloudflare.Env> {
+  enableInternet = false;
+  allowedHosts: string[] = [];
+}

--- a/apps/agent-worker/src/agent-sandbox.ts
+++ b/apps/agent-worker/src/agent-sandbox.ts
@@ -1,8 +1,362 @@
 import { ContainerProxy, Sandbox } from '@cloudflare/sandbox';
 
+import {
+  type AgentHarness,
+  type AgentPublicationTarget,
+  type AgentRepository,
+  type AgentToolName,
+  AgentToolNameSchema,
+  AgentToolRequestSchema,
+  AppendAgentEventsRequestSchema,
+} from '@prairielearn/agent-protocol';
+
+import { isGitReadRequest } from './git-auth.js';
+
 export { ContainerProxy };
 
-export class AgentSandbox extends Sandbox<Cloudflare.Env> {
+export interface SandboxRunContext {
+  conversationId: string;
+  runId: string;
+  courseId: string;
+  capability: string;
+  prairielearnBaseUrl: string;
+  harness: AgentHarness;
+  allowedTools: AgentToolName[];
+  repository?: AgentRepository;
+  publicationTarget?: AgentPublicationTarget;
+}
+
+interface AgentSandboxEnv extends Cloudflare.Env {
+  ANTHROPIC_API_KEY?: string;
+  GITHUB_READ_TOKEN?: string;
+  GITHUB_WRITE_TOKEN?: string;
+  LOCAL_DEVELOPMENT?: string;
+  SANDBOX: DurableObjectNamespace<AgentSandbox>;
+}
+
+const runContextStorageKey = 'agent-run-context';
+
+export class AgentSandbox extends Sandbox<AgentSandboxEnv> {
   enableInternet = false;
-  allowedHosts: string[] = [];
+  allowedHosts = [
+    'api.anthropic.com',
+    'github.com',
+    'prairielearn.internal',
+    'session-store.internal',
+    'worker-events.internal',
+  ];
+
+  async setRunContext(context: SandboxRunContext): Promise<void> {
+    await this.ctx.storage.put(runContextStorageKey, context);
+  }
+
+  async getRunContext(): Promise<SandboxRunContext | null> {
+    return (await this.ctx.storage.get<SandboxRunContext>(runContextStorageKey)) ?? null;
+  }
+
+  async setPublicationTarget(target: AgentPublicationTarget | null): Promise<void> {
+    const context = await this.getRunContext();
+    if (!context) throw new Error('Sandbox run context is not configured');
+    if (target) {
+      await this.setRunContext({ ...context, publicationTarget: target });
+    } else {
+      const next = { ...context };
+      delete next.publicationTarget;
+      await this.setRunContext(next);
+    }
+  }
+}
+
+AgentSandbox.outboundByHost = {
+  'api.anthropic.com': async (
+    request: Request,
+    env: AgentSandboxEnv,
+    handlerContext: { containerId: string },
+  ) => {
+    const context = await getRunContext(env, handlerContext.containerId);
+    if (context.harness !== 'claude' || !env.ANTHROPIC_API_KEY) {
+      return new Response('Anthropic access is not configured for this run', { status: 403 });
+    }
+    const headers = new Headers(request.headers);
+    headers.set('x-api-key', env.ANTHROPIC_API_KEY);
+    return await fetch(new Request(forceHttps(request), { headers }));
+  },
+  'github.com': async (
+    request: Request,
+    env: AgentSandboxEnv,
+    handlerContext: { containerId: string },
+  ) => {
+    const context = await getRunContext(env, handlerContext.containerId);
+    if (
+      !context.repository ||
+      !matchesRepository(request.url, context.repository.https_url) ||
+      !isGitReadRequest(request, context.repository.https_url)
+    ) {
+      return new Response('Git repository is not authorized for this run', { status: 403 });
+    }
+    return await fetchWithGitToken(request, env.GITHUB_READ_TOKEN);
+  },
+  'prairielearn.internal': async (
+    request: Request,
+    env: AgentSandboxEnv,
+    handlerContext: { containerId: string },
+  ) => {
+    const context = await getRunContext(env, handlerContext.containerId);
+    const match = /^\/tools\/([^/]+)$/.exec(new URL(request.url).pathname);
+    if (request.method !== 'POST' || !match) return new Response('Not found', { status: 404 });
+    const toolName = AgentToolNameSchema.parse(match[1]);
+    if (!context.allowedTools.includes(toolName)) {
+      return new Response('Tool is not authorized for this run', { status: 403 });
+    }
+    const toolRequest = AgentToolRequestSchema.parse(await request.clone().json());
+    let enrichedRequest = toolRequest;
+    if (toolName === 'render_question') {
+      const qid = toolRequest.input.qid;
+      if (typeof qid !== 'string') throw new Error('render_question requires a safe qid');
+      const snapshot = await createRenderCheckpoint(env, context, qid);
+      enrichedRequest = {
+        ...toolRequest,
+        input: { ...toolRequest.input, qid: snapshot.qid, files: snapshot.files },
+        expected_revision: snapshot.headSha,
+      };
+    }
+    enrichedRequest = {
+      ...enrichedRequest,
+      operation_id: await stableToolOperationId(context.runId, toolName, enrichedRequest),
+    };
+    if (isLocalFixture(context, env)) return localToolFixture(toolName, context, enrichedRequest);
+
+    const target = new URL(
+      `/pl/api/agent/v1/runs/${encodeURIComponent(context.runId)}/tools/${toolName}`,
+      context.prairielearnBaseUrl,
+    );
+    return await fetch(
+      withCapability(
+        new Request(request, { method: 'POST', body: JSON.stringify(enrichedRequest) }),
+        target,
+        context.capability,
+      ),
+    );
+  },
+  'session-store.internal': async (
+    request: Request,
+    env: AgentSandboxEnv,
+    handlerContext: { containerId: string },
+  ) => {
+    const context = await getRunContext(env, handlerContext.containerId);
+    return await conversationRequest(env, context, request, '/internal/session-store');
+  },
+  'worker-events.internal': async (
+    request: Request,
+    env: AgentSandboxEnv,
+    handlerContext: { containerId: string },
+  ) => {
+    const context = await getRunContext(env, handlerContext.containerId);
+    if (request.method !== 'POST' || new URL(request.url).pathname !== '/events') {
+      return new Response('Not found', { status: 404 });
+    }
+    const body = AppendAgentEventsRequestSchema.parse(await request.clone().json());
+    if (
+      body.events.some(
+        (event) => event.type !== 'assistant_message' && event.type !== 'assistant_message_delta',
+      )
+    ) {
+      return new Response('Sandbox may only emit assistant telemetry', { status: 403 });
+    }
+    return await conversationRequest(
+      env,
+      context,
+      new Request(request, { method: 'POST', body: JSON.stringify(body) }),
+      '/internal/events',
+    );
+  },
+};
+
+async function stableToolOperationId(
+  runId: string,
+  toolName: AgentToolName,
+  request: ReturnType<typeof AgentToolRequestSchema.parse>,
+): Promise<string> {
+  const input = new TextEncoder().encode(
+    canonicalJson({
+      expected_revision: request.expected_revision ?? null,
+      input: request.input,
+      run_id: runId,
+      tool_name: toolName,
+    }),
+  );
+  const digest = await crypto.subtle.digest('SHA-256', input);
+  return `tool-${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+AgentSandbox.outboundHandlers = {
+  authenticatedGithubWrite: async (
+    request: Request,
+    env: AgentSandboxEnv,
+    handlerContext: { containerId: string },
+  ) => {
+    const context = await getRunContext(env, handlerContext.containerId);
+    if (
+      !context.publicationTarget ||
+      !matchesRepository(request.url, context.publicationTarget.https_url)
+    ) {
+      return new Response('Git publication target is not authorized', { status: 403 });
+    }
+    if (!env.GITHUB_WRITE_TOKEN) {
+      return new Response('Git publication credentials are not configured', { status: 503 });
+    }
+    return await fetchWithGitToken(request, env.GITHUB_WRITE_TOKEN);
+  },
+};
+
+async function getRunContext(
+  env: AgentSandboxEnv,
+  containerId: string,
+): Promise<SandboxRunContext> {
+  const sandbox = env.SANDBOX.get(env.SANDBOX.idFromString(containerId));
+  const context = await sandbox.getRunContext();
+  if (!context) throw new Error('Sandbox run context is not configured');
+  return context;
+}
+
+async function conversationRequest(
+  env: AgentSandboxEnv,
+  context: SandboxRunContext,
+  request: Request,
+  pathname: string,
+): Promise<Response> {
+  const coordinator = env.CONVERSATIONS.getByName(context.conversationId);
+  const headers = new Headers(request.headers);
+  headers.set('x-prairielearn-run-id', context.runId);
+  return await coordinator.fetch(
+    new Request(
+      `http://conversation${pathname}${pathname === '/internal/session-store' ? new URL(request.url).pathname : ''}`,
+      {
+        method: request.method,
+        headers,
+        body: request.body,
+      },
+    ),
+  );
+}
+
+function withCapability(request: Request, target: URL, capability: string): Request {
+  const headers = new Headers(request.headers);
+  headers.set('authorization', `Bearer ${capability}`);
+  return new Request(target, {
+    method: request.method,
+    headers,
+    body: request.body,
+    redirect: 'manual',
+  });
+}
+
+async function fetchWithGitToken(request: Request, token: string | undefined): Promise<Response> {
+  if (!token) return new Response('Git credentials are not configured', { status: 503 });
+  const headers = new Headers(request.headers);
+  headers.set('authorization', `Basic ${btoa(`x-access-token:${token}`)}`);
+  return await fetch(new Request(forceHttps(request), { headers, redirect: 'manual' }));
+}
+
+async function createRenderCheckpoint(
+  env: AgentSandboxEnv,
+  context: SandboxRunContext,
+  qid: string,
+): Promise<{ qid: string; files: { path: string; content: string }[]; headSha: string }> {
+  const response = await conversationRequest(
+    env,
+    context,
+    new Request('http://worker/render-checkpoint', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ qid }),
+    }),
+    '/internal/render-checkpoint',
+  );
+  if (!response.ok) throw new Error(`Unable to checkpoint render input: ${await response.text()}`);
+  const body: unknown = await response.json();
+  if (typeof body !== 'object' || body === null) {
+    throw new Error('Render checkpoint returned an invalid Git revision');
+  }
+  const snapshot = body as Record<string, unknown>;
+  if (
+    typeof snapshot.head_sha !== 'string' ||
+    typeof snapshot.qid !== 'string' ||
+    !Array.isArray(snapshot.files) ||
+    !snapshot.files.every(
+      (file) =>
+        typeof file === 'object' &&
+        file !== null &&
+        typeof (file as Record<string, unknown>).path === 'string' &&
+        typeof (file as Record<string, unknown>).content === 'string',
+    )
+  ) {
+    throw new Error('Render checkpoint returned an invalid question snapshot');
+  }
+  return {
+    qid: snapshot.qid,
+    files: snapshot.files as { path: string; content: string }[],
+    headSha: snapshot.head_sha,
+  };
+}
+
+function forceHttps(request: Request): URL {
+  const url = new URL(request.url);
+  url.protocol = 'https:';
+  return url;
+}
+
+function matchesRepository(requestUrl: string, repositoryUrl: string): boolean {
+  const request = forceHttps(new Request(requestUrl));
+  const repository = new URL(repositoryUrl);
+  const repositoryPath = repository.pathname.replace(/\/$/, '');
+  return (
+    request.hostname === repository.hostname &&
+    (request.pathname === repositoryPath || request.pathname.startsWith(`${repositoryPath}/`))
+  );
+}
+
+function isLocalFixture(context: SandboxRunContext, env: AgentSandboxEnv): boolean {
+  return (
+    env.LOCAL_DEVELOPMENT === 'true' &&
+    new URL(context.prairielearnBaseUrl).hostname === 'prairielearn-fixture.invalid'
+  );
+}
+
+function localToolFixture(
+  toolName: AgentToolName,
+  context: SandboxRunContext,
+  request: ReturnType<typeof AgentToolRequestSchema.parse>,
+): Response {
+  return Response.json({
+    operation_id: request.operation_id,
+    event_id: crypto.randomUUID(),
+    result: {
+      fixture: true,
+      tool_name: toolName,
+      course_id: context.courseId,
+      entities:
+        toolName === 'list_entities'
+          ? [{ qid: 'deterministic-question', type: 'question', title: 'Deterministic question' }]
+          : undefined,
+      content: toolName === 'read_course_file' ? '# Deterministic course fixture\n' : undefined,
+      rendered: toolName === 'render_question' ? true : undefined,
+      variant_seed: toolName === 'render_question' ? request.input.variant_seed : undefined,
+      preview:
+        toolName === 'render_question'
+          ? { question_html: '<p>Rendered</p>', answer_html: '' }
+          : undefined,
+    },
+  });
 }

--- a/apps/agent-worker/src/auth.test.ts
+++ b/apps/agent-worker/src/auth.test.ts
@@ -1,0 +1,116 @@
+import { SignJWT } from 'jose';
+import { assert, describe, expect, it } from 'vitest';
+
+import { assertStartCapability, parsePublicationCapability, verifyCapability } from './auth.js';
+
+const secret = 'test-agent-capability-secret-at-least-32-bytes';
+
+describe('run capabilities', () => {
+  it('verifies HS256 claims and binds them to the start body', async () => {
+    const token = await signCapability();
+    const capability = await verifyCapability(
+      new Request('https://worker.test/v1/runs/start', {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      secret,
+    );
+
+    await assertStartCapability(capability, {
+      conversation_id: 'conversation-1',
+      run_id: 'run-1',
+      course_id: '1',
+      prompt: 'Create a question',
+      prairielearn_base_url: 'https://prairielearn.test',
+      harness: 'deterministic',
+    });
+  });
+
+  it('rejects a mismatched run', async () => {
+    const token = await signCapability();
+    const capability = await verifyCapability(
+      new Request('https://worker.test', {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      secret,
+    );
+
+    await expect(
+      assertStartCapability(capability, {
+        conversation_id: 'conversation-1',
+        run_id: 'run-2',
+        course_id: '1',
+        prompt: 'Create a question',
+        prairielearn_base_url: 'https://prairielearn.test',
+        harness: 'deterministic',
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('parses exact publication authorization', async () => {
+    const token = await signCapability({
+      purpose: 'publish',
+      operation_id: 'publish-1',
+      target: {
+        https_url: 'https://github.com/PrairieLearn/course.git',
+        branch: 'pl-agent/course/run-1',
+        head_sha: 'a'.repeat(40),
+      },
+    });
+    const capability = await verifyCapability(
+      new Request('https://worker.test', {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+      secret,
+    );
+
+    assert.deepEqual(parsePublicationCapability(capability.payload), {
+      iss: 'prairielearn',
+      aud: ['prairielearn-agent-worker', 'prairielearn-agent-api'],
+      sub: '7',
+      iat: capability.claims.iat,
+      exp: capability.claims.exp,
+      jti: 'token-1',
+      run_id: 'run-1',
+      conversation_id: 'conversation-1',
+      course_id: '1',
+      authn_user_id: '7',
+      user_id: '7',
+      allowed_tools: ['list_entities'],
+      prompt_sha256: 'd8c0e4503fc49e6698f19e327fd77a3aa9456c9a69243b90cdbc0c563ac7249d',
+      prairielearn_base_url: 'https://prairielearn.test',
+      harness: 'deterministic',
+      purpose: 'publish',
+      operation_id: 'publish-1',
+      target: {
+        https_url: 'https://github.com/PrairieLearn/course.git',
+        branch: 'pl-agent/course/run-1',
+        head_sha: 'a'.repeat(40),
+      },
+    });
+  });
+});
+
+async function signCapability(extra: Record<string, unknown> = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  return await new SignJWT({
+    sub: '7',
+    jti: 'token-1',
+    run_id: 'run-1',
+    conversation_id: 'conversation-1',
+    course_id: '1',
+    authn_user_id: '7',
+    user_id: '7',
+    allowed_tools: ['list_entities'],
+    prairielearn_base_url: 'https://prairielearn.test',
+    harness: 'deterministic',
+    purpose: 'run',
+    prompt_sha256: 'd8c0e4503fc49e6698f19e327fd77a3aa9456c9a69243b90cdbc0c563ac7249d',
+    ...extra,
+  })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuer('prairielearn')
+    .setAudience(['prairielearn-agent-worker', 'prairielearn-agent-api'])
+    .setIssuedAt(now)
+    .setExpirationTime(now + 60)
+    .sign(new TextEncoder().encode(secret));
+}

--- a/apps/agent-worker/src/auth.ts
+++ b/apps/agent-worker/src/auth.ts
@@ -1,0 +1,113 @@
+import { type JWTPayload, jwtVerify } from 'jose';
+
+import {
+  type AgentPublicationCapabilityClaims,
+  AgentPublicationCapabilityClaimsSchema,
+  type AgentRunCapabilityClaims,
+  AgentRunCapabilityClaimsSchema,
+  type StartAgentRunRequest,
+} from '@prairielearn/agent-protocol';
+
+const capabilityIssuer = 'prairielearn';
+const capabilityAudience = 'prairielearn-agent-worker';
+
+export interface VerifiedCapability {
+  claims: AgentRunCapabilityClaims;
+  payload: JWTPayload;
+  token: string;
+}
+
+export async function verifyCapability(
+  request: Request,
+  secret: string,
+): Promise<VerifiedCapability> {
+  const token = parseBearerToken(request.headers.get('authorization'));
+  const { payload, protectedHeader } = await jwtVerify(token, new TextEncoder().encode(secret), {
+    algorithms: ['HS256'],
+    issuer: capabilityIssuer,
+    audience: capabilityAudience,
+  });
+
+  if (protectedHeader.alg !== 'HS256') throw new Error('Unsupported capability algorithm');
+
+  return {
+    claims: AgentRunCapabilityClaimsSchema.parse(payload),
+    payload,
+    token,
+  };
+}
+
+export async function assertStartCapability(
+  capability: VerifiedCapability,
+  body: StartAgentRunRequest,
+): Promise<void> {
+  assertPurpose(capability, 'run');
+  assertEqual(capability.claims.run_id, body.run_id, 'run_id');
+  assertEqual(capability.claims.conversation_id, body.conversation_id, 'conversation_id');
+  assertEqual(capability.claims.course_id, body.course_id, 'course_id');
+  assertEqual(
+    capability.claims.prairielearn_base_url,
+    body.prairielearn_base_url,
+    'prairielearn_base_url',
+  );
+  assertEqual(capability.claims.harness, body.harness, 'harness');
+  if (JSON.stringify(capability.claims.repository) !== JSON.stringify(body.repository)) {
+    throw new Error('Capability repository does not match request');
+  }
+  assertEqual(
+    stringClaim(capability.payload, 'prompt_sha256'),
+    await sha256(body.prompt),
+    'prompt',
+  );
+}
+
+export function assertRunCapability(capability: VerifiedCapability, runId: string): void {
+  assertPurpose(capability, 'control');
+  assertEqual(capability.claims.run_id, runId, 'run_id');
+}
+
+export function assertConversationCapability(
+  capability: VerifiedCapability,
+  conversationId: string,
+): void {
+  assertPurpose(capability, 'delete');
+  assertEqual(capability.claims.conversation_id, conversationId, 'conversation_id');
+}
+
+export function assertLocalControlCapability(
+  capability: VerifiedCapability,
+  conversationId: string,
+): void {
+  assertPurpose(capability, 'control');
+  assertEqual(capability.claims.conversation_id, conversationId, 'conversation_id');
+}
+
+export function parsePublicationCapability(payload: JWTPayload): AgentPublicationCapabilityClaims {
+  return AgentPublicationCapabilityClaimsSchema.parse(payload);
+}
+
+function parseBearerToken(header: string | null): string {
+  if (!header?.startsWith('Bearer ')) throw new Error('Missing bearer capability');
+  const token = header.slice('Bearer '.length).trim();
+  if (!token) throw new Error('Missing bearer capability');
+  return token;
+}
+
+function assertEqual(actual: string, expected: string, name: string): void {
+  if (actual !== expected) throw new Error(`Capability ${name} does not match request`);
+}
+
+function assertPurpose(capability: VerifiedCapability, purpose: string): void {
+  assertEqual(stringClaim(capability.payload, 'purpose'), purpose, 'purpose');
+}
+
+function stringClaim(payload: JWTPayload, name: string): string {
+  const value = payload[name];
+  if (typeof value !== 'string') throw new Error(`Capability ${name} is missing`);
+  return value;
+}
+
+async function sha256(value: string): Promise<string> {
+  const bytes = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return [...new Uint8Array(bytes)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/apps/agent-worker/src/checkpoint.test.ts
+++ b/apps/agent-worker/src/checkpoint.test.ts
@@ -1,0 +1,36 @@
+import { assert, describe, it } from 'vitest';
+
+import {
+  type LocalSmokeCheckpoint,
+  localSmokeCheckpointKey,
+  parseCheckpoint,
+  serializeCheckpoint,
+} from './checkpoint.js';
+
+describe('local smoke checkpoints', () => {
+  it('uses a conversation-scoped R2 key', () => {
+    assert.equal(
+      localSmokeCheckpointKey('conversation-1', 'run-1'),
+      'conversations/conversation-1/runs/run-1/local-smoke.json',
+    );
+  });
+
+  it('round-trips checkpoint content', () => {
+    const checkpoint: LocalSmokeCheckpoint = {
+      version: 1,
+      conversationId: 'conversation-1',
+      runId: 'run-1',
+      command: ['/bin/bash', '-lc', 'printf sandbox-ok'],
+      stdout: 'sandbox-ok',
+      stderr: '',
+      exitCode: 0,
+      createdAt: '2026-08-20T00:00:00.000Z',
+    };
+
+    assert.deepEqual(parseCheckpoint(serializeCheckpoint(checkpoint)), checkpoint);
+  });
+
+  it('rejects malformed checkpoint content', () => {
+    assert.throws(() => parseCheckpoint('{"version":2}'));
+  });
+});

--- a/apps/agent-worker/src/checkpoint.ts
+++ b/apps/agent-worker/src/checkpoint.ts
@@ -1,0 +1,48 @@
+export interface LocalSmokeCheckpoint {
+  version: 1;
+  conversationId: string;
+  runId: string;
+  command: readonly string[];
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  createdAt: string;
+}
+
+export function localSmokeCheckpointKey(conversationId: string, runId: string): string {
+  return `conversations/${conversationId}/runs/${runId}/local-smoke.json`;
+}
+
+export function serializeCheckpoint(checkpoint: LocalSmokeCheckpoint): string {
+  return JSON.stringify(checkpoint);
+}
+
+export function parseCheckpoint(value: string): LocalSmokeCheckpoint {
+  const checkpoint: unknown = JSON.parse(value);
+
+  if (
+    typeof checkpoint !== 'object' ||
+    checkpoint === null ||
+    !('version' in checkpoint) ||
+    checkpoint.version !== 1 ||
+    !('conversationId' in checkpoint) ||
+    typeof checkpoint.conversationId !== 'string' ||
+    !('runId' in checkpoint) ||
+    typeof checkpoint.runId !== 'string' ||
+    !('command' in checkpoint) ||
+    !Array.isArray(checkpoint.command) ||
+    !checkpoint.command.every((part) => typeof part === 'string') ||
+    !('stdout' in checkpoint) ||
+    typeof checkpoint.stdout !== 'string' ||
+    !('stderr' in checkpoint) ||
+    typeof checkpoint.stderr !== 'string' ||
+    !('exitCode' in checkpoint) ||
+    typeof checkpoint.exitCode !== 'number' ||
+    !('createdAt' in checkpoint) ||
+    typeof checkpoint.createdAt !== 'string'
+  ) {
+    throw new Error('Invalid local smoke checkpoint');
+  }
+
+  return checkpoint as LocalSmokeCheckpoint;
+}

--- a/apps/agent-worker/src/conversation-coordinator.ts
+++ b/apps/agent-worker/src/conversation-coordinator.ts
@@ -1,0 +1,108 @@
+import { DurableObject } from 'cloudflare:workers';
+
+import { type ConversationRunState, parseRunId } from './conversation.js';
+
+const stateKey = 'run-state';
+
+export class ConversationCoordinator extends DurableObject<Cloudflare.Env> {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'GET' && url.pathname === '/state') {
+      const state = await this.ctx.storage.get<ConversationRunState>(stateKey);
+      return Response.json(state ?? { status: 'idle' });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/begin') {
+      const body = await parseBody(request);
+      const runId = parseRunId(body.run_id);
+      const state = await this.ctx.storage.transaction(async (transaction) => {
+        const currentState = await transaction.get<ConversationRunState>(stateKey);
+        if (currentState?.status === 'running') return null;
+
+        const nextState: ConversationRunState = {
+          status: 'running',
+          runId,
+          updatedAt: new Date().toISOString(),
+        };
+        await transaction.put(stateKey, nextState);
+        return nextState;
+      });
+
+      if (!state) {
+        return Response.json({ error: 'Conversation already has a running turn' }, { status: 409 });
+      }
+
+      return Response.json(state);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/complete') {
+      const body = await parseBody(request);
+      const runId = parseRunId(body.run_id);
+      const checkpointKey = body.checkpoint_key;
+
+      if (typeof checkpointKey !== 'string') {
+        return Response.json({ error: 'checkpoint_key must be a string' }, { status: 400 });
+      }
+
+      const state = await this.transitionRunningRun(runId, {
+        status: 'complete',
+        runId,
+        updatedAt: new Date().toISOString(),
+        checkpointKey,
+      });
+      if (!state) {
+        return Response.json({ error: 'Run is not active for this conversation' }, { status: 409 });
+      }
+
+      return Response.json(state);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/fail') {
+      const body = await parseBody(request);
+      const runId = parseRunId(body.run_id);
+      const error = body.error;
+
+      if (typeof error !== 'string') {
+        return Response.json({ error: 'error must be a string' }, { status: 400 });
+      }
+
+      const state = await this.transitionRunningRun(runId, {
+        status: 'failed',
+        runId,
+        updatedAt: new Date().toISOString(),
+        error,
+      });
+      if (!state) {
+        return Response.json({ error: 'Run is not active for this conversation' }, { status: 409 });
+      }
+
+      return Response.json(state);
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+
+  private async transitionRunningRun(
+    runId: string,
+    nextState: ConversationRunState,
+  ): Promise<ConversationRunState | null> {
+    return this.ctx.storage.transaction(async (transaction) => {
+      const state = await transaction.get<ConversationRunState>(stateKey);
+      if (state?.status !== 'running' || state.runId !== runId) return null;
+
+      await transaction.put(stateKey, nextState);
+      return nextState;
+    });
+  }
+}
+
+async function parseBody(request: Request): Promise<Record<string, unknown>> {
+  const body: unknown = await request.json();
+
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new Error('Request body must be an object');
+  }
+
+  return body as Record<string, unknown>;
+}

--- a/apps/agent-worker/src/conversation-coordinator.ts
+++ b/apps/agent-worker/src/conversation-coordinator.ts
@@ -1,108 +1,870 @@
+import { type SandboxProcess, getSandbox } from '@cloudflare/sandbox';
 import { DurableObject } from 'cloudflare:workers';
 
-import { type ConversationRunState, parseRunId } from './conversation.js';
+import {
+  type AgentEventInput,
+  type AgentRunStatus,
+  AgentRunStatusResponseSchema,
+  type AgentToolName,
+  AgentToolNameSchema,
+  AppendAgentEventsRequestSchema,
+  type PublishAgentRunRequest,
+  PublishAgentRunRequestSchema,
+  type PublishAgentRunResponse,
+  type StartAgentRunRequest,
+  StartAgentRunRequestSchema,
+} from '@prairielearn/agent-protocol';
 
-const stateKey = 'run-state';
+import { type AgentSandbox, type SandboxRunContext } from './agent-sandbox.js';
+import {
+  createCommittedQuestionSnapshot,
+  createGitCheckpoint,
+  currentGitHead,
+  loadGitCheckpoint,
+  prepareCourseWorkspace,
+  pushExactGitHead,
+  restoreGitCheckpoint,
+} from './git-checkpoints.js';
+import { type PublicationRecord, isCurrentRun, publicationReservation } from './run-guards.js';
+import {
+  deleteConversationSessionStore,
+  deleteR2Prefix,
+  handleSessionStoreRequest,
+} from './session-store.js';
 
-export class ConversationCoordinator extends DurableObject<Cloudflare.Env> {
-  async fetch(request: Request): Promise<Response> {
-    const url = new URL(request.url);
+interface AgentWorkerEnv extends Cloudflare.Env {
+  AGENT_STATE: R2Bucket;
+  GITHUB_WRITE_TOKEN?: string;
+  LOCAL_DEVELOPMENT?: string;
+  SANDBOX: DurableObjectNamespace<AgentSandbox>;
+}
 
-    if (request.method === 'GET' && url.pathname === '/state') {
-      const state = await this.ctx.storage.get<ConversationRunState>(stateKey);
-      return Response.json(state ?? { status: 'idle' });
+interface StoredRun {
+  generation: number;
+  request: StartAgentRunRequest;
+  capability: string;
+  allowedTools: AgentToolName[];
+  status: AgentRunStatus;
+  sandboxId: string;
+  updatedAt: string;
+  processId?: string;
+  sessionId?: string;
+  checkpointKey?: string;
+  error?: string;
+  terminalAcked?: boolean;
+  terminalEvent?: AgentEventInput;
+}
+
+interface ConversationMetadata {
+  sessionId?: string;
+}
+
+interface DeletionCleanup {
+  conversationId: string;
+  sandboxId: string;
+}
+
+type AgentEventDraft = Omit<AgentEventInput, 'event_id'> & { event_id?: string };
+
+const runStateKey = 'run-state';
+const conversationMetadataKey = 'conversation-metadata';
+const deletionCleanupKey = 'deletion-cleanup';
+const harnessConfigPath = '/tmp/prairielearn-agent-run.json';
+const harnessCommand = [
+  'setpriv',
+  '--reuid=prairie-agent',
+  '--regid=prairie-agent',
+  '--init-groups',
+  'node',
+  '/opt/prairielearn-agent/harness.mjs',
+  harnessConfigPath,
+] as const;
+
+export class ConversationCoordinator extends DurableObject<AgentWorkerEnv> {
+  private sessionStoreTail: Promise<void> = Promise.resolve();
+
+  async alarm(): Promise<void> {
+    const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+    if (!state || (await this.ctx.storage.get(deletionCleanupKey))) {
+      return;
     }
-
-    if (request.method === 'POST' && url.pathname === '/begin') {
-      const body = await parseBody(request);
-      const runId = parseRunId(body.run_id);
-      const state = await this.ctx.storage.transaction(async (transaction) => {
-        const currentState = await transaction.get<ConversationRunState>(stateKey);
-        if (currentState?.status === 'running') return null;
-
-        const nextState: ConversationRunState = {
-          status: 'running',
-          runId,
-          updatedAt: new Date().toISOString(),
-        };
-        await transaction.put(stateKey, nextState);
-        return nextState;
-      });
-
-      if (!state) {
-        return Response.json({ error: 'Conversation already has a running turn' }, { status: 409 });
-      }
-
-      return Response.json(state);
+    if (state.terminalEvent && !state.terminalAcked) {
+      await this.deliverTerminalEvent(state);
+      return;
     }
-
-    if (request.method === 'POST' && url.pathname === '/complete') {
-      const body = await parseBody(request);
-      const runId = parseRunId(body.run_id);
-      const checkpointKey = body.checkpoint_key;
-
-      if (typeof checkpointKey !== 'string') {
-        return Response.json({ error: 'checkpoint_key must be a string' }, { status: 400 });
+    if (state.status !== 'running') return;
+    try {
+      if (!state.processId) {
+        await this.launchTurn(state);
+        return;
       }
-
-      const state = await this.transitionRunningRun(runId, {
-        status: 'complete',
-        runId,
-        updatedAt: new Date().toISOString(),
-        checkpointKey,
-      });
-      if (!state) {
-        return Response.json({ error: 'Run is not active for this conversation' }, { status: 409 });
+      const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, state.sandboxId);
+      const process = await sandbox.getProcess(state.processId);
+      if (!process) {
+        await this.launchTurn({ ...state, processId: undefined });
+        return;
       }
-
-      return Response.json(state);
+      const status = await process.status();
+      if (status.state === 'running') {
+        await this.scheduleReconciliation();
+        return;
+      }
+      await this.finalizeTurn(state, process);
+    } catch (error) {
+      await this.failTurn(state, error);
     }
-
-    if (request.method === 'POST' && url.pathname === '/fail') {
-      const body = await parseBody(request);
-      const runId = parseRunId(body.run_id);
-      const error = body.error;
-
-      if (typeof error !== 'string') {
-        return Response.json({ error: 'error must be a string' }, { status: 400 });
-      }
-
-      const state = await this.transitionRunningRun(runId, {
-        status: 'failed',
-        runId,
-        updatedAt: new Date().toISOString(),
-        error,
-      });
-      if (!state) {
-        return Response.json({ error: 'Run is not active for this conversation' }, { status: 409 });
-      }
-
-      return Response.json(state);
-    }
-
-    return new Response('Not found', { status: 404 });
   }
 
-  private async transitionRunningRun(
-    runId: string,
-    nextState: ConversationRunState,
-  ): Promise<ConversationRunState | null> {
-    return this.ctx.storage.transaction(async (transaction) => {
-      const state = await transaction.get<ConversationRunState>(stateKey);
-      if (state?.status !== 'running' || state.runId !== runId) return null;
+  async fetch(request: Request): Promise<Response> {
+    try {
+      const url = new URL(request.url);
 
-      await transaction.put(stateKey, nextState);
-      return nextState;
+      if (request.method === 'GET' && url.pathname === '/state') {
+        const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+        const runId = url.searchParams.get('run_id');
+        return state && isCurrentRun(state.request.run_id, runId)
+          ? Response.json(publicState(state))
+          : new Response('Not found', { status: 404 });
+      }
+
+      if (request.method === 'GET' && url.pathname === '/checkpoint') {
+        const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+        const runId = url.searchParams.get('run_id');
+        if (!state || !isCurrentRun(state.request.run_id, runId)) {
+          return new Response('Not found', { status: 404 });
+        }
+        const checkpoint = await loadGitCheckpoint(
+          this.env.AGENT_STATE,
+          state.request.conversation_id,
+        );
+        return checkpoint
+          ? Response.json({ head_sha: checkpoint.headSha })
+          : new Response('Not found', { status: 404 });
+      }
+
+      if (request.method === 'POST' && url.pathname === '/start') {
+        return await this.start(request);
+      }
+
+      if (request.method === 'POST' && url.pathname === '/cancel') {
+        return await this.cancel(request);
+      }
+
+      if (request.method === 'POST' && url.pathname === '/publish') {
+        return await this.publish(request);
+      }
+
+      if (request.method === 'DELETE' && url.pathname === '/conversation') {
+        return await this.deleteConversation();
+      }
+
+      if (request.method === 'POST' && url.pathname.startsWith('/internal/session-store/')) {
+        const state = await this.requireActiveRun(request.headers.get('x-prairielearn-run-id'));
+        return await this.withSessionStoreLock(
+          async () =>
+            await handleSessionStoreRequest({
+              request: new Request(request.url.replace('/internal/session-store', ''), request),
+              bucket: this.env.AGENT_STATE,
+              storage: this.ctx.storage,
+              conversationId: state.request.conversation_id,
+            }),
+        );
+      }
+
+      if (
+        request.method === 'POST' &&
+        (url.pathname === '/internal/events' || url.pathname === '/internal/events/events')
+      ) {
+        const events = AppendAgentEventsRequestSchema.parse(await request.json()).events;
+        const state = await this.requireActiveRun(request.headers.get('x-prairielearn-run-id'));
+        await this.forwardEvents(state, events);
+        return Response.json({ accepted: events.length });
+      }
+
+      if (request.method === 'POST' && url.pathname === '/internal/render-checkpoint') {
+        const state = await this.requireActiveRun(request.headers.get('x-prairielearn-run-id'));
+        const body = await parseObject(request);
+        if (typeof body.qid !== 'string') throw new Error('render_question qid is missing');
+        const existing = await loadGitCheckpoint(
+          this.env.AGENT_STATE,
+          state.request.conversation_id,
+        );
+        if (!existing) throw new Error('Git checkpoint is unavailable');
+        const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, state.sandboxId);
+        const snapshot = await createCommittedQuestionSnapshot(sandbox, body.qid);
+        const checkpoint = await createGitCheckpoint({
+          sandbox,
+          bucket: this.env.AGENT_STATE,
+          conversationId: state.request.conversation_id,
+          branch: existing.branch,
+        });
+        if (snapshot.headSha !== checkpoint.headSha) {
+          throw new Error('Sandbox changed while creating the render checkpoint');
+        }
+        await this.forwardEvents(state, [
+          {
+            event_id: `${state.request.run_id}:${state.generation}:render:${checkpoint.headSha}`,
+            type: 'checkpoint',
+            data: { kind: 'git_render', head_sha: checkpoint.headSha },
+          },
+        ]);
+        return Response.json({
+          head_sha: checkpoint.headSha,
+          qid: snapshot.qid,
+          files: snapshot.files,
+        });
+      }
+
+      return new Response('Not found', { status: 404 });
+    } catch (error) {
+      return Response.json({ error: errorMessage(error) }, { status: 400 });
+    }
+  }
+
+  private async start(request: Request): Promise<Response> {
+    const body = await parseObject(request);
+    const runRequest = StartAgentRunRequestSchema.parse(body.request);
+    const capability = body.capability;
+    if (typeof capability !== 'string' || capability.length === 0) {
+      throw new Error('capability must be a non-empty string');
+    }
+    if (!Array.isArray(body.allowed_tools)) throw new Error('allowed_tools must be an array');
+    const allowedTools = body.allowed_tools.map((tool) => AgentToolNameSchema.parse(tool));
+
+    const state = await this.ctx.storage.transaction(async (transaction) => {
+      if (await transaction.get(deletionCleanupKey)) {
+        throw new Error('Conversation deletion is in progress');
+      }
+      const current = await transaction.get<StoredRun>(runStateKey);
+      if (
+        current &&
+        (isActive(current.status) || (current.terminalEvent && !current.terminalAcked))
+      ) {
+        return null;
+      }
+      const startKey = consumedStartKey(runRequest.run_id);
+      if (await transaction.get(startKey)) throw new Error('Run start capability was already used');
+      const next: StoredRun = {
+        generation: (current?.generation ?? 0) + 1,
+        request: runRequest,
+        capability,
+        allowedTools,
+        status: 'running',
+        sandboxId: runRequest.conversation_id,
+        updatedAt: new Date().toISOString(),
+      };
+      await transaction.put(startKey, true);
+      await transaction.put(runStateKey, next);
+      return next;
     });
+    if (!state) {
+      return Response.json({ error: 'Conversation already has an active turn' }, { status: 409 });
+    }
+
+    try {
+      await this.launchTurn(state);
+    } catch (error) {
+      await this.failTurn(state, error);
+    }
+    const current = await this.ctx.storage.get<StoredRun>(runStateKey);
+    return Response.json(publicState(current ?? state), { status: 202 });
+  }
+
+  private async launchTurn(initialState: StoredRun): Promise<void> {
+    const { request } = initialState;
+    const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, request.conversation_id);
+    await sandbox.setRunContext(runContext(initialState));
+    const baseline = await prepareCourseWorkspace({
+      sandbox,
+      bucket: this.env.AGENT_STATE,
+      conversationId: request.conversation_id,
+      courseId: request.course_id,
+      runId: request.run_id,
+      repository: request.repository,
+    });
+    const permissions = await sandbox.exec([
+      'chown',
+      '-R',
+      'prairie-agent:prairie-agent',
+      '/workspace/course',
+    ]);
+    const permissionsOutput = await permissions.output({ encoding: 'utf8', timeout: 30_000 });
+    if (permissionsOutput.exitCode !== 0) {
+      throw new Error(`Unable to prepare the agent workspace: ${permissionsOutput.stderr}`);
+    }
+    await this.forwardEvents(initialState, [
+      {
+        event_id: `${request.run_id}:${initialState.generation}:started`,
+        type: 'run_started',
+        data: { sandbox_id: request.conversation_id, restored_head_sha: baseline.headSha },
+      },
+      {
+        event_id: `${request.run_id}:${initialState.generation}:baseline`,
+        type: 'checkpoint',
+        data: { kind: 'git_baseline', head_sha: baseline.headSha },
+      },
+    ]);
+    const metadata =
+      (await this.ctx.storage.get<ConversationMetadata>(conversationMetadataKey)) ?? {};
+    await sandbox.writeFile(
+      harnessConfigPath,
+      JSON.stringify({
+        version: 1,
+        harness: request.harness,
+        conversation_id: request.conversation_id,
+        run_id: request.run_id,
+        course_id: request.course_id,
+        prompt: request.prompt,
+        allowed_tools: initialState.allowedTools,
+        local_development: this.env.LOCAL_DEVELOPMENT === 'true',
+        resume_session_id: metadata.sessionId,
+      }),
+    );
+    const orphan = (await sandbox.listProcesses()).find(
+      (candidate) =>
+        candidate.state === 'running' &&
+        candidate.command.length === harnessCommand.length &&
+        candidate.command.every((part, index) => part === harnessCommand[index]),
+    );
+    if (orphan) {
+      await this.putIfCurrent(initialState, { ...initialState, processId: orphan.id });
+      await this.scheduleReconciliation();
+      return;
+    }
+    const process = await sandbox.exec(harnessCommand, {
+      timeout: request.harness === 'claude' ? 900_000 : 120_000,
+    });
+    const current = await this.ctx.storage.get<StoredRun>(runStateKey);
+    if (!sameRunGeneration(current, initialState) || current.status !== 'running') {
+      await process.kill();
+      return;
+    }
+    await this.putIfCurrent(initialState, { ...current, processId: process.id });
+    await this.scheduleReconciliation();
+  }
+
+  private async finalizeTurn(initialState: StoredRun, process: SandboxProcess): Promise<void> {
+    const output = await process.output({ encoding: 'utf8', timeout: 30_000, maxBytes: 5_000_000 });
+    if (output.exitCode !== 0) {
+      throw new Error(`Agent harness exited with ${output.exitCode}: ${output.stderr}`);
+    }
+    const harnessResult = parseHarnessResult(output.stdout);
+    if (!(await this.isCurrentRunning(initialState))) return;
+    const manifest = await loadGitCheckpoint(
+      this.env.AGENT_STATE,
+      initialState.request.conversation_id,
+    );
+    if (!manifest) throw new Error('Git checkpoint is unavailable');
+    const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, initialState.sandboxId);
+    const checkpoint = await createGitCheckpoint({
+      sandbox,
+      bucket: this.env.AGENT_STATE,
+      conversationId: initialState.request.conversation_id,
+      branch: manifest.branch,
+    });
+    const checkpointKey = `conversations/${initialState.request.conversation_id}/git/latest.json`;
+    await this.forwardEvents(initialState, [
+      {
+        event_id: `${initialState.request.run_id}:${initialState.generation}:completed-checkpoint:${checkpoint.headSha}`,
+        type: 'checkpoint',
+        data: { kind: 'git_incremental', head_sha: checkpoint.headSha, key: checkpointKey },
+      },
+    ]);
+    const completed: StoredRun = {
+      ...initialState,
+      status: 'completed',
+      processId: process.id,
+      sessionId: harnessResult.sessionId,
+      checkpointKey,
+      updatedAt: new Date().toISOString(),
+      terminalAcked: false,
+      terminalEvent: {
+        event_id: `${initialState.request.run_id}:${initialState.generation}:completed`,
+        type: 'run_completed',
+        data: { session_id: harnessResult.sessionId, head_sha: checkpoint.headSha },
+      },
+    };
+    const stored = await this.ctx.storage.transaction(async (transaction) => {
+      const current = await transaction.get<StoredRun>(runStateKey);
+      if (!sameRunGeneration(current, initialState) || current.status !== 'running') return false;
+      await transaction.put(runStateKey, completed);
+      await transaction.put(conversationMetadataKey, {
+        sessionId: harnessResult.sessionId,
+      } satisfies ConversationMetadata);
+      return true;
+    });
+    if (!stored) return;
+    await this.deliverTerminalEvent(completed);
+  }
+
+  private async failTurn(initialState: StoredRun, error: unknown): Promise<void> {
+    const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+    if (!sameRunGeneration(state, initialState)) return;
+    if (state.status === 'cancelling' || state.status === 'cancelled') {
+      await this.finishCancellation(state);
+      return;
+    }
+    const failureCheckpointKey = await this.checkpointEditsBestEffort(state, 'git_failure');
+    const failed: StoredRun = {
+      ...state,
+      status: 'failed',
+      error: errorMessage(error),
+      checkpointKey: failureCheckpointKey ?? state.checkpointKey,
+      updatedAt: new Date().toISOString(),
+      terminalAcked: false,
+      terminalEvent: {
+        event_id: `${state.request.run_id}:${state.generation}:failed`,
+        type: 'run_failed',
+        data: { error: errorMessage(error) },
+      },
+    };
+    if (await this.putIfCurrent(state, failed)) await this.deliverTerminalEvent(failed);
+  }
+
+  private async scheduleReconciliation(): Promise<void> {
+    await this.ctx.storage.setAlarm(Date.now() + 1_000);
+  }
+
+  private async deliverTerminalEvent(state: StoredRun): Promise<void> {
+    if (!state.terminalEvent || state.terminalAcked) return;
+    try {
+      await this.forwardEvents(state, [state.terminalEvent]);
+      await this.putIfCurrent(state, { ...state, terminalAcked: true });
+    } catch {
+      await this.scheduleReconciliation();
+    }
+  }
+
+  private async cancel(request: Request): Promise<Response> {
+    const body = await parseObject(request);
+    const runId = body.run_id;
+    if (typeof runId !== 'string') throw new Error('run_id must be a string');
+    const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+    if (!state || state.request.run_id !== runId) return new Response('Not found', { status: 404 });
+    if (!isActive(state.status)) return Response.json(publicState(state));
+
+    const cancelling: StoredRun = {
+      ...state,
+      status: 'cancelling',
+      updatedAt: new Date().toISOString(),
+    };
+    await this.ctx.storage.put(runStateKey, cancelling);
+    if (state.processId) {
+      const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, state.sandboxId);
+      const process = await sandbox.getProcess(state.processId);
+      await process?.kill();
+    }
+    await this.finishCancellation(cancelling);
+    return Response.json(publicState({ ...cancelling, status: 'cancelled' }));
+  }
+
+  private async finishCancellation(state: StoredRun): Promise<void> {
+    if (state.status === 'cancelled') return;
+    const cancelled: StoredRun = {
+      ...state,
+      status: 'cancelled',
+      updatedAt: new Date().toISOString(),
+      terminalAcked: false,
+      terminalEvent: {
+        event_id: `${state.request.run_id}:${state.generation}:cancelled`,
+        type: 'run_cancelled',
+        data: {},
+      },
+    };
+    const checkpointKey = await this.checkpointEditsBestEffort(state, 'git_cancelled');
+    if (checkpointKey) cancelled.checkpointKey = checkpointKey;
+    if (await this.putIfCurrent(state, cancelled)) await this.deliverTerminalEvent(cancelled);
+  }
+
+  private async publish(request: Request): Promise<Response> {
+    const requestedRunId = new URL(request.url).searchParams.get('run_id');
+    const body = await parseObject(request);
+    const publishRequest = PublishAgentRunRequestSchema.parse(body.request);
+    if (typeof body.jti !== 'string' || body.jti.length === 0) {
+      throw new Error('Publication capability JTI is missing');
+    }
+    const capabilityJti = body.jti;
+    const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+    if (!state || !isCurrentRun(state.request.run_id, requestedRunId)) {
+      return new Response('Not found', { status: 404 });
+    }
+    if (state.status !== 'completed') {
+      return Response.json({ error: 'Run must be complete before publication' }, { status: 409 });
+    }
+    if (
+      state.request.repository &&
+      state.request.repository.https_url !== publishRequest.target.https_url
+    ) {
+      return Response.json(
+        { error: 'Publication repository does not match the run' },
+        { status: 409 },
+      );
+    }
+
+    const reservation = await this.reservePublication(publishRequest, capabilityJti);
+    if (reservation) return Response.json(reservation);
+
+    const publisherId = await publisherSandboxId(
+      state.request.conversation_id,
+      publishRequest.operation_id,
+    );
+    const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, publisherId);
+    const response: PublishAgentRunResponse = {
+      operation_id: publishRequest.operation_id,
+      branch: publishRequest.target.branch,
+      head_sha: publishRequest.target.head_sha,
+    };
+    let writeEnabled = false;
+    let publicationTargetConfigured = false;
+    try {
+      const checkpoint = await loadGitCheckpoint(
+        this.env.AGENT_STATE,
+        state.request.conversation_id,
+      );
+      if (!checkpoint) throw new Error('Git checkpoint is unavailable for publication');
+      await sandbox.setRunContext(runContext(state));
+      await restoreGitCheckpoint(sandbox, this.env.AGENT_STATE, checkpoint, {
+        courseId: state.request.course_id,
+        repository: state.request.repository,
+      });
+      const localHead = await currentGitHead(sandbox);
+      if (localHead !== publishRequest.target.head_sha) {
+        throw new Error('Publication HEAD does not match the sandbox');
+      }
+      if (!isLocalPublication(this.env, publishRequest)) {
+        await sandbox.setPublicationTarget(publishRequest.target);
+        publicationTargetConfigured = true;
+        await sandbox.setOutboundByHost('github.com', 'authenticatedGithubWrite');
+        writeEnabled = true;
+        await pushExactGitHead(
+          sandbox,
+          publishRequest.target.https_url,
+          publishRequest.target.branch,
+          publishRequest.target.head_sha,
+        );
+      }
+      const completed = {
+        request: publishRequest,
+        status: 'completed',
+        response,
+      } satisfies PublicationRecord;
+      await this.ctx.storage.put({
+        [publicationKey(publishRequest.operation_id)]: completed,
+        [publicationJtiKey(capabilityJti)]: completed,
+      });
+      return Response.json(response);
+    } catch (error) {
+      await this.ctx.storage.put(publicationJtiKey(capabilityJti), {
+        request: publishRequest,
+        status: 'failed',
+        error: errorMessage(error),
+      } satisfies PublicationRecord);
+      return Response.json({ error: errorMessage(error) }, { status: 409 });
+    } finally {
+      try {
+        if (writeEnabled) {
+          await sandbox.removeOutboundByHost('github.com');
+        }
+        if (publicationTargetConfigured) {
+          await sandbox.setPublicationTarget(null);
+        }
+      } finally {
+        await sandbox.destroy();
+      }
+    }
+  }
+
+  private async reservePublication(
+    request: PublishAgentRunRequest,
+    capabilityJti: string,
+  ): Promise<PublishAgentRunResponse | null> {
+    return await this.ctx.storage.transaction(async (transaction) => {
+      const completed = await transaction.get<PublicationRecord>(
+        publicationKey(request.operation_id),
+      );
+      const completedReservation = publicationReservation(completed, request);
+      if (completedReservation.kind === 'replay') return completedReservation.response;
+
+      const jtiKey = publicationJtiKey(capabilityJti);
+      const usedJti = await transaction.get<PublicationRecord>(jtiKey);
+      const jtiReservation = publicationReservation(usedJti, request);
+      if (jtiReservation.kind === 'replay') return jtiReservation.response;
+      await transaction.put(jtiKey, { request, status: 'pending' } satisfies PublicationRecord);
+      return null;
+    });
+  }
+
+  private async deleteConversation(): Promise<Response> {
+    const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+    let cleanup = await this.ctx.storage.get<DeletionCleanup>(deletionCleanupKey);
+    if (!cleanup && state) {
+      cleanup = {
+        conversationId: state.request.conversation_id,
+        sandboxId: state.sandboxId,
+      };
+      await this.ctx.storage.put(deletionCleanupKey, cleanup);
+    }
+    if (!cleanup) return new Response(null, { status: 204 });
+    const cleanupErrors: string[] = [];
+    if (state && isActive(state.status)) {
+      await this.ctx.storage.put(runStateKey, {
+        ...state,
+        status: 'cancelled',
+        updatedAt: new Date().toISOString(),
+      } satisfies StoredRun);
+      if (state.processId) {
+        try {
+          const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, state.sandboxId);
+          await (await sandbox.getProcess(state.processId))?.kill();
+        } catch (error) {
+          cleanupErrors.push(`process: ${errorMessage(error)}`);
+        }
+      }
+    }
+    {
+      const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, cleanup.sandboxId);
+      await cleanupStep('sandbox', cleanupErrors, async () => await sandbox.destroy());
+      await cleanupStep(
+        'session store',
+        cleanupErrors,
+        async () =>
+          await deleteConversationSessionStore(
+            this.env.AGENT_STATE,
+            this.ctx.storage,
+            cleanup.conversationId,
+          ),
+      );
+      await cleanupStep(
+        'conversation objects',
+        cleanupErrors,
+        async () =>
+          await deleteR2Prefix(this.env.AGENT_STATE, `conversations/${cleanup.conversationId}/`),
+      );
+    }
+    if (cleanupErrors.length > 0) {
+      return Response.json(
+        { error: 'Conversation cleanup was incomplete', details: cleanupErrors },
+        { status: 500 },
+      );
+    }
+    await this.ctx.storage.deleteAll();
+    return new Response(null, { status: 204 });
+  }
+
+  private async forwardEvents(state: StoredRun, events: AgentEventDraft[]): Promise<void> {
+    const payload = AppendAgentEventsRequestSchema.parse({
+      events: events.map((event) => ({
+        event_id: event.event_id ?? crypto.randomUUID(),
+        ...event,
+      })),
+    });
+    if (isLocalCallback(this.env, state.request)) {
+      const key = `conversations/${state.request.conversation_id}/events/${Date.now().toString().padStart(16, '0')}-${crypto.randomUUID()}.json`;
+      await this.env.AGENT_STATE.put(key, JSON.stringify(payload), {
+        httpMetadata: { contentType: 'application/json' },
+      });
+      return;
+    }
+
+    const target = new URL(
+      `/pl/api/agent/v1/runs/${encodeURIComponent(state.request.run_id)}/events`,
+      state.request.prairielearn_base_url,
+    );
+    let lastError = 'unknown error';
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const response = await fetch(target, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${state.capability}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+        if (response.ok) return;
+        lastError = `HTTP ${response.status}`;
+        if (response.status < 500) break;
+      } catch (error) {
+        lastError = errorMessage(error);
+      }
+    }
+    throw new Error(`PrairieLearn event callback failed: ${lastError}`);
+  }
+
+  private async requireActiveRun(expectedRunId: string | null): Promise<StoredRun> {
+    const state = await this.ctx.storage.get<StoredRun>(runStateKey);
+    if (
+      !state ||
+      !expectedRunId ||
+      state.request.run_id !== expectedRunId ||
+      !isActive(state.status)
+    ) {
+      throw new Error('Run is not active');
+    }
+    return state;
+  }
+
+  private async isCurrentRunning(expected: StoredRun): Promise<boolean> {
+    if (await this.ctx.storage.get(deletionCleanupKey)) return false;
+    const current = await this.ctx.storage.get<StoredRun>(runStateKey);
+    return sameRunGeneration(current, expected) && current.status === 'running';
+  }
+
+  private async putIfCurrent(expected: StoredRun, next: StoredRun): Promise<boolean> {
+    return await this.ctx.storage.transaction(async (transaction) => {
+      if (await transaction.get(deletionCleanupKey)) return false;
+      const current = await transaction.get<StoredRun>(runStateKey);
+      if (!sameRunGeneration(current, expected)) return false;
+      await transaction.put(runStateKey, next);
+      return true;
+    });
+  }
+
+  private async checkpointEditsBestEffort(
+    state: StoredRun,
+    kind: string,
+  ): Promise<string | undefined> {
+    try {
+      const existing = await loadGitCheckpoint(this.env.AGENT_STATE, state.request.conversation_id);
+      if (!existing) return undefined;
+      const sandbox = getSandbox<AgentSandbox>(this.env.SANDBOX, state.sandboxId);
+      const checkpoint = await createGitCheckpoint({
+        sandbox,
+        bucket: this.env.AGENT_STATE,
+        conversationId: state.request.conversation_id,
+        branch: existing.branch,
+      });
+      const key = `conversations/${state.request.conversation_id}/git/latest.json`;
+      await this.forwardEvents(state, [
+        {
+          event_id: `${state.request.run_id}:${state.generation}:${kind}:${checkpoint.headSha}`,
+          type: 'checkpoint',
+          data: { kind, head_sha: checkpoint.headSha, key },
+        },
+      ]);
+      return key;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async withSessionStoreLock(callback: () => Promise<Response>): Promise<Response> {
+    const result = this.sessionStoreTail.then(callback);
+    this.sessionStoreTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await result;
   }
 }
 
-async function parseBody(request: Request): Promise<Record<string, unknown>> {
-  const body: unknown = await request.json();
+function publicState(state: StoredRun) {
+  return AgentRunStatusResponseSchema.parse({
+    conversation_id: state.request.conversation_id,
+    run_id: state.request.run_id,
+    status: state.status,
+    sandbox_id: state.sandboxId,
+    checkpoint_key: state.checkpointKey,
+    error: state.error,
+  });
+}
 
-  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+function runContext(state: StoredRun): SandboxRunContext {
+  return {
+    conversationId: state.request.conversation_id,
+    runId: state.request.run_id,
+    courseId: state.request.course_id,
+    capability: state.capability,
+    prairielearnBaseUrl: state.request.prairielearn_base_url,
+    harness: state.request.harness,
+    allowedTools: state.allowedTools,
+    repository: state.request.repository,
+  };
+}
+
+function parseHarnessResult(stdout: string): { sessionId: string } {
+  const line = stdout.trim().split('\n').at(-1);
+  if (!line) throw new Error('Harness returned no result');
+  const value: unknown = JSON.parse(line);
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('session_id' in value) ||
+    typeof value.session_id !== 'string'
+  ) {
+    throw new Error('Harness returned an invalid session ID');
+  }
+  return { sessionId: value.session_id };
+}
+
+function isActive(status: AgentRunStatus): boolean {
+  return status === 'queued' || status === 'running' || status === 'cancelling';
+}
+
+function sameRunGeneration(
+  current: StoredRun | undefined,
+  expected: StoredRun,
+): current is StoredRun {
+  return (
+    current !== undefined &&
+    current.generation === expected.generation &&
+    current.request.run_id === expected.request.run_id
+  );
+}
+
+function isLocalCallback(env: AgentWorkerEnv, request: StartAgentRunRequest): boolean {
+  return (
+    env.LOCAL_DEVELOPMENT === 'true' &&
+    new URL(request.prairielearn_base_url).hostname === 'prairielearn-fixture.invalid'
+  );
+}
+
+function isLocalPublication(env: AgentWorkerEnv, request: PublishAgentRunRequest): boolean {
+  return (
+    env.LOCAL_DEVELOPMENT === 'true' &&
+    new URL(request.target.https_url).hostname === 'local.invalid'
+  );
+}
+
+function publicationKey(operationId: string): string {
+  return `publication:${operationId}`;
+}
+
+function publicationJtiKey(jti: string): string {
+  return `publication-jti:${jti}`;
+}
+
+function consumedStartKey(runId: string): string {
+  return `consumed-start:${runId}`;
+}
+
+async function parseObject(request: Request): Promise<Record<string, unknown>> {
+  const value: unknown = await request.json();
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error('Request body must be an object');
   }
+  return value as Record<string, unknown>;
+}
 
-  return body as Record<string, unknown>;
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}
+
+async function cleanupStep(
+  name: string,
+  errors: string[],
+  callback: () => Promise<void>,
+): Promise<void> {
+  try {
+    await callback();
+  } catch (error) {
+    errors.push(`${name}: ${errorMessage(error)}`);
+  }
+}
+
+async function publisherSandboxId(conversationId: string, operationId: string): Promise<string> {
+  const input = new TextEncoder().encode(`${conversationId}\0${operationId}`);
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', input));
+  const hash = [...digest].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  return `publisher-${hash.slice(0, 32)}`;
 }

--- a/apps/agent-worker/src/conversation.test.ts
+++ b/apps/agent-worker/src/conversation.test.ts
@@ -1,0 +1,25 @@
+import { assert, describe, it } from 'vitest';
+
+import { parseConversationId, parseRunId } from './conversation.js';
+
+describe('parseConversationId', () => {
+  it('accepts identifiers safe for Durable Object names and R2 keys', () => {
+    assert.equal(parseConversationId('course_123-conversation'), 'course_123-conversation');
+  });
+
+  it.each(['', '../other', 'contains spaces', 'a'.repeat(81), 42, undefined])(
+    'rejects %j',
+    (value) => {
+      assert.throws(() => parseConversationId(value));
+    },
+  );
+});
+
+describe('parseRunId', () => {
+  it('accepts UUIDs', () => {
+    assert.equal(
+      parseRunId('3f690f14-66cd-4c30-8092-c300add0b427'),
+      '3f690f14-66cd-4c30-8092-c300add0b427',
+    );
+  });
+});

--- a/apps/agent-worker/src/conversation.ts
+++ b/apps/agent-worker/src/conversation.ts
@@ -1,27 +1,5 @@
 const conversationIdPattern = /^[A-Za-z0-9_-]{1,80}$/;
 
-export type ConversationRunState =
-  | {
-      status: 'idle';
-    }
-  | {
-      status: 'running';
-      runId: string;
-      updatedAt: string;
-    }
-  | {
-      status: 'complete';
-      runId: string;
-      updatedAt: string;
-      checkpointKey: string;
-    }
-  | {
-      status: 'failed';
-      runId: string;
-      updatedAt: string;
-      error: string;
-    };
-
 export function parseConversationId(value: unknown): string {
   if (typeof value !== 'string' || !conversationIdPattern.test(value)) {
     throw new Error('conversation_id must contain 1-80 letters, numbers, underscores, or hyphens');

--- a/apps/agent-worker/src/conversation.ts
+++ b/apps/agent-worker/src/conversation.ts
@@ -1,0 +1,39 @@
+const conversationIdPattern = /^[A-Za-z0-9_-]{1,80}$/;
+
+export type ConversationRunState =
+  | {
+      status: 'idle';
+    }
+  | {
+      status: 'running';
+      runId: string;
+      updatedAt: string;
+    }
+  | {
+      status: 'complete';
+      runId: string;
+      updatedAt: string;
+      checkpointKey: string;
+    }
+  | {
+      status: 'failed';
+      runId: string;
+      updatedAt: string;
+      error: string;
+    };
+
+export function parseConversationId(value: unknown): string {
+  if (typeof value !== 'string' || !conversationIdPattern.test(value)) {
+    throw new Error('conversation_id must contain 1-80 letters, numbers, underscores, or hyphens');
+  }
+
+  return value;
+}
+
+export function parseRunId(value: unknown): string {
+  if (typeof value !== 'string' || !conversationIdPattern.test(value)) {
+    throw new Error('run_id must contain 1-80 letters, numbers, underscores, or hyphens');
+  }
+
+  return value;
+}

--- a/apps/agent-worker/src/git-auth.test.ts
+++ b/apps/agent-worker/src/git-auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { isGitReadRequest } from './git-auth.js';
+
+const repository = 'https://github.com/prairielearn/course.git';
+
+describe('Git read authorization', () => {
+  it('allows upload-pack and rejects receive-pack even with a usable token', () => {
+    expect(
+      isGitReadRequest(new Request(`${repository}/info/refs?service=git-upload-pack`), repository),
+    ).toBe(true);
+    expect(
+      isGitReadRequest(
+        new Request(`${repository}/git-upload-pack`, { method: 'POST' }),
+        repository,
+      ),
+    ).toBe(true);
+    expect(
+      isGitReadRequest(new Request(`${repository}/info/refs?service=git-receive-pack`), repository),
+    ).toBe(false);
+    expect(
+      isGitReadRequest(
+        new Request(`${repository}/git-receive-pack`, { method: 'POST' }),
+        repository,
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/agent-worker/src/git-auth.ts
+++ b/apps/agent-worker/src/git-auth.ts
@@ -1,0 +1,10 @@
+export function isGitReadRequest(request: Request, repositoryUrl: string): boolean {
+  const url = new URL(request.url);
+  const repositoryPath = new URL(repositoryUrl).pathname.replace(/\/$/, '');
+  return (
+    (request.method === 'GET' &&
+      url.pathname === `${repositoryPath}/info/refs` &&
+      url.searchParams.get('service') === 'git-upload-pack') ||
+    (request.method === 'POST' && url.pathname === `${repositoryPath}/git-upload-pack`)
+  );
+}

--- a/apps/agent-worker/src/git-checkpoints.test.ts
+++ b/apps/agent-worker/src/git-checkpoints.test.ts
@@ -1,0 +1,31 @@
+import { assert, describe, it } from 'vitest';
+
+import { agentBranch, checkpointBindingMatches } from './git-checkpoints.js';
+
+describe('agentBranch', () => {
+  it('produces a stable safe ref', () => {
+    assert.equal(agentBranch('course/1', 'run 1'), 'pl-agent/course-1/run-1');
+  });
+
+  it('binds restored bundles to the authorized course and repository', () => {
+    const repository = {
+      https_url: 'https://github.com/prairielearn/course.git',
+      branch: 'main',
+      base_sha: '1'.repeat(40),
+    };
+    const manifest = {
+      version: 1 as const,
+      conversationId: 'conversation-1',
+      courseId: 'course-1',
+      repository,
+      branch: 'pl-agent/course-1/run-1',
+      headSha: '2'.repeat(40),
+      parts: [],
+      updatedAt: new Date(0).toISOString(),
+    };
+
+    assert.equal(checkpointBindingMatches(manifest, 'course-1', repository), true);
+    assert.equal(checkpointBindingMatches(manifest, 'course-2', repository), false);
+    assert.equal(checkpointBindingMatches(manifest, 'course-1', undefined), false);
+  });
+});

--- a/apps/agent-worker/src/git-checkpoints.ts
+++ b/apps/agent-worker/src/git-checkpoints.ts
@@ -1,0 +1,473 @@
+import type { ISandbox, SandboxCommand } from '@cloudflare/sandbox';
+
+import { type AgentRepository, AgentRepositorySchema } from '@prairielearn/agent-protocol';
+
+const coursePath = '/workspace/course';
+const bundleDirectory = '/tmp/prairielearn-agent-bundles';
+const maxBundleParts = 512;
+const maxBundleBytes = 512 * 1024 * 1024;
+
+interface GitBundlePart {
+  kind: 'baseline' | 'incremental';
+  key: string;
+  sha256: string;
+  headSha: string;
+  size: number;
+}
+
+export interface GitCheckpointManifest {
+  version: 1;
+  conversationId: string;
+  courseId: string;
+  repository?: AgentRepository;
+  branch: string;
+  headSha: string;
+  parts: GitBundlePart[];
+  updatedAt: string;
+}
+
+type SandboxClient = Pick<ISandbox, 'deleteFile' | 'exec' | 'mkdir' | 'readFile' | 'writeFile'>;
+
+export async function prepareCourseWorkspace({
+  sandbox,
+  bucket,
+  conversationId,
+  courseId,
+  runId,
+  repository,
+}: {
+  sandbox: SandboxClient;
+  bucket: R2Bucket;
+  conversationId: string;
+  courseId: string;
+  runId: string;
+  repository?: AgentRepository;
+}): Promise<GitCheckpointManifest> {
+  const existing = await loadGitCheckpoint(bucket, conversationId);
+  if (existing) {
+    assertCheckpointBinding(existing, courseId, repository);
+    await restoreGitCheckpoint(sandbox, bucket, existing, { courseId, repository });
+    return existing;
+  }
+
+  await removeCourseWorkspace(sandbox);
+  const branch = agentBranch(courseId, runId);
+  if (repository) {
+    await execChecked(sandbox, ['git', 'clone', '--no-checkout', repository.https_url, coursePath]);
+    await execChecked(sandbox, [
+      'git',
+      '-C',
+      coursePath,
+      'checkout',
+      '-B',
+      branch,
+      repository.base_sha,
+    ]);
+    await configureGitIdentity(sandbox);
+  } else {
+    await sandbox.mkdir(coursePath, { recursive: true });
+    await execChecked(sandbox, ['git', '-C', coursePath, 'init', '-b', branch]);
+    await configureGitIdentity(sandbox);
+    await sandbox.writeFile(
+      `${coursePath}/README.md`,
+      '# Deterministic PrairieLearn agent course\n',
+    );
+    await execChecked(sandbox, ['git', '-C', coursePath, 'add', 'README.md']);
+    await execChecked(sandbox, [
+      'git',
+      '-C',
+      coursePath,
+      'commit',
+      '-m',
+      'Initialize deterministic agent course',
+    ]);
+  }
+
+  return await createGitCheckpoint({
+    sandbox,
+    bucket,
+    conversationId,
+    courseId,
+    repository,
+    branch,
+  });
+}
+
+export async function createGitCheckpoint({
+  sandbox,
+  bucket,
+  conversationId,
+  courseId,
+  repository,
+  branch,
+}: {
+  sandbox: SandboxClient;
+  bucket: R2Bucket;
+  conversationId: string;
+  courseId?: string;
+  repository?: AgentRepository;
+  branch: string;
+}): Promise<GitCheckpointManifest> {
+  const headSha = (
+    await execChecked(sandbox, ['git', '-C', coursePath, 'rev-parse', 'HEAD'])
+  ).trim();
+  assertGitSha(headSha);
+  const current = await loadGitCheckpoint(bucket, conversationId);
+  if (current && courseId) assertCheckpointBinding(current, courseId, repository);
+  if (current?.headSha === headSha) return current;
+  if ((current?.parts.length ?? 0) >= maxBundleParts) {
+    throw new Error('Git bundle part limit reached');
+  }
+
+  await sandbox.mkdir(bundleDirectory, { recursive: true });
+  const sequence = current?.parts.length ?? 0;
+  const kind = current ? 'incremental' : 'baseline';
+  const localPath = `${bundleDirectory}/${sequence.toString().padStart(6, '0')}.bundle`;
+  const command: SandboxCommand = current
+    ? ['git', '-C', coursePath, 'bundle', 'create', localPath, 'HEAD', `^${current.headSha}`]
+    : ['git', '-C', coursePath, 'bundle', 'create', localPath, '--all'];
+  await execChecked(sandbox, command);
+  const sha256 = await sha256File(sandbox, localPath);
+  const size = Number((await execChecked(sandbox, ['stat', '-c', '%s', localPath])).trim());
+  if (!Number.isSafeInteger(size) || size < 0) throw new Error('Invalid Git bundle size');
+  if ((current?.parts.reduce((sum, part) => sum + part.size, 0) ?? 0) + size > maxBundleBytes) {
+    throw new Error('Git bundle storage limit reached');
+  }
+  const key = `conversations/${conversationId}/git/bundles/${sequence.toString().padStart(6, '0')}-${headSha}.bundle`;
+  const bundle = await sandbox.readFile(localPath, { encoding: 'none' });
+  if (bundle.size !== size) throw new Error('Git bundle size changed before upload');
+  const fixedLength = new FixedLengthStream(size);
+  await Promise.all([
+    bundle.content.pipeTo(fixedLength.writable),
+    bucket.put(key, fixedLength.readable, {
+      onlyIf: { etagDoesNotMatch: '*' },
+      customMetadata: { sha256, headSha, kind, size: String(size) },
+    }),
+  ]);
+  await sandbox.deleteFile(localPath);
+
+  const manifest: GitCheckpointManifest = {
+    version: 1,
+    conversationId,
+    courseId: current?.courseId ?? requireValue(courseId, 'courseId'),
+    repository: current?.repository ?? repository,
+    branch,
+    headSha,
+    parts: [...(current?.parts ?? []), { kind, key, sha256, headSha, size }],
+    updatedAt: new Date().toISOString(),
+  };
+  await bucket.put(gitManifestKey(conversationId), JSON.stringify(manifest), {
+    httpMetadata: { contentType: 'application/json' },
+  });
+  return manifest;
+}
+
+export async function loadGitCheckpoint(
+  bucket: R2Bucket,
+  conversationId: string,
+): Promise<GitCheckpointManifest | null> {
+  const object = await bucket.get(gitManifestKey(conversationId));
+  if (!object) return null;
+  return parseGitCheckpoint(await object.json(), conversationId);
+}
+
+export async function restoreGitCheckpoint(
+  sandbox: SandboxClient,
+  bucket: R2Bucket,
+  manifest: GitCheckpointManifest,
+  expected?: { courseId: string; repository?: AgentRepository },
+): Promise<void> {
+  if (expected) assertCheckpointBinding(manifest, expected.courseId, expected.repository);
+  if (manifest.parts.length === 0 || manifest.parts[0].kind !== 'baseline') {
+    throw new Error('Git checkpoint is missing its baseline bundle');
+  }
+  await removeCourseWorkspace(sandbox);
+  await sandbox.mkdir(bundleDirectory, { recursive: true });
+
+  for (const [index, part] of manifest.parts.entries()) {
+    const object = await bucket.get(part.key);
+    if (!object) throw new Error(`Missing Git bundle: ${part.key}`);
+    const localPath = `${bundleDirectory}/${index.toString().padStart(6, '0')}.bundle`;
+    if (!object.body) throw new Error(`Git bundle has no body: ${part.key}`);
+    await sandbox.writeFile(localPath, object.body);
+    const actualChecksum = await sha256File(sandbox, localPath);
+    if (actualChecksum !== part.sha256) {
+      throw new Error(`Git bundle checksum mismatch: ${part.key}`);
+    }
+
+    if (part.kind === 'baseline') {
+      await execChecked(sandbox, ['git', 'clone', localPath, coursePath]);
+    } else {
+      await execChecked(sandbox, ['git', '-C', coursePath, 'fetch', localPath, 'HEAD']);
+    }
+  }
+
+  await execChecked(sandbox, [
+    'git',
+    '-C',
+    coursePath,
+    'checkout',
+    '-B',
+    manifest.branch,
+    manifest.headSha,
+  ]);
+  await configureGitIdentity(sandbox);
+  const restoredHead = (
+    await execChecked(sandbox, ['git', '-C', coursePath, 'rev-parse', 'HEAD'])
+  ).trim();
+  if (restoredHead !== manifest.headSha) {
+    throw new Error('Restored Git HEAD does not match manifest');
+  }
+}
+
+export async function currentGitHead(sandbox: SandboxClient): Promise<string> {
+  const head = (await execChecked(sandbox, ['git', '-C', coursePath, 'rev-parse', 'HEAD'])).trim();
+  assertGitSha(head);
+  return head;
+}
+
+export async function createCommittedQuestionSnapshot(
+  sandbox: SandboxClient,
+  rawQid: string,
+): Promise<{ qid: string; files: { path: string; content: string }[]; headSha: string }> {
+  const qid = safeRelativePath(rawQid, 'qid');
+  if ((await execChecked(sandbox, ['git', '-C', coursePath, 'status', '--porcelain'])).trim()) {
+    throw new Error('Commit all course edits before calling render_question');
+  }
+  const headSha = (
+    await execChecked(sandbox, ['git', '-C', coursePath, 'rev-parse', 'HEAD'])
+  ).trim();
+  assertGitSha(headSha);
+  const prefix = `questions/${qid}/`;
+  const tree = await execChecked(sandbox, [
+    'git',
+    '-C',
+    coursePath,
+    'ls-tree',
+    '-r',
+    'HEAD',
+    '--',
+    prefix,
+  ]);
+  const candidates = tree
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const modeSeparator = line.indexOf(' ');
+      const pathSeparator = line.indexOf('\t');
+      const mode = line.slice(0, modeSeparator);
+      const repoPath = line.slice(pathSeparator + 1);
+      if (modeSeparator < 1 || pathSeparator < 1 || !repoPath.startsWith(prefix)) {
+        throw new Error('Invalid Git tree entry');
+      }
+      if (mode === '120000') throw new Error('render_question does not allow symlinks');
+      return { repoPath, relativePath: repoPath.slice(prefix.length) };
+    })
+    .filter((file) => isAllowedQuestionFile(file.relativePath));
+  if (candidates.length > 30) throw new Error('render_question includes more than 30 files');
+  if (!candidates.some((file) => file.relativePath === 'question.html')) {
+    throw new Error('render_question requires question.html');
+  }
+  let totalSize = 0;
+  const files = [];
+  for (const file of candidates) {
+    const content = await execChecked(sandbox, [
+      'git',
+      '-C',
+      coursePath,
+      'show',
+      `HEAD:${file.repoPath}`,
+    ]);
+    totalSize += new TextEncoder().encode(content).byteLength;
+    if (totalSize > 1_048_576) throw new Error('render_question files exceed 1 MiB');
+    files.push({ path: file.relativePath, content });
+  }
+  return { qid, files, headSha };
+}
+
+export async function pushExactGitHead(
+  sandbox: SandboxClient,
+  repositoryHttpsUrl: string,
+  branch: string,
+  headSha: string,
+): Promise<void> {
+  assertGitSha(headSha);
+  await execChecked(sandbox, [
+    'git',
+    '-C',
+    coursePath,
+    'push',
+    repositoryHttpsUrl,
+    `${headSha}:refs/heads/${branch}`,
+  ]);
+}
+
+export function agentBranch(courseId: string, runId: string): string {
+  return `pl-agent/${safeRefPart(courseId)}/${safeRefPart(runId)}`;
+}
+
+function gitManifestKey(conversationId: string): string {
+  return `conversations/${conversationId}/git/latest.json`;
+}
+
+function parseGitCheckpoint(value: unknown, conversationId: string): GitCheckpointManifest {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    !('version' in value) ||
+    value.version !== 1 ||
+    !('conversationId' in value) ||
+    value.conversationId !== conversationId ||
+    !('courseId' in value) ||
+    typeof value.courseId !== 'string' ||
+    !('branch' in value) ||
+    typeof value.branch !== 'string' ||
+    !('headSha' in value) ||
+    typeof value.headSha !== 'string' ||
+    !('parts' in value) ||
+    !Array.isArray(value.parts) ||
+    !('updatedAt' in value) ||
+    typeof value.updatedAt !== 'string'
+  ) {
+    throw new Error('Invalid Git checkpoint manifest');
+  }
+  assertGitSha(value.headSha);
+  const parts = value.parts.map((part) => {
+    if (
+      typeof part !== 'object' ||
+      part === null ||
+      Array.isArray(part) ||
+      !('kind' in part) ||
+      (part.kind !== 'baseline' && part.kind !== 'incremental') ||
+      !('key' in part) ||
+      typeof part.key !== 'string' ||
+      !('sha256' in part) ||
+      typeof part.sha256 !== 'string' ||
+      !/^[0-9a-f]{64}$/.test(part.sha256) ||
+      !('headSha' in part) ||
+      typeof part.headSha !== 'string' ||
+      !('size' in part) ||
+      typeof part.size !== 'number' ||
+      !Number.isSafeInteger(part.size) ||
+      !/^\d+$/.test(String(part.size))
+    ) {
+      throw new Error('Invalid Git bundle part');
+    }
+    assertGitSha(part.headSha);
+    return part as GitBundlePart;
+  });
+  const repository =
+    'repository' in value ? AgentRepositorySchema.parse(value.repository) : undefined;
+  return { ...value, repository, parts } as GitCheckpointManifest;
+}
+
+function assertCheckpointBinding(
+  manifest: GitCheckpointManifest,
+  courseId: string,
+  repository: AgentRepository | undefined,
+): void {
+  if (!checkpointBindingMatches(manifest, courseId, repository)) {
+    throw new Error('Git checkpoint does not match the authorized course repository');
+  }
+}
+
+export function checkpointBindingMatches(
+  manifest: GitCheckpointManifest,
+  courseId: string,
+  repository: AgentRepository | undefined,
+): boolean {
+  return (
+    manifest.courseId === courseId &&
+    JSON.stringify(manifest.repository) === JSON.stringify(repository)
+  );
+}
+
+function requireValue(value: string | undefined, name: string): string {
+  if (!value) throw new Error(`${name} is required for the baseline Git checkpoint`);
+  return value;
+}
+
+async function removeCourseWorkspace(sandbox: SandboxClient): Promise<void> {
+  await execChecked(sandbox, ['/bin/rm', '-rf', coursePath, bundleDirectory]);
+}
+
+async function configureGitIdentity(sandbox: SandboxClient): Promise<void> {
+  await execChecked(sandbox, [
+    'git',
+    '-C',
+    coursePath,
+    'config',
+    'user.name',
+    'PrairieLearn Agent',
+  ]);
+  await execChecked(sandbox, [
+    'git',
+    '-C',
+    coursePath,
+    'config',
+    'user.email',
+    'agent@prairielearn.invalid',
+  ]);
+}
+
+async function sha256File(sandbox: SandboxClient, path: string): Promise<string> {
+  const output = (await execChecked(sandbox, ['sha256sum', path])).trim().split(/\s+/, 1)[0];
+  if (!/^[0-9a-f]{64}$/.test(output)) throw new Error('Unable to checksum Git bundle');
+  return output;
+}
+
+async function execChecked(sandbox: SandboxClient, command: SandboxCommand): Promise<string> {
+  const process = await sandbox.exec(command, { timeout: 120_000 });
+  const output = await process.output({ encoding: 'utf8', timeout: 120_000 });
+  if (output.exitCode !== 0) {
+    throw new Error(`${command[0]} exited with ${output.exitCode}: ${output.stderr}`);
+  }
+  return output.stdout;
+}
+
+function safeRefPart(value: string): string {
+  const result = value.replaceAll(/[^A-Za-z0-9._-]/g, '-');
+  if (!result || result === '.' || result === '..') throw new Error('Invalid Git ref component');
+  return result;
+}
+
+function safeRelativePath(path: string, name: string): string {
+  if (path.startsWith('/') || path.includes('\\')) throw new Error(`Invalid ${name}`);
+  const segments = path.split('/');
+  if (
+    segments.length === 0 ||
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === '.' ||
+        segment === '..' ||
+        !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment),
+    )
+  ) {
+    throw new Error(`Invalid ${name}`);
+  }
+  return segments.join('/');
+}
+
+function isAllowedQuestionFile(path: string): boolean {
+  try {
+    safeRelativePath(path, 'question file');
+  } catch {
+    return false;
+  }
+  if (
+    path === 'question.html' ||
+    path === 'question.py' ||
+    path === 'server.py' ||
+    path === 'info.json'
+  ) {
+    return true;
+  }
+  return /^(?:assets\/)?[A-Za-z0-9._/-]+\.(?:css|csv|html|js|json|md|svg|txt)$/.test(path);
+}
+
+function assertGitSha(value: string): void {
+  if (!/^[0-9a-f]{40}$/.test(value)) throw new Error('Invalid Git SHA');
+}

--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -1,129 +1,195 @@
 import { getSandbox } from '@cloudflare/sandbox';
 
+import {
+  PublishAgentRunRequestSchema,
+  StartAgentRunRequestSchema,
+} from '@prairielearn/agent-protocol';
+
 import { AgentSandbox, ContainerProxy } from './agent-sandbox.js';
 import {
-  type LocalSmokeCheckpoint,
-  localSmokeCheckpointKey,
-  parseCheckpoint,
-  serializeCheckpoint,
-} from './checkpoint.js';
+  assertConversationCapability,
+  assertLocalControlCapability,
+  assertRunCapability,
+  assertStartCapability,
+  parsePublicationCapability,
+  verifyCapability,
+} from './auth.js';
 import { ConversationCoordinator } from './conversation-coordinator.js';
-import { parseConversationId } from './conversation.js';
 
 export { AgentSandbox, ContainerProxy, ConversationCoordinator };
 
 type AgentWorkerEnv = Cloudflare.Env & {
+  AGENT_CAPABILITY_SECRET?: string;
+  AGENT_STATE: R2Bucket;
+  AGENT_WORKER_ENABLED?: string;
   LOCAL_DEVELOPMENT?: string;
+  PRAIRIELEARN_ORIGIN?: string;
   SANDBOX: DurableObjectNamespace<AgentSandbox>;
 };
-
-const localSmokeCommand = [
-  '/bin/bash',
-  '-lc',
-  "node --version && git --version && node -e \"import('/opt/prairielearn-agent/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs').then(() => console.log('claude-agent-sdk-ok'))\" && printf 'sandbox-ok\\n'",
-] as const;
 
 export default {
   async fetch(request, env): Promise<Response> {
     const url = new URL(request.url);
 
     if (request.method === 'GET' && url.pathname === '/health') {
-      return Response.json({ status: 'ok' });
+      return Response.json({ status: 'ok', enabled: isEnabled(env) });
     }
+    if (!isEnabled(env)) return new Response('Not found', { status: 404 });
 
-    if (request.method === 'POST' && url.pathname === '/internal/local/smoke') {
-      if (env.LOCAL_DEVELOPMENT !== 'true') {
-        return new Response('Not found', { status: 404 });
+    try {
+      if (!env.AGENT_CAPABILITY_SECRET) {
+        throw new Error('Agent capability verification is not configured');
+      }
+      const capability = await verifyCapability(request, env.AGENT_CAPABILITY_SECRET);
+
+      if (request.method === 'POST' && url.pathname === '/v1/runs/start') {
+        const body = StartAgentRunRequestSchema.parse(await request.json());
+        await assertStartCapability(capability, body);
+        assertPrairieLearnOrigin(env, body.prairielearn_base_url);
+        const coordinator = env.CONVERSATIONS.getByName(body.conversation_id);
+        return await coordinator.fetch(
+          new Request('http://conversation/start', {
+            method: 'POST',
+            body: JSON.stringify({
+              request: body,
+              capability: capability.token,
+              allowed_tools: capability.claims.allowed_tools,
+            }),
+          }),
+        );
       }
 
-      return runLocalSmoke(request, env);
-    }
+      const runMatch = /^\/v1\/runs\/([^/]+)$/.exec(url.pathname);
+      if (request.method === 'GET' && runMatch) {
+        const runId = decodeURIComponent(runMatch[1]);
+        assertRunCapability(capability, runId);
+        const coordinator = env.CONVERSATIONS.getByName(capability.claims.conversation_id);
+        return await coordinator.fetch(
+          new Request(`http://conversation/state?run_id=${encodeURIComponent(runId)}`),
+        );
+      }
 
-    return new Response('Not found', { status: 404 });
+      const cancelMatch = /^\/v1\/runs\/([^/]+)\/cancel$/.exec(url.pathname);
+      if (request.method === 'POST' && cancelMatch) {
+        const runId = decodeURIComponent(cancelMatch[1]);
+        assertRunCapability(capability, runId);
+        const coordinator = env.CONVERSATIONS.getByName(capability.claims.conversation_id);
+        return await coordinator.fetch(
+          new Request('http://conversation/cancel', {
+            method: 'POST',
+            body: JSON.stringify({ run_id: runId }),
+          }),
+        );
+      }
+
+      const publishMatch = /^\/v1\/runs\/([^/]+)\/publish$/.exec(url.pathname);
+      if (request.method === 'POST' && publishMatch) {
+        const runId = decodeURIComponent(publishMatch[1]);
+        const body = PublishAgentRunRequestSchema.parse(await request.json());
+        const publication = parsePublicationCapability(capability.payload);
+        if (
+          capability.claims.run_id !== runId ||
+          publication.operation_id !== body.operation_id ||
+          JSON.stringify(publication.target) !== JSON.stringify(body.target)
+        ) {
+          throw new Error('Publication capability does not match request');
+        }
+        const coordinator = env.CONVERSATIONS.getByName(capability.claims.conversation_id);
+        return await coordinator.fetch(
+          new Request(`http://conversation/publish?run_id=${encodeURIComponent(runId)}`, {
+            method: 'POST',
+            body: JSON.stringify({ request: body, jti: capability.claims.jti }),
+          }),
+        );
+      }
+
+      const conversationMatch = /^\/v1\/conversations\/([^/]+)$/.exec(url.pathname);
+      if (request.method === 'DELETE' && conversationMatch) {
+        const conversationId = decodeURIComponent(conversationMatch[1]);
+        assertConversationCapability(capability, conversationId);
+        const coordinator = env.CONVERSATIONS.getByName(conversationId);
+        return await coordinator.fetch(
+          new Request('http://conversation/conversation', { method: 'DELETE' }),
+        );
+      }
+
+      const localDestroyMatch = /^\/internal\/local\/conversations\/([^/]+)\/destroy-sandbox$/.exec(
+        url.pathname,
+      );
+      if (request.method === 'POST' && localDestroyMatch && env.LOCAL_DEVELOPMENT === 'true') {
+        const conversationId = decodeURIComponent(localDestroyMatch[1]);
+        assertLocalControlCapability(capability, conversationId);
+        await getSandbox<AgentSandbox>(env.SANDBOX, conversationId).destroy();
+        return new Response(null, { status: 204 });
+      }
+
+      const localCheckpointMatch = /^\/internal\/local\/runs\/([^/]+)\/checkpoint$/.exec(
+        url.pathname,
+      );
+      if (request.method === 'GET' && localCheckpointMatch && env.LOCAL_DEVELOPMENT === 'true') {
+        const runId = decodeURIComponent(localCheckpointMatch[1]);
+        assertRunCapability(capability, runId);
+        const coordinator = env.CONVERSATIONS.getByName(capability.claims.conversation_id);
+        return await coordinator.fetch(
+          new Request(`http://conversation/checkpoint?run_id=${encodeURIComponent(runId)}`),
+        );
+      }
+
+      const localObjectCountMatch =
+        /^\/internal\/local\/conversations\/([^/]+)\/object-count$/.exec(url.pathname);
+      if (request.method === 'GET' && localObjectCountMatch && env.LOCAL_DEVELOPMENT === 'true') {
+        const conversationId = decodeURIComponent(localObjectCountMatch[1]);
+        assertConversationCapability(capability, conversationId);
+        let cursor: string | undefined;
+        let count = 0;
+        do {
+          const result = await env.AGENT_STATE.list({
+            prefix: `conversations/${conversationId}/`,
+            cursor,
+          });
+          count += result.objects.length;
+          cursor = result.truncated ? result.cursor : undefined;
+        } while (cursor !== undefined);
+        return Response.json({ count });
+      }
+
+      return new Response('Not found', { status: 404 });
+    } catch (error) {
+      return Response.json({ error: errorMessage(error) }, { status: authenticationStatus(error) });
+    }
   },
 } satisfies ExportedHandler<AgentWorkerEnv>;
 
-async function runLocalSmoke(request: Request, env: AgentWorkerEnv): Promise<Response> {
-  let conversationId: string;
+function isEnabled(env: AgentWorkerEnv): boolean {
+  return env.AGENT_WORKER_ENABLED === 'true' && Boolean(env.AGENT_CAPABILITY_SECRET);
+}
 
-  try {
-    const body: unknown = await request.json();
-    conversationId = parseConversationId(
-      typeof body === 'object' && body !== null && 'conversation_id' in body
-        ? body.conversation_id
-        : undefined,
-    );
-  } catch (error) {
-    return Response.json({ error: errorMessage(error) }, { status: 400 });
-  }
-
-  const runId = crypto.randomUUID();
-  const coordinator = env.CONVERSATIONS.getByName(conversationId);
-  const beginResponse = await coordinator.fetch(
-    new Request('http://conversation/begin', {
-      method: 'POST',
-      body: JSON.stringify({ run_id: runId }),
-    }),
-  );
-
-  if (!beginResponse.ok) return beginResponse;
-
-  try {
-    const sandbox = getSandbox<AgentSandbox>(env.SANDBOX, conversationId);
-    const process = await sandbox.exec(localSmokeCommand, { timeout: 120_000 });
-    const output = await process.output({ encoding: 'utf8', timeout: 120_000 });
-
-    if (output.exitCode !== 0) {
-      throw new Error(`Sandbox smoke command exited with ${output.exitCode}: ${output.stderr}`);
+function assertPrairieLearnOrigin(env: AgentWorkerEnv, baseUrl: string): void {
+  const url = new URL(baseUrl);
+  if (env.LOCAL_DEVELOPMENT === 'true') {
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('Invalid local PrairieLearn callback scheme');
     }
-
-    const checkpointKey = localSmokeCheckpointKey(conversationId, runId);
-    const checkpoint: LocalSmokeCheckpoint = {
-      version: 1,
-      conversationId,
-      runId,
-      command: localSmokeCommand,
-      stdout: output.stdout,
-      stderr: output.stderr,
-      exitCode: output.exitCode,
-      createdAt: new Date().toISOString(),
-    };
-    await env.AGENT_STATE.put(checkpointKey, serializeCheckpoint(checkpoint), {
-      httpMetadata: { contentType: 'application/json' },
-    });
-
-    const storedCheckpoint = await env.AGENT_STATE.get(checkpointKey);
-    if (!storedCheckpoint) throw new Error('R2 checkpoint was not readable after write');
-
-    const restoredCheckpoint = parseCheckpoint(await storedCheckpoint.text());
-    const completeResponse = await coordinator.fetch(
-      new Request('http://conversation/complete', {
-        method: 'POST',
-        body: JSON.stringify({ run_id: runId, checkpoint_key: checkpointKey }),
-      }),
-    );
-    if (!completeResponse.ok) throw new Error(await completeResponse.text());
-
-    return Response.json({
-      status: 'ok',
-      conversation_id: conversationId,
-      run_id: runId,
-      checkpoint_key: checkpointKey,
-      sandbox: {
-        stdout: restoredCheckpoint.stdout,
-        stderr: restoredCheckpoint.stderr,
-        exit_code: restoredCheckpoint.exitCode,
-      },
-    });
-  } catch (error) {
-    await coordinator.fetch(
-      new Request('http://conversation/fail', {
-        method: 'POST',
-        body: JSON.stringify({ run_id: runId, error: errorMessage(error) }),
-      }),
-    );
-    return Response.json({ error: errorMessage(error) }, { status: 500 });
+    return;
   }
+  if (url.protocol !== 'https:') throw new Error('PrairieLearn callback URL must use HTTPS');
+  if (!env.PRAIRIELEARN_ORIGIN) throw new Error('PrairieLearn callback origin is not configured');
+  if (url.origin !== new URL(env.PRAIRIELEARN_ORIGIN).origin) {
+    throw new Error('PrairieLearn callback origin is not authorized');
+  }
+}
+
+function authenticationStatus(error: unknown): number {
+  if (
+    error instanceof Error &&
+    (error.message.includes('capability') ||
+      error.message.includes('signature') ||
+      error.message.includes('JWT') ||
+      error.message.includes('token'))
+  ) {
+    return 401;
+  }
+  return 400;
 }
 
 function errorMessage(error: unknown): string {

--- a/apps/agent-worker/src/index.ts
+++ b/apps/agent-worker/src/index.ts
@@ -1,0 +1,131 @@
+import { getSandbox } from '@cloudflare/sandbox';
+
+import { AgentSandbox, ContainerProxy } from './agent-sandbox.js';
+import {
+  type LocalSmokeCheckpoint,
+  localSmokeCheckpointKey,
+  parseCheckpoint,
+  serializeCheckpoint,
+} from './checkpoint.js';
+import { ConversationCoordinator } from './conversation-coordinator.js';
+import { parseConversationId } from './conversation.js';
+
+export { AgentSandbox, ContainerProxy, ConversationCoordinator };
+
+type AgentWorkerEnv = Cloudflare.Env & {
+  LOCAL_DEVELOPMENT?: string;
+  SANDBOX: DurableObjectNamespace<AgentSandbox>;
+};
+
+const localSmokeCommand = [
+  '/bin/bash',
+  '-lc',
+  "node --version && git --version && node -e \"import('/opt/prairielearn-agent/node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs').then(() => console.log('claude-agent-sdk-ok'))\" && printf 'sandbox-ok\\n'",
+] as const;
+
+export default {
+  async fetch(request, env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'GET' && url.pathname === '/health') {
+      return Response.json({ status: 'ok' });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/internal/local/smoke') {
+      if (env.LOCAL_DEVELOPMENT !== 'true') {
+        return new Response('Not found', { status: 404 });
+      }
+
+      return runLocalSmoke(request, env);
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+} satisfies ExportedHandler<AgentWorkerEnv>;
+
+async function runLocalSmoke(request: Request, env: AgentWorkerEnv): Promise<Response> {
+  let conversationId: string;
+
+  try {
+    const body: unknown = await request.json();
+    conversationId = parseConversationId(
+      typeof body === 'object' && body !== null && 'conversation_id' in body
+        ? body.conversation_id
+        : undefined,
+    );
+  } catch (error) {
+    return Response.json({ error: errorMessage(error) }, { status: 400 });
+  }
+
+  const runId = crypto.randomUUID();
+  const coordinator = env.CONVERSATIONS.getByName(conversationId);
+  const beginResponse = await coordinator.fetch(
+    new Request('http://conversation/begin', {
+      method: 'POST',
+      body: JSON.stringify({ run_id: runId }),
+    }),
+  );
+
+  if (!beginResponse.ok) return beginResponse;
+
+  try {
+    const sandbox = getSandbox<AgentSandbox>(env.SANDBOX, conversationId);
+    const process = await sandbox.exec(localSmokeCommand, { timeout: 120_000 });
+    const output = await process.output({ encoding: 'utf8', timeout: 120_000 });
+
+    if (output.exitCode !== 0) {
+      throw new Error(`Sandbox smoke command exited with ${output.exitCode}: ${output.stderr}`);
+    }
+
+    const checkpointKey = localSmokeCheckpointKey(conversationId, runId);
+    const checkpoint: LocalSmokeCheckpoint = {
+      version: 1,
+      conversationId,
+      runId,
+      command: localSmokeCommand,
+      stdout: output.stdout,
+      stderr: output.stderr,
+      exitCode: output.exitCode,
+      createdAt: new Date().toISOString(),
+    };
+    await env.AGENT_STATE.put(checkpointKey, serializeCheckpoint(checkpoint), {
+      httpMetadata: { contentType: 'application/json' },
+    });
+
+    const storedCheckpoint = await env.AGENT_STATE.get(checkpointKey);
+    if (!storedCheckpoint) throw new Error('R2 checkpoint was not readable after write');
+
+    const restoredCheckpoint = parseCheckpoint(await storedCheckpoint.text());
+    const completeResponse = await coordinator.fetch(
+      new Request('http://conversation/complete', {
+        method: 'POST',
+        body: JSON.stringify({ run_id: runId, checkpoint_key: checkpointKey }),
+      }),
+    );
+    if (!completeResponse.ok) throw new Error(await completeResponse.text());
+
+    return Response.json({
+      status: 'ok',
+      conversation_id: conversationId,
+      run_id: runId,
+      checkpoint_key: checkpointKey,
+      sandbox: {
+        stdout: restoredCheckpoint.stdout,
+        stderr: restoredCheckpoint.stderr,
+        exit_code: restoredCheckpoint.exitCode,
+      },
+    });
+  } catch (error) {
+    await coordinator.fetch(
+      new Request('http://conversation/fail', {
+        method: 'POST',
+        body: JSON.stringify({ run_id: runId, error: errorMessage(error) }),
+      }),
+    );
+    return Response.json({ error: errorMessage(error) }, { status: 500 });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unknown error';
+}

--- a/apps/agent-worker/src/run-guards.test.ts
+++ b/apps/agent-worker/src/run-guards.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { type PublicationRecord, isCurrentRun, publicationReservation } from './run-guards.js';
+
+const request = {
+  operation_id: 'operation-1',
+  target: {
+    https_url: 'https://github.com/prairielearn/course.git',
+    branch: 'pl-agent/course/run-1',
+    head_sha: '1'.repeat(40),
+  },
+};
+const response = {
+  operation_id: request.operation_id,
+  branch: request.target.branch,
+  head_sha: request.target.head_sha,
+};
+
+describe('run guards', () => {
+  it('does not expose a newer current run through an older run URL', () => {
+    expect(isCurrentRun('run-2', 'run-1')).toBe(false);
+    expect(isCurrentRun('run-2', 'run-2')).toBe(true);
+  });
+
+  it('replays an identical completed publication receipt', () => {
+    const existing: PublicationRecord = { request, status: 'completed', response };
+    expect(publicationReservation(existing, request)).toEqual({ kind: 'replay', response });
+  });
+
+  it('rejects pending publication replay and operation ID target reuse', () => {
+    expect(() => publicationReservation({ request, status: 'pending' }, request)).toThrow(
+      'already in progress',
+    );
+    expect(() =>
+      publicationReservation(
+        { request, status: 'completed', response },
+        { ...request, target: { ...request.target, branch: 'another-branch' } },
+      ),
+    ).toThrow('already used');
+  });
+});

--- a/apps/agent-worker/src/run-guards.ts
+++ b/apps/agent-worker/src/run-guards.ts
@@ -1,0 +1,43 @@
+import type { PublishAgentRunRequest, PublishAgentRunResponse } from '@prairielearn/agent-protocol';
+
+export interface PublicationRecord {
+  request: PublishAgentRunRequest;
+  status: 'pending' | 'completed' | 'failed';
+  response?: PublishAgentRunResponse;
+  error?: string;
+}
+
+export type PublicationReservation =
+  | { kind: 'reserve' }
+  | { kind: 'replay'; response: PublishAgentRunResponse };
+
+export function isCurrentRun(currentRunId: string, requestedRunId: string | null): boolean {
+  return requestedRunId !== null && currentRunId === requestedRunId;
+}
+
+export function publicationReservation(
+  existing: PublicationRecord | undefined,
+  request: PublishAgentRunRequest,
+): PublicationReservation {
+  if (!existing) return { kind: 'reserve' };
+  if (!samePublicationRequest(existing.request, request)) {
+    throw new Error('Publication operation ID was already used for another target');
+  }
+  if (existing.status === 'completed' && existing.response) {
+    return { kind: 'replay', response: existing.response };
+  }
+  if (existing.status === 'failed') throw new Error('Publication operation previously failed');
+  throw new Error('Publication operation is already in progress');
+}
+
+function samePublicationRequest(
+  left: PublishAgentRunRequest,
+  right: PublishAgentRunRequest,
+): boolean {
+  return (
+    left.operation_id === right.operation_id &&
+    left.target.https_url === right.target.https_url &&
+    left.target.branch === right.target.branch &&
+    left.target.head_sha === right.target.head_sha
+  );
+}

--- a/apps/agent-worker/src/session-store.test.ts
+++ b/apps/agent-worker/src/session-store.test.ts
@@ -1,0 +1,103 @@
+import { assert, describe, expect, it } from 'vitest';
+
+import { handleSessionStoreRequest, sessionPartKey } from './session-store.js';
+
+describe('session store parts', () => {
+  it('orders immutable parts lexicographically and escapes provider keys', () => {
+    assert.equal(
+      sessionPartKey(
+        'conversation-1',
+        { projectKey: '/workspace/course', sessionId: 'session-1', subpath: 'subagents/agent-1' },
+        12,
+        'part-1',
+      ),
+      'conversations/conversation-1/claude/L3dvcmtzcGFjZS9jb3Vyc2U/c2Vzc2lvbi0x/c3ViYWdlbnRzL2FnZW50LTE/parts/000000000012-part-1.json',
+    );
+  });
+
+  it('deduplicates append batches and retries, loads, and deletes the bound conversation parts', async () => {
+    const objects = new Map<string, string>();
+    const manifests = new Map<string, unknown>();
+    const bucket = {
+      async put(key: string, value: string) {
+        objects.set(key, value);
+      },
+      async get(key: string) {
+        const value = objects.get(key);
+        return value === undefined
+          ? null
+          : {
+              async json() {
+                return JSON.parse(value);
+              },
+            };
+      },
+      async delete(key: string) {
+        objects.delete(key);
+      },
+    } as unknown as R2Bucket;
+    const storage = {
+      async get(key: string) {
+        return manifests.get(key);
+      },
+      async put(key: string, value: unknown) {
+        manifests.set(key, value);
+      },
+      async list(options?: { prefix?: string }) {
+        return new Map(
+          [...manifests].filter(([key]) =>
+            options?.prefix === undefined ? true : key.startsWith(options.prefix),
+          ),
+        );
+      },
+      async delete(keys: string | string[]) {
+        for (const key of Array.isArray(keys) ? keys : [keys]) manifests.delete(key);
+      },
+    } as unknown as DurableObjectStorage;
+    const entry = { type: 'user', uuid: 'entry-1' };
+    const call = async (path: string, body: unknown) =>
+      await handleSessionStoreRequest({
+        request: new Request(`http://session${path}`, {
+          method: 'POST',
+          body: JSON.stringify(body),
+        }),
+        bucket,
+        storage,
+        conversationId: 'conversation-real-id',
+      });
+    const key = { projectKey: '/workspace/course', sessionId: 'session-1' };
+
+    assert.deepEqual(await (await call('/append', { key, entries: [entry, entry] })).json(), {
+      appended: 1,
+      deduplicated: 1,
+    });
+    assert.deepEqual(await (await call('/append', { key, entries: [entry] })).json(), {
+      appended: 0,
+      deduplicated: 1,
+    });
+    assert.deepEqual(await (await call('/load', { key })).json(), { entries: [entry] });
+    assert.equal(
+      [...objects.keys()].every((part) => part.startsWith('conversations/conversation-real-id/')),
+      true,
+    );
+    assert.deepEqual(await (await call('/delete', { key })).json(), { deleted: 1 });
+    assert.equal(objects.size, 0);
+  });
+
+  it('rejects session keys outside the bound course workspace', async () => {
+    const call = async (key: unknown) =>
+      await handleSessionStoreRequest({
+        request: new Request('http://session/append', {
+          method: 'POST',
+          body: JSON.stringify({ key, entries: [{ type: 'user' }] }),
+        }),
+        bucket: {} as R2Bucket,
+        storage: {} as DurableObjectStorage,
+        conversationId: 'conversation-1',
+      });
+
+    await expect(call({ projectKey: '/tmp/attacker', sessionId: 'session-1' })).rejects.toThrow(
+      /workspace\/course/,
+    );
+  });
+});

--- a/apps/agent-worker/src/session-store.ts
+++ b/apps/agent-worker/src/session-store.ts
@@ -1,0 +1,301 @@
+interface SessionKey {
+  projectKey: string;
+  sessionId: string;
+  subpath?: string;
+}
+
+interface SessionStoreEntry {
+  type: string;
+  uuid?: string;
+  [key: string]: unknown;
+}
+
+interface SessionManifest {
+  version: 1;
+  key: SessionKey;
+  nextSequence: number;
+  parts: string[];
+  uuids: string[];
+  modifiedAt: number;
+  totalBytes: number;
+}
+
+const storagePrefix = 'session-manifest:';
+const totalBytesStorageKey = 'session-total-bytes';
+const maxManifestParts = 2_048;
+const maxManifestUuids = 100_000;
+const maxConversationManifests = 256;
+const maxConversationParts = 4_096;
+const maxConversationBytes = 64 * 1024 * 1024;
+const maxAppendBytes = 1024 * 1024;
+const maxAppendEntries = 1_000;
+
+export async function handleSessionStoreRequest({
+  request,
+  bucket,
+  storage,
+  conversationId,
+}: {
+  request: Request;
+  bucket: R2Bucket;
+  storage: DurableObjectStorage;
+  conversationId: string;
+}): Promise<Response> {
+  const url = new URL(request.url);
+  const body = await parseObject(request);
+
+  switch (`${request.method} ${url.pathname}`) {
+    case 'POST /append': {
+      const key = parseSessionKey(body.key);
+      const entries = parseEntries(body.entries);
+      const manifestStorageKey = await storageKey(key);
+      const existingManifest = await storage.get<SessionManifest>(manifestStorageKey);
+      const manifests = await storage.list<SessionManifest>({ prefix: storagePrefix });
+      if (existingManifest === undefined && manifests.size >= maxConversationManifests) {
+        throw new Error('Session store manifest limit reached');
+      }
+      if (
+        [...manifests.values()].reduce((total, item) => total + item.parts.length, 0) >=
+        maxConversationParts
+      ) {
+        throw new Error('Session store conversation part limit reached');
+      }
+      const manifest = existingManifest ?? newManifest(key);
+      if (manifest.parts.length >= maxManifestParts) {
+        throw new Error('Session store part limit reached');
+      }
+      const knownUuids = new Set(manifest.uuids);
+      const appendedEntries = entries.filter((entry) => {
+        if (entry.uuid === undefined) return true;
+        if (knownUuids.has(entry.uuid)) return false;
+        knownUuids.add(entry.uuid);
+        return true;
+      });
+
+      if (appendedEntries.length === 0) {
+        return Response.json({ appended: 0, deduplicated: entries.length });
+      }
+
+      if (knownUuids.size > maxManifestUuids) throw new Error('Session store UUID limit reached');
+
+      const serializedEntries = JSON.stringify(appendedEntries);
+      const appendedBytes = new TextEncoder().encode(serializedEntries).byteLength;
+      if (appendedBytes > maxAppendBytes) throw new Error('Session store append is too large');
+      const currentTotalBytes = (await storage.get<number>(totalBytesStorageKey)) ?? 0;
+      if (currentTotalBytes + appendedBytes > maxConversationBytes) {
+        throw new Error('Session store conversation byte limit reached');
+      }
+
+      const partKey = sessionPartKey(
+        conversationId,
+        key,
+        manifest.nextSequence,
+        crypto.randomUUID(),
+      );
+      await bucket.put(partKey, serializedEntries, {
+        onlyIf: { etagDoesNotMatch: '*' },
+        httpMetadata: { contentType: 'application/json' },
+      });
+
+      const nextManifest: SessionManifest = {
+        ...manifest,
+        nextSequence: manifest.nextSequence + 1,
+        parts: [...manifest.parts, partKey],
+        uuids: [...knownUuids],
+        modifiedAt: Date.now(),
+        totalBytes: (manifest.totalBytes ?? 0) + appendedBytes,
+      };
+      await storage.put(manifestStorageKey, nextManifest);
+      await storage.put(totalBytesStorageKey, currentTotalBytes + appendedBytes);
+      return Response.json({
+        appended: appendedEntries.length,
+        deduplicated: entries.length - appendedEntries.length,
+      });
+    }
+
+    case 'POST /load': {
+      const key = parseSessionKey(body.key);
+      const manifest = await storage.get<SessionManifest>(await storageKey(key));
+      if (!manifest) return Response.json({ entries: null });
+
+      const entries: SessionStoreEntry[] = [];
+      for (const partKey of manifest.parts) {
+        const part = await bucket.get(partKey);
+        if (!part) throw new Error(`Missing immutable session part: ${partKey}`);
+        entries.push(...parseEntries(await part.json()));
+      }
+      return Response.json({ entries });
+    }
+
+    case 'POST /list-subkeys': {
+      const key = parseSessionKey(body.key, false);
+      const manifests = await storage.list<SessionManifest>({ prefix: storagePrefix });
+      const subkeys = [...manifests.values()]
+        .filter(
+          (manifest) =>
+            manifest.key.projectKey === key.projectKey &&
+            manifest.key.sessionId === key.sessionId &&
+            manifest.key.subpath !== undefined,
+        )
+        .map((manifest) => manifest.key.subpath as string)
+        .sort();
+      return Response.json({ subkeys });
+    }
+
+    case 'POST /list-sessions': {
+      const projectKey = body.project_key;
+      if (projectKey !== '/workspace/course') {
+        throw new Error('project_key must be /workspace/course');
+      }
+      const manifests = await storage.list<SessionManifest>({ prefix: storagePrefix });
+      const sessions = [...manifests.values()]
+        .filter(
+          (manifest) =>
+            manifest.key.projectKey === projectKey && manifest.key.subpath === undefined,
+        )
+        .map((manifest) => ({ sessionId: manifest.key.sessionId, mtime: manifest.modifiedAt }));
+      return Response.json({ sessions });
+    }
+
+    case 'POST /delete': {
+      const key = parseSessionKey(body.key, false);
+      const manifests = await storage.list<SessionManifest>({ prefix: storagePrefix });
+      const matches = [...manifests.entries()].filter(
+        ([, manifest]) =>
+          manifest.key.projectKey === key.projectKey && manifest.key.sessionId === key.sessionId,
+      );
+      await Promise.all(
+        matches.flatMap(([, manifest]) => manifest.parts.map((part) => bucket.delete(part))),
+      );
+      await storage.delete(matches.map(([manifestKey]) => manifestKey));
+      const deletedBytes = matches.reduce(
+        (total, [, manifest]) => total + (manifest.totalBytes ?? 0),
+        0,
+      );
+      const totalBytes = (await storage.get<number>(totalBytesStorageKey)) ?? 0;
+      await storage.put(totalBytesStorageKey, Math.max(0, totalBytes - deletedBytes));
+      return Response.json({ deleted: matches.length });
+    }
+  }
+
+  return new Response('Not found', { status: 404 });
+}
+
+export async function deleteConversationSessionStore(
+  bucket: R2Bucket,
+  storage: DurableObjectStorage,
+  conversationId: string,
+): Promise<void> {
+  await deleteR2Prefix(bucket, `conversations/${conversationId}/claude/`);
+  const manifests = await storage.list({ prefix: storagePrefix });
+  await storage.delete([...manifests.keys()]);
+}
+
+export async function deleteR2Prefix(bucket: R2Bucket, prefix: string): Promise<void> {
+  let cursor: string | undefined;
+  do {
+    const result = await bucket.list({ prefix, cursor });
+    await Promise.all(result.objects.map((object) => bucket.delete(object.key)));
+    cursor = result.truncated ? result.cursor : undefined;
+  } while (cursor !== undefined);
+}
+
+export function sessionPartKey(
+  conversationId: string,
+  key: SessionKey,
+  sequence: number,
+  partId: string,
+): string {
+  const subpath = key.subpath === undefined ? 'main' : encodeComponent(key.subpath);
+  return `conversations/${conversationId}/claude/${encodeComponent(key.projectKey)}/${encodeComponent(key.sessionId)}/${subpath}/parts/${sequence.toString().padStart(12, '0')}-${partId}.json`;
+}
+
+async function storageKey(key: SessionKey): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(key));
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return `${storagePrefix}${hex(new Uint8Array(digest))}`;
+}
+
+function newManifest(key: SessionKey): SessionManifest {
+  return {
+    version: 1,
+    key,
+    nextSequence: 0,
+    parts: [],
+    uuids: [],
+    modifiedAt: Date.now(),
+    totalBytes: 0,
+  };
+}
+
+function parseSessionKey(value: unknown, allowSubpath = true): SessionKey {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('key must be an object');
+  }
+  if (!('projectKey' in value) || value.projectKey !== '/workspace/course') {
+    throw new Error('key.projectKey must be /workspace/course');
+  }
+  if (
+    !('sessionId' in value) ||
+    typeof value.sessionId !== 'string' ||
+    !value.sessionId ||
+    value.sessionId.length > 1_024
+  ) {
+    throw new Error('key.sessionId must be between 1 and 1024 characters');
+  }
+  const subpath = 'subpath' in value ? value.subpath : undefined;
+  if (
+    subpath !== undefined &&
+    (!allowSubpath ||
+      typeof subpath !== 'string' ||
+      !subpath.startsWith('subagents/') ||
+      subpath.length > 2_048)
+  ) {
+    throw new Error('Invalid key.subpath');
+  }
+  return { projectKey: value.projectKey, sessionId: value.sessionId, subpath };
+}
+
+function parseEntries(value: unknown): SessionStoreEntry[] {
+  if (!Array.isArray(value)) throw new Error('entries must be an array');
+  if (value.length > maxAppendEntries) throw new Error('Session store entry limit reached');
+  return value.map((entry) => {
+    if (
+      typeof entry !== 'object' ||
+      entry === null ||
+      Array.isArray(entry) ||
+      !('type' in entry) ||
+      typeof entry.type !== 'string' ||
+      entry.type.length > 256
+    ) {
+      throw new Error('Invalid session store entry');
+    }
+    if (
+      'uuid' in entry &&
+      entry.uuid !== undefined &&
+      (typeof entry.uuid !== 'string' || entry.uuid.length > 1_024)
+    ) {
+      throw new Error('Invalid session store entry UUID');
+    }
+    return entry as SessionStoreEntry;
+  });
+}
+
+async function parseObject(request: Request): Promise<Record<string, unknown>> {
+  const value: unknown = await request.json();
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Request body must be an object');
+  }
+  return value as Record<string, unknown>;
+}
+
+function encodeComponent(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+function hex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/apps/agent-worker/tsconfig.json
+++ b/apps/agent-worker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@prairielearn/tsconfig/tsconfig.base.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "WebWorker"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "types": ["./worker-configuration.d.ts"]
+  },
+  "include": ["src/**/*", "worker-configuration.d.ts"]
+}

--- a/apps/agent-worker/vitest.config.ts
+++ b/apps/agent-worker/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    dir: `${import.meta.dirname}/src`,
+    coverage: {
+      reporter: ['html', 'text-summary', 'cobertura'],
+      include: ['src/**/*.{ts,tsx}'],
+    },
+  },
+});

--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -9,7 +9,7 @@
       "class_name": "AgentSandbox",
       "image": "./Dockerfile",
       "instance_type": "lite",
-      "max_instances": 1
+      "max_instances": 20
     }
   ],
   "durable_objects": {

--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -1,0 +1,42 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "prairielearn-agent-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-18",
+  "compatibility_flags": ["nodejs_compat"],
+  "containers": [
+    {
+      "class_name": "AgentSandbox",
+      "image": "./Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 1
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "SANDBOX",
+        "class_name": "AgentSandbox"
+      },
+      {
+        "name": "CONVERSATIONS",
+        "class_name": "ConversationCoordinator"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["AgentSandbox", "ConversationCoordinator"]
+    }
+  ],
+  "r2_buckets": [
+    {
+      "binding": "AGENT_STATE",
+      "bucket_name": "prairielearn-agent-state"
+    }
+  ],
+  "dev": {
+    "port": 8787
+  }
+}

--- a/apps/prairielearn/assets/scripts/esm-bundles/hydrated-components/AgentConversationsPage.ts
+++ b/apps/prairielearn/assets/scripts/esm-bundles/hydrated-components/AgentConversationsPage.ts
@@ -1,0 +1,5 @@
+import { registerHydratedComponent } from '@prairielearn/react/hydrated-component';
+
+import { AgentConversationsPage } from '../../../../src/pages/instructorAgentConversations/components/AgentConversationsPage.js';
+
+registerHydratedComponent(AgentConversationsPage);

--- a/apps/prairielearn/package.json
+++ b/apps/prairielearn/package.json
@@ -48,6 +48,7 @@
     "@node-saml/passport-saml": "^5.1.0",
     "@octokit/rest": "^22.0.1",
     "@panzoom/panzoom": "^4.6.2",
+    "@prairielearn/agent-protocol": "workspace:^",
     "@prairielearn/aws": "workspace:^",
     "@prairielearn/aws-imds": "workspace:^",
     "@prairielearn/bind-mount": "workspace:^",

--- a/apps/prairielearn/src/api/agent/v1/index.test.ts
+++ b/apps/prairielearn/src/api/agent/v1/index.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveAgentCourseFilePath } from './index.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await fs.rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe('resolveAgentCourseFilePath', () => {
+  it('accepts a regular file inside the course', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pl-agent-course-'));
+    temporaryDirectories.push(root);
+    const file = path.join(root, 'questions', 'test', 'question.html');
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, '<pl-question-panel>Test</pl-question-panel>');
+
+    await expect(resolveAgentCourseFilePath(root, 'questions/test/question.html')).resolves.toBe(
+      await fs.realpath(file),
+    );
+  });
+
+  it('rejects a symlink that escapes the course', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'pl-agent-course-'));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'pl-agent-outside-'));
+    temporaryDirectories.push(root, outside);
+    const outsideFile = path.join(outside, 'secret.txt');
+    await fs.writeFile(outsideFile, 'secret');
+    await fs.symlink(outsideFile, path.join(root, 'linked-secret.txt'));
+
+    await expect(resolveAgentCourseFilePath(root, 'linked-secret.txt')).resolves.toBeNull();
+  });
+});

--- a/apps/prairielearn/src/api/agent/v1/index.ts
+++ b/apps/prairielearn/src/api/agent/v1/index.ts
@@ -1,0 +1,557 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+
+import { type Request, Router } from 'express';
+import asyncHandler from 'express-async-handler';
+import { z } from 'zod';
+
+import {
+  type AgentRunCapabilityClaims,
+  AgentToolNameSchema,
+  AgentToolRequestSchema,
+  AgentToolResponseSchema,
+  AppendAgentEventsRequestSchema,
+} from '@prairielearn/agent-protocol';
+import * as error from '@prairielearn/error';
+import { contains } from '@prairielearn/path-utils';
+
+import { validateHTML } from '../../../ee/lib/validateHTML.js';
+import { verifyAgentRunCapability } from '../../../lib/agent-capability.js';
+import { constructCourseOrInstanceContext } from '../../../lib/authz-data.js';
+import { config } from '../../../lib/config.js';
+import { getCourseFilesClient } from '../../../lib/course-files-api.js';
+import { features } from '../../../lib/features/index.js';
+import { getAndRenderVariant } from '../../../lib/question-render.js';
+import type { IssueRenderData } from '../../../lib/question-render.types.js';
+import { getJobOutput } from '../../../mcp/tools/get-job-output.js';
+import { ENTITY_SCOPES, listEntities } from '../../../mcp/tools/list-entities.js';
+import { queryCourseData } from '../../../mcp/tools/query-course-data.js';
+import {
+  appendAgentRunEvents,
+  beginAgentOperation,
+  completeAgentDraftQuestion,
+  completeAgentOperation,
+  failAgentOperation,
+  reclaimAgentOperation,
+  releaseAgentDraftQuestion,
+  reserveAgentDraftQuestion,
+  selectAgentOperation,
+  selectAgentOperationResultEvent,
+  selectAgentRun,
+  selectAgentUserIsAdministrator,
+  selectLatestAgentConversationCheckpoint,
+} from '../../../models/agent-conversation.js';
+import { selectOptionalQuestionByQid, selectQuestionById } from '../../../models/question.js';
+import { selectUserById } from '../../../models/user.js';
+
+const router = Router();
+
+export async function resolveAgentCourseFilePath(
+  coursePath: string,
+  relativePath: string,
+): Promise<string | null> {
+  const [realCoursePath, realFilePath] = await Promise.all([
+    fs.realpath(coursePath),
+    fs.realpath(path.resolve(coursePath, relativePath)),
+  ]);
+  return contains(realCoursePath, realFilePath, false) ? realFilePath : null;
+}
+
+function httpError(status: number, message: string): never {
+  throw new error.HttpStatusError(status, message);
+}
+
+function getBearerToken(authorization: string | undefined): string {
+  if (authorization === undefined) return httpError(401, 'Bearer capability is required.');
+  const match = /^Bearer (\S+)$/i.exec(authorization);
+  return match?.[1] ?? httpError(401, 'Bearer capability is invalid.');
+}
+
+async function authorizeRun(req: Request) {
+  const runId = z.string().min(1).parse(req.params.run_id);
+  let claims: AgentRunCapabilityClaims;
+  try {
+    claims = await verifyAgentRunCapability(getBearerToken(req.headers.authorization));
+  } catch {
+    return httpError(401, 'Bearer capability is invalid or expired.');
+  }
+  if (claims.run_id !== runId) return httpError(403, 'Capability does not match run.');
+  if (claims.purpose !== 'run') {
+    return httpError(403, 'Capability purpose does not allow callbacks.');
+  }
+  const run = await selectAgentRun({ courseId: claims.course_id, runId: claims.run_id });
+  if (
+    run?.conversation_id !== claims.conversation_id ||
+    run.capability_jti !== claims.jti ||
+    run.authn_user_id !== claims.authn_user_id ||
+    run.user_id !== claims.user_id ||
+    run.capability_expires_at.getTime() <= Date.now() ||
+    run.allowed_tools.length !== claims.allowed_tools.length ||
+    run.allowed_tools.some(
+      (tool) => !claims.allowed_tools.includes(AgentToolNameSchema.parse(tool)),
+    )
+  ) {
+    return httpError(403, 'Capability no longer authorizes this run.');
+  }
+  const user = await selectUserById(claims.authn_user_id);
+  const isAdministrator = await selectAgentUserIsAdministrator(user.id);
+  const requestIp = req.ip ?? req.socket.remoteAddress;
+  if (requestIp === undefined) return httpError(400, 'Request IP address is unavailable.');
+  const context = await constructCourseOrInstanceContext({
+    course_id: claims.course_id,
+    course_instance_id: null,
+    ip: requestIp,
+    is_administrator: isAdministrator,
+    overrides: { allow_example_course_override: false },
+    req_date: new Date(),
+    user,
+  });
+  if (
+    context.authzData === null ||
+    !context.authzData.has_course_permission_edit ||
+    context.course.example_course
+  ) {
+    return httpError(403, 'Current course authorization does not allow this operation.');
+  }
+  if (
+    !(await features.enabled('cloud-agent', {
+      course_id: context.course.id,
+      institution_id: context.course.institution_id,
+      user_id: user.id,
+    }))
+  ) {
+    return httpError(403, 'Course agent is no longer enabled.');
+  }
+  return { claims, course: context.course, run, user };
+}
+
+const ListEntitiesInputSchema = z.object({ scope: z.enum(ENTITY_SCOPES) });
+const ReadCourseFileInputSchema = z.object({ path: z.string().min(1).max(4096) });
+const QueryCourseDataInputSchema = z.object({ query: z.string().min(1).max(100_000) });
+const DraftQuestionFileSchema = z.object({
+  content: z.string().max(1_000_000),
+  path: z.string().min(1).max(255),
+});
+const RenderQuestionInputSchema = z
+  .object({
+    files: z.array(DraftQuestionFileSchema).min(1).max(30),
+    qid: z.string().min(1).max(255),
+    variant_seed: z.string().optional(),
+  })
+  .refine(
+    ({ files }) =>
+      files.reduce((total, file) => total + Buffer.byteLength(file.content), 0) <= 1_000_000,
+    'Draft question files may not exceed 1 MiB.',
+  );
+const GetJobOutputInputSchema = z.object({ job_sequence_id: z.string().min(1) });
+
+async function executeTool({
+  toolName,
+  input,
+  course,
+  user,
+  runId,
+  conversationId,
+}: {
+  toolName: z.infer<typeof AgentToolNameSchema>;
+  input: Record<string, unknown>;
+  course: Awaited<ReturnType<typeof authorizeRun>>['course'];
+  user: Awaited<ReturnType<typeof authorizeRun>>['user'];
+  runId: string;
+  conversationId: string;
+}): Promise<Record<string, unknown>> {
+  if (toolName === 'list_entities') {
+    const { scope } = ListEntitiesInputSchema.parse(input);
+    return { entities: await listEntities({ course, scope }) };
+  }
+  if (toolName === 'read_course_file') {
+    const parsed = ReadCourseFileInputSchema.parse(input);
+    const realFilePath = await resolveAgentCourseFilePath(course.path, parsed.path);
+    if (realFilePath === null) {
+      return httpError(400, 'Invalid course path.');
+    }
+    const stat = await fs.stat(realFilePath);
+    if (!stat.isFile() || stat.size > 1_000_000) {
+      return httpError(400, 'Course file is unavailable or too large.');
+    }
+    return { content: await fs.readFile(realFilePath, 'utf8'), path: parsed.path, size: stat.size };
+  }
+  if (toolName === 'query_course_data') {
+    if (
+      !config.devMode ||
+      !(await features.enabled('cloud-agent-arbitrary-sql', {
+        course_id: course.id,
+        institution_id: course.institution_id,
+        user_id: user.id,
+      }))
+    ) {
+      return { available: false, reason: 'Arbitrary SQL is only available in local development.' };
+    }
+    const parsed = QueryCourseDataInputSchema.parse(input);
+    return { available: true, ...(await queryCourseData(parsed.query)) };
+  }
+  if (toolName === 'render_question') {
+    const parsed = RenderQuestionInputSchema.parse(input);
+    if (config.chunksConsumer) {
+      return {
+        issues: [
+          {
+            message: 'Draft rendering is unavailable on chunk-consumer PrairieLearn servers.',
+            type: 'unavailable',
+          },
+        ],
+        rendered: false,
+      };
+    }
+    const allowedAssetExtensions = new Set([
+      '.css',
+      '.csv',
+      '.gif',
+      '.jpeg',
+      '.jpg',
+      '.js',
+      '.json',
+      '.png',
+      '.svg',
+      '.txt',
+      '.webp',
+    ]);
+    for (const file of parsed.files) {
+      const allowedSource = ['info.json', 'question.html', 'question.py', 'server.py'].includes(
+        file.path,
+      );
+      if (
+        !contains('/question', path.resolve('/question', file.path), false) ||
+        (!allowedSource && !allowedAssetExtensions.has(path.extname(file.path).toLowerCase()))
+      ) {
+        return httpError(400, `Draft file path is not allowed: ${file.path}`);
+      }
+    }
+    const questionHtml = parsed.files.find((file) => file.path === 'question.html')?.content;
+    if (questionHtml === undefined) return httpError(400, 'Draft must include question.html.');
+    const htmlValidation = await validateHTML(
+      questionHtml,
+      parsed.files.some((file) => ['question.py', 'server.py'].includes(file.path)),
+    );
+    if (htmlValidation.errors.length > 0) {
+      return {
+        issues: htmlValidation.errors.map((message) => ({ message, type: 'validation' })),
+        rendered: false,
+        warnings: htmlValidation.warnings,
+      };
+    }
+    let question = await selectOptionalQuestionByQid({ course_id: course.id, qid: parsed.qid });
+    if (question === null) {
+      const { reservation, created: reservationCreated } = await reserveAgentDraftQuestion({
+        conversationId,
+        requestedQid: parsed.qid,
+      });
+      if (!reservationCreated) {
+        if (reservation.question_id === null) {
+          return httpError(409, 'Draft question creation is already in progress.');
+        }
+        question = await selectQuestionById(reservation.question_id);
+      } else {
+        const files = Object.fromEntries(
+          parsed.files
+            .filter((file) => file.path !== 'info.json')
+            .map((file) => [file.path === 'question.py' ? 'server.py' : file.path, file.content]),
+        );
+        const created = await getCourseFilesClient()
+          .createQuestion.mutate({
+            authn_user_id: user.id,
+            course_id: course.id,
+            files,
+            has_course_permission_edit: true,
+            is_draft: true,
+            user_id: user.id,
+          })
+          .catch(async (creationError: unknown) => {
+            await releaseAgentDraftQuestion(reservation.id);
+            throw creationError;
+          });
+        if (created.status === 'error') {
+          await releaseAgentDraftQuestion(reservation.id);
+          return httpError(500, `Failed to create draft question (${created.job_sequence_id}).`);
+        }
+        try {
+          await completeAgentDraftQuestion({
+            questionId: created.question_id,
+            reservationId: reservation.id,
+            userId: user.id,
+          });
+        } catch (completionError) {
+          const cleanup = await getCourseFilesClient()
+            .batchDeleteQuestions.mutate({
+              authn_user_id: user.id,
+              course_id: course.id,
+              has_course_permission_edit: true,
+              question_ids: [created.question_id],
+              user_id: user.id,
+            })
+            .catch(async (cleanupError: unknown) => {
+              await releaseAgentDraftQuestion(reservation.id);
+              throw new AggregateError(
+                [completionError, cleanupError],
+                'Failed to register or clean up an agent draft question.',
+              );
+            });
+          await releaseAgentDraftQuestion(reservation.id);
+          if (cleanup.status === 'error') {
+            throw new AggregateError(
+              [completionError],
+              `Failed to register or clean up an agent draft question (${cleanup.job_sequence_id}).`,
+              { cause: completionError },
+            );
+          }
+          throw completionError;
+        }
+        question = await selectQuestionById(created.question_id);
+      }
+    }
+    const draftRoot = await fs.mkdtemp(path.join(os.tmpdir(), `pl-agent-render-${runId}-`));
+    const draftQuestionPath = path.join(draftRoot, 'questions', question.directory ?? parsed.qid);
+    await fs.mkdir(draftQuestionPath, { recursive: true });
+    try {
+      for (const file of parsed.files) {
+        const relativePath = file.path === 'question.py' ? 'server.py' : file.path;
+        const targetPath = path.resolve(draftQuestionPath, relativePath);
+        if (!contains(draftQuestionPath, targetPath, false)) {
+          return httpError(400, 'Draft file path is invalid.');
+        }
+        await fs.mkdir(path.dirname(targetPath), { recursive: true });
+        await fs.writeFile(targetPath, file.content, { encoding: 'utf8', flag: 'wx' });
+      }
+      const draftCourse = { ...course, path: draftRoot };
+      const locals = {
+        authn_user: user,
+        course: draftCourse,
+        is_administrator: false,
+        issues: [] as IssueRenderData[],
+        question,
+        urlPrefix: '',
+        user,
+      };
+      const rendered = await getAndRenderVariant(null, parsed.variant_seed ?? null, locals, {
+        issuesLoadExtraData: true,
+      });
+      return {
+        issues: rendered.issues,
+        preview: {
+          content_type: 'text/html',
+          extra_headers_html: rendered.extraHeadersHtml,
+          html: rendered.questionHtml,
+        },
+        rendered: true,
+        validation_warnings: htmlValidation.warnings,
+        variant_id: rendered.variant.id,
+        variant_seed: rendered.variant.variant_seed,
+      };
+    } finally {
+      await fs.rm(draftRoot, { force: true, recursive: true });
+    }
+  }
+  const parsed = GetJobOutputInputSchema.parse(input);
+  return { ...(await getJobOutput({ course, jobSequenceId: parsed.job_sequence_id })) };
+}
+
+router.post(
+  '/runs/:run_id/events',
+  asyncHandler(async (req, res) => {
+    const { run, course } = await authorizeRun(req);
+    const input = AppendAgentEventsRequestSchema.parse(req.body);
+    let terminalEvent: (typeof input.events)[number] | undefined;
+    for (const event of input.events) {
+      if (['run_started', 'run_cancelled', 'run_failed', 'run_completed'].includes(event.type)) {
+        terminalEvent = event;
+      }
+    }
+    const status =
+      terminalEvent === undefined
+        ? null
+        : terminalEvent.type === 'run_cancelled'
+          ? 'canceled'
+          : terminalEvent.type === 'run_completed'
+            ? 'completed'
+            : terminalEvent.type === 'run_failed'
+              ? 'failed'
+              : 'running';
+    const eventError =
+      terminalEvent?.type === 'run_failed'
+        ? z.string().max(10_000).catch('Agent run failed.').parse(terminalEvent.data.error)
+        : null;
+    const claudeSessionId =
+      terminalEvent?.type === 'run_completed'
+        ? z.string().min(1).max(1024).parse(terminalEvent.data.session_id)
+        : null;
+    const events = await appendAgentRunEvents({
+      claudeSessionId,
+      courseId: course.id,
+      error: eventError,
+      events: input.events,
+      run,
+      terminalStatus: status,
+    });
+    res.json({ events });
+  }),
+);
+
+router.post(
+  '/runs/:run_id/tools/:tool_name',
+  asyncHandler(async (req, res) => {
+    const { claims, course, run, user } = await authorizeRun(req);
+    if (run.status !== 'running') return httpError(409, 'Run is not accepting tool calls.');
+    const toolName = AgentToolNameSchema.parse(req.params.tool_name);
+    if (!claims.allowed_tools.includes(toolName)) return httpError(403, 'Tool is not allowed.');
+    const input = AgentToolRequestSchema.parse(req.body);
+    const existingOperation = await selectAgentOperation(input.operation_id);
+    if (existingOperation !== null) {
+      if (
+        existingOperation.run_id !== run.id ||
+        existingOperation.tool_name !== toolName ||
+        existingOperation.expected_revision !== (input.expected_revision ?? null) ||
+        !isDeepStrictEqual(existingOperation.request, input.input)
+      ) {
+        return httpError(409, 'Operation ID was already used for a different request.');
+      }
+      const event = await selectAgentOperationResultEvent(input.operation_id);
+      if (
+        existingOperation.status === 'completed' &&
+        existingOperation.response !== null &&
+        event !== null
+      ) {
+        res.json(
+          AgentToolResponseSchema.parse({
+            checkpoint_revision: existingOperation.commit_sha ?? undefined,
+            event_id: event.id,
+            operation_id: input.operation_id,
+            result: existingOperation.response,
+          }),
+        );
+        return;
+      }
+      const reclaimed = await reclaimAgentOperation({
+        courseId: course.id,
+        operation: existingOperation,
+        run,
+      });
+      if (reclaimed === null) return httpError(409, 'Operation is already in progress.');
+      try {
+        const result = await executeTool({
+          course,
+          conversationId: run.conversation_id,
+          input: input.input,
+          runId: run.id,
+          toolName,
+          user,
+        });
+        const completed = await completeAgentOperation({
+          commitSha: reclaimed.expected_revision,
+          courseId: course.id,
+          operation: reclaimed,
+          result,
+          run,
+        });
+        res.json(
+          AgentToolResponseSchema.parse({
+            checkpoint_revision: reclaimed.expected_revision ?? undefined,
+            event_id: completed.event.id,
+            operation_id: input.operation_id,
+            result,
+          }),
+        );
+      } catch (toolError) {
+        await failAgentOperation({
+          courseId: course.id,
+          error: toolError instanceof Error ? toolError.message : 'Tool failed.',
+          operation: reclaimed,
+          run,
+        });
+        throw toolError;
+      }
+      return;
+    }
+    const latestCheckpoint = await selectLatestAgentConversationCheckpoint(run.conversation_id);
+    const currentRevision = z
+      .string()
+      .regex(/^[0-9a-f]{40}$/)
+      .nullable()
+      .catch(run.base_commit_sha)
+      .parse(latestCheckpoint?.data.head_sha ?? run.base_commit_sha);
+    if (input.expected_revision !== undefined && input.expected_revision !== currentRevision) {
+      return httpError(409, 'Expected revision does not match this run.');
+    }
+    const begun = await beginAgentOperation({
+      courseId: course.id,
+      expectedRevision: input.expected_revision ?? null,
+      operationId: input.operation_id,
+      request: input.input,
+      run,
+      toolName,
+    });
+    if (!begun.created) {
+      if (
+        begun.operation.run_id !== run.id ||
+        begun.operation.tool_name !== toolName ||
+        begun.operation.expected_revision !== (input.expected_revision ?? null) ||
+        !isDeepStrictEqual(begun.operation.request, input.input)
+      ) {
+        return httpError(409, 'Operation ID was already used for a different request.');
+      }
+      const event = await selectAgentOperationResultEvent(input.operation_id);
+      if (
+        begun.operation.status !== 'completed' ||
+        begun.operation.response === null ||
+        event === null
+      ) {
+        return httpError(409, 'Operation is already in progress or failed.');
+      }
+      res.json(
+        AgentToolResponseSchema.parse({
+          checkpoint_revision: begun.operation.commit_sha ?? undefined,
+          event_id: event.id,
+          operation_id: input.operation_id,
+          result: begun.operation.response,
+        }),
+      );
+      return;
+    }
+    try {
+      const result = await executeTool({
+        course,
+        conversationId: run.conversation_id,
+        input: input.input,
+        runId: run.id,
+        toolName,
+        user,
+      });
+      const completed = await completeAgentOperation({
+        commitSha: currentRevision,
+        courseId: course.id,
+        operation: begun.operation,
+        result,
+        run,
+      });
+      res.json(
+        AgentToolResponseSchema.parse({
+          checkpoint_revision: currentRevision ?? undefined,
+          event_id: completed.event.id,
+          operation_id: input.operation_id,
+          result,
+        }),
+      );
+    } catch (toolError) {
+      await failAgentOperation({
+        courseId: course.id,
+        error: toolError instanceof Error ? toolError.message : 'Tool failed.',
+        operation: begun.operation,
+        run,
+      });
+      throw toolError;
+    }
+  }),
+);
+
+export default router;

--- a/apps/prairielearn/src/components/SideNav.tsx
+++ b/apps/prairielearn/src/components/SideNav.tsx
@@ -70,6 +70,15 @@ const sideNavPagesTabs = {
     },
     {
       activePages: ['course_admin'],
+      activeSubPages: ['agents'],
+      urlSuffix: '/course_admin/agents',
+      iconClasses: 'bi bi-stars',
+      tabLabel: 'Course agent',
+      renderCondition: ({ authz_data, cloud_agent_enabled, course }) =>
+        cloud_agent_enabled && authz_data.has_course_permission_edit && !course.example_course,
+    },
+    {
+      activePages: ['course_admin'],
       activeSubPages: ['issues'],
       urlSuffix: '/course_admin/issues',
       iconClasses: 'fas fa-bug',

--- a/apps/prairielearn/src/lib/agent-capability.test.ts
+++ b/apps/prairielearn/src/lib/agent-capability.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  AgentPublicationCapabilityClaims,
+  AgentRunCapabilityClaims,
+} from '@prairielearn/agent-protocol';
+
+import { withConfig } from '../tests/utils/config.js';
+
+import {
+  signAgentPublicationCapability,
+  signAgentRunCapability,
+  verifyAgentPublicationCapability,
+  verifyAgentRunCapability,
+} from './agent-capability.js';
+
+const SECRET = 'test-agent-capability-secret-at-least-32-bytes';
+
+function runClaims(): AgentRunCapabilityClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    allowed_tools: ['list_entities', 'render_question'],
+    aud: ['prairielearn-agent-worker', 'prairielearn-agent-api'],
+    authn_user_id: '10',
+    conversation_id: '20',
+    course_id: '30',
+    exp: now + 60,
+    harness: 'deterministic',
+    iat: now,
+    iss: 'prairielearn',
+    jti: 'capability-id',
+    prairielearn_base_url: 'https://prairielearn.example',
+    prompt_sha256: 'c'.repeat(64),
+    purpose: 'run',
+    repository: {
+      base_sha: 'a'.repeat(40),
+      branch: 'main',
+      https_url: 'https://github.com/prairielearn/course.git',
+    },
+    run_id: '40',
+    sub: '10',
+    user_id: '10',
+  };
+}
+
+describe('agent capabilities', () => {
+  it('round-trips an audience-bound run capability', async () => {
+    await withConfig({ agentCapabilitySecret: SECRET }, async () => {
+      const claims = runClaims();
+      const token = await signAgentRunCapability(claims);
+      await expect(verifyAgentRunCapability(token)).resolves.toEqual(claims);
+    });
+  });
+
+  it('rejects a modified capability', async () => {
+    await withConfig({ agentCapabilitySecret: SECRET }, async () => {
+      const token = await signAgentRunCapability(runClaims());
+      const [header, payload, signature] = token.split('.');
+      const modified = `${header}.${payload}.${signature.startsWith('a') ? 'b' : 'a'}${signature.slice(1)}`;
+      await expect(verifyAgentRunCapability(modified)).rejects.toThrow();
+    });
+  });
+
+  it('round-trips a publication capability bound to its target', async () => {
+    await withConfig({ agentCapabilitySecret: SECRET }, async () => {
+      const claims: AgentPublicationCapabilityClaims = {
+        ...runClaims(),
+        aud: 'prairielearn-agent-worker',
+        operation_id: 'publish:40:head',
+        purpose: 'publish',
+        target: {
+          branch: 'pl-agent/20-head',
+          head_sha: 'b'.repeat(40),
+          https_url: 'https://github.com/prairielearn/course.git',
+        },
+      };
+      const token = await signAgentPublicationCapability(claims);
+      await expect(verifyAgentPublicationCapability(token)).resolves.toEqual(claims);
+    });
+  });
+});

--- a/apps/prairielearn/src/lib/agent-capability.ts
+++ b/apps/prairielearn/src/lib/agent-capability.ts
@@ -1,0 +1,53 @@
+import { createSecretKey } from 'node:crypto';
+
+import { SignJWT, jwtVerify } from 'jose';
+
+import {
+  type AgentPublicationCapabilityClaims,
+  AgentPublicationCapabilityClaimsSchema,
+  type AgentRunCapabilityClaims,
+  AgentRunCapabilityClaimsSchema,
+} from '@prairielearn/agent-protocol';
+
+import { config } from './config.js';
+
+function getCapabilityKey() {
+  if (config.agentCapabilitySecret === null) {
+    throw new Error('Cloud agent capability signing is not configured');
+  }
+  return createSecretKey(Buffer.from(config.agentCapabilitySecret, 'utf8'));
+}
+
+export async function signAgentRunCapability(claims: AgentRunCapabilityClaims): Promise<string> {
+  return await new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(getCapabilityKey());
+}
+
+export async function signAgentPublicationCapability(
+  claims: AgentPublicationCapabilityClaims,
+): Promise<string> {
+  return await new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .sign(getCapabilityKey());
+}
+
+export async function verifyAgentRunCapability(token: string): Promise<AgentRunCapabilityClaims> {
+  const { payload } = await jwtVerify(token, getCapabilityKey(), {
+    algorithms: ['HS256'],
+    audience: 'prairielearn-agent-api',
+    issuer: 'prairielearn',
+  });
+  return AgentRunCapabilityClaimsSchema.parse(payload);
+}
+
+export async function verifyAgentPublicationCapability(
+  token: string,
+): Promise<AgentPublicationCapabilityClaims> {
+  const { payload } = await jwtVerify(token, getCapabilityKey(), {
+    algorithms: ['HS256'],
+    audience: 'prairielearn-agent-worker',
+    issuer: 'prairielearn',
+  });
+  return AgentPublicationCapabilityClaimsSchema.parse(payload);
+}

--- a/apps/prairielearn/src/lib/config.ts
+++ b/apps/prairielearn/src/lib/config.ts
@@ -173,6 +173,14 @@ export const ConfigSchema = z.object({
    * `https://us.prairielearn.com`.
    */
   serverCanonicalHost: z.string().nullable().default(null),
+  agentCapabilitySecret: z.string().min(32).nullable().default(null),
+  agentCapabilityTtlSeconds: z
+    .number()
+    .int()
+    .positive()
+    .default(60 * 60),
+  agentHarness: z.enum(['deterministic', 'claude']).default('deterministic'),
+  agentWorkerUrl: z.url().nullable().default(null),
   runMigrations: z.boolean().default(true),
   runBatchedMigrations: z.boolean().default(true),
   /**

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -31,6 +31,25 @@ export type EnumAiQuestionGenerationMessageStatus = z.infer<
   typeof EnumAiQuestionGenerationMessageStatusSchema
 >;
 
+export const EnumAgentOperationStatusSchema = z.enum([
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'canceled',
+]);
+export type EnumAgentOperationStatus = z.infer<typeof EnumAgentOperationStatusSchema>;
+
+export const EnumAgentRunStatusSchema = z.enum([
+  'pending',
+  'running',
+  'stopping',
+  'completed',
+  'failed',
+  'canceled',
+]);
+export type EnumAgentRunStatus = z.infer<typeof EnumAgentRunStatusSchema>;
+
 export const EnumAssessmentTypeSchema = z.enum(['Exam', 'RetryExam', 'Basic', 'Game', 'Homework']);
 export type EnumAssessmentType = z.infer<typeof EnumAssessmentTypeSchema>;
 
@@ -308,6 +327,97 @@ export const AdministratorSchema = z.object({
   user_id: IdSchema,
 });
 export type Administrator = z.infer<typeof AdministratorSchema>;
+
+export const AgentArtifactSchema = z.object({
+  content_type: z.string().nullable(),
+  conversation_id: IdSchema,
+  created_at: DateFromISOString,
+  deleted_at: DateFromISOString.nullable(),
+  id: IdSchema,
+  kind: z.string(),
+  metadata: z.record(z.string(), z.unknown()),
+  operation_id: IdSchema.nullable(),
+  run_id: IdSchema.nullable(),
+  sha256: z.string().nullable(),
+  size_bytes: z.coerce.number().nullable(),
+  storage_key: z.string(),
+});
+export type AgentArtifact = z.infer<typeof AgentArtifactSchema>;
+
+export const AgentConversationSchema = z.object({
+  authn_user_id: IdSchema.nullable(),
+  course_id: IdSchema,
+  created_at: DateFromISOString,
+  deleted_at: DateFromISOString.nullable(),
+  id: IdSchema,
+  repository_base_sha: z.string().nullable(),
+  repository_branch: z.string().nullable(),
+  repository_url: z.string().nullable(),
+  title: z.string().nullable(),
+  updated_at: DateFromISOString,
+  user_id: IdSchema.nullable(),
+});
+export type AgentConversation = z.infer<typeof AgentConversationSchema>;
+
+export const AgentEventSchema = z.object({
+  conversation_id: IdSchema,
+  created_at: DateFromISOString,
+  data: z.record(z.string(), z.unknown()),
+  event_id: z.string(),
+  id: IdSchema,
+  operation_id: z.string().nullable(),
+  run_id: IdSchema.nullable(),
+  sequence: z.coerce.number(),
+  type: z.string(),
+});
+export type AgentEvent = z.infer<typeof AgentEventSchema>;
+
+export const AgentDraftQuestionSchema = z.object({
+  conversation_id: IdSchema,
+  created_at: DateFromISOString,
+  id: IdSchema,
+  question_id: IdSchema.nullable(),
+  requested_qid: z.string(),
+});
+export type AgentDraftQuestion = z.infer<typeof AgentDraftQuestionSchema>;
+
+export const AgentOperationSchema = z.object({
+  commit_sha: z.string().nullable(),
+  completed_at: DateFromISOString.nullable(),
+  created_at: DateFromISOString,
+  error: z.string().nullable(),
+  expected_revision: z.string().nullable(),
+  id: IdSchema,
+  job_sequence_id: IdSchema.nullable(),
+  operation_id: z.string(),
+  request: z.record(z.string(), z.unknown()),
+  response: z.record(z.string(), z.unknown()).nullable(),
+  run_id: IdSchema,
+  started_at: DateFromISOString.nullable(),
+  status: EnumAgentOperationStatusSchema,
+  tool_name: z.string(),
+});
+export type AgentOperation = z.infer<typeof AgentOperationSchema>;
+
+export const AgentRunSchema = z.object({
+  allowed_tools: z.array(z.string()),
+  authn_user_id: IdSchema.nullable(),
+  base_commit_sha: z.string().nullable(),
+  capability_expires_at: DateFromISOString,
+  capability_jti: z.uuid(),
+  claude_session_id: z.string().nullable(),
+  completed_at: DateFromISOString.nullable(),
+  conversation_id: IdSchema,
+  created_at: DateFromISOString,
+  error: z.string().nullable(),
+  id: IdSchema,
+  message: z.string(),
+  started_at: DateFromISOString.nullable(),
+  status: EnumAgentRunStatusSchema,
+  stop_requested_at: DateFromISOString.nullable(),
+  user_id: IdSchema.nullable(),
+});
+export type AgentRun = z.infer<typeof AgentRunSchema>;
 
 export const AiGradingCreditCheckoutSessionSchema = z.object({
   agent_user_id: IdSchema,
@@ -1775,6 +1885,12 @@ export type Zone = z.infer<typeof ZoneSchema>;
 export const TableNames = [
   'access_tokens',
   'administrators',
+  'agent_artifacts',
+  'agent_conversations',
+  'agent_draft_questions',
+  'agent_events',
+  'agent_operations',
+  'agent_runs',
   'ai_grading_credit_checkout_sessions',
   'ai_grading_credit_pool_changes',
   'ai_grading_jobs',

--- a/apps/prairielearn/src/lib/features/index.ts
+++ b/apps/prairielearn/src/lib/features/index.ts
@@ -17,6 +17,8 @@ const featureNames = [
   // Can be applied to any context.
   'ai-question-generation',
   'rich-text-editor',
+  'cloud-agent',
+  'cloud-agent-arbitrary-sql',
 
   // LTI 1.1. Deprecated so keep scope to course instance, where possible.
   'lti11',

--- a/apps/prairielearn/src/lib/github.test.ts
+++ b/apps/prairielearn/src/lib/github.test.ts
@@ -7,6 +7,7 @@ import {
   addMachineAccessToRepo,
   checkGithubOrgAccess,
   courseRepoContentUrl,
+  ensureDraftPullRequest,
   httpPrefixForCourseRepo,
 } from './github.js';
 
@@ -14,6 +15,9 @@ const orgsGet = vi.fn();
 const orgsGetMembershipForUser = vi.fn();
 const reposAddCollaborator = vi.fn();
 const teamsAddOrUpdateRepoPermissionsInOrg = vi.fn();
+const gitGetRef = vi.fn();
+const pullsCreate = vi.fn();
+const pullsList = vi.fn();
 
 const orgAccessClient = {
   orgs: { get: orgsGet, getMembershipForUser: orgsGetMembershipForUser },
@@ -24,6 +28,11 @@ const repoAccessClient = {
   teams: { addOrUpdateRepoPermissionsInOrg: teamsAddOrUpdateRepoPermissionsInOrg },
 } as unknown as Parameters<typeof addMachineAccessToRepo>[0];
 
+const pullRequestClient = {
+  git: { getRef: gitGetRef },
+  pulls: { create: pullsCreate, list: pullsList },
+} as unknown as Parameters<typeof ensureDraftPullRequest>[0]['client'];
+
 const job = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), verbose: vi.fn() };
 
 beforeEach(() => {
@@ -31,6 +40,51 @@ beforeEach(() => {
   orgsGetMembershipForUser.mockReset();
   reposAddCollaborator.mockReset();
   teamsAddOrUpdateRepoPermissionsInOrg.mockReset();
+  gitGetRef.mockReset();
+  pullsCreate.mockReset();
+  pullsList.mockReset();
+});
+
+describe('ensureDraftPullRequest', () => {
+  const input = {
+    base: 'main',
+    body: 'Agent changes',
+    client: pullRequestClient,
+    expectedHeadSha: 'a'.repeat(40),
+    head: 'pl-agent/change',
+    owner: 'prairielearn',
+    repo: 'course',
+    title: 'Course agent changes',
+  };
+
+  it('rejects a remote branch at a different commit', async () => {
+    gitGetRef.mockResolvedValue({ data: { object: { sha: 'b'.repeat(40) } } });
+    await expect(ensureDraftPullRequest(input)).rejects.toThrow(
+      'Published GitHub branch does not point to the expected commit.',
+    );
+    expect(pullsCreate).not.toHaveBeenCalled();
+  });
+
+  it('reuses an existing open pull request after a lost response', async () => {
+    gitGetRef.mockResolvedValue({ data: { object: { sha: 'a'.repeat(40) } } });
+    pullsList.mockResolvedValue({ data: [{ html_url: 'https://example.test/pr/12', number: 12 }] });
+    await expect(ensureDraftPullRequest(input)).resolves.toEqual({
+      number: 12,
+      url: 'https://example.test/pr/12',
+    });
+    expect(pullsCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a draft only after verifying the remote head', async () => {
+    gitGetRef.mockResolvedValue({ data: { object: { sha: 'a'.repeat(40) } } });
+    pullsList.mockResolvedValue({ data: [] });
+    pullsCreate.mockResolvedValue({ data: { html_url: 'https://example.test/pr/13', number: 13 } });
+    await expect(ensureDraftPullRequest(input)).resolves.toEqual({
+      number: 13,
+      url: 'https://example.test/pr/13',
+    });
+    expect(pullsCreate).toHaveBeenCalledWith(expect.objectContaining({ draft: true }));
+  });
 });
 
 describe('checkGithubOrgAccess', () => {

--- a/apps/prairielearn/src/lib/github.ts
+++ b/apps/prairielearn/src/lib/github.ts
@@ -30,6 +30,76 @@ function getGithubClient(): Octokit | null {
   return new Octokit({ auth: config.githubClientToken });
 }
 
+export async function createDraftPullRequest({
+  owner,
+  repo,
+  base,
+  head,
+  title,
+  body,
+  expectedHeadSha,
+}: {
+  owner: string;
+  repo: string;
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  expectedHeadSha: string;
+}): Promise<{ number: number; url: string }> {
+  const client = getGithubClient();
+  if (client === null) {
+    throw new Error('GitHub client is not configured.');
+  }
+  return await ensureDraftPullRequest({
+    base,
+    body,
+    client,
+    expectedHeadSha,
+    head,
+    owner,
+    repo,
+    title,
+  });
+}
+
+export async function ensureDraftPullRequest({
+  client,
+  owner,
+  repo,
+  base,
+  head,
+  expectedHeadSha,
+  title,
+  body,
+}: {
+  client: Octokit;
+  owner: string;
+  repo: string;
+  base: string;
+  head: string;
+  expectedHeadSha: string;
+  title: string;
+  body: string;
+}): Promise<{ number: number; url: string }> {
+  const ref = await client.git.getRef({ owner, ref: `heads/${head}`, repo });
+  if (ref.data.object.sha !== expectedHeadSha) {
+    throw new Error('Published GitHub branch does not point to the expected commit.');
+  }
+  const existing = await client.pulls.list({
+    base,
+    head: `${owner}:${head}`,
+    owner,
+    repo,
+    state: 'open',
+  });
+  const pull = existing.data.at(0);
+  if (pull !== undefined) return { number: pull.number, url: pull.html_url };
+
+  const response = await client.pulls.create({ base, body, draft: true, head, owner, repo, title });
+  return { number: response.data.number, url: response.data.html_url };
+}
+
 /*
   Required configuration options to get this working:
   - config.githubClientToken

--- a/apps/prairielearn/src/mcp/tools/query-course-data.test.ts
+++ b/apps/prairielearn/src/mcp/tools/query-course-data.test.ts
@@ -1,0 +1,28 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import * as helperServer from '../../tests/helperServer.js';
+
+import { queryCourseData } from './query-course-data.js';
+
+describe('queryCourseData', () => {
+  beforeAll(helperServer.before());
+  afterAll(helperServer.after);
+  it('rejects writes before they reach Postgres', async () => {
+    await expect(queryCourseData('UPDATE users SET name = name')).rejects.toThrow(
+      'Only SELECT and WITH queries are allowed.',
+    );
+  });
+
+  it('rejects multiple statements', async () => {
+    await expect(queryCourseData('SELECT 1; SELECT 2')).rejects.toThrow(
+      'Only a single statement is allowed.',
+    );
+  });
+
+  it('bounds returned rows', async () => {
+    const result = await queryCourseData('SELECT value FROM generate_series(1, 1001) AS value');
+    expect(result.rows).toHaveLength(1000);
+    expect(result.rowCount).toBe(1001);
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
+++ b/apps/prairielearn/src/middlewares/authzCourseOrInstance.ts
@@ -341,6 +341,7 @@ export interface ResLocalsCourse {
   authz_data: ResLocalsCourseAuthz;
   user: ResLocalsCourseAuthz['user'];
   course_has_course_instances: boolean;
+  cloud_agent_enabled: boolean;
   question_sharing_enabled: boolean;
   is_administrator: boolean;
 }
@@ -696,6 +697,8 @@ export async function authzCourseOrInstance(req: Request, res: Response) {
   res.locals.course_has_course_instances = await selectCourseHasCourseInstances({
     course: res.locals.course,
   });
+
+  res.locals.cloud_agent_enabled = await features.enabledFromLocals('cloud-agent', res.locals);
 
   res.locals.question_sharing_enabled = await features.enabledFromLocals(
     'question-sharing',

--- a/apps/prairielearn/src/migrations/20260820090000_agent_conversations__create.sql
+++ b/apps/prairielearn/src/migrations/20260820090000_agent_conversations__create.sql
@@ -1,0 +1,134 @@
+CREATE TYPE enum_agent_run_status AS ENUM(
+  'pending',
+  'running',
+  'stopping',
+  'completed',
+  'failed',
+  'canceled'
+);
+
+CREATE TYPE enum_agent_operation_status AS ENUM(
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'canceled'
+);
+
+CREATE TABLE agent_conversations (
+  id BIGSERIAL PRIMARY KEY,
+  course_id BIGINT NOT NULL REFERENCES courses (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  authn_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  title TEXT,
+  repository_url TEXT,
+  repository_branch TEXT,
+  repository_base_sha TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ,
+  CHECK (
+    (
+      repository_url IS NULL
+      AND repository_branch IS NULL
+      AND repository_base_sha IS NULL
+    )
+    OR (
+      repository_url IS NOT NULL
+      AND repository_branch IS NOT NULL
+      AND repository_base_sha IS NOT NULL
+    )
+  )
+);
+
+CREATE INDEX agent_conversations_course_id_authn_user_id_idx ON agent_conversations (course_id, authn_user_id)
+WHERE
+  deleted_at IS NULL;
+
+CREATE TABLE agent_draft_questions (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES agent_conversations (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  requested_qid TEXT NOT NULL,
+  question_id BIGINT REFERENCES questions (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (conversation_id, requested_qid),
+  UNIQUE (question_id)
+);
+
+CREATE TABLE agent_runs (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES agent_conversations (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  authn_user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  user_id BIGINT REFERENCES users (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  status enum_agent_run_status NOT NULL DEFAULT 'pending',
+  message TEXT NOT NULL,
+  capability_jti UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  capability_expires_at TIMESTAMPTZ NOT NULL,
+  allowed_tools TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  base_commit_sha TEXT,
+  claude_session_id TEXT,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  stop_requested_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX agent_runs_one_active_per_conversation_idx ON agent_runs (conversation_id)
+WHERE
+  status IN ('pending', 'running', 'stopping');
+
+CREATE INDEX agent_runs_conversation_id_created_at_idx ON agent_runs (conversation_id, created_at);
+
+CREATE TABLE agent_events (
+  id BIGSERIAL PRIMARY KEY,
+  event_id TEXT NOT NULL UNIQUE,
+  conversation_id BIGINT NOT NULL REFERENCES agent_conversations (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  run_id BIGINT REFERENCES agent_runs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  sequence BIGINT NOT NULL,
+  type TEXT NOT NULL,
+  data JSONB NOT NULL DEFAULT '{}'::JSONB,
+  operation_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (conversation_id, sequence)
+);
+
+CREATE INDEX agent_events_run_id_idx ON agent_events (run_id, id);
+
+CREATE TABLE agent_operations (
+  id BIGSERIAL PRIMARY KEY,
+  operation_id TEXT NOT NULL UNIQUE,
+  run_id BIGINT NOT NULL REFERENCES agent_runs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  tool_name TEXT NOT NULL,
+  status enum_agent_operation_status NOT NULL DEFAULT 'pending',
+  request JSONB NOT NULL,
+  response JSONB,
+  error TEXT,
+  expected_revision TEXT,
+  commit_sha TEXT,
+  job_sequence_id BIGINT REFERENCES job_sequences (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX agent_operations_run_id_created_at_idx ON agent_operations (run_id, created_at);
+
+CREATE TABLE agent_artifacts (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES agent_conversations (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  run_id BIGINT REFERENCES agent_runs (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  operation_id BIGINT REFERENCES agent_operations (id) ON UPDATE CASCADE ON DELETE SET NULL,
+  kind TEXT NOT NULL,
+  storage_key TEXT NOT NULL UNIQUE,
+  content_type TEXT,
+  size_bytes BIGINT,
+  sha256 TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX agent_artifacts_conversation_id_idx ON agent_artifacts (conversation_id)
+WHERE
+  deleted_at IS NULL;

--- a/apps/prairielearn/src/models/agent-conversation.sql
+++ b/apps/prairielearn/src/models/agent-conversation.sql
@@ -1,0 +1,558 @@
+-- BLOCK insert_conversation
+INSERT INTO
+  agent_conversations (
+    course_id,
+    authn_user_id,
+    user_id,
+    title,
+    repository_url,
+    repository_branch,
+    repository_base_sha
+  )
+VALUES
+  (
+    $course_id,
+    $authn_user_id,
+    $user_id,
+    $title,
+    $repository_url,
+    $repository_branch,
+    $repository_base_sha
+  )
+RETURNING
+  *;
+
+-- BLOCK select_conversation
+SELECT
+  *
+FROM
+  agent_conversations
+WHERE
+  id = $conversation_id
+  AND course_id = $course_id
+  AND authn_user_id = $authn_user_id
+  AND deleted_at IS NULL;
+
+-- BLOCK select_conversations
+SELECT
+  *
+FROM
+  agent_conversations
+WHERE
+  course_id = $course_id
+  AND authn_user_id = $authn_user_id
+  AND deleted_at IS NULL
+ORDER BY
+  updated_at DESC,
+  id DESC;
+
+-- BLOCK select_runs
+SELECT
+  agent_runs.*
+FROM
+  agent_runs
+  JOIN agent_conversations ON (
+    agent_conversations.id = agent_runs.conversation_id
+  )
+WHERE
+  agent_runs.conversation_id = $conversation_id
+  AND agent_conversations.course_id = $course_id
+ORDER BY
+  agent_runs.created_at,
+  agent_runs.id;
+
+-- BLOCK select_run
+SELECT
+  agent_runs.*
+FROM
+  agent_runs
+  JOIN agent_conversations ON (
+    agent_conversations.id = agent_runs.conversation_id
+  )
+WHERE
+  agent_runs.id = $run_id
+  AND agent_conversations.course_id = $course_id
+  AND agent_conversations.deleted_at IS NULL;
+
+-- BLOCK select_run_for_update
+SELECT
+  *
+FROM
+  agent_runs
+WHERE
+  id = $run_id
+  AND conversation_id = $conversation_id
+FOR UPDATE;
+
+-- BLOCK select_latest_run
+SELECT
+  agent_runs.*
+FROM
+  agent_runs
+  JOIN agent_conversations ON (
+    agent_conversations.id = agent_runs.conversation_id
+  )
+WHERE
+  agent_runs.conversation_id = $conversation_id
+  AND agent_conversations.course_id = $course_id
+ORDER BY
+  agent_runs.created_at DESC,
+  agent_runs.id DESC
+LIMIT
+  1;
+
+-- BLOCK select_artifacts
+SELECT
+  *
+FROM
+  agent_artifacts
+WHERE
+  conversation_id = $conversation_id
+  AND deleted_at IS NULL
+ORDER BY
+  created_at,
+  id;
+
+-- BLOCK select_agent_draft_question
+SELECT
+  *
+FROM
+  agent_draft_questions
+WHERE
+  conversation_id = $conversation_id
+  AND requested_qid = $requested_qid;
+
+-- BLOCK reserve_agent_draft_question
+INSERT INTO
+  agent_draft_questions (conversation_id, requested_qid)
+VALUES
+  ($conversation_id, $requested_qid)
+ON CONFLICT (conversation_id, requested_qid) DO NOTHING
+RETURNING
+  *;
+
+-- BLOCK complete_agent_draft_question
+WITH
+  metadata AS (
+    INSERT INTO
+      draft_question_metadata (question_id, created_by, updated_by)
+    VALUES
+      ($question_id, $user_id, $user_id)
+    ON CONFLICT (question_id) DO NOTHING
+  )
+UPDATE agent_draft_questions
+SET
+  question_id = $question_id
+WHERE
+  id = $id
+  AND question_id IS NULL
+RETURNING
+  *;
+
+-- BLOCK release_agent_draft_question
+DELETE FROM agent_draft_questions
+WHERE
+  id = $id
+  AND question_id IS NULL;
+
+-- BLOCK select_agent_draft_question_ids
+SELECT
+  question_id
+FROM
+  agent_draft_questions
+WHERE
+  conversation_id = $conversation_id
+  AND question_id IS NOT NULL;
+
+-- BLOCK insert_run
+INSERT INTO
+  agent_runs (
+    conversation_id,
+    authn_user_id,
+    user_id,
+    message,
+    capability_jti,
+    capability_expires_at,
+    allowed_tools,
+    base_commit_sha
+  )
+VALUES
+  (
+    $conversation_id,
+    $authn_user_id,
+    $user_id,
+    $message,
+    $capability_jti,
+    $capability_expires_at,
+    $allowed_tools,
+    $base_commit_sha
+  )
+RETURNING
+  *;
+
+-- BLOCK touch_conversation
+UPDATE agent_conversations
+SET
+  updated_at = NOW()
+WHERE
+  id = $conversation_id;
+
+-- BLOCK lock_conversation
+SELECT
+  id
+FROM
+  agent_conversations
+WHERE
+  id = $conversation_id
+FOR UPDATE;
+
+-- BLOCK next_event_sequence
+SELECT
+  COALESCE(MAX(sequence), 0) + 1
+FROM
+  agent_events
+WHERE
+  conversation_id = $conversation_id;
+
+-- BLOCK insert_event
+INSERT INTO
+  agent_events (
+    event_id,
+    conversation_id,
+    run_id,
+    sequence,
+    type,
+    data,
+    operation_id
+  )
+VALUES
+  (
+    $event_id,
+    $conversation_id,
+    $run_id,
+    $sequence,
+    $type,
+    $data,
+    $operation_id
+  )
+ON CONFLICT (event_id) DO NOTHING
+RETURNING
+  *;
+
+-- BLOCK select_event_by_event_id
+SELECT
+  *
+FROM
+  agent_events
+WHERE
+  event_id = $event_id;
+
+-- BLOCK list_events
+SELECT
+  *
+FROM
+  agent_events
+WHERE
+  conversation_id = $conversation_id
+  AND sequence > $after_sequence
+ORDER BY
+  sequence
+LIMIT
+  $limit;
+
+-- BLOCK select_active_run
+SELECT
+  *
+FROM
+  agent_runs
+WHERE
+  conversation_id = $conversation_id
+  AND status IN ('pending', 'running', 'stopping')
+ORDER BY
+  created_at DESC
+LIMIT
+  1;
+
+-- BLOCK request_stop
+UPDATE agent_runs
+SET
+  status = 'stopping',
+  stop_requested_at = COALESCE(stop_requested_at, NOW())
+WHERE
+  id = $run_id
+  AND status IN ('pending', 'running')
+RETURNING
+  *;
+
+-- BLOCK update_run_status
+UPDATE agent_runs
+SET
+  status = $status::enum_agent_run_status,
+  error = $error,
+  claude_session_id = COALESCE($claude_session_id, claude_session_id),
+  started_at = CASE
+    WHEN $status::enum_agent_run_status = 'running' THEN COALESCE(started_at, NOW())
+    ELSE started_at
+  END,
+  completed_at = CASE
+    WHEN $status::enum_agent_run_status IN ('completed', 'failed', 'canceled') THEN COALESCE(completed_at, NOW())
+    ELSE completed_at
+  END
+WHERE
+  id = $run_id
+RETURNING
+  *;
+
+-- BLOCK tombstone_conversation
+UPDATE agent_conversations
+SET
+  deleted_at = NOW(),
+  updated_at = NOW()
+WHERE
+  id = $conversation_id
+  AND deleted_at IS NULL
+RETURNING
+  *;
+
+-- BLOCK tombstone_artifacts
+UPDATE agent_artifacts
+SET
+  deleted_at = NOW(),
+  metadata = '{}'::jsonb,
+  content_type = NULL,
+  sha256 = NULL,
+  size_bytes = NULL,
+  storage_key = CONCAT('deleted/', id, '/', gen_random_uuid())
+WHERE
+  conversation_id = $conversation_id
+  AND deleted_at IS NULL
+RETURNING
+  *;
+
+-- BLOCK select_artifacts_for_update
+SELECT
+  *
+FROM
+  agent_artifacts
+WHERE
+  conversation_id = $conversation_id
+  AND deleted_at IS NULL
+ORDER BY
+  id
+FOR UPDATE;
+
+-- BLOCK select_runs_for_update
+SELECT
+  *
+FROM
+  agent_runs
+WHERE
+  conversation_id = $conversation_id
+ORDER BY
+  id
+FOR UPDATE;
+
+-- BLOCK select_operations_for_update
+SELECT
+  agent_operations.*
+FROM
+  agent_operations
+  JOIN agent_runs ON (agent_runs.id = agent_operations.run_id)
+WHERE
+  agent_runs.conversation_id = $conversation_id
+ORDER BY
+  agent_operations.id
+FOR UPDATE OF
+  agent_operations;
+
+-- BLOCK redact_conversation_runs
+UPDATE agent_runs
+SET
+  status = CASE
+    WHEN status IN ('pending', 'running', 'stopping') THEN 'canceled'
+    ELSE status
+  END,
+  completed_at = CASE
+    WHEN status IN ('pending', 'running', 'stopping') THEN COALESCE(completed_at, NOW())
+    ELSE completed_at
+  END,
+  message = '[deleted]',
+  error = NULL,
+  capability_jti = gen_random_uuid(),
+  capability_expires_at = NOW(),
+  allowed_tools = ARRAY[]::text[],
+  claude_session_id = NULL
+WHERE
+  conversation_id = $conversation_id
+RETURNING
+  *;
+
+-- BLOCK redact_conversation_events
+UPDATE agent_events
+SET
+  data = '{}'::jsonb,
+  operation_id = NULL
+WHERE
+  conversation_id = $conversation_id;
+
+-- BLOCK redact_conversation_operations
+UPDATE agent_operations
+SET
+  request = '{}'::jsonb,
+  response = NULL,
+  error = NULL,
+  job_sequence_id = NULL
+WHERE
+  run_id IN (
+    SELECT
+      id
+    FROM
+      agent_runs
+    WHERE
+      conversation_id = $conversation_id
+  )
+RETURNING
+  *;
+
+-- BLOCK delete_conversation_draft_questions
+DELETE FROM agent_draft_questions
+WHERE
+  conversation_id = $conversation_id;
+
+-- BLOCK insert_operation
+INSERT INTO
+  agent_operations (
+    operation_id,
+    run_id,
+    tool_name,
+    status,
+    request,
+    expected_revision,
+    started_at
+  )
+VALUES
+  (
+    $operation_id,
+    $run_id,
+    $tool_name,
+    'running',
+    $request,
+    $expected_revision,
+    NOW()
+  )
+ON CONFLICT (operation_id) DO NOTHING
+RETURNING
+  *;
+
+-- BLOCK select_operation
+SELECT
+  *
+FROM
+  agent_operations
+WHERE
+  operation_id = $operation_id;
+
+-- BLOCK complete_operation
+UPDATE agent_operations
+SET
+  status = 'completed',
+  response = $response,
+  commit_sha = $commit_sha,
+  completed_at = NOW()
+WHERE
+  operation_id = $operation_id
+RETURNING
+  *;
+
+-- BLOCK fail_operation
+UPDATE agent_operations
+SET
+  status = 'failed',
+  error = $error,
+  completed_at = NOW()
+WHERE
+  operation_id = $operation_id
+RETURNING
+  *;
+
+-- BLOCK retry_operation
+UPDATE agent_operations
+SET
+  status = 'running',
+  error = NULL,
+  completed_at = NULL,
+  started_at = NOW()
+WHERE
+  id = $id
+  AND status = 'failed'
+RETURNING
+  *;
+
+-- BLOCK reclaim_operation
+UPDATE agent_operations
+SET
+  status = 'running',
+  error = NULL,
+  completed_at = NULL,
+  started_at = NOW()
+WHERE
+  id = $id
+  AND (
+    status = 'failed'
+    OR (
+      status = 'running'
+      AND started_at < NOW() - INTERVAL '15 minutes'
+    )
+  )
+RETURNING
+  *;
+
+-- BLOCK select_event_for_operation
+SELECT
+  *
+FROM
+  agent_events
+WHERE
+  operation_id = $operation_id
+  AND type = $type
+ORDER BY
+  sequence DESC
+LIMIT
+  1;
+
+-- BLOCK select_latest_checkpoint
+SELECT
+  *
+FROM
+  agent_events
+WHERE
+  run_id = $run_id
+  AND type = 'checkpoint'
+ORDER BY
+  sequence DESC
+LIMIT
+  1;
+
+-- BLOCK select_latest_conversation_checkpoint
+SELECT
+  *
+FROM
+  agent_events
+WHERE
+  conversation_id = $conversation_id
+  AND type = 'checkpoint'
+ORDER BY
+  sequence DESC
+LIMIT
+  1;
+
+-- BLOCK select_is_administrator
+SELECT
+  EXISTS (
+    SELECT
+      1
+    FROM
+      administrators
+    WHERE
+      user_id = $user_id
+  );

--- a/apps/prairielearn/src/models/agent-conversation.test.ts
+++ b/apps/prairielearn/src/models/agent-conversation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAgentRunStatusTransitionAllowed } from './agent-conversation.js';
+
+describe('agent run status transitions', () => {
+  it.each([
+    ['pending', 'running'],
+    ['pending', 'failed'],
+    ['pending', 'canceled'],
+    ['running', 'completed'],
+    ['running', 'failed'],
+    ['running', 'canceled'],
+    ['stopping', 'completed'],
+    ['stopping', 'failed'],
+    ['stopping', 'canceled'],
+    ['completed', 'completed'],
+  ] as const)('allows %s -> %s', (from, to) => {
+    expect(isAgentRunStatusTransitionAllowed(from, to)).toBe(true);
+  });
+
+  it.each([
+    ['pending', 'completed'],
+    ['running', 'pending'],
+    ['completed', 'running'],
+    ['failed', 'running'],
+    ['canceled', 'running'],
+  ] as const)('rejects %s -> %s', (from, to) => {
+    expect(isAgentRunStatusTransitionAllowed(from, to)).toBe(false);
+  });
+});

--- a/apps/prairielearn/src/models/agent-conversation.ts
+++ b/apps/prairielearn/src/models/agent-conversation.ts
@@ -1,0 +1,811 @@
+import { isDeepStrictEqual } from 'node:util';
+
+import { z } from 'zod';
+
+import type { AgentEventInput, AgentRepository } from '@prairielearn/agent-protocol';
+import {
+  execute,
+  loadSqlEquiv,
+  queryOptionalRow,
+  queryRow,
+  queryRows,
+  queryScalar,
+  queryScalars,
+  runInTransactionAsync,
+} from '@prairielearn/postgres';
+import { IdSchema } from '@prairielearn/zod';
+
+import {
+  type AgentArtifact,
+  AgentArtifactSchema,
+  type AgentConversation,
+  AgentConversationSchema,
+  type AgentDraftQuestion,
+  AgentDraftQuestionSchema,
+  type AgentEvent,
+  AgentEventSchema,
+  type AgentOperation,
+  AgentOperationSchema,
+  type AgentRun,
+  AgentRunSchema,
+  type EnumAgentRunStatus,
+} from '../lib/db-types.js';
+
+import { insertAuditEvent } from './audit-event.js';
+
+const sql = loadSqlEquiv(import.meta.url);
+
+function redactRun(run: AgentRun) {
+  return {
+    ...run,
+    capability_jti: '[redacted]',
+    claude_session_id: run.claude_session_id === null ? null : '[redacted]',
+    error: run.error === null ? null : '[redacted]',
+    message: '[redacted]',
+  };
+}
+
+function redactOperation(operation: AgentOperation) {
+  return {
+    ...operation,
+    request: {},
+    response: operation.response === null ? null : {},
+  };
+}
+
+function redactArtifact(artifact: AgentArtifact) {
+  return {
+    ...artifact,
+    metadata: {},
+    storage_key: '[redacted]',
+  };
+}
+
+export function isAgentRunStatusTransitionAllowed(
+  from: EnumAgentRunStatus,
+  to: EnumAgentRunStatus,
+): boolean {
+  if (from === to) return true;
+  return (
+    (from === 'pending' && ['running', 'failed', 'canceled'].includes(to)) ||
+    (from === 'running' && ['completed', 'failed', 'canceled'].includes(to)) ||
+    (from === 'stopping' && ['completed', 'failed', 'canceled'].includes(to))
+  );
+}
+
+export async function createAgentConversation({
+  courseId,
+  authnUserId,
+  userId,
+  title,
+  repository,
+}: {
+  courseId: string;
+  authnUserId: string;
+  userId: string;
+  title: string | null;
+  repository: AgentRepository | undefined;
+}): Promise<AgentConversation> {
+  return await runInTransactionAsync(async () => {
+    const conversation = await queryRow(
+      sql.insert_conversation,
+      {
+        authn_user_id: authnUserId,
+        course_id: courseId,
+        repository_base_sha: repository?.base_sha ?? null,
+        repository_branch: repository?.branch ?? null,
+        repository_url: repository?.https_url ?? null,
+        title,
+        user_id: userId,
+      },
+      AgentConversationSchema,
+    );
+    await insertAuditEvent({
+      tableName: 'agent_conversations',
+      action: 'insert',
+      agentAuthnUserId: authnUserId,
+      agentUserId: userId,
+      courseId,
+      newRow: conversation,
+      rowId: conversation.id,
+    });
+    return conversation;
+  });
+}
+
+export async function selectAgentConversation({
+  conversationId,
+  courseId,
+  authnUserId,
+}: {
+  conversationId: string;
+  courseId: string;
+  authnUserId: string;
+}): Promise<AgentConversation | null> {
+  return await queryOptionalRow(
+    sql.select_conversation,
+    {
+      authn_user_id: authnUserId,
+      conversation_id: conversationId,
+      course_id: courseId,
+    },
+    AgentConversationSchema,
+  );
+}
+
+export async function selectAgentConversations({
+  courseId,
+  authnUserId,
+}: {
+  courseId: string;
+  authnUserId: string;
+}): Promise<AgentConversation[]> {
+  return await queryRows(
+    sql.select_conversations,
+    { authn_user_id: authnUserId, course_id: courseId },
+    AgentConversationSchema,
+  );
+}
+
+export async function selectAgentRuns({
+  conversationId,
+  courseId,
+}: {
+  conversationId: string;
+  courseId: string;
+}): Promise<AgentRun[]> {
+  return await queryRows(
+    sql.select_runs,
+    { conversation_id: conversationId, course_id: courseId },
+    AgentRunSchema,
+  );
+}
+
+export async function selectAgentRun({
+  runId,
+  courseId,
+}: {
+  runId: string;
+  courseId: string;
+}): Promise<AgentRun | null> {
+  return await queryOptionalRow(
+    sql.select_run,
+    { course_id: courseId, run_id: runId },
+    AgentRunSchema,
+  );
+}
+
+export async function selectLatestAgentRun({
+  conversationId,
+  courseId,
+}: {
+  conversationId: string;
+  courseId: string;
+}): Promise<AgentRun | null> {
+  return await queryOptionalRow(
+    sql.select_latest_run,
+    { conversation_id: conversationId, course_id: courseId },
+    AgentRunSchema,
+  );
+}
+
+export async function selectAgentArtifacts(conversationId: string): Promise<AgentArtifact[]> {
+  return await queryRows(
+    sql.select_artifacts,
+    { conversation_id: conversationId },
+    AgentArtifactSchema,
+  );
+}
+
+async function selectAgentDraftQuestion({
+  conversationId,
+  requestedQid,
+}: {
+  conversationId: string;
+  requestedQid: string;
+}): Promise<AgentDraftQuestion | null> {
+  return await queryOptionalRow(
+    sql.select_agent_draft_question,
+    { conversation_id: conversationId, requested_qid: requestedQid },
+    AgentDraftQuestionSchema,
+  );
+}
+
+export async function reserveAgentDraftQuestion({
+  conversationId,
+  requestedQid,
+}: {
+  conversationId: string;
+  requestedQid: string;
+}): Promise<{ reservation: AgentDraftQuestion; created: boolean }> {
+  const inserted = await queryOptionalRow(
+    sql.reserve_agent_draft_question,
+    { conversation_id: conversationId, requested_qid: requestedQid },
+    AgentDraftQuestionSchema,
+  );
+  if (inserted !== null) return { created: true, reservation: inserted };
+  const existing = await selectAgentDraftQuestion({ conversationId, requestedQid });
+  if (existing === null) throw new Error('Agent draft question reservation disappeared.');
+  return { created: false, reservation: existing };
+}
+
+export async function completeAgentDraftQuestion({
+  reservationId,
+  questionId,
+  userId,
+}: {
+  reservationId: string;
+  questionId: string;
+  userId: string;
+}): Promise<AgentDraftQuestion> {
+  return await queryRow(
+    sql.complete_agent_draft_question,
+    { id: reservationId, question_id: questionId, user_id: userId },
+    AgentDraftQuestionSchema,
+  );
+}
+
+export async function releaseAgentDraftQuestion(reservationId: string): Promise<void> {
+  await execute(sql.release_agent_draft_question, { id: reservationId });
+}
+
+export async function selectAgentDraftQuestionIds(conversationId: string): Promise<string[]> {
+  return await queryScalars(
+    sql.select_agent_draft_question_ids,
+    { conversation_id: conversationId },
+    IdSchema,
+  );
+}
+
+async function appendEventsInCurrentTransaction({
+  conversationId,
+  runId,
+  events,
+  allowNew = true,
+}: {
+  conversationId: string;
+  runId: string | null;
+  events: AgentEventInput[];
+  allowNew?: boolean;
+}): Promise<AgentEvent[]> {
+  await queryScalar(sql.lock_conversation, { conversation_id: conversationId }, IdSchema);
+  let sequence = await queryScalar(
+    sql.next_event_sequence,
+    { conversation_id: conversationId },
+    z.coerce.number(),
+  );
+  const inserted: AgentEvent[] = [];
+  for (const event of events) {
+    const existing = await queryOptionalRow(
+      sql.select_event_by_event_id,
+      { event_id: event.event_id },
+      AgentEventSchema,
+    );
+    if (existing !== null) {
+      if (
+        existing.conversation_id !== conversationId ||
+        existing.run_id !== runId ||
+        existing.type !== event.type ||
+        existing.operation_id !== (event.operation_id ?? null) ||
+        !isDeepStrictEqual(existing.data, event.data)
+      ) {
+        throw new Error(`Agent event ID ${event.event_id} was reused with different content.`);
+      }
+      inserted.push(existing);
+      continue;
+    }
+    if (!allowNew) {
+      throw new Error('Cannot append a new event to a terminal agent run.');
+    }
+    inserted.push(
+      await queryRow(
+        sql.insert_event,
+        {
+          conversation_id: conversationId,
+          data: event.data,
+          event_id: event.event_id,
+          operation_id: event.operation_id ?? null,
+          run_id: runId,
+          sequence,
+          type: event.type,
+        },
+        AgentEventSchema,
+      ),
+    );
+    sequence++;
+  }
+  await execute(sql.touch_conversation, { conversation_id: conversationId });
+  return inserted;
+}
+
+export async function appendAgentRunEvents({
+  run,
+  courseId,
+  events,
+  terminalStatus,
+  error,
+  claudeSessionId,
+}: {
+  run: AgentRun;
+  courseId: string;
+  events: AgentEventInput[];
+  terminalStatus: EnumAgentRunStatus | null;
+  error: string | null;
+  claudeSessionId: string | null;
+}): Promise<AgentEvent[]> {
+  return await runInTransactionAsync(async () => {
+    await queryScalar(sql.lock_conversation, { conversation_id: run.conversation_id }, IdSchema);
+    const currentRun = await queryRow(
+      sql.select_run_for_update,
+      { conversation_id: run.conversation_id, run_id: run.id },
+      AgentRunSchema,
+    );
+    const inserted = await appendEventsInCurrentTransaction({
+      allowNew: !['completed', 'failed', 'canceled'].includes(currentRun.status),
+      conversationId: currentRun.conversation_id,
+      events,
+      runId: currentRun.id,
+    });
+    if (terminalStatus !== null && terminalStatus !== currentRun.status) {
+      if (!isAgentRunStatusTransitionAllowed(currentRun.status, terminalStatus)) {
+        throw new Error(
+          `Invalid agent run status transition: ${currentRun.status} -> ${terminalStatus}`,
+        );
+      }
+      const updated = await queryRow(
+        sql.update_run_status,
+        {
+          claude_session_id: claudeSessionId,
+          error,
+          run_id: currentRun.id,
+          status: terminalStatus,
+        },
+        AgentRunSchema,
+      );
+      await insertAuditEvent({
+        tableName: 'agent_runs',
+        action: 'update',
+        actionDetail: 'status',
+        agentAuthnUserId: currentRun.authn_user_id,
+        agentUserId: currentRun.user_id,
+        courseId,
+        newRow: redactRun(updated),
+        oldRow: redactRun(currentRun),
+        rowId: currentRun.id,
+      });
+    }
+    return inserted;
+  });
+}
+
+export async function listAgentEvents({
+  conversationId,
+  afterSequence,
+  limit = 201,
+}: {
+  conversationId: string;
+  afterSequence: number;
+  limit?: number;
+}): Promise<AgentEvent[]> {
+  return await queryRows(
+    sql.list_events,
+    { after_sequence: afterSequence, conversation_id: conversationId, limit },
+    AgentEventSchema,
+  );
+}
+
+export async function createAgentRun({
+  conversation,
+  authnUserId,
+  userId,
+  message,
+  capabilityJti,
+  capabilityExpiresAt,
+  allowedTools,
+  baseCommitSha,
+}: {
+  conversation: AgentConversation;
+  authnUserId: string;
+  userId: string;
+  message: string;
+  capabilityJti: string;
+  capabilityExpiresAt: Date;
+  allowedTools: string[];
+  baseCommitSha: string | null;
+}): Promise<AgentRun> {
+  return await runInTransactionAsync(async () => {
+    const run = await queryRow(
+      sql.insert_run,
+      {
+        allowed_tools: allowedTools,
+        authn_user_id: authnUserId,
+        base_commit_sha: baseCommitSha,
+        capability_expires_at: capabilityExpiresAt,
+        capability_jti: capabilityJti,
+        conversation_id: conversation.id,
+        message,
+        user_id: userId,
+      },
+      AgentRunSchema,
+    );
+    await appendEventsInCurrentTransaction({
+      conversationId: conversation.id,
+      events: [{ data: { message }, event_id: `user-message:${run.id}`, type: 'user_message' }],
+      runId: run.id,
+    });
+    await insertAuditEvent({
+      tableName: 'agent_runs',
+      action: 'insert',
+      agentAuthnUserId: authnUserId,
+      agentUserId: userId,
+      courseId: conversation.course_id,
+      newRow: redactRun(run),
+      rowId: run.id,
+    });
+    return run;
+  });
+}
+
+export async function selectActiveAgentRun(conversationId: string): Promise<AgentRun | null> {
+  return await queryOptionalRow(
+    sql.select_active_run,
+    { conversation_id: conversationId },
+    AgentRunSchema,
+  );
+}
+
+export async function requestAgentRunStop({
+  run,
+  courseId,
+}: {
+  run: AgentRun;
+  courseId: string;
+}): Promise<AgentRun> {
+  return await runInTransactionAsync(async () => {
+    const updated = await queryOptionalRow(sql.request_stop, { run_id: run.id }, AgentRunSchema);
+    if (!updated) return run;
+    await insertAuditEvent({
+      tableName: 'agent_runs',
+      action: 'update',
+      actionDetail: 'status',
+      agentAuthnUserId: run.authn_user_id,
+      agentUserId: run.user_id,
+      courseId,
+      newRow: redactRun(updated),
+      oldRow: redactRun(run),
+      rowId: run.id,
+    });
+    return updated;
+  });
+}
+
+export async function tombstoneAgentConversation({
+  conversation,
+}: {
+  conversation: AgentConversation;
+}): Promise<void> {
+  await runInTransactionAsync(async () => {
+    const deleted = await queryRow(
+      sql.tombstone_conversation,
+      { conversation_id: conversation.id },
+      AgentConversationSchema,
+    );
+    const oldArtifacts = await queryRows(
+      sql.select_artifacts_for_update,
+      { conversation_id: conversation.id },
+      AgentArtifactSchema,
+    );
+    const deletedArtifacts = await queryRows(
+      sql.tombstone_artifacts,
+      { conversation_id: conversation.id },
+      AgentArtifactSchema,
+    );
+    const oldRuns = await queryRows(
+      sql.select_runs_for_update,
+      { conversation_id: conversation.id },
+      AgentRunSchema,
+    );
+    const deletedRuns = await queryRows(
+      sql.redact_conversation_runs,
+      { conversation_id: conversation.id },
+      AgentRunSchema,
+    );
+    const oldOperations = await queryRows(
+      sql.select_operations_for_update,
+      { conversation_id: conversation.id },
+      AgentOperationSchema,
+    );
+    const deletedOperations = await queryRows(
+      sql.redact_conversation_operations,
+      { conversation_id: conversation.id },
+      AgentOperationSchema,
+    );
+    await execute(sql.redact_conversation_events, { conversation_id: conversation.id });
+    await execute(sql.delete_conversation_draft_questions, {
+      conversation_id: conversation.id,
+    });
+    const oldRunsById = new Map(oldRuns.map((run) => [run.id, run]));
+    const oldOperationsById = new Map(oldOperations.map((operation) => [operation.id, operation]));
+    const oldArtifactsById = new Map(oldArtifacts.map((artifact) => [artifact.id, artifact]));
+    for (const run of deletedRuns) {
+      await insertAuditEvent({
+        tableName: 'agent_runs',
+        action: 'update',
+        actionDetail: 'deleted',
+        agentAuthnUserId: conversation.authn_user_id,
+        agentUserId: conversation.user_id,
+        courseId: conversation.course_id,
+        newRow: redactRun(run),
+        oldRow: redactRun(oldRunsById.get(run.id)!),
+        rowId: run.id,
+      });
+    }
+    for (const operation of deletedOperations) {
+      await insertAuditEvent({
+        tableName: 'agent_operations',
+        action: 'update',
+        actionDetail: 'deleted',
+        agentAuthnUserId: conversation.authn_user_id,
+        agentUserId: conversation.user_id,
+        courseId: conversation.course_id,
+        newRow: redactOperation(operation),
+        oldRow: redactOperation(oldOperationsById.get(operation.id)!),
+        rowId: operation.id,
+      });
+    }
+    for (const artifact of deletedArtifacts) {
+      await insertAuditEvent({
+        tableName: 'agent_artifacts',
+        action: 'update',
+        actionDetail: 'deleted',
+        agentAuthnUserId: conversation.authn_user_id,
+        agentUserId: conversation.user_id,
+        courseId: conversation.course_id,
+        newRow: redactArtifact(artifact),
+        oldRow: redactArtifact(oldArtifactsById.get(artifact.id)!),
+        rowId: artifact.id,
+      });
+    }
+    await insertAuditEvent({
+      tableName: 'agent_conversations',
+      action: 'update',
+      actionDetail: 'deleted',
+      agentAuthnUserId: conversation.authn_user_id,
+      agentUserId: conversation.user_id,
+      courseId: conversation.course_id,
+      newRow: deleted,
+      oldRow: conversation,
+      rowId: conversation.id,
+    });
+  });
+}
+
+export async function beginAgentOperation({
+  operationId,
+  run,
+  toolName,
+  request,
+  expectedRevision,
+  courseId,
+}: {
+  operationId: string;
+  run: AgentRun;
+  toolName: string;
+  request: Record<string, unknown>;
+  expectedRevision: string | null;
+  courseId: string;
+}): Promise<{ operation: AgentOperation; created: boolean }> {
+  return await runInTransactionAsync(async () => {
+    const inserted = await queryOptionalRow(
+      sql.insert_operation,
+      {
+        expected_revision: expectedRevision,
+        operation_id: operationId,
+        request,
+        run_id: run.id,
+        tool_name: toolName,
+      },
+      AgentOperationSchema,
+    );
+    if (!inserted) {
+      const operation = await queryRow(
+        sql.select_operation,
+        { operation_id: operationId },
+        AgentOperationSchema,
+      );
+      return { created: false, operation };
+    }
+    await appendEventsInCurrentTransaction({
+      conversationId: run.conversation_id,
+      events: [
+        {
+          data: { input: request, tool_name: toolName },
+          event_id: `tool-call:${operationId}`,
+          operation_id: operationId,
+          type: 'tool_call',
+        },
+      ],
+      runId: run.id,
+    });
+    await insertAuditEvent({
+      tableName: 'agent_operations',
+      action: 'insert',
+      agentAuthnUserId: run.authn_user_id,
+      agentUserId: run.user_id,
+      courseId,
+      newRow: redactOperation(inserted),
+      rowId: inserted.id,
+    });
+    return { created: true, operation: inserted };
+  });
+}
+
+export async function selectAgentOperationResultEvent(
+  operationId: string,
+): Promise<AgentEvent | null> {
+  return await queryOptionalRow(
+    sql.select_event_for_operation,
+    { operation_id: operationId, type: 'tool_result' },
+    AgentEventSchema,
+  );
+}
+
+export async function selectAgentOperation(operationId: string): Promise<AgentOperation | null> {
+  return await queryOptionalRow(
+    sql.select_operation,
+    { operation_id: operationId },
+    AgentOperationSchema,
+  );
+}
+
+export async function selectLatestAgentCheckpoint(runId: string): Promise<AgentEvent | null> {
+  return await queryOptionalRow(sql.select_latest_checkpoint, { run_id: runId }, AgentEventSchema);
+}
+
+export async function selectLatestAgentConversationCheckpoint(
+  conversationId: string,
+): Promise<AgentEvent | null> {
+  return await queryOptionalRow(
+    sql.select_latest_conversation_checkpoint,
+    { conversation_id: conversationId },
+    AgentEventSchema,
+  );
+}
+
+export async function selectAgentUserIsAdministrator(userId: string): Promise<boolean> {
+  return await queryScalar(sql.select_is_administrator, { user_id: userId }, z.boolean());
+}
+
+export async function completeAgentOperation({
+  operation,
+  run,
+  result,
+  commitSha,
+  courseId,
+}: {
+  operation: AgentOperation;
+  run: AgentRun;
+  result: Record<string, unknown>;
+  commitSha: string | null;
+  courseId: string;
+}): Promise<{ operation: AgentOperation; event: AgentEvent }> {
+  return await runInTransactionAsync(async () => {
+    const updated = await queryRow(
+      sql.complete_operation,
+      { commit_sha: commitSha, operation_id: operation.operation_id, response: result },
+      AgentOperationSchema,
+    );
+    const [event] = await appendEventsInCurrentTransaction({
+      conversationId: run.conversation_id,
+      events: [
+        {
+          data: { result, tool_name: operation.tool_name },
+          event_id: `tool-result:${operation.operation_id}`,
+          operation_id: operation.operation_id,
+          type: 'tool_result',
+        },
+      ],
+      runId: run.id,
+    });
+    await insertAuditEvent({
+      tableName: 'agent_operations',
+      action: 'update',
+      actionDetail: 'completed',
+      agentAuthnUserId: run.authn_user_id,
+      agentUserId: run.user_id,
+      courseId,
+      newRow: redactOperation(updated),
+      oldRow: redactOperation(operation),
+      rowId: operation.id,
+    });
+    return { event, operation: updated };
+  });
+}
+
+export async function failAgentOperation({
+  operation,
+  run,
+  error,
+  courseId,
+}: {
+  operation: AgentOperation;
+  run: AgentRun;
+  error: string;
+  courseId: string;
+}): Promise<void> {
+  await runInTransactionAsync(async () => {
+    const updated = await queryRow(
+      sql.fail_operation,
+      { error, operation_id: operation.operation_id },
+      AgentOperationSchema,
+    );
+    await insertAuditEvent({
+      tableName: 'agent_operations',
+      action: 'update',
+      actionDetail: 'failed',
+      agentAuthnUserId: run.authn_user_id,
+      agentUserId: run.user_id,
+      courseId,
+      newRow: redactOperation(updated),
+      oldRow: redactOperation(operation),
+      rowId: operation.id,
+    });
+  });
+}
+
+export async function retryAgentOperation({
+  operation,
+  run,
+  courseId,
+}: {
+  operation: AgentOperation;
+  run: AgentRun;
+  courseId: string;
+}): Promise<AgentOperation> {
+  return await runInTransactionAsync(async () => {
+    const updated = await queryRow(sql.retry_operation, { id: operation.id }, AgentOperationSchema);
+    await insertAuditEvent({
+      tableName: 'agent_operations',
+      action: 'update',
+      actionDetail: 'retried',
+      agentAuthnUserId: run.authn_user_id,
+      agentUserId: run.user_id,
+      courseId,
+      newRow: redactOperation(updated),
+      oldRow: redactOperation(operation),
+      rowId: operation.id,
+    });
+    return updated;
+  });
+}
+
+export async function reclaimAgentOperation({
+  operation,
+  run,
+  courseId,
+}: {
+  operation: AgentOperation;
+  run: AgentRun;
+  courseId: string;
+}): Promise<AgentOperation | null> {
+  return await runInTransactionAsync(async () => {
+    const updated = await queryOptionalRow(
+      sql.reclaim_operation,
+      { id: operation.id },
+      AgentOperationSchema,
+    );
+    if (updated === null) return null;
+    await insertAuditEvent({
+      tableName: 'agent_operations',
+      action: 'update',
+      actionDetail: 'retried',
+      agentAuthnUserId: run.authn_user_id,
+      agentUserId: run.user_id,
+      courseId,
+      newRow: redactOperation(updated),
+      oldRow: redactOperation(operation),
+      rowId: operation.id,
+    });
+    return updated;
+  });
+}

--- a/apps/prairielearn/src/models/audit-event.types.ts
+++ b/apps/prairielearn/src/models/audit-event.types.ts
@@ -7,6 +7,10 @@ import type { TableName } from '../lib/db-types.js';
  * The value will be taken from parameters, or inferred from the current row data or row ID if not provided.
  */
 export const requiredTableFields = {
+  agent_artifacts: ['course_id'],
+  agent_conversations: ['course_id'],
+  agent_operations: ['course_id'],
+  agent_runs: ['course_id'],
   ai_grading_credit_checkout_sessions: ['course_instance_id'],
   course_instances: ['course_instance_id'],
   course_instance_ai_grading_credentials: ['course_instance_id'],
@@ -29,6 +33,22 @@ export const requiredTableFields = {
  * This lists all the possible table+action_detail combinations that are supported.
  */
 export type SupportedTableActionCombination =
+  | {
+      tableName: 'agent_artifacts';
+      actionDetail?: 'deleted' | null;
+    }
+  | {
+      tableName: 'agent_conversations';
+      actionDetail?: 'deleted' | null;
+    }
+  | {
+      tableName: 'agent_operations';
+      actionDetail?: 'completed' | 'deleted' | 'failed' | 'retried' | null;
+    }
+  | {
+      tableName: 'agent_runs';
+      actionDetail?: 'deleted' | 'status' | null;
+    }
   | {
       tableName: 'ai_grading_credit_checkout_sessions';
       actionDetail?: 'refund' | null;

--- a/apps/prairielearn/src/pages/instructorAgentConversations/components/AgentConversationsPage.test.tsx
+++ b/apps/prairielearn/src/pages/instructorAgentConversations/components/AgentConversationsPage.test.tsx
@@ -1,0 +1,90 @@
+import { assert, describe, it } from 'vitest';
+
+import {
+  getAgentConversationUiState,
+  getQuestionPreview,
+  shouldPollAgentEventPage,
+} from './AgentConversationsPage.js';
+
+describe('getAgentConversationUiState', () => {
+  it('marks pending and running turns as active', () => {
+    assert.isTrue(getAgentConversationUiState({ status: 'pending' }, []).runActive);
+    assert.isTrue(getAgentConversationUiState({ status: 'running' }, []).runActive);
+    assert.isTrue(getAgentConversationUiState({ status: 'stopping' }, []).runActive);
+  });
+
+  it('offers retry after a failed or canceled turn', () => {
+    assert.isTrue(getAgentConversationUiState({ status: 'failed' }, []).runRetryable);
+    assert.isTrue(getAgentConversationUiState({ status: 'canceled' }, []).runRetryable);
+    assert.isFalse(getAgentConversationUiState({ status: 'completed' }, []).runRetryable);
+  });
+
+  it('offers publication only for a completed checkpoint', () => {
+    assert.isFalse(
+      getAgentConversationUiState({ status: 'running', checkpoint_key: 'checkpoint' }, [])
+        .canPublish,
+    );
+    assert.isFalse(getAgentConversationUiState({ status: 'completed' }, []).canPublish);
+    assert.isTrue(
+      getAgentConversationUiState({ status: 'completed' }, [{ sequence: 10, type: 'checkpoint' }])
+        .canPublish,
+    );
+    assert.isTrue(
+      getAgentConversationUiState({ status: 'completed', head_sha: '0123456789abcdef' }, [])
+        .canPublish,
+    );
+  });
+});
+
+describe('shouldPollAgentEventPage', () => {
+  it('polls active turns and waits for their terminal event', () => {
+    assert.isTrue(shouldPollAgentEventPage({ events: [] }, { status: 'running' }));
+    assert.isTrue(
+      shouldPollAgentEventPage(
+        { events: [{ type: 'assistant_message' }] },
+        { status: 'completed' },
+      ),
+    );
+    assert.isFalse(
+      shouldPollAgentEventPage({ events: [{ type: 'run_completed' }] }, { status: 'completed' }),
+    );
+  });
+
+  it('lets the next cursor page own polling when more events are available', () => {
+    assert.isFalse(
+      shouldPollAgentEventPage(
+        { events: [{ type: 'tool_call' }], hasMore: true },
+        { status: 'running' },
+      ),
+    );
+  });
+});
+
+describe('getQuestionPreview', () => {
+  it('extracts a rendered question and its deterministic seed', () => {
+    const preview = getQuestionPreview({
+      type: 'tool_result',
+      data: {
+        tool_name: 'render_question',
+        result: {
+          rendered: true,
+          variant_seed: 'v1',
+          preview: { extra_headers_html: '<style>body{color:red}</style>', html: '<p>Hello</p>' },
+        },
+      },
+    });
+    assert.include(preview?.html, '<style>body{color:red}</style>');
+    assert.include(preview?.html, '<p>Hello</p>');
+    assert.equal(preview?.variantSeed, 'v1');
+  });
+
+  it('ignores non-render and failed render tool results', () => {
+    assert.isNull(getQuestionPreview({ type: 'assistant_message', data: {} }));
+    assert.isNull(
+      getQuestionPreview({
+        type: 'tool_result',
+        data: { tool_name: 'render_question', result: { rendered: false } },
+      }),
+    );
+  });
+});

--- a/apps/prairielearn/src/pages/instructorAgentConversations/components/AgentConversationsPage.tsx
+++ b/apps/prairielearn/src/pages/instructorAgentConversations/components/AgentConversationsPage.tsx
@@ -1,0 +1,751 @@
+import { QueryClient, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type SyntheticEvent, useState } from 'react';
+import { Modal } from 'react-bootstrap';
+
+import { formatDate } from '@prairielearn/formatter';
+
+import { AppErrorAlert, getAppError } from '../../../lib/client/errors.js';
+import { QueryClientProviderDebug } from '../../../lib/client/tanstackQuery.js';
+import type { AgentConversationsError } from '../../../trpc/course/agent-conversations.js';
+import { createCourseTrpcClient } from '../../../trpc/course/client.js';
+import { TRPCProvider, useTRPC } from '../../../trpc/course/context.js';
+
+const POLL_INTERVAL_MS = 2_000;
+const ACTIVE_RUN_STATUSES = new Set(['pending', 'queued', 'running', 'stopping', 'cancelling']);
+const RETRYABLE_RUN_STATUSES = new Set(['failed', 'canceled', 'cancelled']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getProperty(value: unknown, property: string): unknown {
+  return isRecord(value) ? value[property] : undefined;
+}
+
+function getArrayProperty(value: unknown, property: string): unknown[] {
+  const result = getProperty(value, property);
+  return Array.isArray(result) ? result : [];
+}
+
+function getStringProperty(value: unknown, ...properties: string[]): string | null {
+  for (const property of properties) {
+    const result = getProperty(value, property);
+    if (typeof result === 'string' && result.length > 0) return result;
+    if (typeof result === 'number' || typeof result === 'bigint') return String(result);
+  }
+  return null;
+}
+
+function getNumberProperty(value: unknown, ...properties: string[]): number | null {
+  for (const property of properties) {
+    const result = getProperty(value, property);
+    if (typeof result === 'number' && Number.isSafeInteger(result)) return result;
+    if (typeof result === 'string') {
+      const parsed = Number(result);
+      if (Number.isSafeInteger(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
+function getConversationId(conversation: unknown): string {
+  return getStringProperty(conversation, 'id') ?? '';
+}
+
+function getConversationTitle(conversation: unknown): string {
+  const id = getConversationId(conversation);
+  return getStringProperty(conversation, 'title') ?? `Conversation ${id}`;
+}
+
+function getLatestRun(detail: unknown): unknown {
+  const explicitlyLatest =
+    getProperty(detail, 'latestRun') ??
+    getProperty(detail, 'latest_run') ??
+    getProperty(detail, 'currentRun') ??
+    getProperty(detail, 'current_run');
+  if (explicitlyLatest) return explicitlyLatest;
+  return getArrayProperty(detail, 'runs').at(-1);
+}
+
+function getRunStatus(run: unknown): string | null {
+  return getStringProperty(run, 'status')?.toLowerCase() ?? null;
+}
+
+function isRunActive(run: unknown): boolean {
+  const status = getRunStatus(run);
+  return status !== null && ACTIVE_RUN_STATUSES.has(status);
+}
+
+function isRunRetryable(run: unknown): boolean {
+  const status = getRunStatus(run);
+  return status !== null && RETRYABLE_RUN_STATUSES.has(status);
+}
+
+export function getAgentConversationUiState(run: unknown, events: unknown[]) {
+  const status = getRunStatus(run);
+  const hasCheckpoint =
+    [
+      'head_sha',
+      'headSha',
+      'checkpoint_sha',
+      'checkpointSha',
+      'checkpoint_key',
+      'checkpointKey',
+    ].some((property) => getStringProperty(run, property) !== null) ||
+    events.some((event) => getEventType(event) === 'checkpoint');
+
+  return {
+    canPublish: status === 'completed' && hasCheckpoint,
+    runActive: isRunActive(run),
+    runRetryable: isRunRetryable(run),
+    status,
+  };
+}
+
+export function shouldPollAgentEventPage(page: unknown, run: unknown): boolean {
+  if (getProperty(page, 'hasMore') === true) return false;
+  if (isRunActive(run)) return true;
+
+  const status = getRunStatus(run);
+  const expectedTerminalEvent =
+    status === 'completed'
+      ? 'run_completed'
+      : status === 'failed'
+        ? 'run_failed'
+        : status === 'canceled' || status === 'cancelled'
+          ? 'run_cancelled'
+          : null;
+  if (expectedTerminalEvent === null) return false;
+
+  const lastEvent = getArrayProperty(page, 'events').at(-1);
+  return getEventType(lastEvent) !== expectedTerminalEvent;
+}
+
+function formatUnknownDate(value: unknown, timezone: string): string | null {
+  if (value instanceof Date) return formatDate(value, timezone);
+  if (typeof value !== 'string') return null;
+  const date = new Date(value);
+  return Number.isNaN(date.valueOf()) ? null : formatDate(date, timezone);
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(
+    value,
+    (_key, item: unknown) => (typeof item === 'bigint' ? item.toString() : item),
+    2,
+  );
+}
+
+function safeUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return value.startsWith('/') || value.startsWith('https://') || value.startsWith('http://')
+    ? value
+    : null;
+}
+
+function getLink(value: unknown): string | null {
+  for (const property of ['url', 'href', 'download_url', 'downloadUrl']) {
+    const url = safeUrl(getProperty(value, property));
+    if (url) return url;
+  }
+  return null;
+}
+
+function getEventData(event: unknown): unknown {
+  return getProperty(event, 'data') ?? getProperty(event, 'payload');
+}
+
+function getEventType(event: unknown): string {
+  return getStringProperty(event, 'type') ?? 'event';
+}
+
+function getEventMessage(event: unknown): string | null {
+  const data = getEventData(event);
+  return getStringProperty(data, 'message', 'text', 'content', 'delta');
+}
+
+export function getQuestionPreview(event: unknown): {
+  html: string;
+  variantSeed: string | null;
+} | null {
+  if (getEventType(event) !== 'tool_result') return null;
+  const data = getEventData(event);
+  if (getStringProperty(data, 'tool_name') !== 'render_question') return null;
+  const result = getProperty(data, 'result');
+  if (getProperty(result, 'rendered') !== true) return null;
+  const preview = getProperty(result, 'preview');
+  const html = getStringProperty(preview, 'html');
+  if (html === null) return null;
+  const extraHeadersHtml = getStringProperty(preview, 'extra_headers_html') ?? '';
+  return {
+    html: `<!doctype html><html><head><meta charset="utf-8">${extraHeadersHtml}</head><body>${html}</body></html>`,
+    variantSeed: getStringProperty(result, 'variant_seed'),
+  };
+}
+
+function eventLabel(type: string): string {
+  return type.replaceAll('_', ' ').replace(/^./, (character) => character.toUpperCase());
+}
+
+function statusBadgeClass(status: string | null): string {
+  switch (status) {
+    case 'completed':
+      return 'text-bg-success';
+    case 'failed':
+      return 'text-bg-danger';
+    case 'canceled':
+    case 'cancelled':
+      return 'text-bg-secondary';
+    case 'pending':
+    case 'queued':
+    case 'stopping':
+    case 'cancelling':
+      return 'text-bg-warning';
+    case 'running':
+      return 'text-bg-primary';
+    default:
+      return 'text-bg-light';
+  }
+}
+
+function TimelineEvent({ event, timezone }: { event: unknown; timezone: string }) {
+  const type = getEventType(event);
+  const data = getEventData(event);
+  const message = getEventMessage(event);
+  const link = getLink(data) ?? getLink(event);
+  const createdAt = formatUnknownDate(
+    getProperty(event, 'created_at') ?? getProperty(event, 'createdAt'),
+    timezone,
+  );
+  const isMessage = type === 'user_message' || type.startsWith('assistant_message');
+  const questionPreview = getQuestionPreview(event);
+
+  return (
+    <li className="list-group-item px-0 py-3 border-start-0 border-end-0">
+      <div className="d-flex align-items-start gap-2">
+        <span className={`badge ${isMessage ? 'text-bg-light' : 'text-bg-secondary'}`}>
+          {eventLabel(type)}
+        </span>
+        {createdAt && <small className="text-muted ms-auto">{createdAt}</small>}
+      </div>
+      {message && (
+        <div className="mt-2 text-break" style={{ whiteSpace: 'pre-wrap' }}>
+          {message}
+        </div>
+      )}
+      {link && (
+        <div className="mt-2">
+          <a href={link}>Open related item</a>
+        </div>
+      )}
+      {questionPreview && (
+        <section className="mt-3" aria-label="Rendered question preview">
+          <div className="d-flex align-items-center mb-2">
+            <strong>Question preview</strong>
+            {questionPreview.variantSeed && (
+              <small className="text-muted ms-auto">
+                Variant seed: <code>{questionPreview.variantSeed}</code>
+              </small>
+            )}
+          </div>
+          <iframe
+            className="border rounded w-100 bg-white"
+            sandbox="allow-forms allow-scripts"
+            srcDoc={questionPreview.html}
+            style={{ minHeight: '24rem' }}
+            title="Rendered PrairieLearn question"
+          />
+        </section>
+      )}
+      {!isMessage && data !== undefined && (
+        <details className="mt-2">
+          <summary>Details</summary>
+          <pre className="bg-light border rounded p-2 mt-2 mb-0 text-wrap">{formatJson(data)}</pre>
+        </details>
+      )}
+    </li>
+  );
+}
+
+function TimelineContinuation({
+  afterSequence,
+  conversationId,
+  latestRun,
+  timezone,
+}: {
+  afterSequence: number;
+  conversationId: string;
+  latestRun: unknown;
+  timezone: string;
+}) {
+  const trpc = useTRPC();
+  const eventsQuery = useQuery({
+    ...trpc.agentConversations.listEvents.queryOptions({ conversationId, afterSequence }),
+    refetchInterval: (query) =>
+      shouldPollAgentEventPage(query.state.data, latestRun) ? POLL_INTERVAL_MS : false,
+  });
+  const events = getArrayProperty(eventsQuery.data, 'events');
+  const hasMore = getProperty(eventsQuery.data, 'hasMore') === true;
+  const nextSequence = getNumberProperty(eventsQuery.data, 'nextSequence');
+  const error = getAppError<AgentConversationsError['ListEvents']>(eventsQuery.error);
+
+  return (
+    <>
+      {error && (
+        <li>
+          <AppErrorAlert error={error} render={{ UNKNOWN: ({ message }) => message }} />
+        </li>
+      )}
+      {events.map((event) => (
+        <TimelineEvent
+          key={
+            getStringProperty(event, 'id', 'sequence') ??
+            `${getEventType(event)}-${formatJson(event)}`
+          }
+          event={event}
+          timezone={timezone}
+        />
+      ))}
+      {hasMore && nextSequence !== null && nextSequence > afterSequence && (
+        <TimelineContinuation
+          afterSequence={nextSequence}
+          conversationId={conversationId}
+          latestRun={latestRun}
+          timezone={timezone}
+        />
+      )}
+    </>
+  );
+}
+
+function ConversationList({
+  conversations,
+  selectedConversationId,
+  onSelect,
+  onCreate,
+  creating,
+  displayTimezone,
+}: {
+  conversations: unknown[];
+  selectedConversationId: string | null;
+  onSelect: (conversationId: string) => void;
+  onCreate: () => void;
+  creating: boolean;
+  displayTimezone: string;
+}) {
+  return (
+    <div className="card h-100">
+      <div className="card-header d-flex align-items-center gap-2">
+        <h2 className="h5 mb-0">Conversations</h2>
+        <button
+          type="button"
+          className="btn btn-sm btn-primary ms-auto"
+          disabled={creating}
+          onClick={onCreate}
+        >
+          {creating ? (
+            <span className="spinner-border spinner-border-sm me-1" aria-hidden="true" />
+          ) : (
+            <i className="bi bi-plus-lg me-1" aria-hidden="true" />
+          )}
+          New
+        </button>
+      </div>
+      <div className="list-group list-group-flush overflow-auto">
+        {conversations.length === 0 ? (
+          <div className="p-3 text-muted">Start a conversation to work on this course.</div>
+        ) : (
+          conversations.map((conversation) => {
+            const conversationId = getConversationId(conversation);
+            const updatedAt = formatUnknownDate(
+              getProperty(conversation, 'updated_at') ?? getProperty(conversation, 'updatedAt'),
+              displayTimezone,
+            );
+            return (
+              <button
+                key={conversationId}
+                type="button"
+                className={`list-group-item list-group-item-action ${
+                  conversationId === selectedConversationId ? 'active' : ''
+                }`}
+                aria-current={conversationId === selectedConversationId ? 'page' : undefined}
+                onClick={() => onSelect(conversationId)}
+              >
+                <span className="d-block text-truncate">{getConversationTitle(conversation)}</span>
+                {updatedAt && <small className="d-block opacity-75 mt-1">{updatedAt}</small>}
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ConversationWorkspace({
+  conversationId,
+  displayTimezone,
+  onDeleted,
+}: {
+  conversationId: string;
+  displayTimezone: string;
+  onDeleted: () => void;
+}) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [message, setMessage] = useState('');
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const detailQuery = useQuery({
+    ...trpc.agentConversations.get.queryOptions({ conversationId }),
+    refetchInterval: (query) =>
+      isRunActive(getLatestRun(query.state.data)) ? POLL_INTERVAL_MS : false,
+  });
+  const latestRun = getLatestRun(detailQuery.data);
+  const eventsQuery = useQuery({
+    ...trpc.agentConversations.listEvents.queryOptions({ conversationId }),
+    refetchInterval: (query) =>
+      shouldPollAgentEventPage(query.state.data, latestRun) ? POLL_INTERVAL_MS : false,
+  });
+  const events = getArrayProperty(eventsQuery.data, 'events');
+  const hasMoreEvents = getProperty(eventsQuery.data, 'hasMore') === true;
+  const nextSequence = getNumberProperty(eventsQuery.data, 'nextSequence');
+  const checkpoint = getProperty(detailQuery.data, 'checkpoint');
+  const { canPublish, runActive, runRetryable, status } = getAgentConversationUiState(
+    latestRun,
+    checkpoint ? [...events, checkpoint] : events,
+  );
+
+  async function refreshConversation() {
+    await Promise.all([
+      queryClient.invalidateQueries(trpc.agentConversations.list.queryFilter()),
+      queryClient.invalidateQueries(trpc.agentConversations.get.queryFilter({ conversationId })),
+      queryClient.invalidateQueries(
+        trpc.agentConversations.listEvents.queryFilter({ conversationId }),
+      ),
+    ]);
+  }
+
+  const startTurnMutation = useMutation(
+    trpc.agentConversations.startTurn.mutationOptions({
+      onSuccess: async () => {
+        setMessage('');
+        await refreshConversation();
+      },
+    }),
+  );
+  const stopMutation = useMutation(
+    trpc.agentConversations.stop.mutationOptions({ onSuccess: refreshConversation }),
+  );
+  const deleteMutation = useMutation(
+    trpc.agentConversations.delete.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(trpc.agentConversations.list.queryFilter());
+        onDeleted();
+      },
+    }),
+  );
+  const publishMutation = useMutation(
+    trpc.agentConversations.publish.mutationOptions({ onSuccess: refreshConversation }),
+  );
+
+  const mutationError =
+    getAppError<AgentConversationsError['StartTurn']>(startTurnMutation.error) ??
+    getAppError<AgentConversationsError['Stop']>(stopMutation.error) ??
+    getAppError<AgentConversationsError['Delete']>(deleteMutation.error) ??
+    getAppError<AgentConversationsError['Publish']>(publishMutation.error);
+  const queryError =
+    getAppError<AgentConversationsError['Get']>(detailQuery.error) ??
+    getAppError<AgentConversationsError['ListEvents']>(eventsQuery.error);
+  const retryMessage = getStringProperty(latestRun, 'message', 'prompt');
+  const artifacts = getArrayProperty(detailQuery.data, 'artifacts');
+
+  function submitMessage(event: SyntheticEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || runActive) return;
+    startTurnMutation.mutate({ conversationId, message: trimmedMessage });
+  }
+
+  return (
+    <div className="card h-100">
+      <div className="card-header d-flex flex-wrap align-items-center gap-2">
+        <h2 className="h5 mb-0">Conversation</h2>
+        {status && <span className={`badge ${statusBadgeClass(status)}`}>{status}</span>}
+        <div className="d-flex gap-2 ms-auto">
+          {runActive && (
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-danger"
+              disabled={stopMutation.isPending}
+              onClick={() => stopMutation.mutate({ conversationId })}
+            >
+              <i className="bi bi-stop-circle me-1" aria-hidden="true" />
+              Stop
+            </button>
+          )}
+          {canPublish && (
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-primary"
+              disabled={publishMutation.isPending}
+              onClick={() => publishMutation.mutate({ conversationId })}
+            >
+              {publishMutation.isPending ? (
+                <span className="spinner-border spinner-border-sm me-1" aria-hidden="true" />
+              ) : (
+                <i className="bi bi-git me-1" aria-hidden="true" />
+              )}
+              Create draft pull request
+            </button>
+          )}
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-secondary"
+            disabled={deleteMutation.isPending}
+            onClick={() => setShowDeleteModal(true)}
+          >
+            <i className="bi bi-trash me-1" aria-hidden="true" />
+            Delete
+          </button>
+        </div>
+      </div>
+
+      <AppErrorAlert
+        className="m-3 mb-0"
+        error={mutationError ?? queryError}
+        render={{ UNKNOWN: ({ message: errorMessage }) => errorMessage }}
+        onDismiss={() => {
+          startTurnMutation.reset();
+          stopMutation.reset();
+          deleteMutation.reset();
+          publishMutation.reset();
+        }}
+      />
+
+      <div className="card-body overflow-auto" aria-live="polite" aria-busy={runActive}>
+        {events.length === 0 ? (
+          <div className="text-center text-muted py-5">
+            <i className="bi bi-stars fs-2 d-block mb-2" aria-hidden="true" />
+            Describe what you want to change, investigate, or create in this course.
+          </div>
+        ) : (
+          <ol className="list-group list-group-flush list-unstyled mb-0">
+            {events.map((event) => (
+              <TimelineEvent
+                key={
+                  getStringProperty(event, 'id', 'sequence') ??
+                  `${getEventType(event)}-${formatJson(event)}`
+                }
+                event={event}
+                timezone={displayTimezone}
+              />
+            ))}
+            {hasMoreEvents && nextSequence !== null && (
+              <TimelineContinuation
+                afterSequence={nextSequence}
+                conversationId={conversationId}
+                latestRun={latestRun}
+                timezone={displayTimezone}
+              />
+            )}
+          </ol>
+        )}
+
+        {artifacts.length > 0 && (
+          <section className="border-top pt-3 mt-3" aria-labelledby="agent-artifacts-heading">
+            <h3 id="agent-artifacts-heading" className="h6">
+              Artifacts
+            </h3>
+            <ul className="mb-0">
+              {artifacts.map((artifact) => {
+                const link = getLink(artifact) ?? getLink(getProperty(artifact, 'metadata'));
+                const label = getStringProperty(artifact, 'title', 'name', 'kind') ?? 'Artifact';
+                return (
+                  <li
+                    key={
+                      getStringProperty(artifact, 'id', 'sha256', 'storage_key', 'storageKey') ??
+                      formatJson(artifact)
+                    }
+                  >
+                    {link ? <a href={link}>{label}</a> : label}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+      </div>
+
+      <div className="card-footer">
+        {runRetryable && retryMessage && (
+          <div className="d-flex align-items-center gap-2 mb-2">
+            <span className="text-muted small">The last turn did not complete.</span>
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-secondary"
+              disabled={startTurnMutation.isPending}
+              onClick={() => startTurnMutation.mutate({ conversationId, message: retryMessage })}
+            >
+              <i className="bi bi-arrow-clockwise me-1" aria-hidden="true" />
+              Retry
+            </button>
+          </div>
+        )}
+        <form onSubmit={submitMessage}>
+          <label htmlFor="agent-message" className="visually-hidden">
+            Message
+          </label>
+          <textarea
+            id="agent-message"
+            className="form-control"
+            rows={3}
+            value={message}
+            placeholder={runActive ? 'The agent is working…' : 'Message the course agent'}
+            disabled={runActive || startTurnMutation.isPending}
+            onChange={(event) => setMessage(event.target.value)}
+          />
+          <div className="d-flex align-items-center mt-2">
+            <small className="text-muted">Runs continue if you leave this page.</small>
+            <button
+              type="submit"
+              className="btn btn-primary ms-auto"
+              disabled={runActive || startTurnMutation.isPending || message.trim().length === 0}
+            >
+              {startTurnMutation.isPending && (
+                <span className="spinner-border spinner-border-sm me-1" aria-hidden="true" />
+              )}
+              {status === 'completed' ? 'Resume' : 'Send message'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      <Modal
+        show={showDeleteModal}
+        aria-labelledby="agent-conversation-delete-modal-title"
+        onHide={() => setShowDeleteModal(false)}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="agent-conversation-delete-modal-title">Delete conversation?</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          This deletes the conversation history and its saved artifacts. This action cannot be
+          undone.
+        </Modal.Body>
+        <Modal.Footer>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            disabled={deleteMutation.isPending}
+            onClick={() => setShowDeleteModal(false)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-danger"
+            disabled={deleteMutation.isPending}
+            onClick={() => deleteMutation.mutate({ conversationId })}
+          >
+            {deleteMutation.isPending && (
+              <span className="spinner-border spinner-border-sm me-1" aria-hidden="true" />
+            )}
+            Delete conversation
+          </button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+}
+
+function AgentConversationsInner({ displayTimezone }: { displayTimezone: string }) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
+  const listQuery = useQuery(trpc.agentConversations.list.queryOptions());
+  const conversations = getArrayProperty(listQuery.data, 'conversations');
+  const createMutation = useMutation(
+    trpc.agentConversations.create.mutationOptions({
+      onSuccess: async (data) => {
+        const conversationId = getConversationId(getProperty(data, 'conversation'));
+        await queryClient.invalidateQueries(trpc.agentConversations.list.queryFilter());
+        setSelectedConversationId(conversationId);
+      },
+    }),
+  );
+
+  const activeConversationId =
+    selectedConversationId ??
+    (conversations.length > 0 ? getConversationId(conversations[0]) : null);
+
+  const listError =
+    getAppError<AgentConversationsError['List']>(listQuery.error) ??
+    getAppError<AgentConversationsError['Create']>(createMutation.error);
+
+  return (
+    <>
+      <h1 className="visually-hidden">Course agent</h1>
+      <AppErrorAlert
+        error={listError}
+        render={{ UNKNOWN: ({ message }) => message }}
+        onDismiss={() => createMutation.reset()}
+      />
+      <div className="row g-3 h-100">
+        <div className="col-12 col-lg-3" style={{ minHeight: 0 }}>
+          <ConversationList
+            conversations={conversations}
+            selectedConversationId={activeConversationId}
+            creating={createMutation.isPending}
+            displayTimezone={displayTimezone}
+            onCreate={() => createMutation.mutate({})}
+            onSelect={(conversationId) => setSelectedConversationId(conversationId)}
+          />
+        </div>
+        <div className="col-12 col-lg-9" style={{ minHeight: 0 }}>
+          {activeConversationId ? (
+            <ConversationWorkspace
+              key={activeConversationId}
+              conversationId={activeConversationId}
+              displayTimezone={displayTimezone}
+              onDeleted={() => setSelectedConversationId(null)}
+            />
+          ) : (
+            <div className="card h-100">
+              <div className="card-body d-flex align-items-center justify-content-center text-muted text-center">
+                Create a conversation to begin working with the course agent.
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function AgentConversationsPage({
+  courseId,
+  displayTimezone,
+  isDevMode,
+  trpcCsrfToken,
+}: {
+  courseId: string;
+  displayTimezone: string;
+  isDevMode: boolean;
+  trpcCsrfToken: string;
+}) {
+  const [queryClient] = useState(() => new QueryClient());
+  const [trpcClient] = useState(() =>
+    createCourseTrpcClient({ csrfToken: trpcCsrfToken, courseId }),
+  );
+
+  return (
+    <QueryClientProviderDebug client={queryClient} isDevMode={isDevMode}>
+      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+        <AgentConversationsInner displayTimezone={displayTimezone} />
+      </TRPCProvider>
+    </QueryClientProviderDebug>
+  );
+}
+
+AgentConversationsPage.displayName = 'AgentConversationsPage';

--- a/apps/prairielearn/src/pages/instructorAgentConversations/instructorAgentConversations.tsx
+++ b/apps/prairielearn/src/pages/instructorAgentConversations/instructorAgentConversations.tsx
@@ -1,0 +1,69 @@
+import { Router } from 'express';
+
+import { HttpStatusError } from '@prairielearn/error';
+import { Hydrate } from '@prairielearn/react/server';
+import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
+
+import { PageLayout } from '../../components/PageLayout.js';
+import { extractPageContext } from '../../lib/client/page-context.js';
+import { getCourseTrpcUrl } from '../../lib/client/url.js';
+import { config } from '../../lib/config.js';
+import { features } from '../../lib/features/index.js';
+import { typedAsyncHandler } from '../../lib/res-locals.js';
+
+import { AgentConversationsPage } from './components/AgentConversationsPage.js';
+
+const router = Router();
+
+router.get(
+  '/',
+  typedAsyncHandler<'course' | 'course-instance'>(async (_req, res) => {
+    const { authz_data: authzData, course } = extractPageContext(res.locals, {
+      pageType: 'course',
+      accessType: 'instructor',
+    });
+
+    if (!(await features.enabledFromLocals('cloud-agent', res.locals))) {
+      throw new HttpStatusError(403, 'Access denied (feature not available)');
+    }
+    if (!authzData.has_course_permission_edit) {
+      throw new HttpStatusError(403, 'Access denied (must be course editor)');
+    }
+    if (course.example_course) {
+      throw new HttpStatusError(403, 'Access denied. Cannot use the agent in the example course.');
+    }
+
+    const trpcCsrfToken = generatePrefixCsrfToken(
+      { url: getCourseTrpcUrl(course.id), authn_user_id: res.locals.authn_user.id },
+      config.secretKey,
+    );
+
+    res.send(
+      PageLayout({
+        resLocals: res.locals,
+        pageTitle: 'Course agent',
+        navContext: {
+          type: 'instructor',
+          page: 'course_admin',
+          subPage: 'agents',
+        },
+        options: {
+          fullWidth: true,
+          fullHeight: true,
+        },
+        content: (
+          <Hydrate fullHeight>
+            <AgentConversationsPage
+              courseId={course.id}
+              displayTimezone={course.display_timezone}
+              isDevMode={config.devMode}
+              trpcCsrfToken={trpcCsrfToken}
+            />
+          </Hydrate>
+        ),
+      }),
+    );
+  }),
+);
+
+export default router;

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -851,6 +851,7 @@ export async function initExpress(): Promise<Express> {
   // API ///////////////////////////////////////////////////////////////
 
   app.use('/pl/api/trpc', (await import('./api/trpc/index.js')).default);
+  app.use('/pl/api/agent/v1', (await import('./api/agent/v1/index.js')).default);
   app.use('/pl/api/v1', (await import('./api/v1/index.js')).default);
 
   //////////////////////////////////////////////////////////////////////
@@ -1222,6 +1223,10 @@ export async function initExpress(): Promise<Express> {
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/questions',
     (await import('./pages/instructorQuestions/instructorQuestions.js')).default,
+  );
+  app.use(
+    '/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/agents',
+    (await import('./pages/instructorAgentConversations/instructorAgentConversations.js')).default,
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/getting_started',
@@ -1714,6 +1719,10 @@ export async function initExpress(): Promise<Express> {
   app.use(
     '/pl/course/:course_id(\\d+)/course_admin/questions',
     (await import('./pages/instructorQuestions/instructorQuestions.js')).default,
+  );
+  app.use(
+    '/pl/course/:course_id(\\d+)/course_admin/agents',
+    (await import('./pages/instructorAgentConversations/instructorAgentConversations.js')).default,
   );
   if (isEnterprise()) {
     app.use(

--- a/apps/prairielearn/src/tests/agentConversations.test.ts
+++ b/apps/prairielearn/src/tests/agentConversations.test.ts
@@ -1,0 +1,70 @@
+import { TRPCClientError } from '@trpc/client';
+import { afterAll, assert, beforeAll, describe, expect, it } from 'vitest';
+
+import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
+
+import { getCourseTrpcUrl } from '../lib/client/url.js';
+import { config } from '../lib/config.js';
+import { selectUserByUid } from '../models/user.js';
+import { createCourseTrpcClient } from '../trpc/course/client.js';
+
+import * as helperServer from './helperServer.js';
+import { withConfig } from './utils/config.js';
+
+const siteUrl = `http://localhost:${config.serverPort}`;
+
+async function createClient(cookie = '') {
+  assert(config.authUid);
+  const authnUserId = (await selectUserByUid(config.authUid)).id;
+  return createCourseTrpcClient({
+    courseId: '1',
+    csrfToken: generatePrefixCsrfToken(
+      { authn_user_id: authnUserId, url: getCourseTrpcUrl('1') },
+      config.secretKey,
+    ),
+    extraHeaders: { cookie },
+    urlBase: siteUrl,
+  });
+}
+
+describe('agent conversations authorization', { timeout: 30_000 }, () => {
+  beforeAll(helperServer.before());
+  afterAll(helperServer.after);
+
+  it('is unavailable when the feature is disabled', async () => {
+    await withConfig({ features: { 'cloud-agent': false } }, async () => {
+      await expect((await createClient()).agentConversations.list.query()).rejects.toBeInstanceOf(
+        TRPCClientError,
+      );
+    });
+  });
+
+  it('allows an editor to create and list an owned conversation', async () => {
+    await withConfig({ features: { 'cloud-agent': true } }, async () => {
+      const client = await createClient();
+      const created = await client.agentConversations.create.mutate({});
+      const listed = await client.agentConversations.list.query();
+      expect(listed.conversations.map((conversation) => conversation.id)).toContain(
+        created.conversation.id,
+      );
+    });
+  });
+
+  it('rejects a user without course edit permission', async () => {
+    await withConfig({ features: { 'cloud-agent': true } }, async () => {
+      const client = await createClient(
+        'pl2_requested_course_role=None; pl2_requested_course_instance_role=None',
+      );
+      await expect(client.agentConversations.list.query()).rejects.toBeInstanceOf(TRPCClientError);
+    });
+  });
+
+  it('rejects effective-user impersonation', async () => {
+    await withConfig({ features: { 'cloud-agent': true } }, async () => {
+      const client = await createClient(
+        'pl2_requested_uid=staff04@example.com; pl2_requested_course_role=Editor',
+      );
+      await expect(client.agentConversations.list.query()).rejects.toBeInstanceOf(TRPCClientError);
+    });
+  });
+});

--- a/apps/prairielearn/src/tests/e2e/agentConversations.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/agentConversations.spec.ts
@@ -1,0 +1,67 @@
+import { createTest, expect } from './fixtures.js';
+
+const agentWorkerUrl = process.env.AGENT_WORKER_URL;
+const test = createTest({
+  agentCapabilitySecret: 'local-agent-capability-secret-32-bytes',
+  agentHarness: 'deterministic',
+  agentWorkerUrl: agentWorkerUrl ?? 'http://localhost:1',
+  features: {
+    'cloud-agent': true,
+    'cloud-agent-arbitrary-sql': true,
+  },
+});
+
+test.skip(agentWorkerUrl === undefined, 'Requires the local Wrangler agent Worker.');
+
+test('creates, resumes, publishes, and deletes a durable agent conversation', async ({
+  page,
+  courseInstance,
+}) => {
+  test.setTimeout(240_000);
+  await page.goto(`/pl/course_instance/${courseInstance.id}/instructor/course_admin/agents`);
+  await expect(page).toHaveTitle(/Course agent/);
+
+  await page.getByRole('button', { name: 'New' }).click();
+  const message = page.getByLabel('Message');
+  await message.fill('Inspect the course and make a deterministic question edit.');
+  await page.getByRole('button', { name: 'Send message' }).click();
+
+  await expect(
+    page
+      .getByText(
+        'Deterministic response for: Inspect the course and make a deterministic question edit.',
+        { exact: true },
+      )
+      .first(),
+  ).toBeVisible({ timeout: 180_000 });
+  await expect(page.getByText('completed', { exact: true })).toBeVisible();
+  const previews = page.getByRole('region', { name: 'Rendered question preview' });
+  await expect(previews).toHaveCount(1);
+  await expect(previews.first().getByTitle('Rendered PrairieLearn question')).toBeVisible();
+  await expect(previews.first()).toContainText('Variant seed: 1');
+
+  await message.fill('Resume the same durable session and make one more edit.');
+  await page.getByRole('button', { name: 'Resume' }).click();
+  await expect(
+    page
+      .getByText(
+        'Deterministic response for: Resume the same durable session and make one more edit.',
+        { exact: true },
+      )
+      .first(),
+  ).toBeVisible({ timeout: 180_000 });
+  await expect(page.getByText('completed', { exact: true })).toBeVisible();
+  await expect(previews).toHaveCount(2);
+
+  const toolResults = page.getByText('Tool result', { exact: true });
+  const toolResultCount = await toolResults.count();
+  await page.getByRole('button', { name: 'Create draft pull request' }).click();
+  await expect(toolResults).toHaveCount(toolResultCount + 1, { timeout: 30_000 });
+
+  await page.getByRole('button', { name: 'Delete' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Delete conversation?' });
+  await dialog.getByRole('button', { name: 'Delete conversation' }).click();
+  await expect(
+    page.getByText('Create a conversation to begin working with the course agent.'),
+  ).toBeVisible();
+});

--- a/apps/prairielearn/src/trpc/course/agent-conversations.ts
+++ b/apps/prairielearn/src/trpc/course/agent-conversations.ts
@@ -1,0 +1,622 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
+
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import {
+  type AgentRepository,
+  type AgentRunCapabilityClaims,
+  AgentToolNameSchema,
+  PublishAgentRunRequestSchema,
+  PublishAgentRunResponseSchema,
+  StartAgentRunRequestSchema,
+} from '@prairielearn/agent-protocol';
+import { IdSchema } from '@prairielearn/zod';
+
+import {
+  signAgentPublicationCapability,
+  signAgentRunCapability,
+} from '../../lib/agent-capability.js';
+import { config } from '../../lib/config.js';
+import { getCourseFilesClient } from '../../lib/course-files-api.js';
+import type { AgentConversation } from '../../lib/db-types.js';
+import { features } from '../../lib/features/index.js';
+import { parseGithubRepository } from '../../lib/github-utils.js';
+import { createDraftPullRequest } from '../../lib/github.js';
+import { idsEqual } from '../../lib/id.js';
+import {
+  appendAgentRunEvents,
+  beginAgentOperation,
+  completeAgentOperation,
+  createAgentConversation,
+  createAgentRun,
+  failAgentOperation,
+  listAgentEvents,
+  requestAgentRunStop,
+  retryAgentOperation,
+  selectActiveAgentRun,
+  selectAgentArtifacts,
+  selectAgentConversation,
+  selectAgentConversations,
+  selectAgentDraftQuestionIds,
+  selectAgentOperationResultEvent,
+  selectAgentRuns,
+  selectLatestAgentCheckpoint,
+  selectLatestAgentRun,
+  tombstoneAgentConversation,
+} from '../../models/agent-conversation.js';
+
+import {
+  type TRPCContext,
+  requireCoursePermissionEdit,
+  requireNotExampleCourse,
+  t,
+} from './init.js';
+
+export interface AgentConversationsError {
+  Create: never;
+  Delete: never;
+  Get: never;
+  List: never;
+  ListEvents: never;
+  Publish: never;
+  StartTurn: never;
+  Stop: never;
+}
+
+const requireCloudAgent = t.middleware(async ({ ctx, next }) => {
+  const enabled = await features.enabled('cloud-agent', {
+    course_id: ctx.course.id,
+    institution_id: ctx.course.institution_id,
+    user_id: ctx.authz_data.authn_user.id,
+  });
+  if (!enabled) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Course agent is not enabled.' });
+  }
+  if (!idsEqual(ctx.authz_data.authn_user.id, ctx.authz_data.user.id)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Course agent cannot be used while acting as another user.',
+    });
+  }
+  return await next();
+});
+
+const protectedProcedure = t.procedure
+  .use(requireCloudAgent)
+  .use(requireCoursePermissionEdit)
+  .use(requireNotExampleCourse);
+
+const ConversationInputSchema = z.object({ conversationId: IdSchema });
+
+function notFound(): never {
+  throw new TRPCError({ code: 'NOT_FOUND', message: 'Conversation not found.' });
+}
+
+async function getConversation(ctx: TRPCContext, conversationId: string) {
+  const conversation = await selectAgentConversation({
+    authnUserId: ctx.authz_data.authn_user.id,
+    conversationId,
+    courseId: ctx.course.id,
+  });
+  return conversation ?? notFound();
+}
+
+function publicRun<T extends { capability_jti: string }>({
+  capability_jti: _capabilityJti,
+  ...run
+}: T) {
+  return run;
+}
+
+function getRepository(ctx: TRPCContext): AgentRepository | undefined {
+  if (ctx.course.repository === null || ctx.course.commit_hash === null) return undefined;
+  const parsed = parseGithubRepository(ctx.course.repository);
+  if (parsed === null || !/^[0-9a-f]{40}$/.test(ctx.course.commit_hash)) return undefined;
+  return {
+    base_sha: ctx.course.commit_hash,
+    branch: ctx.course.branch,
+    https_url: `https://github.com/${parsed.owner}/${parsed.repo}.git`,
+  };
+}
+
+function getConversationRepository(
+  ctx: TRPCContext,
+  conversation: AgentConversation,
+): AgentRepository | undefined {
+  if (
+    conversation.repository_url === null ||
+    conversation.repository_branch === null ||
+    conversation.repository_base_sha === null
+  ) {
+    return undefined;
+  }
+  const current =
+    ctx.course.repository === null ? null : parseGithubRepository(ctx.course.repository);
+  const currentUrl =
+    current === null ? null : `https://github.com/${current.owner}/${current.repo}.git`;
+  if (currentUrl !== conversation.repository_url) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'The course repository changed after this conversation was created.',
+    });
+  }
+  return {
+    base_sha: conversation.repository_base_sha,
+    branch: conversation.repository_branch,
+    https_url: conversation.repository_url,
+  };
+}
+
+function makeRunClaims({
+  ctx,
+  runId,
+  conversationId,
+  jti,
+  expiresAt,
+  allowedTools,
+  baseUrl,
+  repository,
+  purpose,
+  prompt,
+}: {
+  ctx: TRPCContext;
+  runId: string;
+  conversationId: string;
+  jti: string;
+  expiresAt: Date;
+  allowedTools: z.infer<typeof AgentToolNameSchema>[];
+  baseUrl: string;
+  repository: AgentRepository | undefined;
+  purpose: AgentRunCapabilityClaims['purpose'];
+  prompt: string;
+}): AgentRunCapabilityClaims {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    allowed_tools: allowedTools,
+    aud:
+      purpose === 'run'
+        ? ['prairielearn-agent-worker', 'prairielearn-agent-api']
+        : 'prairielearn-agent-worker',
+    authn_user_id: ctx.authz_data.authn_user.id,
+    conversation_id: conversationId,
+    course_id: ctx.course.id,
+    exp: Math.floor(expiresAt.getTime() / 1000),
+    harness: config.agentHarness,
+    iat: now,
+    iss: 'prairielearn',
+    jti,
+    prairielearn_base_url: baseUrl,
+    prompt_sha256: createHash('sha256').update(prompt).digest('hex'),
+    purpose,
+    repository,
+    run_id: runId,
+    sub: ctx.authz_data.authn_user.id,
+    user_id: ctx.authz_data.user.id,
+  };
+}
+
+async function callWorker(path: string, token: string, init: RequestInit = {}) {
+  if (config.agentWorkerUrl === null) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Course agent is not configured.',
+    });
+  }
+  const response = await fetch(new URL(path, config.agentWorkerUrl), {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  });
+  if (!response.ok) {
+    throw new TRPCError({
+      code: 'BAD_GATEWAY',
+      message: `Course agent worker returned ${response.status}.`,
+    });
+  }
+  return response;
+}
+
+const create = protectedProcedure.input(z.object({})).mutation(async ({ ctx }) => {
+  const conversation = await createAgentConversation({
+    authnUserId: ctx.authz_data.authn_user.id,
+    courseId: ctx.course.id,
+    repository: getRepository(ctx),
+    title: null,
+    userId: ctx.authz_data.user.id,
+  });
+  return { conversation };
+});
+
+const list = protectedProcedure.query(async ({ ctx }) => ({
+  conversations: await selectAgentConversations({
+    authnUserId: ctx.authz_data.authn_user.id,
+    courseId: ctx.course.id,
+  }),
+}));
+
+const get = protectedProcedure.input(ConversationInputSchema).query(async ({ ctx, input }) => {
+  const conversation = await getConversation(ctx, input.conversationId);
+  const [runs, artifacts] = await Promise.all([
+    selectAgentRuns({ conversationId: conversation.id, courseId: ctx.course.id }),
+    selectAgentArtifacts(conversation.id),
+  ]);
+  const checkpoint = runs.length === 0 ? null : await selectLatestAgentCheckpoint(runs.at(-1)!.id);
+  return {
+    artifacts: artifacts.map(({ storage_key: _storageKey, ...artifact }) => artifact),
+    conversation,
+    checkpoint,
+    runs: runs.map(publicRun),
+  };
+});
+
+const listEvents = protectedProcedure
+  .input(
+    ConversationInputSchema.extend({ afterSequence: z.number().int().nonnegative().optional() }),
+  )
+  .query(async ({ ctx, input }) => {
+    const conversation = await getConversation(ctx, input.conversationId);
+    const rows = await listAgentEvents({
+      afterSequence: input.afterSequence ?? 0,
+      conversationId: conversation.id,
+    });
+    const hasMore = rows.length > 200;
+    const events = rows.slice(0, 200);
+    return {
+      events,
+      hasMore,
+      nextSequence: events.at(-1)?.sequence ?? input.afterSequence ?? 0,
+    };
+  });
+
+const startTurn = protectedProcedure
+  .input(
+    ConversationInputSchema.extend({
+      message: z.string().trim().min(1).max(100_000),
+    }),
+  )
+  .mutation(async ({ ctx, input }) => {
+    if (config.agentCapabilitySecret === null || config.agentWorkerUrl === null) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Course agent is not configured.',
+      });
+    }
+    const conversation = await getConversation(ctx, input.conversationId);
+    if ((await selectActiveAgentRun(conversation.id)) !== null) {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'This conversation already has an active run.',
+      });
+    }
+    const repository = getConversationRepository(ctx, conversation);
+    if (config.agentHarness === 'claude' && repository === undefined) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Claude runs require a GitHub repository and synced commit.',
+      });
+    }
+    const baseUrl = config.serverCanonicalHost ?? ctx.requestOrigin;
+    const arbitrarySqlEnabled =
+      config.devMode &&
+      (await features.enabled('cloud-agent-arbitrary-sql', {
+        course_id: ctx.course.id,
+        institution_id: ctx.course.institution_id,
+        user_id: ctx.authz_data.authn_user.id,
+      }));
+    const allowedTools = AgentToolNameSchema.options.filter(
+      (tool) => tool !== 'query_course_data' || arbitrarySqlEnabled,
+    );
+    const expiresAt = new Date(Date.now() + config.agentCapabilityTtlSeconds * 1000);
+    const jti = randomUUID();
+    const run = await createAgentRun({
+      allowedTools,
+      authnUserId: ctx.authz_data.authn_user.id,
+      baseCommitSha: repository?.base_sha ?? null,
+      capabilityExpiresAt: expiresAt,
+      capabilityJti: jti,
+      conversation,
+      message: input.message,
+      userId: ctx.authz_data.user.id,
+    });
+    const claims = makeRunClaims({
+      allowedTools,
+      baseUrl,
+      conversationId: conversation.id,
+      ctx,
+      expiresAt,
+      jti,
+      prompt: input.message,
+      purpose: 'run',
+      repository,
+      runId: run.id,
+    });
+    const token = await signAgentRunCapability(claims);
+    const body = StartAgentRunRequestSchema.parse({
+      conversation_id: conversation.id,
+      course_id: ctx.course.id,
+      harness: config.agentHarness,
+      prairielearn_base_url: baseUrl,
+      prompt: input.message,
+      repository,
+      run_id: run.id,
+    });
+    try {
+      await callWorker('/v1/runs/start', token, { body: JSON.stringify(body), method: 'POST' });
+    } catch (error) {
+      await appendAgentRunEvents({
+        claudeSessionId: null,
+        courseId: ctx.course.id,
+        error: error instanceof Error ? error.message : 'Worker did not accept the run.',
+        events: [
+          {
+            data: { error: 'Worker did not accept the run.' },
+            event_id: `run-failed:prairielearn:${run.id}`,
+            type: 'run_failed',
+          },
+        ],
+        run,
+        terminalStatus: 'failed',
+      });
+      throw error;
+    }
+    return { run: publicRun(run) };
+  });
+
+const stop = protectedProcedure.input(ConversationInputSchema).mutation(async ({ ctx, input }) => {
+  const conversation = await getConversation(ctx, input.conversationId);
+  const run = await selectActiveAgentRun(conversation.id);
+  if (run === null) return { run: null };
+  const repository = getConversationRepository(ctx, conversation);
+  const claims = makeRunClaims({
+    allowedTools: AgentToolNameSchema.array().parse(run.allowed_tools),
+    baseUrl: config.serverCanonicalHost ?? ctx.requestOrigin,
+    conversationId: conversation.id,
+    ctx,
+    expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+    jti: randomUUID(),
+    prompt: run.message,
+    purpose: 'control',
+    repository,
+    runId: run.id,
+  });
+  const token = await signAgentRunCapability(claims);
+  const stoppingRun = await requestAgentRunStop({ courseId: ctx.course.id, run });
+  await callWorker(`/v1/runs/${run.id}/cancel`, token, { method: 'POST' });
+  return { run: publicRun(stoppingRun) };
+});
+
+const deleteConversation = protectedProcedure
+  .input(ConversationInputSchema)
+  .mutation(async ({ ctx, input }) => {
+    const conversation = await getConversation(ctx, input.conversationId);
+    const run = await selectLatestAgentRun({
+      conversationId: conversation.id,
+      courseId: ctx.course.id,
+    });
+    if (run !== null) {
+      const deleteExpiresAt = new Date(Date.now() + 5 * 60 * 1000);
+      const token = await signAgentRunCapability(
+        makeRunClaims({
+          allowedTools: AgentToolNameSchema.array().parse(run.allowed_tools),
+          baseUrl: config.serverCanonicalHost ?? ctx.requestOrigin,
+          conversationId: conversation.id,
+          ctx,
+          expiresAt: deleteExpiresAt,
+          jti: randomUUID(),
+          prompt: run.message,
+          purpose: 'delete',
+          repository: getConversationRepository(ctx, conversation),
+          runId: run.id,
+        }),
+      );
+      await callWorker(`/v1/conversations/${conversation.id}`, token, { method: 'DELETE' });
+    }
+    const draftQuestionIds = await selectAgentDraftQuestionIds(conversation.id);
+    if (draftQuestionIds.length > 0) {
+      const result = await getCourseFilesClient().batchDeleteQuestions.mutate({
+        authn_user_id: ctx.authz_data.authn_user.id,
+        course_id: ctx.course.id,
+        has_course_permission_edit: true,
+        question_ids: draftQuestionIds,
+        user_id: ctx.authz_data.user.id,
+      });
+      if (result.status === 'error') {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to delete agent draft questions (${result.job_sequence_id}).`,
+        });
+      }
+    }
+    await tombstoneAgentConversation({ conversation });
+    return { deleted: true };
+  });
+
+const CheckpointSchema = z.looseObject({ head_sha: z.string().regex(/^[0-9a-f]{40}$/) });
+
+const publish = protectedProcedure
+  .input(ConversationInputSchema)
+  .mutation(async ({ ctx, input }) => {
+    const conversation = await getConversation(ctx, input.conversationId);
+    const run = await selectLatestAgentRun({
+      conversationId: conversation.id,
+      courseId: ctx.course.id,
+    });
+    if (run?.status !== 'completed') {
+      throw new TRPCError({ code: 'PRECONDITION_FAILED', message: 'A completed run is required.' });
+    }
+    const checkpoint = await selectLatestAgentCheckpoint(run.id);
+    if (checkpoint === null) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'No publishable checkpoint exists.',
+      });
+    }
+    const { head_sha: headSha } = CheckpointSchema.parse(checkpoint.data);
+    const repository = getConversationRepository(ctx, conversation);
+    const localFixturePublish = config.devMode && repository === undefined;
+    const localOnlyPublish = config.devMode && config.agentWorkerUrl === null;
+    if (repository === undefined && !localFixturePublish) {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'Course repository is unavailable.',
+      });
+    }
+    const operationId = `publish:${run.id}:${headSha}`;
+    const branch = `pl-agent/${conversation.id}-${headSha.slice(0, 12)}`;
+    const target = {
+      branch,
+      head_sha: headSha,
+      https_url: repository?.https_url ?? 'https://local.invalid/prairielearn/agent-fixture.git',
+    };
+    const request = PublishAgentRunRequestSchema.parse({ operation_id: operationId, target });
+    const begun = await beginAgentOperation({
+      courseId: ctx.course.id,
+      expectedRevision: headSha,
+      operationId,
+      request,
+      run,
+      toolName: 'publish',
+    });
+    let operation = begun.operation;
+    if (!begun.created) {
+      if (
+        operation.run_id !== run.id ||
+        operation.tool_name !== 'publish' ||
+        operation.expected_revision !== headSha ||
+        !isDeepStrictEqual(operation.request, request)
+      ) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'Publication operation ID was already used for another request.',
+        });
+      }
+      const event = await selectAgentOperationResultEvent(operationId);
+      if (operation.status === 'completed' && operation.response !== null && event !== null) {
+        return { event, operation, published: operation.response };
+      }
+      if (operation.status !== 'failed') {
+        throw new TRPCError({ code: 'CONFLICT', message: 'Publication is already in progress.' });
+      }
+      operation = await retryAgentOperation({ courseId: ctx.course.id, operation, run });
+    }
+    if (localOnlyPublish) {
+      const result = {
+        branch,
+        head_sha: headSha,
+        local: true,
+        operation_id: operationId,
+        receipt: `local-publish:${operationId}`,
+        repository: target.https_url,
+      };
+      const completed = await completeAgentOperation({
+        commitSha: headSha,
+        courseId: ctx.course.id,
+        operation,
+        result,
+        run,
+      });
+      return { ...completed, published: result };
+    }
+    const runClaims = makeRunClaims({
+      allowedTools: AgentToolNameSchema.array().parse(run.allowed_tools),
+      baseUrl: config.serverCanonicalHost ?? ctx.requestOrigin,
+      conversationId: conversation.id,
+      ctx,
+      expiresAt: new Date(Date.now() + Math.min(config.agentCapabilityTtlSeconds, 300) * 1000),
+      jti: randomUUID(),
+      prompt: run.message,
+      purpose: 'publish',
+      repository,
+      runId: run.id,
+    });
+    const token = await signAgentPublicationCapability({
+      ...runClaims,
+      operation_id: operationId,
+      purpose: 'publish',
+      target,
+    });
+    try {
+      const response = await callWorker(`/v1/runs/${run.id}/publish`, token, {
+        body: JSON.stringify(request),
+        method: 'POST',
+      });
+      const pushed = PublishAgentRunResponseSchema.parse(await response.json());
+      if (pushed.head_sha !== headSha || pushed.branch !== branch) {
+        throw new TRPCError({
+          code: 'BAD_GATEWAY',
+          message: 'Worker returned a mismatched publication.',
+        });
+      }
+      if (localFixturePublish) {
+        const result = {
+          ...pushed,
+          local: true,
+          receipt: `local-worker-publish:${operationId}`,
+          repository: target.https_url,
+        };
+        const completed = await completeAgentOperation({
+          commitSha: pushed.head_sha,
+          courseId: ctx.course.id,
+          operation,
+          result,
+          run,
+        });
+        return { ...completed, published: result };
+      }
+      if (repository === undefined) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Course repository is unavailable.',
+        });
+      }
+      const parsedRepository = parseGithubRepository(repository.https_url);
+      if (parsedRepository === null) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'GitHub repository is invalid.',
+        });
+      }
+      const pullRequest = await createDraftPullRequest({
+        base: repository.branch,
+        body: 'Draft changes created by the PrairieLearn course agent.',
+        expectedHeadSha: pushed.head_sha,
+        head: pushed.branch,
+        owner: parsedRepository.owner,
+        repo: parsedRepository.repo,
+        title: 'Course agent changes',
+      });
+      const result = { ...pushed, pull_request: pullRequest };
+      const completed = await completeAgentOperation({
+        commitSha: pushed.head_sha,
+        courseId: ctx.course.id,
+        operation,
+        result,
+        run,
+      });
+      return { ...completed, published: result };
+    } catch (publishError) {
+      await failAgentOperation({
+        courseId: ctx.course.id,
+        error: publishError instanceof Error ? publishError.message : 'Publication failed.',
+        operation,
+        run,
+      });
+      throw publishError;
+    }
+  });
+
+export const agentConversationsRouter = t.router({
+  create,
+  delete: deleteConversation,
+  get,
+  list,
+  listEvents,
+  publish,
+  startTurn,
+  stop,
+});

--- a/apps/prairielearn/src/trpc/course/init.ts
+++ b/apps/prairielearn/src/trpc/course/init.ts
@@ -6,7 +6,7 @@ import { extractPageContext } from '../../lib/client/page-context.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 import { appErrorFormatter } from '../app-errors.js';
 
-export function createContext({ res }: CreateExpressContextOptions) {
+export function createContext({ req, res }: CreateExpressContextOptions) {
   const locals = res.locals as ResLocalsForPage<'course'>;
   const { authz_data: authzData, course } = extractPageContext(locals, {
     pageType: 'course',
@@ -17,6 +17,7 @@ export function createContext({ res }: CreateExpressContextOptions) {
     course,
     authz_data: authzData,
     locals,
+    requestOrigin: `${req.protocol}://${req.get('host')}`,
   };
 }
 

--- a/apps/prairielearn/src/trpc/course/trpc.ts
+++ b/apps/prairielearn/src/trpc/course/trpc.ts
@@ -2,6 +2,7 @@ import { createExpressMiddleware } from '@trpc/server/adapters/express';
 
 import { handleTrpcError } from '../../lib/trpc.js';
 
+import { agentConversationsRouter } from './agent-conversations.js';
 import { assessmentModulesRouter } from './assessment-modules.js';
 import { courseStaffRouter } from './course-staff.js';
 import { createContext, t } from './init.js';
@@ -9,6 +10,7 @@ import { questionsRouter } from './questions.js';
 import { sharingRouter } from './sharing.js';
 
 const courseRouter = t.router({
+  agentConversations: agentConversationsRouter,
   assessmentModules: assessmentModulesRouter,
   courseStaff: courseStaffRouter,
   questions: questionsRouter,

--- a/database/enums/enum_agent_operation_status.pg
+++ b/database/enums/enum_agent_operation_status.pg
@@ -1,0 +1,1 @@
+pending, running, completed, failed, canceled

--- a/database/enums/enum_agent_run_status.pg
+++ b/database/enums/enum_agent_run_status.pg
@@ -1,0 +1,1 @@
+pending, running, stopping, completed, failed, canceled

--- a/database/tables/agent_artifacts.pg
+++ b/database/tables/agent_artifacts.pg
@@ -1,0 +1,23 @@
+columns
+    content_type: text
+    conversation_id: bigint not null
+    created_at: timestamp with time zone not null default now()
+    deleted_at: timestamp with time zone
+    id: bigint not null default nextval('agent_artifacts_id_seq'::regclass)
+    kind: text not null
+    metadata: jsonb not null default '{}'::jsonb
+    operation_id: bigint
+    run_id: bigint
+    sha256: text
+    size_bytes: bigint
+    storage_key: text not null
+
+indexes
+    agent_artifacts_pkey: PRIMARY KEY (id) USING btree (id)
+    agent_artifacts_storage_key_key: UNIQUE CONSTRAINT, btree (storage_key)
+    agent_artifacts_conversation_id_idx: USING btree (conversation_id) WHERE (deleted_at IS NULL)
+
+foreign-key constraints
+    agent_artifacts_conversation_id_fkey: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_artifacts_operation_id_fkey: FOREIGN KEY (operation_id) REFERENCES agent_operations(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_artifacts_run_id_fkey: FOREIGN KEY (run_id) REFERENCES agent_runs(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/agent_conversations.pg
+++ b/database/tables/agent_conversations.pg
@@ -1,0 +1,30 @@
+columns
+    authn_user_id: bigint
+    course_id: bigint not null
+    created_at: timestamp with time zone not null default now()
+    deleted_at: timestamp with time zone
+    id: bigint not null default nextval('agent_conversations_id_seq'::regclass)
+    repository_base_sha: text
+    repository_branch: text
+    repository_url: text
+    title: text
+    updated_at: timestamp with time zone not null default now()
+    user_id: bigint
+
+indexes
+    agent_conversations_pkey: PRIMARY KEY (id) USING btree (id)
+    agent_conversations_course_id_authn_user_id_idx: USING btree (course_id, authn_user_id) WHERE (deleted_at IS NULL)
+
+foreign-key constraints
+    agent_conversations_authn_user_id_fkey: FOREIGN KEY (authn_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_conversations_course_id_fkey: FOREIGN KEY (course_id) REFERENCES courses(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_conversations_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+
+check constraints
+    agent_conversations_check: CHECK ((((repository_url IS NULL) AND (repository_branch IS NULL) AND (repository_base_sha IS NULL)) OR ((repository_url IS NOT NULL) AND (repository_branch IS NOT NULL) AND (repository_base_sha IS NOT NULL))))
+
+referenced by
+    agent_draft_questions: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_artifacts: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_events: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_runs: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/agent_draft_questions.pg
+++ b/database/tables/agent_draft_questions.pg
@@ -1,0 +1,15 @@
+columns
+    conversation_id: bigint not null
+    created_at: timestamp with time zone not null default now()
+    id: bigint not null default nextval('agent_draft_questions_id_seq'::regclass)
+    question_id: bigint
+    requested_qid: text not null
+
+indexes
+    agent_draft_questions_pkey: PRIMARY KEY (id) USING btree (id)
+    agent_draft_questions_conversation_id_requested_qid_key: UNIQUE CONSTRAINT, btree (conversation_id, requested_qid)
+    agent_draft_questions_question_id_key: UNIQUE CONSTRAINT, btree (question_id)
+
+foreign-key constraints
+    agent_draft_questions_conversation_id_fkey: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_draft_questions_question_id_fkey: FOREIGN KEY (question_id) REFERENCES questions(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/agent_events.pg
+++ b/database/tables/agent_events.pg
@@ -1,0 +1,20 @@
+columns
+    conversation_id: bigint not null
+    created_at: timestamp with time zone not null default now()
+    data: jsonb not null default '{}'::jsonb
+    event_id: text not null
+    id: bigint not null default nextval('agent_events_id_seq'::regclass)
+    operation_id: text
+    run_id: bigint
+    sequence: bigint not null
+    type: text not null
+
+indexes
+    agent_events_pkey: PRIMARY KEY (id) USING btree (id)
+    agent_events_conversation_id_sequence_key: UNIQUE CONSTRAINT, btree (conversation_id, sequence)
+    agent_events_event_id_key: UNIQUE CONSTRAINT, btree (event_id)
+    agent_events_run_id_idx: USING btree (run_id, id)
+
+foreign-key constraints
+    agent_events_conversation_id_fkey: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_events_run_id_fkey: FOREIGN KEY (run_id) REFERENCES agent_runs(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/agent_operations.pg
+++ b/database/tables/agent_operations.pg
@@ -1,0 +1,27 @@
+columns
+    commit_sha: text
+    completed_at: timestamp with time zone
+    created_at: timestamp with time zone not null default now()
+    error: text
+    expected_revision: text
+    id: bigint not null default nextval('agent_operations_id_seq'::regclass)
+    job_sequence_id: bigint
+    operation_id: text not null
+    request: jsonb not null
+    response: jsonb
+    run_id: bigint not null
+    started_at: timestamp with time zone
+    status: enum_agent_operation_status not null default 'pending'::enum_agent_operation_status
+    tool_name: text not null
+
+indexes
+    agent_operations_pkey: PRIMARY KEY (id) USING btree (id)
+    agent_operations_operation_id_key: UNIQUE CONSTRAINT, btree (operation_id)
+    agent_operations_run_id_created_at_idx: USING btree (run_id, created_at)
+
+foreign-key constraints
+    agent_operations_job_sequence_id_fkey: FOREIGN KEY (job_sequence_id) REFERENCES job_sequences(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_operations_run_id_fkey: FOREIGN KEY (run_id) REFERENCES agent_runs(id) ON UPDATE CASCADE ON DELETE CASCADE
+
+referenced by
+    agent_artifacts: FOREIGN KEY (operation_id) REFERENCES agent_operations(id) ON UPDATE CASCADE ON DELETE SET NULL

--- a/database/tables/agent_runs.pg
+++ b/database/tables/agent_runs.pg
@@ -1,0 +1,33 @@
+columns
+    allowed_tools: ARRAY not null default ARRAY[]::text[]
+    authn_user_id: bigint
+    base_commit_sha: text
+    capability_expires_at: timestamp with time zone not null
+    capability_jti: uuid not null default gen_random_uuid()
+    claude_session_id: text
+    completed_at: timestamp with time zone
+    conversation_id: bigint not null
+    created_at: timestamp with time zone not null default now()
+    error: text
+    id: bigint not null default nextval('agent_runs_id_seq'::regclass)
+    message: text not null
+    started_at: timestamp with time zone
+    status: enum_agent_run_status not null default 'pending'::enum_agent_run_status
+    stop_requested_at: timestamp with time zone
+    user_id: bigint
+
+indexes
+    agent_runs_pkey: PRIMARY KEY (id) USING btree (id)
+    agent_runs_capability_jti_key: UNIQUE CONSTRAINT, btree (capability_jti)
+    agent_runs_conversation_id_created_at_idx: USING btree (conversation_id, created_at)
+    agent_runs_one_active_per_conversation_idx: UNIQUE, btree (conversation_id) WHERE (status = ANY (ARRAY['pending'::enum_agent_run_status, 'running'::enum_agent_run_status, 'stopping'::enum_agent_run_status]))
+
+foreign-key constraints
+    agent_runs_authn_user_id_fkey: FOREIGN KEY (authn_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_runs_conversation_id_fkey: FOREIGN KEY (conversation_id) REFERENCES agent_conversations(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_runs_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+
+referenced by
+    agent_artifacts: FOREIGN KEY (run_id) REFERENCES agent_runs(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_events: FOREIGN KEY (run_id) REFERENCES agent_runs(id) ON UPDATE CASCADE ON DELETE CASCADE
+    agent_operations: FOREIGN KEY (run_id) REFERENCES agent_runs(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/courses.pg
+++ b/database/tables/courses.pg
@@ -42,6 +42,7 @@ foreign-key constraints
     courses_sync_job_sequence_id_fkey: FOREIGN KEY (sync_job_sequence_id) REFERENCES job_sequences(id) ON UPDATE CASCADE ON DELETE SET NULL
 
 referenced by
+    agent_conversations: FOREIGN KEY (course_id) REFERENCES courses(id) ON UPDATE CASCADE ON DELETE CASCADE
     ai_grading_jobs: FOREIGN KEY (course_id) REFERENCES courses(id) ON UPDATE CASCADE ON DELETE CASCADE
     assessment_modules: FOREIGN KEY (course_id) REFERENCES courses(id) ON UPDATE CASCADE ON DELETE CASCADE
     assessment_sets: FOREIGN KEY (course_id) REFERENCES courses(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/job_sequences.pg
+++ b/database/tables/job_sequences.pg
@@ -34,6 +34,7 @@ foreign-key constraints
     job_sequences_user_id_fkey: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE
 
 referenced by
+    agent_operations: FOREIGN KEY (job_sequence_id) REFERENCES job_sequences(id) ON UPDATE CASCADE ON DELETE SET NULL
     ai_grading_jobs: FOREIGN KEY (job_sequence_id) REFERENCES job_sequences(id) ON UPDATE CASCADE ON DELETE SET NULL
     ai_question_generation_messages: FOREIGN KEY (job_sequence_id) REFERENCES job_sequences(id) ON UPDATE CASCADE ON DELETE SET NULL
     ai_question_generation_prompts: FOREIGN KEY (job_sequence_id) REFERENCES job_sequences(id) ON UPDATE CASCADE ON DELETE SET NULL

--- a/database/tables/questions.pg
+++ b/database/tables/questions.pg
@@ -55,6 +55,7 @@ foreign-key constraints
     questions_topic_id_fkey: FOREIGN KEY (topic_id) REFERENCES topics(id) ON UPDATE CASCADE ON DELETE SET NULL
 
 referenced by
+    agent_draft_questions: FOREIGN KEY (question_id) REFERENCES questions(id) ON UPDATE CASCADE ON DELETE CASCADE
     ai_question_generation_messages: FOREIGN KEY (question_id) REFERENCES questions(id) ON UPDATE CASCADE ON DELETE CASCADE
     ai_question_generation_prompts: FOREIGN KEY (question_id) REFERENCES questions(id) ON UPDATE CASCADE ON DELETE SET NULL
     assessment_questions: FOREIGN KEY (question_id) REFERENCES questions(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/database/tables/users.pg
+++ b/database/tables/users.pg
@@ -22,6 +22,10 @@ foreign-key constraints
     users_lti_course_instance_id_fkey: FOREIGN KEY (lti_course_instance_id) REFERENCES course_instances(id) ON UPDATE CASCADE ON DELETE SET NULL
 
 referenced by
+    agent_conversations: FOREIGN KEY (authn_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_conversations: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_runs: FOREIGN KEY (authn_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
+    agent_runs: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE SET NULL
     access_tokens: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE
     administrators: FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE
     ai_grading_credit_checkout_sessions: FOREIGN KEY (agent_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -244,6 +244,7 @@ export default [
     // We don't want to lint these files.
     'apps/prairielearn/v2-question-servers/*',
     'apps/prairielearn/public/*',
+    'apps/*/.wrangler/*',
     'apps/agent-worker/worker-configuration.d.ts',
 
     // Transpiled code

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -244,6 +244,7 @@ export default [
     // We don't want to lint these files.
     'apps/prairielearn/v2-question-servers/*',
     'apps/prairielearn/public/*',
+    'apps/agent-worker/worker-configuration.d.ts',
 
     // Transpiled code
     'apps/*/dist/*',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "capture-access-control-screenshots": "CAPTURE_SCREENSHOTS=1 pnpm --filter @prairielearn/prairielearn test:e2e src/tests/e2e/captureAccessControlScreenshots.spec.ts",
     "capture-onboarding-screenshots": "CAPTURE_SCREENSHOTS=1 pnpm --filter @prairielearn/prairielearn test:e2e captureOnboardingScreenshots",
     "dev": "pnpm --filter @prairielearn/prairielearn dev",
+    "dev-agent": "node scripts/agent/dev.mjs",
     "dev-agent-worker": "pnpm --filter @prairielearn/agent-worker dev",
     "dev-bun": "pnpm --filter @prairielearn/prairielearn dev:bun",
     "dev-vite": "pnpm --filter @prairielearn/prairielearn dev:vite",
@@ -38,6 +39,7 @@
     "start": "pnpm --filter @prairielearn/prairielearn start",
     "start-workspace-host": "pnpm --filter @prairielearn/workspace-host start",
     "test": "vitest run --coverage",
+    "test-agent": "node scripts/agent/test.mjs",
     "version": "changeset version && pnpm install --no-frozen-lockfile --lockfile-only"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "capture-access-control-screenshots": "CAPTURE_SCREENSHOTS=1 pnpm --filter @prairielearn/prairielearn test:e2e src/tests/e2e/captureAccessControlScreenshots.spec.ts",
     "capture-onboarding-screenshots": "CAPTURE_SCREENSHOTS=1 pnpm --filter @prairielearn/prairielearn test:e2e captureOnboardingScreenshots",
     "dev": "pnpm --filter @prairielearn/prairielearn dev",
+    "dev-agent-worker": "pnpm --filter @prairielearn/agent-worker dev",
     "dev-bun": "pnpm --filter @prairielearn/prairielearn dev:bun",
     "dev-vite": "pnpm --filter @prairielearn/prairielearn dev:vite",
     "dev-workspace-host": "pnpm --filter @prairielearn/workspace-host dev",

--- a/packages/agent-protocol/package.json
+++ b/packages/agent-protocol/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@prairielearn/agent-protocol",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=24.0.0"
+  },
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsgo",
+    "test": "vitest run --coverage"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@prairielearn/tsconfig": "workspace:^",
+    "@types/node": "^24.13.3",
+    "@typescript/native-preview": "beta",
+    "@vitest/coverage-v8": "^4.1.10",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/agent-protocol/src/index.test.ts
+++ b/packages/agent-protocol/src/index.test.ts
@@ -1,0 +1,139 @@
+import { assert, describe, it } from 'vitest';
+
+import {
+  AgentPublicationCapabilityClaimsSchema,
+  AgentRunCapabilityClaimsSchema,
+  AgentToolRequestSchema,
+  StartAgentRunRequestSchema,
+} from './index.js';
+
+describe('StartAgentRunRequestSchema', () => {
+  it('parses a deterministic local run', () => {
+    assert.deepEqual(
+      StartAgentRunRequestSchema.parse({
+        conversation_id: 'conversation-1',
+        run_id: 'run-1',
+        course_id: '1',
+        prompt: 'Create a question',
+        prairielearn_base_url: 'http://host.docker.internal:3000',
+        harness: 'deterministic',
+      }),
+      {
+        conversation_id: 'conversation-1',
+        run_id: 'run-1',
+        course_id: '1',
+        prompt: 'Create a question',
+        prairielearn_base_url: 'http://host.docker.internal:3000',
+        harness: 'deterministic',
+      },
+    );
+  });
+
+  it('rejects non-HTTPS repositories', () => {
+    assert.throws(() =>
+      StartAgentRunRequestSchema.parse({
+        conversation_id: 'conversation-1',
+        run_id: 'run-1',
+        course_id: '1',
+        prompt: 'Create a question',
+        prairielearn_base_url: 'http://localhost:3000',
+        harness: 'claude',
+        repository: {
+          https_url: 'http://github.com/PrairieLearn/test.git',
+          branch: 'master',
+          base_sha: 'a'.repeat(40),
+        },
+      }),
+    );
+  });
+});
+
+describe('AgentRunCapabilityClaimsSchema', () => {
+  it('requires bounded identity and tool claims', () => {
+    assert.equal(
+      AgentRunCapabilityClaimsSchema.parse({
+        iss: 'prairielearn',
+        aud: ['prairielearn-agent-worker', 'prairielearn-agent-api'],
+        sub: '7',
+        iat: 1,
+        exp: 2,
+        jti: 'token-1',
+        run_id: 'run-1',
+        conversation_id: 'conversation-1',
+        course_id: '1',
+        authn_user_id: '7',
+        user_id: '7',
+        allowed_tools: ['list_entities', 'render_question'],
+        purpose: 'run',
+        prompt_sha256: 'a'.repeat(64),
+        prairielearn_base_url: 'https://prairielearn.example',
+        harness: 'deterministic',
+      }).run_id,
+      'run-1',
+    );
+  });
+
+  it('rejects an invalid purpose, audience, or prompt hash', () => {
+    const claims = {
+      iss: 'prairielearn',
+      aud: ['prairielearn-agent-worker', 'prairielearn-agent-api'],
+      sub: '7',
+      iat: 1,
+      exp: 2,
+      jti: 'token-1',
+      run_id: 'run-1',
+      conversation_id: 'conversation-1',
+      course_id: '1',
+      authn_user_id: '7',
+      user_id: '7',
+      allowed_tools: [],
+      prairielearn_base_url: 'https://prairielearn.example',
+      harness: 'deterministic',
+      purpose: 'run',
+      prompt_sha256: 'a'.repeat(64),
+    };
+    assert.throws(() => AgentRunCapabilityClaimsSchema.parse({ ...claims, purpose: 'admin' }));
+    assert.throws(() => AgentRunCapabilityClaimsSchema.parse({ ...claims, aud: 'other-service' }));
+    assert.throws(() =>
+      AgentRunCapabilityClaimsSchema.parse({ ...claims, prompt_sha256: 'short' }),
+    );
+  });
+});
+
+describe('AgentPublicationCapabilityClaimsSchema', () => {
+  it('binds publication to an operation and exact Git target', () => {
+    assert.equal(
+      AgentPublicationCapabilityClaimsSchema.parse({
+        iss: 'prairielearn',
+        aud: 'prairielearn-agent-worker',
+        sub: '7',
+        iat: 1,
+        exp: 2,
+        jti: 'publication-token-1',
+        run_id: 'run-1',
+        conversation_id: 'conversation-1',
+        course_id: '1',
+        authn_user_id: '7',
+        user_id: '7',
+        allowed_tools: [],
+        prairielearn_base_url: 'https://prairielearn.example',
+        harness: 'deterministic',
+        purpose: 'publish',
+        prompt_sha256: 'b'.repeat(64),
+        operation_id: 'operation-1',
+        target: {
+          https_url: 'https://github.com/PrairieLearn/test.git',
+          branch: 'pl-agent/course-1/run-1',
+          head_sha: 'a'.repeat(40),
+        },
+      }).target.branch,
+      'pl-agent/course-1/run-1',
+    );
+  });
+});
+
+describe('AgentToolRequestSchema', () => {
+  it('rejects an empty operation id', () => {
+    assert.throws(() => AgentToolRequestSchema.parse({ operation_id: '', input: {} }));
+  });
+});

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -1,0 +1,150 @@
+import { z } from 'zod';
+
+const IdSchema = z.string().min(1).max(128);
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+export const AgentHarnessSchema = z.enum(['deterministic', 'claude']);
+export type AgentHarness = z.infer<typeof AgentHarnessSchema>;
+
+export const AgentRepositorySchema = z.object({
+  https_url: z.url().refine((url) => url.startsWith('https://'), 'Repository URL must use HTTPS'),
+  branch: z.string().min(1).max(255),
+  base_sha: z.string().regex(/^[0-9a-f]{40}$/),
+});
+export type AgentRepository = z.infer<typeof AgentRepositorySchema>;
+
+export const AgentToolNameSchema = z.enum([
+  'list_entities',
+  'read_course_file',
+  'query_course_data',
+  'render_question',
+  'get_job_output',
+]);
+export type AgentToolName = z.infer<typeof AgentToolNameSchema>;
+
+export const AgentEventTypeSchema = z.enum([
+  'run_started',
+  'user_message',
+  'assistant_message_delta',
+  'assistant_message',
+  'tool_call',
+  'tool_result',
+  'checkpoint',
+  'approval_required',
+  'run_cancelled',
+  'run_failed',
+  'run_completed',
+]);
+export type AgentEventType = z.infer<typeof AgentEventTypeSchema>;
+
+export const AgentRunCapabilityClaimsSchema = z.object({
+  iss: z.literal('prairielearn'),
+  aud: z.union([
+    z.enum(['prairielearn-agent-worker', 'prairielearn-agent-api']),
+    z.array(z.enum(['prairielearn-agent-worker', 'prairielearn-agent-api'])).min(1),
+  ]),
+  sub: IdSchema,
+  iat: z.number().int().nonnegative(),
+  exp: z.number().int().positive(),
+  jti: IdSchema,
+  run_id: IdSchema,
+  conversation_id: IdSchema,
+  course_id: IdSchema,
+  authn_user_id: IdSchema,
+  user_id: IdSchema,
+  allowed_tools: z.array(AgentToolNameSchema),
+  purpose: z.enum(['run', 'control', 'delete', 'publish']),
+  prompt_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+  prairielearn_base_url: z.url(),
+  harness: AgentHarnessSchema,
+  repository: AgentRepositorySchema.optional(),
+});
+export type AgentRunCapabilityClaims = z.infer<typeof AgentRunCapabilityClaimsSchema>;
+
+export const AgentPublicationTargetSchema = z.object({
+  https_url: z.url().refine((url) => url.startsWith('https://'), 'Repository URL must use HTTPS'),
+  branch: z.string().min(1).max(255),
+  head_sha: z.string().regex(/^[0-9a-f]{40}$/),
+});
+export type AgentPublicationTarget = z.infer<typeof AgentPublicationTargetSchema>;
+
+export const AgentPublicationCapabilityClaimsSchema = AgentRunCapabilityClaimsSchema.extend({
+  purpose: z.literal('publish'),
+  operation_id: IdSchema,
+  target: AgentPublicationTargetSchema,
+});
+export type AgentPublicationCapabilityClaims = z.infer<
+  typeof AgentPublicationCapabilityClaimsSchema
+>;
+
+export const StartAgentRunRequestSchema = z.object({
+  conversation_id: IdSchema,
+  run_id: IdSchema,
+  course_id: IdSchema,
+  prompt: z.string().min(1).max(100_000),
+  prairielearn_base_url: z.url(),
+  harness: AgentHarnessSchema,
+  repository: AgentRepositorySchema.optional(),
+});
+export type StartAgentRunRequest = z.infer<typeof StartAgentRunRequestSchema>;
+
+export const AgentRunStatusSchema = z.enum([
+  'queued',
+  'running',
+  'cancelling',
+  'cancelled',
+  'failed',
+  'completed',
+]);
+export type AgentRunStatus = z.infer<typeof AgentRunStatusSchema>;
+
+export const AgentRunStatusResponseSchema = z.object({
+  conversation_id: IdSchema,
+  run_id: IdSchema,
+  status: AgentRunStatusSchema,
+  sandbox_id: z.string().optional(),
+  checkpoint_key: z.string().optional(),
+  error: z.string().optional(),
+});
+export type AgentRunStatusResponse = z.infer<typeof AgentRunStatusResponseSchema>;
+
+export const AgentEventInputSchema = z.object({
+  event_id: IdSchema,
+  type: AgentEventTypeSchema,
+  data: JsonObjectSchema,
+  operation_id: IdSchema.optional(),
+});
+export type AgentEventInput = z.infer<typeof AgentEventInputSchema>;
+
+export const AppendAgentEventsRequestSchema = z.object({
+  events: z.array(AgentEventInputSchema).min(1).max(100),
+});
+export type AppendAgentEventsRequest = z.infer<typeof AppendAgentEventsRequestSchema>;
+
+export const AgentToolRequestSchema = z.object({
+  operation_id: IdSchema,
+  input: JsonObjectSchema,
+  expected_revision: z.string().optional(),
+});
+export type AgentToolRequest = z.infer<typeof AgentToolRequestSchema>;
+
+export const AgentToolResponseSchema = z.object({
+  operation_id: IdSchema,
+  event_id: IdSchema,
+  result: JsonObjectSchema,
+  checkpoint_revision: z.string().optional(),
+});
+export type AgentToolResponse = z.infer<typeof AgentToolResponseSchema>;
+
+export const PublishAgentRunRequestSchema = z.object({
+  operation_id: IdSchema,
+  target: AgentPublicationTargetSchema,
+});
+export type PublishAgentRunRequest = z.infer<typeof PublishAgentRunRequestSchema>;
+
+export const PublishAgentRunResponseSchema = z.object({
+  operation_id: IdSchema,
+  branch: z.string().min(1).max(255),
+  head_sha: z.string().regex(/^[0-9a-f]{40}$/),
+});
+export type PublishAgentRunResponse = z.infer<typeof PublishAgentRunResponseSchema>;

--- a/packages/agent-protocol/tsconfig.json
+++ b/packages/agent-protocol/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@prairielearn/tsconfig/tsconfig.package-node.json"
+}

--- a/packages/agent-protocol/vitest.config.ts
+++ b/packages/agent-protocol/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    dir: `${import.meta.dirname}/src`,
+    coverage: {
+      reporter: ['html', 'text-summary', 'cobertura'],
+      include: ['src/**/*.{ts,tsx}'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,12 @@ importers:
       '@cloudflare/sandbox':
         specifier: 0.13.0-next.738.2
         version: 0.13.0-next.738.2
+      '@prairielearn/agent-protocol':
+        specifier: workspace:^
+        version: link:../../packages/agent-protocol
+      jose:
+        specifier: ^6.2.8
+        version: 6.2.8
     devDependencies:
       '@prairielearn/tsconfig':
         specifier: workspace:^
@@ -544,6 +550,9 @@ importers:
       '@panzoom/panzoom':
         specifier: ^4.6.2
         version: 4.6.2
+      '@prairielearn/agent-protocol':
+        specifier: workspace:^
+        version: link:../../packages/agent-protocol
       '@prairielearn/aws':
         specifier: workspace:^
         version: link:../../packages/aws
@@ -1551,6 +1560,28 @@ importers:
         specifier: beta
         version: 7.0.0-dev.20260421.2
 
+  packages/agent-protocol:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@prairielearn/tsconfig':
+        specifier: workspace:^
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      '@typescript/native-preview':
+        specifier: beta
+        version: 7.0.0-dev.20260421.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
+
   packages/aws:
     dependencies:
       '@aws-sdk/client-auto-scaling':
@@ -1649,7 +1680,7 @@ importers:
         version: link:../sentry
       ioredis:
         specifier: ^6.0.0
-        version: 6.0.0(supports-color@7.2.0)
+        version: 6.0.0(supports-color@10.2.2)
       lru-cache:
         specifier: ^11.5.2
         version: 11.5.2
@@ -2873,7 +2904,7 @@ importers:
         version: link:../zod
       '@socket.io/redis-emitter':
         specifier: ^5.1.0
-        version: 5.1.0(supports-color@7.2.0)
+        version: 5.1.0(supports-color@10.2.2)
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
@@ -13740,14 +13771,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@socket.io/redis-emitter@5.1.0(supports-color@7.2.0)':
-    dependencies:
-      debug: 4.3.7(supports-color@7.2.0)
-      notepack.io: 3.0.1
-      socket.io-parser: 4.2.7(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@speed-highlight/core@1.2.24': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -17108,17 +17131,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ioredis@6.0.0(supports-color@7.2.0):
-    dependencies:
-      '@ioredis/commands': 2.0.0
-      cluster-key-slot: 1.1.1
-      debug: 4.4.3(supports-color@7.2.0)
-      denque: 2.1.0
-      redis-errors: 1.2.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
@@ -19505,13 +19517,6 @@ snapshots:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  socket.io-parser@4.2.7(supports-color@7.2.0):
-    dependencies:
-      '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,34 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  apps/agent-worker:
+    dependencies:
+      '@cloudflare/sandbox':
+        specifier: 0.13.0-next.738.2
+        version: 0.13.0-next.738.2
+    devDependencies:
+      '@prairielearn/tsconfig':
+        specifier: workspace:^
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      '@typescript/native-preview':
+        specifier: beta
+        version: 7.0.0-dev.20260421.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
+      typescript-cp:
+        specifier: ^0.1.11
+        version: 0.1.11(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
+      wrangler:
+        specifier: ^4.120.0
+        version: 4.123.0
+
   apps/grader-host:
     dependencies:
       '@aws-sdk/client-auto-scaling':
@@ -617,7 +645,7 @@ importers:
         version: link:../../packages/signed-token
       '@prairielearn/sketchresponse':
         specifier: ^0.1.4
-        version: 0.1.4(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
+        version: 0.1.4(stylelint@16.26.1(supports-color@10.2.2)(typescript@6.0.3))
       '@prairielearn/tree-sitter-htmlmustache':
         specifier: ^1.4.3
         version: 1.4.3(node-gyp-build@4.8.4)(prettier@3.8.5)
@@ -638,10 +666,10 @@ importers:
         version: link:../../packages/zod
       '@pyroscope/nodejs':
         specifier: ^0.4.13
-        version: 0.4.13(express@4.22.2(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 0.4.13(express@4.22.2(supports-color@10.2.2))(supports-color@7.2.0)
       '@socket.io/redis-adapter':
         specifier: ^8.3.0
-        version: 8.3.0(socket.io-adapter@2.5.8(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 8.3.0(socket.io-adapter@2.5.8(supports-color@10.2.2))(supports-color@7.2.0)
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
         version: 8.19.4
@@ -782,7 +810,7 @@ importers:
         version: 1.2.0
       body-parser:
         specifier: ^1.20.6 <2
-        version: 1.20.6(supports-color@7.2.0)
+        version: 1.20.6(supports-color@10.2.2)
       bootstrap:
         specifier: ^5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -830,7 +858,7 @@ importers:
         version: 1.1.2
       dockerode:
         specifier: ^5.0.1
-        version: 5.0.1(supports-color@7.2.0)
+        version: 5.0.1(supports-color@10.2.2)
       domhandler:
         specifier: ^6.0.1
         version: 6.0.1
@@ -854,7 +882,7 @@ importers:
         version: 9.6.1
       express:
         specifier: ^4.22.2 <5
-        version: 4.22.2(supports-color@7.2.0)
+        version: 4.22.2(supports-color@10.2.2)
       express-async-handler:
         specifier: ^1.2.0
         version: 1.2.0
@@ -887,7 +915,7 @@ importers:
         version: 3.9.0
       google-auth-library:
         specifier: ^10.9.1
-        version: 10.9.1(supports-color@7.2.0)
+        version: 10.9.1(supports-color@10.2.2)
       he:
         specifier: ^1.2.0
         version: 1.2.0
@@ -917,7 +945,7 @@ importers:
         version: 2.1.0
       ioredis:
         specifier: ^6.0.0
-        version: 6.0.0(supports-color@7.2.0)
+        version: 6.0.0(supports-color@10.2.2)
       isbinaryfile:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1058,13 +1086,13 @@ importers:
         version: 7.84.0(react@19.2.8)
       react-markdown:
         specifier: ^10.1.0
-        version: 10.1.0(@types/react@19.2.18)(react@19.2.8)(supports-color@7.2.0)
+        version: 10.1.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2)
       remark-gfm:
         specifier: ^4.0.1
-        version: 4.0.1(supports-color@7.2.0)
+        version: 4.0.1(supports-color@10.2.2)
       remark-parse:
         specifier: ^11.0.0
-        version: 11.0.0(supports-color@7.2.0)
+        version: 11.0.0(supports-color@10.2.2)
       remark-stringify:
         specifier: ^11.0.0
         version: 11.0.0
@@ -1103,13 +1131,13 @@ importers:
         version: 1.7.1
       socket.io:
         specifier: ^4.8.3
-        version: 4.8.3(supports-color@7.2.0)
+        version: 4.8.3(supports-color@10.2.2)
       socket.io-adapter:
         specifier: ^2.5.8
-        version: 2.5.8(supports-color@7.2.0)
+        version: 2.5.8(supports-color@10.2.2)
       socket.io-client:
         specifier: ^4.8.3
-        version: 4.8.3(supports-color@7.2.0)
+        version: 4.8.3(supports-color@10.2.2)
       streamifier:
         specifier: ^0.1.1
         version: 0.1.1
@@ -1176,7 +1204,7 @@ importers:
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
-        version: 1.30.0(supports-color@7.2.0)(zod@4.4.3)
+        version: 1.30.0(supports-color@10.2.2)(zod@4.4.3)
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
@@ -1401,7 +1429,7 @@ importers:
         version: link:../../packages/workspace-utils
       '@socket.io/redis-emitter':
         specifier: ^5.1.0
-        version: 5.1.0(supports-color@7.2.0)
+        version: 5.1.0(supports-color@10.2.2)
       archiver:
         specifier: ^8.0.0
         version: 8.0.0
@@ -1413,22 +1441,22 @@ importers:
         version: 0.5.0
       body-parser:
         specifier: ^1.20.6 <2
-        version: 1.20.6(supports-color@7.2.0)
+        version: 1.20.6(supports-color@10.2.2)
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@7.2.0)
       dockerode:
         specifier: ^5.0.1
-        version: 5.0.1(supports-color@7.2.0)
+        version: 5.0.1(supports-color@10.2.2)
       express:
         specifier: ^4.22.2 <5
-        version: 4.22.2(supports-color@7.2.0)
+        version: 4.22.2(supports-color@10.2.2)
       express-async-handler:
         specifier: ^1.2.0
         version: 1.2.0
       ioredis:
         specifier: ^6.0.0
-        version: 6.0.0(supports-color@7.2.0)
+        version: 6.0.0(supports-color@10.2.2)
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
@@ -1649,7 +1677,7 @@ importers:
         version: 0.28.1
       express-static-gzip:
         specifier: ^2.2.0 <3
-        version: 2.2.0(supports-color@7.2.0)
+        version: 2.2.0(supports-color@10.2.2)
       fs-extra:
         specifier: ^11.4.0
         version: 11.4.0
@@ -1683,7 +1711,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       express:
         specifier: ^4.22.2 <5
-        version: 4.22.2(supports-color@7.2.0)
+        version: 4.22.2(supports-color@10.2.2)
       get-port:
         specifier: ^7.2.0
         version: 7.2.0
@@ -1853,58 +1881,58 @@ importers:
     dependencies:
       '@eslint-react/eslint-plugin':
         specifier: ^5.18.1
-        version: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@eslint/config-helpers':
         specifier: ^0.6.0
         version: 0.6.0
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+        version: 10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@prairielearn/eslint-plugin':
         specifier: workspace:^
         version: link:../eslint-plugin-prairielearn
       '@stylistic/eslint-plugin':
         specifier: ^5.10.0
-        version: 5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+        version: 5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@tanstack/eslint-plugin-query':
         specifier: ^5.101.4
-        version: 5.101.4(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 5.101.4(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/utils':
         specifier: ^8.66.0
-        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@vitest/eslint-plugin':
         specifier: ^1.6.26
-        version: 1.6.26(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)(vitest@4.1.10)
+        version: 1.6.26(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)
       eslint:
         specifier: ^10.0.0
-        version: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+        version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-import-resolver-typescript:
         specifier: ^4.4.5
-        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0)
       eslint-plugin-import-x:
         specifier: ^4.17.1
-        version: 4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0)
       eslint-plugin-jsdoc:
         specifier: ^63.3.3
-        version: 63.3.3(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 63.3.3(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0)
       eslint-plugin-jsx-a11y-x:
         specifier: ^0.2.0
-        version: 0.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+        version: 0.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-no-floating-promise:
         specifier: ^2.0.0
         version: 2.0.0
       eslint-plugin-perfectionist:
         specifier: ^5.10.0
-        version: 5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: ^0.11.1
-        version: 0.11.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+        version: 0.11.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-unicorn:
         specifier: ^73.0.0
-        version: 73.0.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+        version: 73.0.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-you-dont-need-lodash-underscore:
         specifier: ^6.14.0
         version: 6.14.0
@@ -1916,7 +1944,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.66.0
-        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
     devDependencies:
       '@prairielearn/tsconfig':
         specifier: workspace:^
@@ -1932,10 +1960,10 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.66.0
-        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint:
         specifier: ^10.0.0
-        version: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+        version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1951,7 +1979,7 @@ importers:
         version: 24.13.3
       '@typescript-eslint/rule-tester':
         specifier: ^8.66.0
-        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+        version: 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types':
         specifier: ^8.66.0
         version: 8.66.0
@@ -1984,7 +2012,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       express:
         specifier: ^4.22.2 <5
-        version: 4.22.2(supports-color@7.2.0)
+        version: 4.22.2(supports-color@10.2.2)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
@@ -2265,28 +2293,28 @@ importers:
         version: 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-aws-sdk':
         specifier: ^0.76.0
-        version: 0.76.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.76.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-connect':
         specifier: ^0.64.0
-        version: 0.64.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-dns':
         specifier: ^0.64.0
-        version: 0.64.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-express':
         specifier: ^0.69.0
-        version: 0.69.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-http':
         specifier: ^0.221.0
-        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-ioredis':
         specifier: ^0.69.0
-        version: 0.69.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-pg':
         specifier: ^0.73.0
-        version: 0.73.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/instrumentation-redis':
         specifier: ^0.69.0
-        version: 0.69.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/resource-detector-aws':
         specifier: ^2.21.0
         version: 2.21.0(@opentelemetry/api@1.9.1)
@@ -2298,7 +2326,7 @@ importers:
         version: 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node':
         specifier: ^0.221.0
-        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+        version: 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.10.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
@@ -2594,7 +2622,7 @@ importers:
         version: 10.69.0
       '@sentry/node-core':
         specifier: ^10.69.0
-        version: 10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+        version: 10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
       execa:
         specifier: ^9.6.1
         version: 9.6.1
@@ -2659,7 +2687,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       express:
         specifier: ^4.22.2 <5
-        version: 4.22.2(supports-color@7.2.0)
+        version: 4.22.2(supports-color@10.2.2)
       fetch-cookie:
         specifier: ^3.2.0
         version: 3.2.0
@@ -2854,7 +2882,7 @@ importers:
         version: 11.0.22
       socket.io:
         specifier: ^4.8.3
-        version: 4.8.3(supports-color@7.2.0)
+        version: 4.8.3(supports-color@10.2.2)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3266,6 +3294,66 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
+  '@cloudflare/containers@0.3.7':
+    resolution: {integrity: sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==}
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/sandbox@0.13.0-next.738.2':
+    resolution: {integrity: sha512-fD5rANNn4L6rHHsxaOi4gME31VBSF9pdvyaeQv+4OBhYThfpgonHvqcLC1lUHmV4R6OXUDt+NVJOzK2d9CNMxw==}
+    peerDependencies:
+      '@openai/agents': ^0.3.3
+      '@opencode-ai/sdk': ^1.1.40
+      '@xterm/xterm': '>=5.0.0'
+    peerDependenciesMeta:
+      '@openai/agents':
+        optional: true
+      '@opencode-ai/sdk':
+        optional: true
+      '@xterm/xterm':
+        optional: true
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    resolution: {integrity: sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    resolution: {integrity: sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    resolution: {integrity: sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    resolution: {integrity: sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    resolution: {integrity: sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
@@ -3306,6 +3394,10 @@ packages:
 
   '@cropper/utils@2.1.1':
     resolution: {integrity: sha512-0eQs08WyQUNFMfU3ieE091dEQkrW0YdgZ3n6Thnk1EUQv45ypfiL+MevHwr7UzNnUlqUYR2FNSCgE6qBxK0sFw==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
@@ -3783,10 +3875,22 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-arm64@0.35.3':
     resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.35.3':
@@ -3795,14 +3899,29 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-freebsd-wasm32@0.35.3':
     resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
     engines: {node: '>=20.9.0'}
     os: [freebsd]
 
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.3.2':
     resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.3.2':
@@ -3810,9 +3929,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-arm64@1.3.2':
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -3822,9 +3953,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -3834,9 +3977,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -3846,9 +4001,21 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -3858,10 +4025,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
     os: [linux]
     libc: [glibc]
 
@@ -3872,10 +4053,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
@@ -3886,10 +4081,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
     os: [linux]
     libc: [glibc]
 
@@ -3900,10 +4109,24 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
     os: [linux]
     libc: [musl]
 
@@ -3914,14 +4137,29 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
     engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
 
   '@img/sharp-webcontainers-wasm32@0.35.3':
     resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
     engines: {node: '>=20.9.0'}
     cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
 
   '@img/sharp-win32-arm64@0.35.3':
     resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
@@ -3929,10 +4167,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.35.3':
     resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
     engines: {node: ^20.9.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.35.3':
@@ -3972,6 +4222,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -4693,6 +4946,15 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@postgres-language-server/cli-aarch64-apple-darwin@0.25.7':
     resolution: {integrity: sha512-AxZZoj99iWGvQQspHB/qO4TaiTZjmZlZuqcltIO8zu9fpm5HUyTcmM4i+eP0TI6MDyBnLUxs+qWB71Cn1REkbw==}
     engines: {node: '>=20'}
@@ -5007,6 +5269,10 @@ packages:
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
     engines: {node: '>=18'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -5057,6 +5323,9 @@ packages:
 
   '@socket.io/redis-emitter@5.1.0':
     resolution: {integrity: sha512-QQUFPBq6JX7JIuM/X1811ymKlAfwufnQ8w6G2/59Jaqp09hdF1GJ/+e8eo/XdcmT0TqkvcSa2TT98ggTXa5QYw==}
+
+  '@speed-highlight/core@1.2.24':
+    resolution: {integrity: sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6215,6 +6484,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
+
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
@@ -6334,6 +6606,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   blocked-at@1.2.0:
     resolution: {integrity: sha512-Ba9yhK4KcFrgqEPgsU0qVGiMimf+VrD9QJo9pgwjg4yl0GXwgOJS8IRx2rPepQjalrmUdGTqX47bSuJLUMLX7w==}
@@ -6465,6 +6740,9 @@ packages:
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  capnweb@0.8.0:
+    resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -6692,6 +6970,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cookies@0.9.1:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
@@ -7180,6 +7462,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -8841,6 +9126,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  miniflare@5.20260811.1-alpha:
+    resolution: {integrity: sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
@@ -9909,6 +10198,10 @@ packages:
     resolution: {integrity: sha512-JfVoxf4FxQI5qpsPbkHhZo+n6N9YMJobyl4oGEUBb/31oQYlgTjkXQD8PBiafS2UbWoxrTO0Z5PJUBXEPAG1Zw==}
     engines: {node: '>=16.0.0'}
 
+  sharp@0.35.2:
+    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+    engines: {node: '>=20.9.0'}
+
   sharp@0.35.3:
     resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
     engines: {node: '>=20.9.0'}
@@ -10172,6 +10465,10 @@ packages:
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -10455,6 +10752,9 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -10736,6 +11036,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260811.1:
+    resolution: {integrity: sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.123.0:
+    resolution: {integrity: sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260811.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -10746,6 +11061,18 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
@@ -10879,6 +11206,12 @@ packages:
   yoctocolors@2.2.0:
     resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zip-stream@7.0.5:
     resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
@@ -11322,12 +11655,12 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@7.2.0)':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
@@ -11360,19 +11693,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11398,6 +11731,18 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8(supports-color@10.2.2)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.29.8(supports-color@7.2.0)':
     dependencies:
@@ -11554,6 +11899,38 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
+  '@cloudflare/containers@0.3.7': {}
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/sandbox@0.13.0-next.738.2':
+    dependencies:
+      '@cloudflare/containers': 0.3.7
+      aws4fetch: 1.0.20
+      capnweb: 0.8.0
+      hono: 4.13.2
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260811.1
+
+  '@cloudflare/workerd-darwin-64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260811.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260811.1':
+    optional: true
+
   '@colors/colors@1.6.0': {}
 
   '@cortex-js/compute-engine@0.55.6':
@@ -11627,6 +12004,10 @@ snapshots:
       '@cropper/element-viewer': 2.1.1
 
   '@cropper/utils@2.1.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -11828,6 +12209,11 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))':
+    dependencies:
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))':
     dependencies:
       eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
@@ -11835,89 +12221,97 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint-react/ast@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/ast@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       string-ts: 2.3.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/core@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/core@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint-plugin@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/eslint-plugin@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
-      eslint-plugin-react-dom: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint-plugin-react-jsx: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint-plugin-react-naming-convention: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint-plugin-react-rsc: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint-plugin-react-web-api: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint-plugin-react-x: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-plugin-react-dom: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint-plugin-react-jsx: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint-plugin-react-naming-convention: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint-plugin-react-rsc: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint-plugin-react-web-api: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint-plugin-react-x: 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/eslint@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/eslint@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/jsx@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/jsx@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/shared@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/shared@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/var@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@eslint-react/var@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-array@0.23.5(supports-color@10.2.2)':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3(supports-color@10.2.2)
+      minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
 
@@ -11950,9 +12344,9 @@ snapshots:
       mdn-data: 2.29.0
       source-map-js: 1.2.1
 
-  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))':
+  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))':
     optionalDependencies:
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -12065,9 +12459,19 @@ snapshots:
 
   '@img/colour@1.1.0': {}
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
     optional: true
 
   '@img/sharp-darwin-x64@0.35.3':
@@ -12075,39 +12479,79 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
   '@img/sharp-freebsd-wasm32@0.35.3':
     dependencies:
       '@img/sharp-wasm32': 0.35.3
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
     optional: true
 
   '@img/sharp-linux-arm64@0.35.3':
@@ -12115,9 +12559,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
+    optional: true
+
   '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
     optional: true
 
   '@img/sharp-linux-ppc64@0.35.3':
@@ -12125,9 +12579,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
     optional: true
 
   '@img/sharp-linux-s390x@0.35.3':
@@ -12135,9 +12599,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
@@ -12145,9 +12619,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-wasm32@0.35.3':
@@ -12155,15 +12639,29 @@ snapshots:
       '@emnapi/runtime': 1.11.2
     optional: true
 
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
   '@img/sharp-webcontainers-wasm32@0.35.3':
     dependencies:
       '@img/sharp-wasm32': 0.35.3
     optional: true
 
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
   '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
   '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@img/sharp-win32-x64@0.35.3':
@@ -12202,6 +12700,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12247,7 +12750,7 @@ snapshots:
 
   '@mathjax/mathjax-newcm-font@4.1.3': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.2)
       ajv: 8.20.0
@@ -12257,8 +12760,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1(supports-color@7.2.0)
-      express-rate-limit: 8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0)
+      express: 5.2.1(supports-color@10.2.2)
+      express-rate-limit: 8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)
       hono: 4.13.2
       jose: 6.2.8
       json-schema-typed: 8.0.2
@@ -12500,65 +13003,65 @@ snapshots:
       '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
-  '@opentelemetry/instrumentation-aws-sdk@0.76.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-aws-sdk@0.76.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/semantic-conventions': 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-connect@0.64.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-connect@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/semantic-conventions': 1.43.0
       '@types/connect': 3.4.38
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-dns@0.64.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-dns@0.64.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-express@0.69.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-express@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/semantic-conventions': 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/semantic-conventions': 1.43.0
       forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-ioredis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/redis-common': 0.38.3
       '@opentelemetry/semantic-conventions': 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.73.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-pg@0.73.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/semantic-conventions': 1.43.0
       '@opentelemetry/sql-common': 0.42.0(@opentelemetry/api@1.9.1)
       '@types/pg': 8.15.6
@@ -12566,21 +13069,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-redis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation-redis@0.69.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/redis-common': 0.38.3
       '@opentelemetry/semantic-conventions': 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
       import-in-the-middle: 3.3.3
-      require-in-the-middle: 8.0.1(supports-color@7.2.0)
+      require-in-the-middle: 8.0.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12647,7 +13150,7 @@ snapshots:
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)':
+  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.221.0
@@ -12665,7 +13168,7 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-b3': 2.10.0(@opentelemetry/api@1.9.1)
@@ -12915,6 +13418,18 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@postgres-language-server/cli-aarch64-apple-darwin@0.25.7':
     optional: true
 
@@ -12948,7 +13463,7 @@ snapshots:
 
   '@prairielearn/excalidraw-builds@1.0.0': {}
 
-  '@prairielearn/sketchresponse@0.1.4(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))':
+  '@prairielearn/sketchresponse@0.1.4(stylelint@16.26.1(supports-color@10.2.2)(typescript@6.0.3))':
     dependencies:
       buffer: 6.0.3
       classnames: 2.5.1
@@ -12961,7 +13476,7 @@ snapshots:
       pepjs: 0.5.3
       sass: 1.102.0
       sass-loader: 16.0.8(sass@1.102.0)
-      stylelint-scss: 6.14.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
+      stylelint-scss: 6.14.0(stylelint@16.26.1(supports-color@10.2.2)(typescript@6.0.3))
       sweetalert2: 11.26.25
     transitivePeerDependencies:
       - '@rspack/core'
@@ -13004,7 +13519,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@pyroscope/nodejs@0.4.13(express@4.22.2(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@pyroscope/nodejs@0.4.13(express@4.22.2(supports-color@10.2.2))(supports-color@7.2.0)':
     dependencies:
       '@datadog/pprof': 5.14.4
       debug: 4.4.3(supports-color@7.2.0)
@@ -13012,7 +13527,7 @@ snapshots:
       regenerator-runtime: 0.14.1
       source-map: 0.7.6
     optionalDependencies:
-      express: 4.22.2(supports-color@7.2.0)
+      express: 4.22.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -13125,7 +13640,7 @@ snapshots:
     dependencies:
       '@sentry/conventions': 0.16.0
 
-  '@sentry/node-core@10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.16.0
       '@sentry/core': 10.69.0
@@ -13135,7 +13650,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@7.2.0)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)
       '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
 
   '@sentry/opentelemetry@10.69.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
@@ -13151,6 +13666,8 @@ snapshots:
       ajv: 8.20.0
 
   '@sindresorhus/base62@1.0.0': {}
+
+  '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -13206,12 +13723,20 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.8(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.8(supports-color@10.2.2))(supports-color@7.2.0)':
     dependencies:
       debug: 4.3.7(supports-color@7.2.0)
       notepack.io: 3.0.1
-      socket.io-adapter: 2.5.8(supports-color@7.2.0)
+      socket.io-adapter: 2.5.8(supports-color@10.2.2)
       uid2: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@socket.io/redis-emitter@5.1.0(supports-color@10.2.2)':
+    dependencies:
+      debug: 4.3.7(supports-color@10.2.2)
+      notepack.io: 3.0.1
+      socket.io-parser: 4.2.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -13223,13 +13748,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@speed-highlight/core@1.2.24': {}
+
   '@standard-schema/spec@1.1.0': {}
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))':
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@typescript-eslint/types': 8.66.0
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -13239,10 +13766,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tanstack/eslint-plugin-query@5.101.4(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@tanstack/eslint-plugin-query@5.101.4(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -13950,15 +14477,15 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -13966,34 +14493,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.66.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.66.0(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/rule-tester@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       ajv: 6.15.0
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
       semver: 7.8.5
@@ -14010,13 +14537,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@10.2.2)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -14024,13 +14551,13 @@ snapshots:
 
   '@typescript-eslint/types@8.66.0': {}
 
-  '@typescript-eslint/typescript-estree@8.66.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.66.0(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/visitor-keys': 8.66.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -14039,13 +14566,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -14174,13 +14701,13 @@ snapshots:
       tinyrainbow: 3.1.1
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
 
-  '@vitest/eslint-plugin@1.6.26(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)(vitest@4.1.10)':
+  '@vitest/eslint-plugin@1.6.26(@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       typescript: 6.0.3
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.5)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -14397,6 +14924,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  aws4fetch@1.0.20: {}
+
   axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
@@ -14489,17 +15018,19 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blake3-wasm@2.1.5: {}
+
   blocked-at@1.2.0: {}
 
   blocked@1.3.0: {}
 
   bluebird@3.7.2: {}
 
-  body-parser@1.20.6(supports-color@7.2.0):
+  body-parser@1.20.6(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9(supports-color@7.2.0)
+      debug: 2.6.9(supports-color@10.2.2)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -14512,11 +15043,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.3.0(supports-color@7.2.0):
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
@@ -14643,6 +15174,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001809: {}
+
+  capnweb@0.8.0: {}
 
   ccount@2.0.1: {}
 
@@ -14843,6 +15376,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   cookies@0.9.1:
     dependencies:
@@ -15106,11 +15641,23 @@ snapshots:
 
   debounce@3.0.0: {}
 
+  debug@2.6.9(supports-color@10.2.2):
+    dependencies:
+      ms: 2.0.0
+    optionalDependencies:
+      supports-color: 10.2.2
+
   debug@2.6.9(supports-color@7.2.0):
     dependencies:
       ms: 2.0.0
     optionalDependencies:
       supports-color: 7.2.0
+
+  debug@4.3.7(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.3.7(supports-color@7.2.0):
     dependencies:
@@ -15123,6 +15670,12 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 7.2.0
+
+  debug@4.4.3(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@7.2.0):
     dependencies:
@@ -15205,12 +15758,32 @@ snapshots:
 
   discontinuous-range@1.0.0: {}
 
+  docker-modem@5.0.7(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
   docker-modem@5.0.7(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       readable-stream: 3.6.2
       split-ca: 1.0.1
       ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@5.0.1(supports-color@10.2.2):
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7(supports-color@10.2.2)
+      protobufjs: 7.6.5
+      tar-fs: 2.1.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15369,6 +15942,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  error-stack-parser-es@1.0.5: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -15435,10 +16010,10 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.12.2
 
-  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
@@ -15446,16 +16021,16 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0):
     dependencies:
       '@typescript-eslint/types': 8.66.0
       comment-parser: 1.4.7
       debug: 4.4.3(supports-color@7.2.0)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
       minimatch: 10.2.6
@@ -15463,11 +16038,11 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.12.2
     optionalDependencies:
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsdoc@63.3.3(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-jsdoc@63.3.3(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@7.2.0):
     dependencies:
       '@es-joy/jsdoccomment': 0.91.0
       '@es-joy/resolve.exports': 1.2.0
@@ -15475,7 +16050,7 @@ snapshots:
       comment-parser: 1.4.7
       debug: 4.4.3(supports-color@7.2.0)
       escape-string-regexp: 4.0.0
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       espree: 11.2.0
       esquery: 1.7.0
       html-entities: 2.6.0
@@ -15487,13 +16062,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsx-a11y-x@0.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-plugin-jsx-a11y-x@0.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       aria-query: 5.3.2
       axe-core: 4.12.1
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       jsx-ast-utils-x: 0.1.0
       language-tags: 1.0.9
       minimatch: 10.2.6
@@ -15502,114 +16077,114 @@ snapshots:
     dependencies:
       requireindex: 1.2.0
 
-  eslint-plugin-perfectionist@5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-perfectionist@5.10.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-react-dom@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-react-dom@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/jsx': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/jsx': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/parser': 7.29.8
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-jsx@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-react-jsx@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/jsx': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/jsx': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-react-naming-convention@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-rsc@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-react-rsc@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-web-api@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-react-web-api@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       birecord: 0.1.2
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  eslint-plugin-react-x@5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/jsx': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@eslint-react/ast': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/core': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/eslint': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/jsx': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/shared': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@eslint-react/var': 5.18.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/types': 8.66.0
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       string-ts: 2.3.1
       ts-api-utils: 2.5.0(typescript@6.0.3)
       ts-pattern: 5.9.0
@@ -15617,14 +16192,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-you-might-not-need-an-effect@0.11.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-plugin-react-you-might-not-need-an-effect@0.11.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       globals: 16.5.0
 
-  eslint-plugin-unicorn@73.0.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-plugin-unicorn@73.0.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       '@eslint/css-tree': 4.0.5
       browserslist: 4.28.7
       change-case: 5.4.4
@@ -15632,7 +16207,7 @@ snapshots:
       core-js-compat: 3.50.0
       detect-indent: 7.0.2
       entities: 4.5.0
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       find-up-simple: 1.0.1
       globals: 17.9.0
       indent-string: 5.0.0
@@ -15662,6 +16237,43 @@ snapshots:
   eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@10.2.2)
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@10.2.2)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0):
     dependencies:
@@ -15771,26 +16383,26 @@ snapshots:
 
   express-async-handler@1.2.0: {}
 
-  express-rate-limit@8.6.2(express@5.2.1(supports-color@7.2.0))(supports-color@7.2.0):
+  express-rate-limit@8.6.2(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
-      express: 5.2.1(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.5.0
     transitivePeerDependencies:
       - supports-color
 
-  express-static-gzip@2.2.0(supports-color@7.2.0):
+  express-static-gzip@2.2.0(supports-color@10.2.2):
     dependencies:
       parseurl: 1.3.3
-      serve-static: 1.16.3(supports-color@7.2.0)
+      serve-static: 1.16.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.2(supports-color@7.2.0):
+  express@4.22.2(supports-color@10.2.2):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.6(supports-color@7.2.0)
+      body-parser: 1.20.6(supports-color@10.2.2)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -15813,7 +16425,7 @@ snapshots:
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2(supports-color@7.2.0)
-      serve-static: 1.16.3(supports-color@7.2.0)
+      serve-static: 1.16.3(supports-color@10.2.2)
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -15822,20 +16434,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1(supports-color@7.2.0):
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0(supports-color@7.2.0)
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@7.2.0)
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -15846,9 +16458,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@7.2.0)
-      send: 1.2.1(supports-color@7.2.0)
-      serve-static: 2.2.1(supports-color@7.2.0)
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -15998,9 +16610,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1(supports-color@7.2.0):
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -16084,6 +16696,14 @@ snapshots:
 
   function-timeout@1.0.2: {}
 
+  gaxios@7.3.0(supports-color@10.2.2):
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gaxios@7.3.0(supports-color@7.2.0):
     dependencies:
       extend: 3.0.2
@@ -16092,9 +16712,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2(supports-color@7.2.0):
+  gcp-metadata@8.1.2(supports-color@10.2.2):
     dependencies:
-      gaxios: 7.3.0(supports-color@7.2.0)
+      gaxios: 7.3.0(supports-color@10.2.2)
       google-logging-utils: 1.1.4
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -16210,12 +16830,12 @@ snapshots:
     dependencies:
       delegate: 3.2.0
 
-  google-auth-library@10.9.1(supports-color@7.2.0):
+  google-auth-library@10.9.1(supports-color@10.2.2):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
       gaxios: 7.3.0(supports-color@7.2.0)
-      gcp-metadata: 8.1.2(supports-color@7.2.0)
+      gcp-metadata: 8.1.2(supports-color@10.2.2)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
@@ -16247,7 +16867,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
+  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
     dependencies:
       '@types/estree': 1.0.9
       '@types/hast': 3.0.5
@@ -16256,9 +16876,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -16390,6 +17010,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6(supports-color@7.2.0):
     dependencies:
       agent-base: 7.1.4
@@ -16469,6 +17096,17 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ioredis@6.0.0(supports-color@10.2.2):
+    dependencies:
+      '@ioredis/commands': 2.0.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3(supports-color@10.2.2)
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ioredis@6.0.0(supports-color@7.2.0):
     dependencies:
@@ -17052,14 +17690,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.3(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2(supports-color@10.2.2)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -17077,67 +17715,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
+  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@7.2.0):
+  mdast-util-gfm@3.1.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
+  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
+  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -17145,7 +17783,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -17154,13 +17792,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
+  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -17413,6 +18051,28 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
+  micromark@4.0.2(supports-color@10.2.2):
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3(supports-color@10.2.2)
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   micromark@4.0.2(supports-color@7.2.0):
     dependencies:
       '@types/debug': 4.1.13
@@ -17457,6 +18117,18 @@ snapshots:
   mime@4.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  miniflare@5.20260811.1-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260811.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimatch@10.2.6:
     dependencies:
@@ -18296,17 +18968,17 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.8)(supports-color@7.2.0):
+  react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.8)(supports-color@10.2.2):
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 19.2.18
       devlop: 1.1.0
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.1
       react: 19.2.8
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-rehype: 11.1.2
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -18389,21 +19061,21 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
-  remark-gfm@4.0.1(supports-color@7.2.0):
+  remark-gfm@4.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@7.2.0):
+  remark-parse@11.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -18429,9 +19101,9 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1(supports-color@7.2.0):
+  require-in-the-middle@8.0.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -18495,9 +19167,9 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
-  router@2.2.0(supports-color@7.2.0):
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -18591,6 +19263,24 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@0.19.2(supports-color@10.2.2):
+    dependencies:
+      debug: 2.6.9(supports-color@10.2.2)
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   send@0.19.2(supports-color@7.2.0):
     dependencies:
       debug: 2.6.9(supports-color@7.2.0)
@@ -18609,9 +19299,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1(supports-color@7.2.0):
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -18638,21 +19328,21 @@ snapshots:
       parseurl: 1.3.3
       safe-buffer: 5.2.1
 
-  serve-static@1.16.3(supports-color@7.2.0):
+  serve-static@1.16.3(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2(supports-color@7.2.0)
+      send: 0.19.2(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1(supports-color@7.2.0):
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@7.2.0)
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -18665,6 +19355,38 @@ snapshots:
   sh-syntax@0.5.8:
     dependencies:
       tslib: 2.8.1
+
+  sharp@0.35.2:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
+      '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
+      '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
 
   sharp@0.35.3(@types/node@24.13.3):
     dependencies:
@@ -18759,25 +19481,32 @@ snapshots:
 
   smol-toml@1.7.1: {}
 
-  socket.io-adapter@2.5.8(supports-color@7.2.0):
+  socket.io-adapter@2.5.8(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-client@4.8.3(supports-color@7.2.0):
+  socket.io-client@4.8.3(supports-color@10.2.2):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3(supports-color@7.2.0)
       engine.io-client: 6.6.6(supports-color@7.2.0)
-      socket.io-parser: 4.2.7(supports-color@7.2.0)
+      socket.io-parser: 4.2.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  socket.io-parser@4.2.7(supports-color@10.2.2):
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   socket.io-parser@4.2.7(supports-color@7.2.0):
     dependencies:
@@ -18786,15 +19515,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.3(supports-color@7.2.0):
+  socket.io@4.8.3(supports-color@10.2.2):
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
       debug: 4.4.3(supports-color@7.2.0)
       engine.io: 6.6.9(supports-color@7.2.0)
-      socket.io-adapter: 2.5.8(supports-color@7.2.0)
-      socket.io-parser: 4.2.7(supports-color@7.2.0)
+      socket.io-adapter: 2.5.8(supports-color@10.2.2)
+      socket.io-parser: 4.2.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -18940,7 +19669,7 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylelint-scss@6.14.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3)):
+  stylelint-scss@6.14.0(stylelint@16.26.1(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
       css-tree: 3.2.1
       is-plain-object: 5.0.0
@@ -18950,9 +19679,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.4
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
+      stylelint: 16.26.1(supports-color@10.2.2)(typescript@6.0.3)
 
-  stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3):
+  stylelint@16.26.1(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
@@ -18965,7 +19694,7 @@ snapshots:
       cosmiconfig: 9.0.2(typescript@6.0.3)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@10.2.2)
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 11.1.5
@@ -19006,6 +19735,8 @@ snapshots:
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
+
+  supports-color@10.2.2: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -19248,13 +19979,13 @@ snapshots:
       rimraf: 6.1.3
       typescript: 6.0.3
 
-  typescript-eslint@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3):
+  typescript-eslint@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@7.2.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)(supports-color@7.2.0)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.66.0(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -19290,6 +20021,10 @@ snapshots:
   undici@6.28.0: {}
 
   undici@7.29.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unicorn-magic@0.3.0: {}
 
@@ -19555,6 +20290,30 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260811.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260811.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260811.1
+      '@cloudflare/workerd-linux-64': 1.20260811.1
+      '@cloudflare/workerd-linux-arm64': 1.20260811.1
+      '@cloudflare/workerd-windows-64': 1.20260811.1
+
+  wrangler@4.123.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260811.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260811.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260811.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -19567,6 +20326,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+
+  ws@8.21.0: {}
 
   ws@8.21.1: {}
 
@@ -19663,6 +20424,19 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors@2.2.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.24
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zip-stream@7.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ allowBuilds:
   sharp: false
   ssh2: false
   unrs-resolver: false
+  workerd: true
 
 supportedArchitectures:
   # @postgres-language-server/cli currently tags its glibc Linux binaries with

--- a/scripts/agent/dev.mjs
+++ b/scripts/agent/dev.mjs
@@ -1,0 +1,105 @@
+import { spawn, spawnSync } from 'node:child_process';
+
+import { localCapabilitySecret, repositoryRoot, writeLocalAgentConfig } from './local-config.mjs';
+
+const docker = spawnSync('docker', ['info'], { cwd: repositoryRoot, stdio: 'ignore' });
+if (docker.status !== 0) {
+  throw new Error('Docker is required for the Cloudflare Sandbox. Start Docker and try again.');
+}
+
+const { configPath, serverPort, stateDirectory, workerPort } = await writeLocalAgentConfig();
+const processes = [
+  spawn('pnpm', ['--filter', '@prairielearn/prairielearn', 'dev'], {
+    cwd: repositoryRoot,
+    env: { ...process.env, PL_CONFIG_PATH: configPath },
+    stdio: 'inherit',
+  }),
+  spawn(
+    'pnpm',
+    [
+      '--filter',
+      '@prairielearn/agent-worker',
+      'exec',
+      'wrangler',
+      'dev',
+      '--local',
+      '--port',
+      workerPort,
+      '--persist-to',
+      stateDirectory,
+      '--var',
+      'LOCAL_DEVELOPMENT:true',
+      '--var',
+      'AGENT_WORKER_ENABLED:true',
+      '--var',
+      `AGENT_CAPABILITY_SECRET:${localCapabilitySecret}`,
+    ],
+    { cwd: repositoryRoot, stdio: 'inherit' },
+  ),
+];
+
+let stopping = false;
+
+function stop(signal = 'SIGTERM') {
+  if (stopping) return;
+  stopping = true;
+  for (const child of processes) child.kill(signal);
+}
+
+process.on('SIGINT', () => stop('SIGINT'));
+process.on('SIGTERM', () => stop('SIGTERM'));
+
+try {
+  await Promise.all([
+    waitForHttp(`http://localhost:${serverPort}/pl/webhooks/ping`, processes[0]),
+    waitForHttp(`http://localhost:${workerPort}/health`, processes[1]),
+  ]);
+} catch (error) {
+  stop();
+  throw error;
+}
+
+process.stdout.write(
+  [
+    '',
+    'PrairieLearn cloud-agent development stack is ready:',
+    `  PrairieLearn: http://localhost:${serverPort}`,
+    `  Agent page: http://localhost:${serverPort}/pl/course/<course_id>/course_admin/agents`,
+    `  Worker health: http://localhost:${workerPort}/health`,
+    `  Wrangler state: ${stateDirectory}`,
+    '  Feature flags: cloud-agent, cloud-agent-arbitrary-sql (development only)',
+    '',
+  ].join('\n'),
+);
+
+const results = await Promise.all(
+  processes.map(
+    (child) =>
+      new Promise((resolve, reject) => {
+        child.once('error', reject);
+        child.once('exit', (code, signal) => {
+          stop();
+          resolve({ code, signal });
+        });
+      }),
+  ),
+);
+const failed = results.find(({ code, signal }) => code !== 0 && signal === null);
+if (failed) process.exitCode = failed.code ?? 1;
+
+async function waitForHttp(url, child) {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`${url} could not become ready because its process exited.`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Both PrairieLearn and the first Sandbox image build can take time to start.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`${url} did not become ready within three minutes.`);
+}

--- a/scripts/agent/local-config.mjs
+++ b/scripts/agent/local-config.mjs
@@ -1,0 +1,69 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const repositoryRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+export const localCapabilitySecret = 'local-agent-capability-secret-32-bytes';
+
+export async function writeLocalAgentConfig() {
+  const localCourseConfig = {};
+  for (const configPath of [
+    path.join(os.homedir(), '.config', 'prairielearn', 'config.json'),
+    path.join(repositoryRoot, 'config.json'),
+    path.join(repositoryRoot, 'apps', 'prairielearn', 'config.json'),
+  ]) {
+    try {
+      const parsed = JSON.parse(await fs.readFile(configPath, 'utf8'));
+      if (!isRecord(parsed)) continue;
+
+      // Course paths are the only values inherited from a developer's normal
+      // config. In particular, never copy database, Redis, S3, or auth settings
+      // into the agent stack: it enables arbitrary SQL in development.
+      if (isStringArray(parsed.courseDirs)) {
+        localCourseConfig.courseDirs = parsed.courseDirs;
+      }
+      if (typeof parsed.coursesRoot === 'string') {
+        localCourseConfig.coursesRoot = parsed.coursesRoot;
+      }
+      if (typeof parsed.exampleCoursePath === 'string') {
+        localCourseConfig.exampleCoursePath = parsed.exampleCoursePath;
+      }
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+
+  const serverPort = process.env.AGENT_PRAIRIELEARN_PORT ?? process.env.CONDUCTOR_PORT ?? '3000';
+  const workerPort = process.env.AGENT_WORKER_PORT ?? '8787';
+  const config = {
+    ...localCourseConfig,
+    devMode: true,
+    postgresqlHost: 'localhost',
+    postgresqlSsl: false,
+    redisUrl: process.env.CONDUCTOR_PORT ? undefined : 'redis://localhost:6379/',
+    nonVolatileRedisUrl: process.env.CONDUCTOR_PORT ? undefined : 'redis://localhost:6379/',
+    serverPort,
+    serverCanonicalHost: `http://localhost:${serverPort}`,
+    agentWorkerUrl: `http://localhost:${workerPort}`,
+    agentCapabilitySecret: localCapabilitySecret,
+    agentHarness: 'deterministic',
+    features: {
+      'cloud-agent': true,
+      'cloud-agent-arbitrary-sql': true,
+    },
+  };
+  const stateDirectory = path.join(repositoryRoot, '.wrangler', 'agent-local');
+  const configPath = path.join(stateDirectory, 'prairielearn-config.json');
+  await fs.mkdir(stateDirectory, { recursive: true });
+  await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+  return { configPath, serverPort, stateDirectory, workerPort };
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value) {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}

--- a/scripts/agent/test.mjs
+++ b/scripts/agent/test.mjs
@@ -1,0 +1,162 @@
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { localCapabilitySecret, repositoryRoot } from './local-config.mjs';
+
+const outputDirectory = await fsPromises.mkdtemp(
+  path.join(os.tmpdir(), 'prairielearn-agent-test-'),
+);
+const logPath = path.join(outputDirectory, 'agent-test.log');
+const log = fs.createWriteStream(logPath, { flags: 'a' });
+const workerPort = process.env.AGENT_WORKER_PORT ?? '8787';
+
+process.stdout.write(`Agent test output: ${outputDirectory}\n`);
+
+try {
+  const docker = spawnSync('docker', ['info'], { cwd: repositoryRoot, stdio: 'ignore' });
+  if (docker.status !== 0) {
+    throw new Error('Docker is required for the Cloudflare Sandbox. Start Docker and try again.');
+  }
+
+  await run('pnpm', ['--filter', '@prairielearn/agent-protocol', 'build']);
+  await run('pnpm', ['--filter', '@prairielearn/agent-protocol', 'test']);
+  await run('pnpm', ['--filter', '@prairielearn/agent-worker', 'build']);
+  await run('pnpm', ['--filter', '@prairielearn/agent-worker', 'test:unit']);
+  await run('pnpm', [
+    'test',
+    'apps/prairielearn/src/lib/agent-capability.test.ts',
+    'apps/prairielearn/src/models/agent-conversation.test.ts',
+    'apps/prairielearn/src/mcp/tools/query-course-data.test.ts',
+    'apps/prairielearn/src/tests/agentConversations.test.ts',
+    'apps/prairielearn/src/pages/instructorAgentConversations/components/AgentConversationsPage.test.tsx',
+  ]);
+
+  const smokeStatePath = path.join(outputDirectory, 'smoke-state.json');
+  let worker = startWorker();
+  try {
+    await waitForWorker(worker);
+    await run(
+      'pnpm',
+      ['--filter', '@prairielearn/agent-worker', 'test:smoke', '--', 'start', smokeStatePath],
+      { AGENT_WORKER_URL: `http://localhost:${workerPort}` },
+    );
+    worker.kill('SIGTERM');
+    await waitForExit(worker);
+    await waitForWorkerShutdown();
+    worker = startWorker();
+    await waitForWorker(worker);
+    await run(
+      'pnpm',
+      ['--filter', '@prairielearn/agent-worker', 'test:smoke', '--', 'resume', smokeStatePath],
+      { AGENT_WORKER_URL: `http://localhost:${workerPort}` },
+    );
+    await run(
+      'pnpm',
+      [
+        '--filter',
+        '@prairielearn/prairielearn',
+        'test:e2e',
+        'src/tests/e2e/agentConversations.spec.ts',
+      ],
+      { AGENT_WORKER_URL: `http://localhost:${workerPort}` },
+    );
+  } finally {
+    worker.kill('SIGTERM');
+    await waitForExit(worker);
+  }
+
+  process.stdout.write(`Agent MVP tests passed. Logs: ${logPath}\n`);
+} catch (error) {
+  process.stderr.write(`Agent MVP tests failed. Logs: ${logPath}\n`);
+  throw error;
+} finally {
+  log.end();
+}
+
+function startWorker() {
+  const stateDirectory = path.join(outputDirectory, 'wrangler-state');
+  const workerDirectory = path.join(repositoryRoot, 'apps', 'agent-worker');
+  const worker = spawn(
+    path.join(workerDirectory, 'node_modules', '.bin', 'wrangler'),
+    [
+      'dev',
+      '--local',
+      '--port',
+      workerPort,
+      '--persist-to',
+      stateDirectory,
+      '--var',
+      'LOCAL_DEVELOPMENT:true',
+      '--var',
+      'AGENT_WORKER_ENABLED:true',
+      '--var',
+      `AGENT_CAPABILITY_SECRET:${localCapabilitySecret}`,
+    ],
+    { cwd: workerDirectory, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  worker.stdout.pipe(process.stdout);
+  worker.stderr.pipe(process.stderr);
+  worker.stdout.pipe(log, { end: false });
+  worker.stderr.pipe(log, { end: false });
+  return worker;
+}
+
+async function waitForWorker(worker) {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    if (worker.exitCode !== null) {
+      throw new Error(`Wrangler exited before becoming healthy (${worker.exitCode}).`);
+    }
+    try {
+      const response = await fetch(`http://localhost:${workerPort}/health`);
+      if (response.ok) {
+        const body = await response.json();
+        if (body.enabled === true) return;
+      }
+    } catch {
+      // Wrangler may take a few minutes to build the Sandbox image on the first run.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error('Wrangler did not become healthy within three minutes.');
+}
+
+async function waitForWorkerShutdown() {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`http://localhost:${workerPort}/health`);
+    } catch {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Wrangler did not release its local port after shutdown.');
+}
+
+async function run(command, args, extraEnv = {}) {
+  const child = spawn(command, args, {
+    cwd: repositoryRoot,
+    env: { ...process.env, ...extraEnv },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  child.stdout.pipe(log, { end: false });
+  child.stderr.pipe(log, { end: false });
+  const { code, signal } = await waitForExit(child);
+  if (code !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed (${signal ?? code}).`);
+  }
+}
+
+function waitForExit(child) {
+  if (child.exitCode !== null) return Promise.resolve({ code: child.exitCode, signal: null });
+  return new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  });
+}


### PR DESCRIPTION
# Description

Stacks the feature-flagged cloud course-agent MVP on #15640, which contains the architecture and design discussion.

This implements the end-to-end instructor workflow behind the `cloud-agent` feature flag:

- a minimal PrairieLearn conversation UI for starting, resuming, stopping, publishing, and deleting agent work, including a sandboxed single-variant question preview;
- PrairieLearn-owned conversation, run, event, operation, artifact, audit, and draft-question persistence with editor/course authorization on every entry point;
- signed, purpose-bound run capabilities shared through `@prairielearn/agent-protocol`, without placing PrairieLearn database credentials in the sandbox;
- a Cloudflare Worker backed by a per-conversation Durable Object, Cloudflare Sandbox containers, and R2 checkpoints for Claude session data and incremental Git bundles;
- an unprivileged Claude Agent SDK harness with Bash plus locally executed PrairieLearn tools for entity lookup, course-file reads, instructor-visible data queries, and `render_question`;
- model-free publication from a fresh sandbox, with exact Git-head verification and find-or-create draft PR behavior using PrairieLearn's existing GitHub App credentials;
- durable cancellation, terminal-event delivery, idempotent tool/publication operations, bounded session storage, and deletion that removes R2 state and redacts conversation content in PostgreSQL.

`query_course_data` has an additional `cloud-agent-arbitrary-sql` flag and is restricted to development mode while production row-level isolation is still being designed. The local deterministic harness and publication receipt make the entire workflow testable without Anthropic or GitHub credentials; production uses the Claude harness and GitHub integration when their secrets are configured. The MVP UI polls durable events rather than using token-level SSE.

AI assistance: the majority of the implementation and verification was completed by Codex, with the architecture and product decisions directed through the attached discussion.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

- Ran `pnpm test-agent` against Docker and Wrangler. The acceptance workflow started an unprivileged sandbox, created and committed a question, rendered exactly one variant, stopped Wrangler, restarted it against the same persisted Durable Object/R2 state, restored the Git bundle chain into a fresh sandbox, replayed publication idempotently, resumed the conversation, canceled a run, deleted the conversation, and verified that its R2 prefix contained zero objects.
- The same command ran the browser workflow against a real local PrairieLearn server: two turns in one durable conversation, two embedded question previews, local publication, and deletion through the instructor UI.
- Added focused protocol, Worker, capability, run-state, authorization, query, render-preview, Git-auth, checkpoint, and session-store coverage.
