### PR TITLE
Clarify authentication options in docs

### DIFF
--- a/docs/running-in-production/authentication.md
+++ b/docs/running-in-production/authentication.md
@@ -1,9 +1,10 @@
 # Authentication
 
-PrairieLearn currently has a few ways to do user authentication.
+In a self-hosted PrairieLearn instance, PrairieLearn currently supports [Google OAuth 2](#google-oauth-2) as the main method of user authentication. While [LTI 1.1](../courseInstance/index.md#lti-support) is also available, it is currently deprecated and should be avoided for new deployments. [LTI 1.3](../lti13.md) is supported for interoperability with learning management systems, but not as an authentication method.
 
-- [Google OAuth 2](#google-oauth-2)
-- [LTI](../courseInstance/index.md#lti-overview)
+!!! note "SAML and Azure authentication"
+
+    Authentication using SAML or Azure are only available as enterprise features, and are not supported in self-hosted PrairieLearn instances. If you are interested in these features, please visit <https://www.prairielearn.com> for information about paid hosting and enterprise support.
 
 ## Google OAuth 2
 
@@ -30,7 +31,3 @@ Now add the keys to `config.json`:
 ```
 
 You should now be able to use Google to log in to your PrairieLearn instance.
-
-## LTI
-
-Check out the [course instance LTI docs](../courseInstance/index.md#lti-overview) to learn more about LTI.

--- a/docs/running-in-production/authentication.md
+++ b/docs/running-in-production/authentication.md
@@ -4,14 +4,14 @@ PrairieLearn currently uses [Google OAuth 2](#google-oauth-2) as its only suppor
 
 !!! note "SAML and Azure authentication"
 
-    Authentication using SAML or Azure are only available as enterprise features, and are not supported in self-hosted PrairieLearn instances. If you are interested in these features, please visit <https://www.prairielearn.com> for information about paid hosting and enterprise support.
+    Authentication using SAML or Azure are available only as enterprise features, and are not supported in self-hosted PrairieLearn instances. If you are interested in these features, please visit <https://www.prairielearn.com> for information about paid hosting and enterprise support.
 
 ## Google OAuth 2
 
 To start, create a [Google Cloud account](https://cloud.google.com/) and then:
 
 - Click [console](https://console.cloud.google.com/) to log in to your console.
-- Create a project then got to [APIs & Services](https://console.cloud.google.com/apis/dashboard).
+- Create a project then go to [APIs & Services](https://console.cloud.google.com/apis/dashboard).
   - Go to `OAuth consent screen` and complete the consent form.
   - Proceed to `Credentials` and create a new `OAuth client ID`.
   - Select `Web application`.

--- a/docs/running-in-production/authentication.md
+++ b/docs/running-in-production/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-In a self-hosted PrairieLearn instance, PrairieLearn currently supports [Google OAuth 2](#google-oauth-2) as the main method of user authentication. While [LTI 1.1](../courseInstance/index.md#lti-support) is also available, it is currently deprecated and should be avoided for new deployments. [LTI 1.3](../lti13.md) is supported for interoperability with learning management systems, but not as an authentication method.
+PrairieLearn currently uses [Google OAuth 2](#google-oauth-2) as its only supported method of user authentication for self-hosted PrairieLearn instances. While [LTI 1.1](../courseInstance/index.md#lti-support) is also available, it is currently deprecated and should be avoided for new deployments. [LTI 1.3](../lti13.md) is supported for interoperability with learning management systems, but not as an authentication method.
 
 !!! note "SAML and Azure authentication"
 


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Current version of docs still suggest LTI as an option. This PR clarifies that Google is the only supported auth method for self-hosted instances, and adds a note on SAML/Azure in enterprise mode.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: minor wording.

# Testing

NA.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
