### PR TITLE
Fix symbolic input exponent insertion

### DIFF
--- a/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
+++ b/apps/prairielearn/elements/pl-symbolic-input/pl-symbolic-input.js
@@ -386,7 +386,8 @@
         id: 'power',
         label: () => '<span class="ML__insert-template">x<sup>y</sup></span>',
         onMenuSelect: () =>
-          isSelected(mf) ? mf.insert('\\left({#@}\\right)^{#?}') : mf.insert('{#@}^{#?}'),
+          // Keep power bases ungrouped so implicit fraction insertion does not detach their superscripts.
+          isSelected(mf) ? mf.insert('\\left({#@}\\right)^{#?}') : mf.insert('#@^{#?}'),
       },
       {
         id: 'sqrt',
@@ -415,12 +416,12 @@
       rows: [
         [
           ...onlyIfSets('[separator]'),
-          makeShortcutProxy({ class: 'small', latex: '{#@}^{#?}' }, mf),
+          makeShortcutProxy({ class: 'small', latex: '#@^{#?}' }, mf),
           makeShortcutProxy(
             {
               class: 'small',
-              latex: '{#@}^{2}',
-              variants: [{ class: 'small', latex: '{#@}^{3}' }],
+              latex: '#@^{2}',
+              variants: [{ class: 'small', latex: '#@^{3}' }],
             },
             mf,
           ),
@@ -714,10 +715,10 @@
     // Additional shortcuts for instant replacement inside the pl-symbolic-input box
     const inlineShortcuts = {
       '**': {
-        value: '{#@}^{#?}',
+        value: '#@^{#?}',
       },
       '^': {
-        value: '{#@}^{#?}',
+        value: '#@^{#?}',
       },
       '*': {
         value: '{#@}\\cdot',


### PR DESCRIPTION

## Summary

Fix symbolic input fraction insertion after an exponent.

Power templates previously wrapped the base in an extra group, which allowed subsequent fraction insertion to detach the superscript from its base. This removes that grouping while preserving parentheses around selected multi-term bases.

- [x] I have disclosed the level of AI assistance used: Reproduced and fixed by AI, human reviewed and tested

## Testing

- Typing `e^{4x}\frac{4x-1}{9x^2}` in this sequence (`e ^ 4 ← x → ( 4 x - 1 ) / 9 x ^ 2`) should produce `\frac{e^{4x}(4x-1)}{9x^2}` instead of poping the frac into the exponent.


https://github.com/user-attachments/assets/148b3b6a-8c39-4040-8770-f001217787ee

