### PR TITLE
Simplify QTI remote image copying

### DIFF
--- a/apps/prairielearn/src/lib/qti-import-drafts.ts
+++ b/apps/prairielearn/src/lib/qti-import-drafts.ts
@@ -17,10 +17,6 @@ const QtiImportDraftDataSchema = z.object({
 
 type QtiImportDraftData = z.infer<typeof QtiImportDraftDataSchema>;
 
-type QtiImportDraft = QtiImportDraftData & {
-  draftId: string;
-};
-
 interface CreateQtiImportDraftData {
   courseId: string;
   courseInstanceId: string;
@@ -54,7 +50,7 @@ export async function readQtiImportDraft({
   courseId: string;
   courseInstanceId: string;
   userId: string;
-}): Promise<QtiImportDraft> {
+}): Promise<QtiImportDraftData> {
   const buffer = await getFromS3(getFileStoreS3Bucket(), draftKey(draftId), true);
   const data = QtiImportDraftDataSchema.parse(JSON.parse(buffer.toString('utf8')));
   if (
@@ -64,9 +60,9 @@ export async function readQtiImportDraft({
   ) {
     throw new Error('QTI import draft does not belong to this course instance or user');
   }
-  return { ...data, draftId };
+  return data;
 }
 
-export async function deleteQtiImportDraft(draft: QtiImportDraft): Promise<void> {
-  await deleteFromS3(getFileStoreS3Bucket(), draftKey(draft.draftId));
+export async function deleteQtiImportDraft(draftId: string): Promise<void> {
+  await deleteFromS3(getFileStoreS3Bucket(), draftKey(draftId));
 }

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
@@ -1,9 +1,13 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import type { SerializedQuestionOutput } from '../instructorQtiImport.types.js';
+import type {
+  SerializedConversionResult,
+  SerializedQuestionOutput,
+} from '../instructorQtiImport.types.js';
 
 import {
+  ImportSummary,
   NonRubricWarnings,
   QuestionBankDeduplicationWarning,
   buildQuestionWarningsByDirectoryName,
@@ -14,10 +18,12 @@ function makeQuestion({
   directoryName,
   sourceId,
   title = sourceId,
+  remoteImageCopy,
 }: {
   directoryName: string;
   sourceId: string;
   title?: string;
+  remoteImageCopy?: SerializedQuestionOutput['remoteImageCopy'];
 }): SerializedQuestionOutput {
   return {
     draftId: 'draft',
@@ -34,9 +40,42 @@ function makeQuestion({
     questionHtml: '<pl-question-panel></pl-question-panel>',
     clientFiles: {},
     skippedVideos: [],
-    remoteImagesCopied: 0,
+    ...(remoteImageCopy && { remoteImageCopy }),
   };
 }
+
+describe('ImportSummary', () => {
+  it('shows the number of remote image references that will be copied', () => {
+    const result: SerializedConversionResult = {
+      draftId: 'draft',
+      sourceId: 'bank',
+      title: 'Question bank',
+      sourceType: 'question-bank',
+      directoryName: 'question-bank',
+      questions: [
+        makeQuestion({
+          directoryName: 'imported/question-bank/q1',
+          sourceId: 'q1',
+          remoteImageCopy: {
+            referencesFound: 3,
+            referencesCopied: 2,
+            referencesLeftRemote: 1,
+            filesCreated: 0,
+          },
+        }),
+      ],
+      warnings: [],
+    };
+
+    const html = renderToStaticMarkup(
+      <ImportSummary results={[result]} strippedAccessRules={null} parseWarnings={[]} />,
+    );
+
+    expect(html).toContain(
+      '<strong>2</strong> remote image references will be copied into this course',
+    );
+  });
+});
 
 describe('NonRubricWarnings', () => {
   it('includes duplicate question title warnings in the overview', () => {

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
@@ -34,6 +34,7 @@ function makeQuestion({
     questionHtml: '<pl-question-panel></pl-question-panel>',
     clientFiles: {},
     skippedVideos: [],
+    copiedExternalImageFileCount: 0,
   };
 }
 

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
@@ -1,13 +1,9 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import type {
-  SerializedConversionResult,
-  SerializedQuestionOutput,
-} from '../instructorQtiImport.types.js';
+import type { SerializedQuestionOutput } from '../instructorQtiImport.types.js';
 
 import {
-  ImportSummary,
   NonRubricWarnings,
   QuestionBankDeduplicationWarning,
   buildQuestionWarningsByDirectoryName,
@@ -18,12 +14,10 @@ function makeQuestion({
   directoryName,
   sourceId,
   title = sourceId,
-  remoteImageCopy,
 }: {
   directoryName: string;
   sourceId: string;
   title?: string;
-  remoteImageCopy?: SerializedQuestionOutput['remoteImageCopy'];
 }): SerializedQuestionOutput {
   return {
     draftId: 'draft',
@@ -40,42 +34,8 @@ function makeQuestion({
     questionHtml: '<pl-question-panel></pl-question-panel>',
     clientFiles: {},
     skippedVideos: [],
-    ...(remoteImageCopy && { remoteImageCopy }),
   };
 }
-
-describe('ImportSummary', () => {
-  it('shows the number of remote image references that will be copied', () => {
-    const result: SerializedConversionResult = {
-      draftId: 'draft',
-      sourceId: 'bank',
-      title: 'Question bank',
-      sourceType: 'question-bank',
-      directoryName: 'question-bank',
-      questions: [
-        makeQuestion({
-          directoryName: 'imported/question-bank/q1',
-          sourceId: 'q1',
-          remoteImageCopy: {
-            referencesFound: 3,
-            referencesCopied: 2,
-            referencesLeftRemote: 1,
-            filesCreated: 0,
-          },
-        }),
-      ],
-      warnings: [],
-    };
-
-    const html = renderToStaticMarkup(
-      <ImportSummary results={[result]} strippedAccessRules={null} parseWarnings={[]} />,
-    );
-
-    expect(html).toContain(
-      '<strong>2</strong> remote image references will be copied into this course',
-    );
-  });
-});
 
 describe('NonRubricWarnings', () => {
   it('includes duplicate question title warnings in the overview', () => {

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -220,16 +220,14 @@ export function ImportSummary({
     ),
   );
   const totalQuestions = uniqueQuestions.size;
-  const totalAssets = [...uniqueQuestions.values()].reduce(
-    (sum, question) => sum + Object.keys(question.clientFiles).length,
-    0,
-  );
-  // Count created files rather than rewritten <img> references so this uses the same unit as
-  // totalAssets; repeated uses of the same downloaded image share one client file.
-  const totalExternalImageFilesCopied = [...uniqueQuestions.values()].reduce(
-    (sum, question) => sum + (question.copiedExternalImageFileCount ?? 0),
-    0,
-  );
+  let totalAssets = 0;
+  let totalExternalImageFilesCopied = 0;
+  let totalSkippedVideos = 0;
+  for (const question of uniqueQuestions.values()) {
+    totalAssets += Object.keys(question.clientFiles).length;
+    totalExternalImageFilesCopied += question.copiedExternalImageFileCount;
+    totalSkippedVideos += question.skippedVideos.length;
+  }
 
   const allWarnings = results.flatMap((r) => r.warnings);
   const rubricWarnings = allWarnings.filter((w) => isRubricWarning(w.message));
@@ -239,11 +237,6 @@ export function ImportSummary({
     .filter((w) => !isRubricWarning(w.message) && w.message.includes('Unsupported'))
     .map((w) => w.message);
   const uniqueUnsupported = [...new Set(unsupportedTypes)];
-
-  const totalSkippedVideos = [...uniqueQuestions.values()].reduce(
-    (sum, question) => sum + question.skippedVideos.length,
-    0,
-  );
 
   const notImportedItems: string[] = [];
   if (hasRubricIssues) notImportedItems.push('Rubrics (not supported in QTI quiz exports)');

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -224,6 +224,9 @@ export function ImportSummary({
     (sum, question) => sum + Object.keys(question.clientFiles).length,
     0,
   );
+  // A single downloaded file can replace multiple <img> references, so report the number of
+  // references that will stop depending on a remote URL. Uncopied references remain remote and
+  // are communicated through warnings instead.
   const totalRemoteImageReferencesCopied = [...uniqueQuestions.values()].reduce(
     (sum, question) => sum + (question.remoteImageCopy?.referencesCopied ?? 0),
     0,

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -220,14 +220,14 @@ export function ImportSummary({
     ),
   );
   const totalQuestions = uniqueQuestions.size;
-  let totalAssets = 0;
-  let totalRemoteImagesCopied = 0;
-  let totalSkippedVideos = 0;
-  for (const question of uniqueQuestions.values()) {
-    totalAssets += Object.keys(question.clientFiles).length;
-    totalRemoteImagesCopied += question.remoteImagesCopied;
-    totalSkippedVideos += question.skippedVideos.length;
-  }
+  const totalAssets = [...uniqueQuestions.values()].reduce(
+    (sum, question) => sum + Object.keys(question.clientFiles).length,
+    0,
+  );
+  const totalRemoteImageReferencesCopied = [...uniqueQuestions.values()].reduce(
+    (sum, question) => sum + (question.remoteImageCopy?.referencesCopied ?? 0),
+    0,
+  );
 
   const allWarnings = results.flatMap((r) => r.warnings);
   const rubricWarnings = allWarnings.filter((w) => isRubricWarning(w.message));
@@ -237,6 +237,11 @@ export function ImportSummary({
     .filter((w) => !isRubricWarning(w.message) && w.message.includes('Unsupported'))
     .map((w) => w.message);
   const uniqueUnsupported = [...new Set(unsupportedTypes)];
+
+  const totalSkippedVideos = [...uniqueQuestions.values()].reduce(
+    (sum, question) => sum + question.skippedVideos.length,
+    0,
+  );
 
   const notImportedItems: string[] = [];
   if (hasRubricIssues) notImportedItems.push('Rubrics (not supported in QTI quiz exports)');
@@ -286,10 +291,11 @@ export function ImportSummary({
                   {totalAssets !== 1 ? 's' : ''}
                 </li>
               )}
-              {totalRemoteImagesCopied > 0 && (
+              {totalRemoteImageReferencesCopied > 0 && (
                 <li>
-                  <strong>{totalRemoteImagesCopied}</strong> remote image
-                  {totalRemoteImagesCopied !== 1 ? 's' : ''} will be copied into this course
+                  <strong>{totalRemoteImageReferencesCopied}</strong> remote image reference
+                  {totalRemoteImageReferencesCopied !== 1 ? 's' : ''} will be copied into this
+                  course
                 </li>
               )}
             </ul>

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -224,11 +224,10 @@ export function ImportSummary({
     (sum, question) => sum + Object.keys(question.clientFiles).length,
     0,
   );
-  // A single downloaded file can replace multiple <img> references, so report the number of
-  // references that will stop depending on a remote URL. Uncopied references remain remote and
-  // are communicated through warnings instead.
-  const totalRemoteImageReferencesCopied = [...uniqueQuestions.values()].reduce(
-    (sum, question) => sum + (question.remoteImageCopy?.referencesCopied ?? 0),
+  // Count created files rather than rewritten <img> references so this uses the same unit as
+  // totalAssets; repeated uses of the same downloaded image share one client file.
+  const totalExternalImageFilesCopied = [...uniqueQuestions.values()].reduce(
+    (sum, question) => sum + (question.copiedExternalImageFileCount ?? 0),
     0,
   );
 
@@ -292,13 +291,13 @@ export function ImportSummary({
                 <li>
                   <strong>{totalAssets}</strong> image{totalAssets !== 1 ? 's' : ''} and other asset
                   {totalAssets !== 1 ? 's' : ''}
-                </li>
-              )}
-              {totalRemoteImageReferencesCopied > 0 && (
-                <li>
-                  <strong>{totalRemoteImageReferencesCopied}</strong> remote image reference
-                  {totalRemoteImageReferencesCopied !== 1 ? 's' : ''} will be copied into this
-                  course
+                  {totalExternalImageFilesCopied > 0 && (
+                    <>
+                      , including <strong>{totalExternalImageFilesCopied}</strong> image
+                      {totalExternalImageFilesCopied !== 1 ? 's' : ''} that will be copied from
+                      external websites
+                    </>
+                  )}
                 </li>
               )}
             </ul>

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.test.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.test.ts
@@ -40,6 +40,7 @@ function makeQuestions(directoryPrefix: string, questionSourceId: string, questi
           'image.png': 'aW1hZ2U=',
         },
         skippedVideos: [] as string[],
+        copiedExternalImageFileCount: 0,
       },
     ],
     warnings: [

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.test.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.test.ts
@@ -4,11 +4,7 @@ import fs from 'fs-extra';
 import * as tmp from 'tmp-promise';
 import { assert, describe, expect, it } from 'vitest';
 
-import {
-  type ConversionResult,
-  type IRAssessment,
-  QtiImportRemoteImageCopier,
-} from '@prairielearn/question-conversion';
+import type { ConversionResult } from '@prairielearn/question-conversion';
 
 import {
   countDeduplicatedQuestionBankQuestions,
@@ -44,7 +40,6 @@ function makeQuestions(directoryPrefix: string, questionSourceId: string, questi
           'image.png': 'aW1hZ2U=',
         },
         skippedVideos: [] as string[],
-        remoteImagesCopied: 0,
       },
     ],
     warnings: [
@@ -112,19 +107,6 @@ function makeResult({
   };
 }
 
-async function processRemoteImages(
-  result: ConversionResult,
-  copier: QtiImportRemoteImageCopier,
-): Promise<void> {
-  const itemContainer: IRAssessment = {
-    sourceId: result.sourceId,
-    title: result.assessmentTitle,
-    sourceType: 'assessment',
-    questions: [],
-  };
-  await copier.afterEmit(result, itemContainer);
-}
-
 function makeConversionResult({
   sourceType,
   directoryName,
@@ -149,6 +131,7 @@ function makeConversionResult({
     },
     questions: [],
     warnings: [],
+    reports: [],
   };
 }
 
@@ -240,7 +223,6 @@ describe('serializeConversionResult', () => {
       }),
       'defaultwebctcategory-2',
       '/nonexistent',
-      new QtiImportRemoteImageCopier(),
     );
 
     assert(result.sourceType === 'assessment');
@@ -255,14 +237,13 @@ describe('serializeConversionResult', () => {
       }),
       'unfiled-questions-2',
       '/nonexistent',
-      new QtiImportRemoteImageCopier(),
     );
 
     assert(result.sourceType === 'question-bank');
     expect(result.directoryName).toBe('unfiled-questions-2');
   });
 
-  it('includes copied remote images in the stored question output without an external-image warning', async () => {
+  it('preserves the remote-image copy report without duplicating its warning', async () => {
     const conversionResult = makeConversionResult({
       sourceType: 'assessment',
       directoryName: 'quiz',
@@ -281,110 +262,33 @@ describe('serializeConversionResult', () => {
       clientFiles: new Map(),
       skippedFiles: [],
     });
-    const copier = new QtiImportRemoteImageCopier(async () => ({
-      content: Buffer.from('image contents'),
-      extension: 'png',
-    }));
-    await processRemoteImages(conversionResult, copier);
-
-    const { result } = await serializeConversionResult(
-      conversionResult,
-      'quiz',
-      '/nonexistent',
-      copier,
-    );
-
-    expect(result.questions[0].remoteImagesCopied).toBe(1);
-    expect(Object.keys(result.questions[0].clientFiles)).toHaveLength(1);
-    expect(result.questions[0].questionHtml).toContain('<pl-figure');
-    expect(result.questions[0].questionHtml).not.toContain('canvas.example');
-    expect(result.warnings).toEqual([]);
-  });
-
-  it('keeps a focused warning when a remote image cannot be copied', async () => {
-    const conversionResult = makeConversionResult({
-      sourceType: 'assessment',
-      directoryName: 'quiz',
+    conversionResult.warnings.push({
+      questionId: 'source-q1',
+      code: 'remote-image-copy-failed',
+      message: 'Some remote images could not be copied.',
     });
-    conversionResult.questions.push({
-      directoryName: 'q1',
-      sourceId: 'source-q1',
-      infoJson: {
-        uuid: 'question-uuid',
-        title: 'Question',
-        topic: 'Imported',
-        tags: ['imported'],
-        type: 'v3',
-      },
-      questionHtml: '<img src="https://canvas.example/image?verifier=secret">',
-      clientFiles: new Map(),
-      skippedFiles: [],
+    conversionResult.reports.push({
+      type: 'remote-image-copy',
+      questionId: 'source-q1',
+      referencesFound: 2,
+      referencesCopied: 1,
+      referencesLeftRemote: 1,
+      filesCreated: 1,
     });
-    const copier = new QtiImportRemoteImageCopier(async () => {
-      throw new Error('unavailable');
+
+    const { result } = await serializeConversionResult(conversionResult, 'quiz', '/nonexistent');
+
+    expect(result.questions[0].remoteImageCopy).toEqual({
+      referencesFound: 2,
+      referencesCopied: 1,
+      referencesLeftRemote: 1,
+      filesCreated: 1,
     });
-    await processRemoteImages(conversionResult, copier);
-
-    const { result } = await serializeConversionResult(
-      conversionResult,
-      'quiz',
-      '/nonexistent',
-      copier,
-    );
-
-    expect(result.questions[0].questionHtml).toContain('canvas.example');
-    expect(result.questions[0].remoteImagesCopied).toBe(0);
     expect(result.warnings).toEqual([
       {
         questionId: 'source-q1',
-        message:
-          '1 remote image could not be copied because of its URL, availability, size, or format.',
-      },
-    ]);
-  });
-
-  it('keeps the generic warning for an unattempted URL when another image fails', async () => {
-    const conversionResult = makeConversionResult({
-      sourceType: 'assessment',
-      directoryName: 'quiz',
-    });
-    conversionResult.questions.push({
-      directoryName: 'q1',
-      sourceId: 'source-q1',
-      infoJson: {
-        uuid: 'question-uuid',
-        title: 'Question',
-        topic: 'Imported',
-        tags: ['imported'],
-        type: 'v3',
-      },
-      questionHtml:
-        '<img src="https://canvas.example/unavailable.png"><img src="://invalid.example/image.png">',
-      clientFiles: new Map(),
-      skippedFiles: [],
-    });
-    const copier = new QtiImportRemoteImageCopier(async () => {
-      throw new Error('unavailable');
-    });
-    await processRemoteImages(conversionResult, copier);
-
-    const { result } = await serializeConversionResult(
-      conversionResult,
-      'quiz',
-      '/nonexistent',
-      copier,
-    );
-
-    expect(result.warnings).toEqual([
-      {
-        questionId: 'source-q1',
-        message:
-          '2 remote images could not be copied because of their URLs, availability, size, or format.',
-      },
-      {
-        questionId: 'imported/quiz/q1',
-        message: 'Question contains an image reference to a remote URL.',
-        level: 'warn',
+        code: 'remote-image-copy-failed',
+        message: 'Some remote images could not be copied.',
       },
     ]);
   });

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.test.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.test.ts
@@ -270,20 +270,12 @@ describe('serializeConversionResult', () => {
     conversionResult.reports.push({
       type: 'remote-image-copy',
       questionId: 'source-q1',
-      referencesFound: 2,
-      referencesCopied: 1,
-      referencesLeftRemote: 1,
       filesCreated: 1,
     });
 
     const { result } = await serializeConversionResult(conversionResult, 'quiz', '/nonexistent');
 
-    expect(result.questions[0].remoteImageCopy).toEqual({
-      referencesFound: 2,
-      referencesCopied: 1,
-      referencesLeftRemote: 1,
-      filesCreated: 1,
-    });
+    expect(result.questions[0].copiedExternalImageFileCount).toBe(1);
     expect(result.warnings).toEqual([
       {
         questionId: 'source-q1',

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
@@ -461,7 +461,7 @@ export async function serializeConversionResult(
         (warning) =>
           warning.questionId === q.sourceId && warning.code === 'remote-image-copy-failed',
       );
-      const remoteImageCopy = result.reports.find(
+      const remoteImageCopyReport = result.reports.find(
         (report) => report.type === 'remote-image-copy' && report.questionId === q.sourceId,
       );
       const seenMessages = new Set<string>();
@@ -481,13 +481,8 @@ export async function serializeConversionResult(
         serverPy: q.serverPy,
         clientFiles: files,
         skippedVideos: q.skippedFiles,
-        ...(remoteImageCopy && {
-          remoteImageCopy: {
-            referencesFound: remoteImageCopy.referencesFound,
-            referencesCopied: remoteImageCopy.referencesCopied,
-            referencesLeftRemote: remoteImageCopy.referencesLeftRemote,
-            filesCreated: remoteImageCopy.filesCreated,
-          },
+        ...(remoteImageCopyReport && {
+          copiedExternalImageFileCount: remoteImageCopyReport.filesCreated,
         }),
       };
     }),

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
@@ -481,9 +481,7 @@ export async function serializeConversionResult(
         serverPy: q.serverPy,
         clientFiles: files,
         skippedVideos: q.skippedFiles,
-        ...(remoteImageCopyReport && {
-          copiedExternalImageFileCount: remoteImageCopyReport.filesCreated,
-        }),
+        copiedExternalImageFileCount: remoteImageCopyReport?.filesCreated ?? 0,
       };
     }),
   );

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
@@ -462,7 +462,7 @@ export async function serializeConversionResult(
           warning.questionId === q.sourceId && warning.code === 'remote-image-copy-failed',
       );
       const remoteImageCopyReport = result.reports.find(
-        (report) => report.type === 'remote-image-copy' && report.questionId === q.sourceId,
+        (report) => report.questionId === q.sourceId,
       );
       const seenMessages = new Set<string>();
       for (const d of await lintQuestionHtml(q.questionHtml)) {

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
@@ -418,12 +418,7 @@ async function convertEntry(
 
   return {
     ok: true,
-    value: await serializeConversionResult(
-      result,
-      assessmentSlug,
-      webResourcesDir,
-      remoteImageCopier,
-    ),
+    value: await serializeConversionResult(result, assessmentSlug, webResourcesDir),
   };
 }
 
@@ -444,7 +439,6 @@ export async function serializeConversionResult(
   result: ConversionResult,
   assessmentSlug: string,
   webResourcesDir: string,
-  remoteImageCopier: QtiImportRemoteImageCopier,
 ): Promise<SerializedEntryResult> {
   const extraWarnings: ConversionWarning[] = [];
   const questionPrefix = `imported/${assessmentSlug}`;
@@ -455,7 +449,6 @@ export async function serializeConversionResult(
       // questions live under the prefix path (e.g. "imported/quiz-slug/q1").
       // This must match the IDs used in the assessment zones.
       const questionId = `${questionPrefix}/${q.directoryName}`;
-      const remoteImageCopy = remoteImageCopier.getCopyResult(q);
       const { files, missingFiles } = await serializeClientFiles(q.clientFiles, webResourcesDir);
       if (missingFiles.length > 0) {
         extraWarnings.push({
@@ -464,13 +457,16 @@ export async function serializeConversionResult(
           level: 'warn',
         });
       }
+      const hasRemoteImageCopyWarning = result.warnings.some(
+        (warning) =>
+          warning.questionId === q.sourceId && warning.code === 'remote-image-copy-failed',
+      );
+      const remoteImageCopy = result.reports.find(
+        (report) => report.type === 'remote-image-copy' && report.questionId === q.sourceId,
+      );
       const seenMessages = new Set<string>();
       for (const d of await lintQuestionHtml(q.questionHtml)) {
-        if (
-          remoteImageCopy.failedImageCount > 0 &&
-          remoteImageCopy.unattemptedRemoteImageCount === 0 &&
-          d.ruleName === 'pl-remote-image-url'
-        ) {
+        if (hasRemoteImageCopyWarning && d.ruleName === 'pl-remote-image-url') {
           continue;
         }
         if (seenMessages.has(d.message)) continue;
@@ -485,7 +481,14 @@ export async function serializeConversionResult(
         serverPy: q.serverPy,
         clientFiles: files,
         skippedVideos: q.skippedFiles,
-        remoteImagesCopied: remoteImageCopy.remoteImagesCopied,
+        ...(remoteImageCopy && {
+          remoteImageCopy: {
+            referencesFound: remoteImageCopy.referencesFound,
+            referencesCopied: remoteImageCopy.referencesCopied,
+            referencesLeftRemote: remoteImageCopy.referencesLeftRemote,
+            filesCreated: remoteImageCopy.filesCreated,
+          },
+        }),
       };
     }),
   );

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
@@ -20,7 +20,8 @@ export interface SerializedQuestionOutput {
   clientFiles: Record<string, { size: number }>;
   /** Video files that were excluded from this question's assets. */
   skippedVideos: string[];
-  copiedExternalImageFileCount?: number;
+  /** Number of unique client files created from external images. */
+  copiedExternalImageFileCount: number;
 }
 
 interface StoredSerializedQuestionOutput extends Omit<

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
@@ -4,9 +4,12 @@ import type {
   PLAssessmentInfoJson,
   PLAssessmentZone,
   PLQuestionInfoJson,
+  RemoteImageCopyReport,
 } from '@prairielearn/question-conversion';
 
 export const QTI_IMPORT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+type SerializedRemoteImageCopyReport = Omit<RemoteImageCopyReport, 'type' | 'questionId'>;
 
 /** Question output sent to the browser. Binary client file contents stay in an import draft. */
 export interface SerializedQuestionOutput {
@@ -20,8 +23,7 @@ export interface SerializedQuestionOutput {
   clientFiles: Record<string, { size: number }>;
   /** Video files that were excluded from this question's assets. */
   skippedVideos: string[];
-  /** Remote images that will be copied into this course. */
-  remoteImagesCopied: number;
+  remoteImageCopy?: SerializedRemoteImageCopyReport;
 }
 
 interface StoredSerializedQuestionOutput extends Omit<

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
@@ -4,12 +4,9 @@ import type {
   PLAssessmentInfoJson,
   PLAssessmentZone,
   PLQuestionInfoJson,
-  RemoteImageCopyReport,
 } from '@prairielearn/question-conversion';
 
 export const QTI_IMPORT_MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
-
-type SerializedRemoteImageCopyReport = Omit<RemoteImageCopyReport, 'type' | 'questionId'>;
 
 /** Question output sent to the browser. Binary client file contents stay in an import draft. */
 export interface SerializedQuestionOutput {
@@ -23,7 +20,7 @@ export interface SerializedQuestionOutput {
   clientFiles: Record<string, { size: number }>;
   /** Video files that were excluded from this question's assets. */
   skippedVideos: string[];
-  remoteImageCopy?: SerializedRemoteImageCopyReport;
+  copiedExternalImageFileCount?: number;
 }
 
 interface StoredSerializedQuestionOutput extends Omit<

--- a/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
@@ -6,7 +6,7 @@ import { pipeline } from 'node:stream/promises';
 import { ZipArchive } from 'archiver';
 
 import { getCourseAdminQuestionsUrl } from '../../lib/client/url.js';
-import { deleteQtiImportDraft, readQtiImportDraft } from '../../lib/qti-import-drafts.js';
+import { deleteQtiImportDraft } from '../../lib/qti-import-drafts.js';
 import type { UploadResponse } from '../../pages/instructorQtiImport/instructorQtiImport.types.js';
 
 import { expect, test } from './fixtures.js';
@@ -816,13 +816,7 @@ test.describe('QTI Import', () => {
 
     await expect(page.getByText('What can be imported')).toBeVisible({ timeout: 15000 });
 
-    const draft = await readQtiImportDraft({
-      draftId: uploadBody.results[0].questions[0].draftId,
-      courseId: courseInstance.course_id,
-      courseInstanceId: courseInstance.id,
-      userId: '1',
-    });
-    await deleteQtiImportDraft(draft);
+    await deleteQtiImportDraft(uploadBody.results[0].questions[0].draftId);
     await page.getByRole('button', { name: 'Import 1 assessment' }).click();
 
     await expect(

--- a/apps/prairielearn/src/trpc/courseInstance/qti-import.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/qti-import.ts
@@ -80,14 +80,7 @@ const StoredSerializedQuestionOutputSchema = z.object({
   serverPy: z.string().optional(),
   clientFiles: z.record(z.string(), z.string()),
   skippedVideos: z.array(z.string()),
-  remoteImageCopy: z
-    .object({
-      referencesFound: z.number().int().nonnegative(),
-      referencesCopied: z.number().int().nonnegative(),
-      referencesLeftRemote: z.number().int().nonnegative(),
-      filesCreated: z.number().int().nonnegative(),
-    })
-    .optional(),
+  copiedExternalImageFileCount: z.number().int().nonnegative().optional(),
 });
 
 const StoredSerializedConversionResultForHydrationSchema = z.object({

--- a/apps/prairielearn/src/trpc/courseInstance/qti-import.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/qti-import.ts
@@ -80,7 +80,8 @@ const StoredSerializedQuestionOutputSchema = z.object({
   serverPy: z.string().optional(),
   clientFiles: z.record(z.string(), z.string()),
   skippedVideos: z.array(z.string()),
-  copiedExternalImageFileCount: z.number().int().nonnegative().optional(),
+  // Drafts created before external image copying was added omit this field.
+  copiedExternalImageFileCount: z.number().int().nonnegative().default(0),
 });
 
 const StoredSerializedConversionResultForHydrationSchema = z.object({

--- a/apps/prairielearn/src/trpc/courseInstance/qti-import.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/qti-import.ts
@@ -80,7 +80,14 @@ const StoredSerializedQuestionOutputSchema = z.object({
   serverPy: z.string().optional(),
   clientFiles: z.record(z.string(), z.string()),
   skippedVideos: z.array(z.string()),
-  remoteImagesCopied: z.number().default(0),
+  remoteImageCopy: z
+    .object({
+      referencesFound: z.number().int().nonnegative(),
+      referencesCopied: z.number().int().nonnegative(),
+      referencesLeftRemote: z.number().int().nonnegative(),
+      filesCreated: z.number().int().nonnegative(),
+    })
+    .optional(),
 });
 
 const StoredSerializedConversionResultForHydrationSchema = z.object({

--- a/packages/public-fetch/src/index.test.ts
+++ b/packages/public-fetch/src/index.test.ts
@@ -5,12 +5,9 @@ import type { AddressInfo } from 'node:net';
 import * as pem from 'pem';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-import {
-  createPublicFetch,
-  isPublicIpAddress,
-  publicFetch,
-  resolvePublicAddress,
-} from './index.js';
+import { isPublicIpAddress, resolvePublicAddressWithLookup } from './network.js';
+
+import { createPublicFetch, publicFetch } from './index.js';
 
 let certificate: pem.CertificateCreationResult;
 
@@ -111,17 +108,19 @@ describe('isPublicIpAddress', () => {
 describe('resolvePublicAddress', () => {
   it('rejects a hostname if any resolved address is not public', async () => {
     await expect(
-      resolvePublicAddress('example.com', {
-        lookupAddresses: async () => [{ address: '8.8.8.8' }, { address: '127.0.0.1' }],
-      }),
+      resolvePublicAddressWithLookup('example.com', async () => [
+        { address: '8.8.8.8' },
+        { address: '127.0.0.1' },
+      ]),
     ).rejects.toThrow('public address');
   });
 
   it('returns the first address when every resolved address is public', async () => {
     await expect(
-      resolvePublicAddress('example.com', {
-        lookupAddresses: async () => [{ address: '8.8.8.8' }, { address: '1.1.1.1' }],
-      }),
+      resolvePublicAddressWithLookup('example.com', async () => [
+        { address: '8.8.8.8' },
+        { address: '1.1.1.1' },
+      ]),
     ).resolves.toBe('8.8.8.8');
   });
 });
@@ -230,19 +229,6 @@ describe('publicFetch', () => {
     expect(didResolve).toBe(false);
   });
 
-  it('rejects HTTP before resolving the host', async () => {
-    let didResolve = false;
-    const fetch = createTestPublicFetch({
-      resolveAddress: async () => {
-        didResolve = true;
-        return '127.0.0.1';
-      },
-    });
-
-    await expect(fetch('http://public.example/resource')).rejects.toThrow('HTTPS');
-    expect(didResolve).toBe(false);
-  });
-
   it('rejects a redirect to a non-public address before connecting', async () => {
     let internalRequestCount = 0;
     await withHttpsServer(
@@ -262,7 +248,7 @@ describe('publicFetch', () => {
             const fetch = createTestPublicFetch({
               resolveAddress: async (hostname) => {
                 if (hostname === 'public.example') return '127.0.0.1';
-                return resolvePublicAddress(hostname);
+                return resolvePublicAddressWithLookup(hostname, async () => []);
               },
             });
 
@@ -276,86 +262,12 @@ describe('publicFetch', () => {
     expect(internalRequestCount).toBe(0);
   });
 
-  it('uses the Fetch redirect limit', async () => {
-    let requestCount = 0;
-    await withHttpsServer(
-      (_request, response) => {
-        requestCount += 1;
-        response.writeHead(302, { Location: '/redirect' });
-        response.end();
-      },
-      async (port) => {
-        const fetch = createTestPublicFetch({ resolveAddress: async () => '127.0.0.1' });
-        await expect(fetch(`https://public.example:${port}/redirect`)).rejects.toThrow();
-      },
-    );
-    expect(requestCount).toBe(21);
-  });
-
   it('can be aborted while resolving the host', async () => {
     const fetch = createTestPublicFetch({ resolveAddress: async () => new Promise(() => {}) });
 
     await expect(
       fetch('https://public.example/resource', { signal: AbortSignal.timeout(10) }),
     ).rejects.toThrow();
-  });
-
-  it('applies an abort signal while streaming the response body', async () => {
-    await withHttpsServer(
-      (_request, response) => {
-        response.writeHead(200);
-        response.write('partial');
-      },
-      async (port) => {
-        const fetch = createTestPublicFetch({ resolveAddress: async () => '127.0.0.1' });
-        const abortController = new AbortController();
-        const response = await fetch(`https://public.example:${port}/resource`, {
-          signal: abortController.signal,
-        });
-
-        const bodyPromise = response.text();
-        abortController.abort();
-        await expect(bodyPromise).rejects.toThrow();
-      },
-    );
-  });
-
-  it('does not forward sensitive headers across origins', async () => {
-    const requestHeaders: http.IncomingHttpHeaders[] = [];
-    await withHttpsServer(
-      (request, finalResponse) => {
-        requestHeaders.push(request.headers);
-        finalResponse.end('contents');
-      },
-      async (finalPort) => {
-        await withHttpsServer(
-          (request, redirectResponse) => {
-            requestHeaders.push(request.headers);
-            redirectResponse.writeHead(302, {
-              Location: `https://other.example:${finalPort}/resource`,
-            });
-            redirectResponse.end();
-          },
-          async (redirectPort) => {
-            const fetch = createTestPublicFetch({ resolveAddress: async () => '127.0.0.1' });
-            const response = await fetch(`https://public.example:${redirectPort}/redirect`, {
-              headers: {
-                Authorization: 'Bearer token',
-                Cookie: 'session=secret',
-                'X-Request-Id': 'request-id',
-              },
-            });
-            await response.text();
-          },
-        );
-      },
-    );
-
-    expect(requestHeaders[0].authorization).toBe('Bearer token');
-    expect(requestHeaders[0].cookie).toBe('session=secret');
-    expect(requestHeaders[1].authorization).toBeUndefined();
-    expect(requestHeaders[1].cookie).toBeUndefined();
-    expect(requestHeaders[1]['x-request-id']).toBe('request-id');
   });
 
   it('rejects redirects to HTTP before connecting', async () => {

--- a/packages/public-fetch/src/index.test.ts
+++ b/packages/public-fetch/src/index.test.ts
@@ -216,18 +216,21 @@ describe('publicFetch', () => {
     expect(didResolve).toBe(false);
   });
 
-  it('rejects non-HTTPS protocols before resolving the host', async () => {
-    let didResolve = false;
-    const fetch = createTestPublicFetch({
-      resolveAddress: async () => {
-        didResolve = true;
-        return '127.0.0.1';
-      },
-    });
+  it.each(['http://public.example/resource', 'data:text/plain,contents'])(
+    'rejects non-HTTPS URL %s before resolving the host',
+    async (url) => {
+      let didResolve = false;
+      const fetch = createTestPublicFetch({
+        resolveAddress: async () => {
+          didResolve = true;
+          return '127.0.0.1';
+        },
+      });
 
-    await expect(fetch('data:text/plain,contents')).rejects.toThrow('HTTPS');
-    expect(didResolve).toBe(false);
-  });
+      await expect(fetch(url)).rejects.toThrow('HTTPS');
+      expect(didResolve).toBe(false);
+    },
+  );
 
   it('rejects a redirect to a non-public address before connecting', async () => {
     let internalRequestCount = 0;

--- a/packages/public-fetch/src/index.ts
+++ b/packages/public-fetch/src/index.ts
@@ -2,7 +2,6 @@ import { lookup as dnsLookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 import type { SecureContextOptions } from 'node:tls';
 
-import ipaddr from 'ipaddr.js';
 import {
   Agent,
   Request,
@@ -13,22 +12,14 @@ import {
   fetch as undiciFetch,
 } from 'undici';
 
-export type ResolveAddress = (hostname: string) => Promise<string>;
+import { resolvePublicAddressWithLookup, unwrapHostname } from './network.js';
 
-type LookupAddresses = (hostname: string) => Promise<readonly { address: string }[]>;
+export type ResolveAddress = (hostname: string) => Promise<string>;
 
 export type PublicFetchInit = Omit<RequestInit, 'dispatcher'>;
 export type PublicFetch = (input: RequestInfo, init?: PublicFetchInit) => Promise<Response>;
 
 const defaultConnector = buildConnector({});
-
-export function isPublicIpAddress(address: string): boolean {
-  try {
-    return ipaddr.process(address).range() === 'unicast';
-  } catch {
-    return false;
-  }
-}
 
 export function validatePublicHttpsUrl(url: URL): void {
   if (url.protocol !== 'https:') {
@@ -39,21 +30,10 @@ export function validatePublicHttpsUrl(url: URL): void {
   }
 }
 
-export async function resolvePublicAddress(
-  hostname: string,
-  {
-    lookupAddresses = async (hostname) => dnsLookup(hostname, { all: true, verbatim: true }),
-  }: { lookupAddresses?: LookupAddresses } = {},
-): Promise<string> {
-  const unwrappedHostname = unwrapHostname(hostname);
-  const addresses = isIP(unwrappedHostname)
-    ? [{ address: unwrappedHostname }]
-    : await lookupAddresses(unwrappedHostname);
-
-  if (addresses.length === 0 || addresses.some(({ address }) => !isPublicIpAddress(address))) {
-    throw new Error('Host did not resolve to a public address');
-  }
-  return addresses[0].address;
+async function resolvePublicAddress(hostname: string): Promise<string> {
+  return resolvePublicAddressWithLookup(hostname, (hostname) =>
+    dnsLookup(hostname, { all: true, verbatim: true }),
+  );
 }
 
 /**
@@ -104,7 +84,3 @@ export function createPublicFetch({
 }
 
 export const publicFetch = createPublicFetch();
-
-function unwrapHostname(hostname: string): string {
-  return hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
-}

--- a/packages/public-fetch/src/network.ts
+++ b/packages/public-fetch/src/network.ts
@@ -1,0 +1,32 @@
+import { isIP } from 'node:net';
+
+import ipaddr from 'ipaddr.js';
+
+export type LookupAddresses = (hostname: string) => Promise<readonly { address: string }[]>;
+
+export function isPublicIpAddress(address: string): boolean {
+  try {
+    return ipaddr.process(address).range() === 'unicast';
+  } catch {
+    return false;
+  }
+}
+
+export async function resolvePublicAddressWithLookup(
+  hostname: string,
+  lookupAddresses: LookupAddresses,
+): Promise<string> {
+  const unwrappedHostname = unwrapHostname(hostname);
+  const addresses = isIP(unwrappedHostname)
+    ? [{ address: unwrappedHostname }]
+    : await lookupAddresses(unwrappedHostname);
+
+  if (addresses.length === 0 || addresses.some(({ address }) => !isPublicIpAddress(address))) {
+    throw new Error('Host did not resolve to a public address');
+  }
+  return addresses[0].address;
+}
+
+export function unwrapHostname(hostname: string): string {
+  return hostname.startsWith('[') ? hostname.slice(1, -1) : hostname;
+}

--- a/packages/question-conversion/README.md
+++ b/packages/question-conversion/README.md
@@ -36,8 +36,7 @@ For programmatic use, `@prairielearn/question-conversion` exports a small surfac
 
 The pipeline is `parse` (XML → IR) → `transform` (per-question normalization) → `emit` (IR → PrairieLearn files), with optional processing hooks around emission. `bin/convert.ts` runs these stages and orchestrates the file-system side. Canvas equation images are converted back to their LaTeX source during parsing, before local images are rewritten and feedback is emitted into `server.py`.
 
-`PLEmitter#emit(...)` is synchronous. Use the async `emitProcessed(...)` method when the emitted
-output needs processing:
+`PLEmitter#emit(...)` is synchronous. Use the async `emitProcessed(...)` method when the emitted output needs processing:
 
 ```ts
 const result = await emitter.emitProcessed(ir, {

--- a/packages/question-conversion/src/emitters/emitter.ts
+++ b/packages/question-conversion/src/emitters/emitter.ts
@@ -16,12 +16,6 @@ export interface ConversionWarning {
 export interface RemoteImageCopyReport {
   type: 'remote-image-copy';
   questionId: string;
-  /** Number of remote image references found in the question and its feedback. */
-  referencesFound: number;
-  /** Number of references rewritten to use a local client file. */
-  referencesCopied: number;
-  /** Number of references left unchanged because they could not be copied. */
-  referencesLeftRemote: number;
   /** Number of unique client files created, after content-based deduplication. */
   filesCreated: number;
 }

--- a/packages/question-conversion/src/emitters/emitter.ts
+++ b/packages/question-conversion/src/emitters/emitter.ts
@@ -6,9 +6,28 @@ export interface ConversionWarning {
   questionId: string;
   message: string;
   level?: 'warn' | 'info';
+  /** Machine-readable identifier for consumers that need to handle a warning specially. */
+  code?: 'remote-image-copy-failed';
   /** When set, the warning is about an external question bank from another source course. */
   externalCourseId?: string;
 }
+
+/** Per-question outcome from copying remote image references into PrairieLearn client files. */
+export interface RemoteImageCopyReport {
+  type: 'remote-image-copy';
+  questionId: string;
+  /** Number of remote image references found in the question and its feedback. */
+  referencesFound: number;
+  /** Number of references rewritten to use a local client file. */
+  referencesCopied: number;
+  /** Number of references left unchanged because they could not be copied. */
+  referencesLeftRemote: number;
+  /** Number of unique client files created, after content-based deduplication. */
+  filesCreated: number;
+}
+
+/** Structured information produced during conversion. */
+export type ConversionReport = RemoteImageCopyReport;
 
 /** Options for emitting PL output. */
 export interface EmitOptions {
@@ -27,7 +46,7 @@ export interface ConversionProcessor {
 
 /** Options for processing and emitting PrairieLearn output. */
 export interface EmitProcessedOptions extends EmitOptions {
-  processors: readonly ConversionProcessor[];
+  processors?: readonly ConversionProcessor[];
 }
 
 interface ConversionResultBase {
@@ -40,6 +59,7 @@ interface ConversionResultBase {
   assessment: PLAssessmentOutput;
   questions: PLQuestionOutput[];
   warnings: ConversionWarning[];
+  reports: ConversionReport[];
 }
 
 interface AssessmentConversionResult extends ConversionResultBase {
@@ -62,6 +82,6 @@ export interface OutputEmitter {
   /** Runs processors around emission, awaiting each hook in order. */
   emitProcessed(
     itemContainer: IRItemContainer,
-    options: EmitProcessedOptions,
+    options?: EmitProcessedOptions,
   ): Promise<ConversionResult>;
 }

--- a/packages/question-conversion/src/emitters/pl-emitter.ts
+++ b/packages/question-conversion/src/emitters/pl-emitter.ts
@@ -73,6 +73,7 @@ export class PLEmitter implements OutputEmitter {
         assessment: assessmentOutput,
         questions,
         warnings,
+        reports: [],
       };
     }
 
@@ -84,12 +85,13 @@ export class PLEmitter implements OutputEmitter {
       assessment: assessmentOutput,
       questions,
       warnings,
+      reports: [],
     };
   }
 
   async emitProcessed(
     itemContainer: IRItemContainer,
-    { processors, ...options }: EmitProcessedOptions,
+    { processors = [], ...options }: EmitProcessedOptions = {},
   ): Promise<ConversionResult> {
     for (const processor of processors) {
       await processor.beforeEmit?.(itemContainer);

--- a/packages/question-conversion/src/index.ts
+++ b/packages/question-conversion/src/index.ts
@@ -32,11 +32,13 @@ export type {
 export { PLEmitter } from './emitters/pl-emitter.js';
 export type {
   ConversionProcessor,
+  ConversionReport,
   OutputEmitter,
   ConversionResult,
   ConversionWarning,
   EmitOptions,
   EmitProcessedOptions,
+  RemoteImageCopyReport,
 } from './emitters/emitter.js';
 export type { BodyEmitHandler } from './emitters/body-emit-handler.js';
 export { BodyEmitRegistry } from './emitters/body-emit-handler.js';
@@ -87,5 +89,4 @@ export { slugify } from './utils/slugify.js';
 export { normalizeImsFilePath, safeDecodeURIComponent } from './utils/ims-file-path.js';
 
 // Processors
-export { QtiImportRemoteImageCopier, fetchRemoteImage } from './remote-image-copier.js';
-export type { FetchedRemoteImage, RemoteImageCopyResult } from './remote-image-copier.js';
+export { QtiImportRemoteImageCopier } from './remote-image-copier.js';

--- a/packages/question-conversion/src/pipeline.test.ts
+++ b/packages/question-conversion/src/pipeline.test.ts
@@ -27,41 +27,6 @@ describe('convert (integration)', () => {
       );
     });
 
-    it('preserves parsed Canvas equations through emission', async () => {
-      const xml = readFileSync(path.join(QTI12_FIXTURES, 'canvas-checkbox.xml'), 'utf-8').replace(
-        '        </resprocessing>',
-        `        </resprocessing>
-        <itemfeedback ident="a1_fb">
-          <flow_mat><material><mattext texttype="text/html">&lt;img data-equation-content="x^2" src="equation.svg"&gt;</mattext></material></flow_mat>
-        </itemfeedback>`,
-      );
-
-      const result = await convert(xml);
-
-      expect(result.questions[0].serverPy).toContain('$x^2$');
-      expect(result.questions[0].serverPy).not.toContain('data-equation-content');
-    });
-
-    it('runs processors around emission', async () => {
-      const xml = readFileSync(path.join(QTI12_FIXTURES, 'canvas-mc.xml'), 'utf-8');
-
-      const result = await convert(xml, {
-        processors: [
-          {
-            beforeEmit(itemContainer) {
-              itemContainer.questions[0].title = 'Processed Hashing';
-            },
-            afterEmit(result) {
-              result.warnings.push({ questionId: 'q1', message: 'Processed' });
-            },
-          },
-        ],
-      });
-
-      expect(result.warnings).toContainEqual({ questionId: 'q1', message: 'Processed' });
-      expect(result.questions[0].infoJson.title).toBe('Processed Hashing');
-    });
-
     it('converts a true/false quiz end-to-end', async () => {
       const xml = readFileSync(path.join(QTI12_FIXTURES, 'canvas-tf.xml'), 'utf-8');
       const result = await convert(xml);

--- a/packages/question-conversion/src/pipeline.ts
+++ b/packages/question-conversion/src/pipeline.ts
@@ -57,6 +57,5 @@ export async function convertWith(
   options?: ConvertOptions,
 ): Promise<ConversionResult> {
   const ir = await parseAssessment(xmlContent, parsers, options);
-  const { processors = [], ...emitOptions } = options ?? {};
-  return emitter.emitProcessed(ir, { ...emitOptions, processors });
+  return emitter.emitProcessed(ir, options);
 }

--- a/packages/question-conversion/src/remote-image-copier.test.ts
+++ b/packages/question-conversion/src/remote-image-copier.test.ts
@@ -67,9 +67,21 @@ function makeAssessment(question: IRQuestion): IRAssessment {
   };
 }
 
+async function processPrompt(
+  promptHtml: string,
+  copier: QtiImportRemoteImageCopier,
+  assets: IRQuestion['assets'] = new Map(),
+) {
+  return new PLEmitter().emitProcessed(makeAssessment(makeQuestion({ promptHtml, assets })), {
+    processors: [copier],
+  });
+}
+
 describe('QtiImportRemoteImageCopier', () => {
   it('processes conversion results and records uncopied-image warnings', async () => {
-    const copier = new QtiImportRemoteImageCopier(async () => {
+    const requestedUrls: string[] = [];
+    const copier = new QtiImportRemoteImageCopier(async (url) => {
+      requestedUrls.push(url.href);
       throw new Error('unavailable');
     });
 
@@ -77,17 +89,39 @@ describe('QtiImportRemoteImageCopier', () => {
       makeAssessment(
         makeQuestion({
           promptHtml:
-            '<img src="https://canvas.example/unavailable.png"><img src="://invalid.example/image.png">',
+            '<img src="https://canvas.example/unavailable.png"><img src="http://canvas.example/insecure.png"><img src="://invalid.example/image.png">',
+          feedback: {
+            incorrect: '<img src="https://canvas.example/feedback.png">',
+          },
         }),
       ),
       { processors: [copier] },
     );
 
+    expect(requestedUrls).toEqual([
+      'https://canvas.example/feedback.png',
+      'https://canvas.example/unavailable.png',
+    ]);
+    expect(result.questions[0].questionHtml).toContain('https://canvas.example/unavailable.png');
+    expect(result.questions[0].questionHtml).toContain('http://canvas.example/insecure.png');
+    expect(result.questions[0].questionHtml).toContain('://invalid.example/image.png');
+    expect(result.questions[0].serverPy).toContain('https://canvas.example/feedback.png');
     expect(result.warnings).toEqual([
       {
         questionId: 'source-q1',
+        code: 'remote-image-copy-failed',
         message:
-          '2 remote images could not be copied because of their URLs, availability, size, or format.',
+          '4 remote image references could not be copied into the course and were left unchanged. Their URLs may be invalid or insecure, or the images may be unavailable, too large, or in an unsupported format.',
+      },
+    ]);
+    expect(result.reports).toEqual([
+      {
+        type: 'remote-image-copy',
+        questionId: 'source-q1',
+        referencesFound: 4,
+        referencesCopied: 0,
+        referencesLeftRemote: 4,
+        filesCreated: 0,
       },
     ]);
   });
@@ -127,27 +161,15 @@ describe('QtiImportRemoteImageCopier', () => {
     );
     expect(question.questionHtml).not.toContain('canvas.example');
     expect(question.questionHtml).toContain('<pl-figure');
-    expect(copier.getCopyResult(question).remoteImagesCopied).toBe(2);
     expect(result.warnings).toEqual([]);
-  });
-
-  it('warns when a feedback image cannot be copied and preserves its remote URL', async () => {
-    const copier = new QtiImportRemoteImageCopier(async () => {
-      throw new Error('unavailable');
-    });
-    const imageUrl = 'https://canvas.example/feedback.png';
-
-    const result = await new PLEmitter().emitProcessed(
-      makeAssessment(makeQuestion({ feedback: { incorrect: `<img src="${imageUrl}">` } })),
-      { processors: [copier] },
-    );
-
-    expect(result.questions[0].serverPy).toContain(imageUrl);
-    expect(result.warnings).toEqual([
+    expect(result.reports).toEqual([
       {
+        type: 'remote-image-copy',
         questionId: 'source-q1',
-        message:
-          '1 remote image could not be copied because of its URL, availability, size, or format.',
+        referencesFound: 3,
+        referencesCopied: 3,
+        referencesLeftRemote: 0,
+        filesCreated: 1,
       },
     ]);
   });
@@ -159,78 +181,35 @@ describe('QtiImportRemoteImageCopier', () => {
       return { content: Buffer.from('image contents'), extension: 'png' };
     });
 
-    const result = await copier.copyRemoteImages(
+    const result = await processPrompt(
       [
-        '<p><img src="https://canvas.example/files/1/preview?verifier=secret" alt="Graph" width="200"></p>',
-        '<img src="https://canvas.example/files/1/preview?verifier=secret">',
+        '<p><img src="https://canvas.example/files/1/preview?verifier=secret#first" alt="Graph" width="200"></p>',
+        '<img src="//canvas.example/files/1/preview?verifier=secret#second">',
       ].join(''),
-      new Set(),
+      copier,
     );
+    const question = result.questions[0];
 
     expect(requestedUrls).toEqual(['https://canvas.example/files/1/preview?verifier=secret']);
-    expect(result.remoteImagesCopied).toBe(1);
-    expect(result.failedImageCount).toBe(0);
-    expect(result.unattemptedRemoteImageCount).toBe(0);
-    expect(result.files.size).toBe(1);
-    expect(result.html).not.toContain('canvas.example');
-    expect(result.html).not.toContain('verifier');
-    expect(result.html.match(/<pl-figure/g)).toHaveLength(2);
-    expect(result.html).toContain('directory="clientFilesQuestion"');
-    expect(result.html).toContain('display="inline"');
-    expect(result.html).toContain('alt="Graph"');
-    expect(result.html).toContain('width="200"');
-  });
-
-  it('normalizes protocol-relative image URLs and ignores fragments when deduplicating', async () => {
-    const requestedUrls: string[] = [];
-    const copier = new QtiImportRemoteImageCopier(async (url) => {
-      requestedUrls.push(url.href);
-      return { content: Buffer.from('image contents'), extension: 'jpg' };
-    });
-
-    const result = await copier.copyRemoteImages(
-      [
-        '<img src=" //canvas.example/files/1/preview#first">',
-        '<img src="//canvas.example/files/1/preview#second">',
-      ].join(''),
-      new Set(),
-    );
-
-    expect(requestedUrls).toEqual(['https://canvas.example/files/1/preview']);
-    expect(result.remoteImagesCopied).toBe(1);
-    expect(result.html.match(/<pl-figure/g)).toHaveLength(2);
-  });
-
-  it('leaves a remote reference unchanged when it cannot be fetched', async () => {
-    const copier = new QtiImportRemoteImageCopier(async () => {
-      throw new Error('unavailable');
-    });
-    const html = '<img src="https://canvas.example/files/1/preview?verifier=secret">';
-
-    const result = await copier.copyRemoteImages(html, new Set());
-
-    expect(result.html).toBe(html);
-    expect(result.files.size).toBe(0);
-    expect(result.remoteImagesCopied).toBe(0);
-    expect(result.failedImageCount).toBe(1);
-    expect(result.unattemptedRemoteImageCount).toBe(0);
-  });
-
-  it('counts insecure or malformed remote references that were not attempted', async () => {
-    let fetchCount = 0;
-    const copier = new QtiImportRemoteImageCopier(async () => {
-      fetchCount += 1;
-      return { content: Buffer.from('image contents'), extension: 'png' };
-    });
-
-    const result = await copier.copyRemoteImages(
-      '<img src="http://canvas.example/insecure.png"><img src="://invalid.example/image.png">',
-      new Set(),
-    );
-
-    expect(fetchCount).toBe(0);
-    expect(result.failedImageCount).toBe(0);
-    expect(result.unattemptedRemoteImageCount).toBe(2);
+    expect(question.clientFiles.size).toBe(1);
+    expect(question.questionHtml).not.toContain('canvas.example');
+    expect(question.questionHtml).not.toContain('verifier');
+    expect(question.questionHtml.match(/<pl-figure/g)).toHaveLength(2);
+    expect(question.questionHtml).toContain('directory="clientFilesQuestion"');
+    expect(question.questionHtml).toContain('display="inline"');
+    expect(question.questionHtml).toContain('alt="Graph"');
+    expect(question.questionHtml).toContain('width="200"');
+    expect(result.warnings).toEqual([]);
+    expect(result.reports).toEqual([
+      {
+        type: 'remote-image-copy',
+        questionId: 'source-q1',
+        referencesFound: 2,
+        referencesCopied: 2,
+        referencesLeftRemote: 0,
+        filesCreated: 1,
+      },
+    ]);
   });
 
   it('does not overwrite an existing client file with the generated filename', async () => {
@@ -241,13 +220,19 @@ describe('QtiImportRemoteImageCopier', () => {
       extension: 'png',
     }));
 
-    const result = await copier.copyRemoteImages(
+    const result = await processPrompt(
       '<img src="https://canvas.example/image.png">',
-      new Set([`remote-${digest}.png`]),
+      copier,
+      new Map([
+        [
+          `remote-${digest}.png`,
+          { type: 'base64', value: Buffer.from('different contents').toString('base64') },
+        ],
+      ]),
     );
 
-    expect(result.files.has(`remote-${digest}-2.png`)).toBe(true);
-    expect(result.html).toContain(`file-name="remote-${digest}-2.png"`);
+    expect(result.questions[0].clientFiles.has(`remote-${digest}-2.png`)).toBe(true);
+    expect(result.questions[0].questionHtml).toContain(`file-name="remote-${digest}-2.png"`);
   });
 
   it('limits the number of remote images copied across an import', async () => {
@@ -260,11 +245,19 @@ describe('QtiImportRemoteImageCopier', () => {
       (_, index) => `<img src="https://canvas.example/image-${index}.png">`,
     ).join('');
 
-    const result = await copier.copyRemoteImages(html, new Set());
+    const result = await processPrompt(html, copier);
 
-    expect(result.remoteImagesCopied).toBe(100);
-    expect(result.failedImageCount).toBe(1);
-    expect(result.html).toContain('https://canvas.example/image-100.png');
+    expect(result.questions[0].questionHtml.match(/<pl-figure/g)).toHaveLength(100);
+    expect(result.questions[0].questionHtml).toContain('https://canvas.example/image-100.png');
+    expect(result.warnings[0].code).toBe('remote-image-copy-failed');
+    expect(result.reports[0]).toEqual({
+      type: 'remote-image-copy',
+      questionId: 'source-q1',
+      referencesFound: 101,
+      referencesCopied: 100,
+      referencesLeftRemote: 1,
+      filesCreated: 100,
+    });
   });
 
   it('bounds concurrent remote image requests', async () => {
@@ -282,45 +275,48 @@ describe('QtiImportRemoteImageCopier', () => {
       (_, index) => `<img src="https://canvas.example/image-${index}.png">`,
     ).join('');
 
-    await copier.copyRemoteImages(html, new Set());
+    await processPrompt(html, copier);
 
     expect(maximumActiveRequestCount).toBe(5);
   });
 
   it('hands a released request slot to the queued batch before starting a later batch', async () => {
-    const copier = new QtiImportRemoteImageCopier();
     const startedRequests: string[] = [];
     const releaseActiveRequests: (() => void)[] = [];
-    const scheduleRequest = (name: string, block = false) =>
-      copier['scheduleRequest'](() => {
-        startedRequests.push(name);
-        if (!block) return Promise.resolve();
-        return new Promise<void>((resolve) => releaseActiveRequests.push(resolve));
-      });
-    const initialRequests = Array.from({ length: 5 }, (_, index) =>
-      scheduleRequest(`initial-${index}`, true),
+    const copier = new QtiImportRemoteImageCopier(async (url) => {
+      startedRequests.push(url.pathname);
+      if (url.pathname !== '/initial-queued.png' && url.pathname !== '/later.png') {
+        await new Promise<void>((resolve) => releaseActiveRequests.push(resolve));
+      }
+      return { content: Buffer.from(url.pathname), extension: 'png' };
+    });
+    const initialBatch = processPrompt(
+      Array.from(
+        { length: 6 },
+        (_, index) =>
+          `<img src="https://canvas.example/${index === 5 ? 'initial-queued' : `initial-${index}`}.png">`,
+      ).join(''),
+      copier,
     );
-    const queuedRequest = scheduleRequest('initial-queued');
+    const laterBatch = processPrompt('<img src="https://canvas.example/later.png">', copier);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(startedRequests).toEqual([
-      'initial-0',
-      'initial-1',
-      'initial-2',
-      'initial-3',
-      'initial-4',
+      '/initial-0.png',
+      '/initial-1.png',
+      '/initial-2.png',
+      '/initial-3.png',
+      '/initial-4.png',
     ]);
 
     releaseActiveRequests.shift()?.();
-    const laterRequest = new Promise<void>((resolve, reject) => {
-      // Run after the active request releases its slot but before the queued request resumes.
-      queueMicrotask(() => scheduleRequest('later').then(resolve, reject));
-    });
     await new Promise<void>((resolve) => setImmediate(resolve));
 
-    expect(startedRequests.slice(5)).toEqual(['initial-queued', 'later']);
+    expect(startedRequests.slice(5)).toEqual(['/initial-queued.png', '/later.png']);
 
     releaseActiveRequests.forEach((release) => release());
-    await Promise.all([...initialRequests, queuedRequest, laterRequest]);
+    await Promise.all([initialBatch, laterBatch]);
   });
 
   it('stops starting downloads after reaching the aggregate byte limit', async () => {
@@ -336,11 +332,19 @@ describe('QtiImportRemoteImageCopier', () => {
       (_, index) => `<img src="https://canvas.example/image-${index}.png">`,
     ).join('');
 
-    const result = await copier.copyRemoteImages(html, new Set());
+    const result = await processPrompt(html, copier);
 
     expect(fetchCount).toBeLessThan(20);
-    expect(result.remoteImagesCopied).toBe(5);
-    expect(result.failedImageCount).toBe(15);
+    expect(result.questions[0].questionHtml.match(/<pl-figure/g)).toHaveLength(5);
+    expect(result.warnings[0].code).toBe('remote-image-copy-failed');
+    expect(result.reports[0]).toEqual({
+      type: 'remote-image-copy',
+      questionId: 'source-q1',
+      referencesFound: 20,
+      referencesCopied: 5,
+      referencesLeftRemote: 15,
+      filesCreated: 1,
+    });
   });
 });
 

--- a/packages/question-conversion/src/remote-image-copier.test.ts
+++ b/packages/question-conversion/src/remote-image-copier.test.ts
@@ -111,19 +111,10 @@ describe('QtiImportRemoteImageCopier', () => {
         questionId: 'source-q1',
         code: 'remote-image-copy-failed',
         message:
-          '4 remote image references could not be copied into the course and were left unchanged. Their URLs may be invalid or insecure, or the images may be unavailable, too large, or in an unsupported format.',
+          '4 images could not be copied into the course and were left unchanged. Their URLs may be invalid or insecure, or the images may be unavailable, too large, or in an unsupported format.',
       },
     ]);
-    expect(result.reports).toEqual([
-      {
-        type: 'remote-image-copy',
-        questionId: 'source-q1',
-        referencesFound: 4,
-        referencesCopied: 0,
-        referencesLeftRemote: 4,
-        filesCreated: 0,
-      },
-    ]);
+    expect(result.reports).toEqual([]);
   });
 
   it('copies remote feedback images before emission and resolves their client-file URLs', async () => {
@@ -166,9 +157,6 @@ describe('QtiImportRemoteImageCopier', () => {
       {
         type: 'remote-image-copy',
         questionId: 'source-q1',
-        referencesFound: 3,
-        referencesCopied: 3,
-        referencesLeftRemote: 0,
         filesCreated: 1,
       },
     ]);
@@ -204,9 +192,6 @@ describe('QtiImportRemoteImageCopier', () => {
       {
         type: 'remote-image-copy',
         questionId: 'source-q1',
-        referencesFound: 2,
-        referencesCopied: 2,
-        referencesLeftRemote: 0,
         filesCreated: 1,
       },
     ]);
@@ -253,9 +238,6 @@ describe('QtiImportRemoteImageCopier', () => {
     expect(result.reports[0]).toEqual({
       type: 'remote-image-copy',
       questionId: 'source-q1',
-      referencesFound: 101,
-      referencesCopied: 100,
-      referencesLeftRemote: 1,
       filesCreated: 100,
     });
   });
@@ -340,9 +322,6 @@ describe('QtiImportRemoteImageCopier', () => {
     expect(result.reports[0]).toEqual({
       type: 'remote-image-copy',
       questionId: 'source-q1',
-      referencesFound: 20,
-      referencesCopied: 5,
-      referencesLeftRemote: 15,
       filesCreated: 1,
     });
   });

--- a/packages/question-conversion/src/remote-image-copier.ts
+++ b/packages/question-conversion/src/remote-image-copier.ts
@@ -6,11 +6,7 @@ import { fileTypeFromBuffer } from 'file-type';
 
 import { type PublicFetch, publicFetch, validatePublicHttpsUrl } from '@prairielearn/public-fetch';
 
-import type {
-  ConversionProcessor,
-  ConversionResult,
-  RemoteImageCopyReport,
-} from './emitters/emitter.js';
+import type { ConversionProcessor, ConversionResult } from './emitters/emitter.js';
 import type { IRItemContainer, IRQuestion } from './types/ir.js';
 import type { PLQuestionOutput } from './types/pl-output.js';
 import { CLIENT_FILES_QUESTION_URL, rewriteImagesAsPlFigure } from './utils/html.js';
@@ -44,14 +40,16 @@ interface FetchedRemoteImage {
 type ConsumeBytes = (byteLength: number) => void;
 type FetchRemoteImage = (url: URL, consumeBytes: ConsumeBytes) => Promise<FetchedRemoteImage>;
 type ImageReplacement = 'pl-figure' | 'img';
-type RemoteImageCopyOutcome = Omit<RemoteImageCopyReport, 'type' | 'questionId'>;
+
+interface RemoteImageCopyOutcome {
+  filesCreated: number;
+  referencesLeftRemote: number;
+}
 
 function emptyRemoteImageCopyOutcome(): RemoteImageCopyOutcome {
   return {
-    referencesFound: 0,
-    referencesCopied: 0,
-    referencesLeftRemote: 0,
     filesCreated: 0,
+    referencesLeftRemote: 0,
   };
 }
 
@@ -60,10 +58,8 @@ function combineRemoteImageCopyOutcomes(
 ): RemoteImageCopyOutcome {
   return outcomes.reduce<RemoteImageCopyOutcome>(
     (combined, outcome) => ({
-      referencesFound: combined.referencesFound + outcome.referencesFound,
-      referencesCopied: combined.referencesCopied + outcome.referencesCopied,
-      referencesLeftRemote: combined.referencesLeftRemote + outcome.referencesLeftRemote,
       filesCreated: combined.filesCreated + outcome.filesCreated,
+      referencesLeftRemote: combined.referencesLeftRemote + outcome.referencesLeftRemote,
     }),
     emptyRemoteImageCopyOutcome(),
   );
@@ -179,12 +175,10 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         const url = parseRemoteImageUrl(source);
         if (!url) {
           if (isRemoteImageReference(source)) {
-            outcome.referencesFound += 1;
             outcome.referencesLeftRemote += 1;
           }
           return;
         }
-        outcome.referencesFound += 1;
 
         const image = { $image, fragmentIndex };
         const existing = imagesByUrl.get(url.href);
@@ -235,7 +229,6 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
             $image.attr('src', `${CLIENT_FILES_QUESTION_URL}/${filename}`);
             fragments[fragmentIndex].changed = true;
           }
-          outcome.referencesCopied += elements.length;
         })(),
       );
     }
@@ -341,11 +334,11 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         feedbackCopyOutcomes.get(question.sourceId) ?? emptyRemoteImageCopyOutcome(),
         copyResult,
       );
-      if (outcome.referencesFound > 0) {
+      if (outcome.filesCreated > 0) {
         result.reports.push({
           type: 'remote-image-copy',
           questionId: question.sourceId,
-          ...outcome,
+          filesCreated: outcome.filesCreated,
         });
       }
       if (outcome.referencesLeftRemote === 0) continue;
@@ -353,12 +346,12 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
       const referenceCount = outcome.referencesLeftRemote;
       const cause =
         referenceCount === 1
-          ? 'The URL may be invalid or insecure, or the image may be unavailable, too large, or in an unsupported format.'
+          ? 'Its URL may be invalid or insecure, or the image may be unavailable, too large, or in an unsupported format.'
           : 'Their URLs may be invalid or insecure, or the images may be unavailable, too large, or in an unsupported format.';
       result.warnings.push({
         questionId: question.sourceId,
         code: 'remote-image-copy-failed',
-        message: `${referenceCount} remote image reference${referenceCount === 1 ? '' : 's'} could not be copied into the course and ${referenceCount === 1 ? 'was' : 'were'} left unchanged. ${cause}`,
+        message: `${referenceCount} image${referenceCount === 1 ? '' : 's'} could not be copied into the course and ${referenceCount === 1 ? 'was' : 'were'} left unchanged. ${cause}`,
       });
     }
   }

--- a/packages/question-conversion/src/remote-image-copier.ts
+++ b/packages/question-conversion/src/remote-image-copier.ts
@@ -39,7 +39,13 @@ interface FetchedRemoteImage {
 
 type ConsumeBytes = (byteLength: number) => void;
 type FetchRemoteImage = (url: URL, consumeBytes: ConsumeBytes) => Promise<FetchedRemoteImage>;
-type ImageReplacement = 'pl-figure' | 'img';
+type ImageOutputElement = 'pl-figure' | 'img';
+
+interface CopyRemoteImagesOptions {
+  reservedFilenames: Set<string>;
+  existingFiles: ReadonlyMap<string, Buffer | string>;
+  outputElement: ImageOutputElement;
+}
 
 interface RemoteImageCopyOutcome {
   filesCreated: number;
@@ -76,7 +82,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
   private activeRequestCount = 0;
   private readonly requestQueue: (() => void)[] = [];
   private readonly fetchCache = new Map<string, Promise<FetchedRemoteImage>>();
-  private readonly feedbackCopyOutcomes = new WeakMap<
+  private readonly feedbackOutcomesByItemContainer = new WeakMap<
     IRItemContainer,
     Map<string, RemoteImageCopyOutcome>
   >();
@@ -86,7 +92,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
       fetchRemoteImage(url, { consumeBytes }),
   ) {}
 
-  private fetchWithCache(url: URL): Promise<FetchedRemoteImage> {
+  private fetchImageWithCache(url: URL): Promise<FetchedRemoteImage> {
     let promise = this.fetchCache.get(url.href);
     if (!promise) {
       if (this.attemptedImageCount >= MAX_REMOTE_IMAGE_COUNT) {
@@ -132,28 +138,23 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
     }
   }
 
-  private async copyHtml(
-    html: string,
-    existingFilenames: Set<string>,
-    existingFiles: ReadonlyMap<string, Buffer | string>,
-    replacement: ImageReplacement,
-  ) {
-    const result = await this.copyHtmlFragments(
+  private async copyRemoteImagesInHtml(html: string, options: CopyRemoteImagesOptions) {
+    const { rewrittenHtmlFragments, ...result } = await this.copyRemoteImagesInHtmlFragments(
       [html],
-      existingFilenames,
-      existingFiles,
-      replacement,
+      options,
     );
-    return { ...result, html: result.html[0] };
+    return { ...result, rewrittenHtml: rewrittenHtmlFragments[0] };
   }
 
-  private async copyHtmlFragments(
-    html: readonly string[],
-    existingFilenames: Set<string>,
-    existingFiles: ReadonlyMap<string, Buffer | string>,
-    replacement: ImageReplacement,
+  /**
+   * Copies remote images across a batch of HTML fragments and returns the rewritten fragments in
+   * the same order. Processing them together deduplicates images shared by multiple fragments.
+   */
+  private async copyRemoteImagesInHtmlFragments(
+    htmlFragments: readonly string[],
+    { reservedFilenames, existingFiles, outputElement }: CopyRemoteImagesOptions,
   ) {
-    const fragments = html.map((originalHtml) => ({
+    const fragments = htmlFragments.map((originalHtml) => ({
       originalHtml,
       $: cheerio.load(originalHtml, null, false),
       changed: false,
@@ -190,7 +191,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
       });
     }
 
-    const files = new Map<string, Buffer>();
+    const createdFiles = new Map<string, Buffer>();
     const filenameByDigest = new Map<string, string>();
     for (const [filename, content] of existingFiles) {
       if (!Buffer.isBuffer(content)) continue;
@@ -202,7 +203,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         (async () => {
           let image: FetchedRemoteImage;
           try {
-            image = await this.fetchWithCache(url);
+            image = await this.fetchImageWithCache(url);
           } catch {
             outcome.referencesLeftRemote += elements.length;
             return;
@@ -218,10 +219,10 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
               return;
             }
 
-            filename = allocateFilename(`remote-${digest}.${image.extension}`, existingFilenames);
+            filename = allocateFilename(`remote-${digest}.${image.extension}`, reservedFilenames);
             filenameByDigest.set(digest, filename);
-            existingFilenames.add(filename);
-            files.set(filename, image.content);
+            reservedFilenames.add(filename);
+            createdFiles.set(filename, image.content);
             this.storedImageBytes += image.content.byteLength;
           }
 
@@ -235,44 +236,57 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
     await Promise.all(copyPromises);
 
     return {
-      html: fragments.map((fragment) => {
+      rewrittenHtmlFragments: fragments.map((fragment) => {
         if (!fragment.changed) return fragment.originalHtml;
         const rewrittenHtml = fragment.$.html();
-        return replacement === 'pl-figure'
+        return outputElement === 'pl-figure'
           ? rewriteImagesAsPlFigure(rewrittenHtml, { display: 'inline' })
           : rewrittenHtml;
       }),
-      files,
+      createdFiles,
       ...outcome,
-      filesCreated: files.size,
+      filesCreated: createdFiles.size,
     };
   }
 
-  private async copyIntoQuestion(question: PLQuestionOutput) {
-    const result = await this.copyHtml(
+  /**
+   * Copies remote images from emitted question HTML into its client files. Running after emission
+   * covers the prompt, answer choices, and any other HTML produced by a body handler.
+   */
+  private async copyRemoteImagesInQuestionHtml(
+    question: PLQuestionOutput,
+  ): Promise<RemoteImageCopyOutcome> {
+    const { createdFiles, rewrittenHtml, ...outcome } = await this.copyRemoteImagesInHtml(
       question.questionHtml,
-      new Set(question.clientFiles.keys()),
-      question.clientFiles,
-      'pl-figure',
+      {
+        reservedFilenames: new Set(question.clientFiles.keys()),
+        existingFiles: question.clientFiles,
+        outputElement: 'pl-figure',
+      },
     );
-    question.questionHtml = result.html;
-    for (const [filename, content] of result.files) {
+    question.questionHtml = rewrittenHtml;
+    for (const [filename, content] of createdFiles) {
       question.clientFiles.set(filename, content);
     }
-    return result;
+    return outcome;
   }
 
-  private async copyFeedback(question: IRQuestion): Promise<RemoteImageCopyOutcome> {
+  /**
+   * Copies remote images referenced by feedback HTML before PrairieLearn emission.
+   *
+   * The emitter may serialize feedback into question HTML attributes or generated grading code,
+   * so the fragments must be rewritten while they are still represented in the IR. This mutates
+   * both `question.feedback` and `question.assets`.
+   */
+  private async copyRemoteImagesInFeedback(question: IRQuestion): Promise<RemoteImageCopyOutcome> {
     const feedback = question.feedback;
     if (!feedback) return emptyRemoteImageCopyOutcome();
 
-    const html: string[] = [];
-    const updateHtml: ((html: string) => void)[] = [];
-    const addFragment = (fragment: string, update: (html: string) => void) => {
-      html.push(fragment);
-      updateHtml.push(update);
+    const fragments: { html: string; writeBack: (rewrittenHtml: string) => void }[] = [];
+    const addFragment = (html: string, writeBack: (rewrittenHtml: string) => void) => {
+      fragments.push({ html, writeBack });
     };
-    for (const key of ['correct', 'incorrect', 'general'] as const) {
+    for (const key of ['correct', 'incorrect'] as const) {
       if (feedback[key]) {
         addFragment(feedback[key], (value) => {
           feedback[key] = value;
@@ -287,7 +301,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         });
       }
     }
-    if (html.length === 0) return emptyRemoteImageCopyOutcome();
+    if (fragments.length === 0) return emptyRemoteImageCopyOutcome();
 
     const existingFiles = new Map<string, Buffer>();
     for (const [filename, asset] of question.assets) {
@@ -295,44 +309,51 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         existingFiles.set(filename, Buffer.from(asset.value, 'base64'));
       }
     }
-    const result = await this.copyHtmlFragments(
-      html,
-      new Set(question.assets.keys()),
-      existingFiles,
-      'img',
-    );
-    for (const [filename, content] of result.files) {
+    const { createdFiles, rewrittenHtmlFragments, ...outcome } =
+      await this.copyRemoteImagesInHtmlFragments(
+        fragments.map((fragment) => fragment.html),
+        {
+          reservedFilenames: new Set(question.assets.keys()),
+          existingFiles,
+          // Feedback may be emitted inside an element attribute or inserted after grading, so it
+          // must remain ordinary HTML rather than being converted to a nested PrairieLearn element.
+          outputElement: 'img',
+        },
+      );
+    for (const [filename, content] of createdFiles) {
       question.assets.set(filename, {
         type: 'base64',
         value: content.toString('base64'),
       });
     }
-    result.html.forEach((value, index) => updateHtml[index](value));
+    rewrittenHtmlFragments.forEach((rewrittenHtml, index) => {
+      fragments[index].writeBack(rewrittenHtml);
+    });
 
-    return result;
+    return outcome;
   }
 
   async beforeEmit(itemContainer: IRItemContainer): Promise<void> {
     const outcomes = new Map<string, RemoteImageCopyOutcome>();
-    this.feedbackCopyOutcomes.set(itemContainer, outcomes);
+    this.feedbackOutcomesByItemContainer.set(itemContainer, outcomes);
     await Promise.all(
       itemContainer.questions.map(async (question) => {
-        outcomes.set(question.sourceId, await this.copyFeedback(question));
+        outcomes.set(question.sourceId, await this.copyRemoteImagesInFeedback(question));
       }),
     );
   }
 
   async afterEmit(result: ConversionResult, itemContainer: IRItemContainer): Promise<void> {
-    const feedbackCopyOutcomes = this.feedbackCopyOutcomes.get(itemContainer) ?? new Map();
-    const copyResults = await Promise.all(
-      result.questions.map((question) => this.copyIntoQuestion(question)),
+    const feedbackOutcomes = this.feedbackOutcomesByItemContainer.get(itemContainer) ?? new Map();
+    const questionHtmlOutcomes = await Promise.all(
+      result.questions.map((question) => this.copyRemoteImagesInQuestionHtml(question)),
     );
 
-    for (const [index, copyResult] of copyResults.entries()) {
+    for (const [index, questionHtmlOutcome] of questionHtmlOutcomes.entries()) {
       const question = result.questions[index];
       const outcome = combineRemoteImageCopyOutcomes(
-        feedbackCopyOutcomes.get(question.sourceId) ?? emptyRemoteImageCopyOutcome(),
-        copyResult,
+        feedbackOutcomes.get(question.sourceId) ?? emptyRemoteImageCopyOutcome(),
+        questionHtmlOutcome,
       );
       if (outcome.filesCreated > 0) {
         result.reports.push({

--- a/packages/question-conversion/src/remote-image-copier.ts
+++ b/packages/question-conversion/src/remote-image-copier.ts
@@ -4,18 +4,16 @@ import * as cheerio from 'cheerio';
 import type { Element } from 'domhandler';
 import { fileTypeFromBuffer } from 'file-type';
 
-import {
-  type PublicFetch,
-  type ResolveAddress,
-  createPublicFetch,
-  publicFetch,
-  validatePublicHttpsUrl,
-} from '@prairielearn/public-fetch';
+import { type PublicFetch, publicFetch, validatePublicHttpsUrl } from '@prairielearn/public-fetch';
 
-import type { ConversionProcessor, ConversionResult } from './emitters/emitter.js';
+import type {
+  ConversionProcessor,
+  ConversionResult,
+  RemoteImageCopyReport,
+} from './emitters/emitter.js';
 import type { IRItemContainer, IRQuestion } from './types/ir.js';
 import type { PLQuestionOutput } from './types/pl-output.js';
-import { CLIENT_FILES_QUESTION_URL } from './utils/html.js';
+import { CLIENT_FILES_QUESTION_URL, rewriteImagesAsPlFigure } from './utils/html.js';
 
 // These limits cap both remote work and the amount of binary data retained by a conversion. The
 // 10 MiB per-image limit matches PrairieLearn's image-upload limit; 100 URLs and 50 MiB total allow
@@ -38,39 +36,38 @@ const SUPPORTED_IMAGE_TYPES = new Map([
 ]);
 const ACCEPTED_IMAGE_CONTENT_TYPES = [...SUPPORTED_IMAGE_TYPES.keys()].join(', ');
 
-export interface FetchedRemoteImage {
+interface FetchedRemoteImage {
   content: Buffer;
   extension: string;
-}
-
-export interface RemoteImageCopyResult {
-  html: string;
-  files: Map<string, Buffer>;
-  remoteImagesCopied: number;
-  failedImageCount: number;
-  unattemptedRemoteImageCount: number;
 }
 
 type ConsumeBytes = (byteLength: number) => void;
 type FetchRemoteImage = (url: URL, consumeBytes: ConsumeBytes) => Promise<FetchedRemoteImage>;
 type ImageReplacement = 'pl-figure' | 'img';
+type RemoteImageCopyOutcome = Omit<RemoteImageCopyReport, 'type' | 'questionId'>;
 
-interface RemoteImageCopyStats {
-  remoteImagesCopied: number;
-  failedImageCount: number;
-  unattemptedRemoteImageCount: number;
+function emptyRemoteImageCopyOutcome(): RemoteImageCopyOutcome {
+  return {
+    referencesFound: 0,
+    referencesCopied: 0,
+    referencesLeftRemote: 0,
+    filesCreated: 0,
+  };
 }
 
-interface RemoteImageFragmentsCopyResult extends RemoteImageCopyStats {
-  html: string[];
-  files: Map<string, Buffer>;
+function combineRemoteImageCopyOutcomes(
+  ...outcomes: readonly RemoteImageCopyOutcome[]
+): RemoteImageCopyOutcome {
+  return outcomes.reduce<RemoteImageCopyOutcome>(
+    (combined, outcome) => ({
+      referencesFound: combined.referencesFound + outcome.referencesFound,
+      referencesCopied: combined.referencesCopied + outcome.referencesCopied,
+      referencesLeftRemote: combined.referencesLeftRemote + outcome.referencesLeftRemote,
+      filesCreated: combined.filesCreated + outcome.filesCreated,
+    }),
+    emptyRemoteImageCopyOutcome(),
+  );
 }
-
-const EMPTY_COPY_STATS: RemoteImageCopyStats = {
-  remoteImagesCopied: 0,
-  failedImageCount: 0,
-  unattemptedRemoteImageCount: 0,
-};
 
 /**
  * Copies remote images across one complete QTI conversion while enforcing import-wide limits.
@@ -83,12 +80,10 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
   private activeRequestCount = 0;
   private readonly requestQueue: (() => void)[] = [];
   private readonly fetchCache = new Map<string, Promise<FetchedRemoteImage>>();
-  private readonly feedbackCopyStats = new WeakMap<
+  private readonly feedbackCopyOutcomes = new WeakMap<
     IRItemContainer,
-    Map<string, RemoteImageCopyStats>
+    Map<string, RemoteImageCopyOutcome>
   >();
-
-  private readonly questionCopyResults = new WeakMap<PLQuestionOutput, RemoteImageCopyResult>();
 
   constructor(
     private readonly fetchImage: FetchRemoteImage = (url, consumeBytes) =>
@@ -141,19 +136,12 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
     }
   }
 
-  async copyRemoteImages(
-    html: string,
-    existingFilenames: Set<string>,
-  ): Promise<RemoteImageCopyResult> {
-    return this.copyHtml(html, existingFilenames, new Map(), 'pl-figure');
-  }
-
   private async copyHtml(
     html: string,
     existingFilenames: Set<string>,
     existingFiles: ReadonlyMap<string, Buffer | string>,
     replacement: ImageReplacement,
-  ): Promise<RemoteImageCopyResult> {
+  ) {
     const result = await this.copyHtmlFragments(
       [html],
       existingFilenames,
@@ -168,7 +156,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
     existingFilenames: Set<string>,
     existingFiles: ReadonlyMap<string, Buffer | string>,
     replacement: ImageReplacement,
-  ): Promise<RemoteImageFragmentsCopyResult> {
+  ) {
     const fragments = html.map((originalHtml) => ({
       originalHtml,
       $: cheerio.load(originalHtml, null, false),
@@ -181,7 +169,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         elements: { $image: cheerio.Cheerio<Element>; fragmentIndex: number }[];
       }
     >();
-    let unattemptedRemoteImageCount = 0;
+    const outcome = emptyRemoteImageCopyOutcome();
 
     for (const [fragmentIndex, fragment] of fragments.entries()) {
       fragment.$('img[src]').each((_, element) => {
@@ -190,11 +178,13 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         if (!source) return;
         const url = parseRemoteImageUrl(source);
         if (!url) {
-          if (/^(?:https?:\/\/|:\/\/)/i.test(source.trim())) {
-            unattemptedRemoteImageCount += 1;
+          if (isRemoteImageReference(source)) {
+            outcome.referencesFound += 1;
+            outcome.referencesLeftRemote += 1;
           }
           return;
         }
+        outcome.referencesFound += 1;
 
         const image = { $image, fragmentIndex };
         const existing = imagesByUrl.get(url.href);
@@ -212,9 +202,6 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
       if (!Buffer.isBuffer(content)) continue;
       filenameByDigest.set(contentDigest(content), filename);
     }
-    let remoteImagesCopied = 0;
-    let failedImageCount = 0;
-
     const copyPromises: Promise<void>[] = [];
     for (const { url, elements } of imagesByUrl.values()) {
       copyPromises.push(
@@ -223,7 +210,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
           try {
             image = await this.fetchWithCache(url);
           } catch {
-            failedImageCount += 1;
+            outcome.referencesLeftRemote += elements.length;
             return;
           }
 
@@ -233,7 +220,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
           let filename = filenameByDigest.get(digest);
           if (!filename) {
             if (this.storedImageBytes + image.content.byteLength > MAX_TOTAL_REMOTE_IMAGE_BYTES) {
-              failedImageCount += 1;
+              outcome.referencesLeftRemote += elements.length;
               return;
             }
 
@@ -245,41 +232,30 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
           }
 
           for (const { $image, fragmentIndex } of elements) {
-            const $ = fragments[fragmentIndex].$;
-            if (replacement === 'img') {
-              $image.attr('src', `${CLIENT_FILES_QUESTION_URL}/${filename}`);
-            } else {
-              const $figure = $('<pl-figure></pl-figure>');
-              $figure.attr('file-name', filename);
-              $figure.attr('directory', 'clientFilesQuestion');
-              $figure.attr('display', 'inline');
-
-              const alt = $image.attr('alt');
-              const width = $image.attr('width');
-              if (alt) $figure.attr('alt', alt);
-              if (width) $figure.attr('width', width);
-              $image.replaceWith($figure);
-            }
+            $image.attr('src', `${CLIENT_FILES_QUESTION_URL}/${filename}`);
             fragments[fragmentIndex].changed = true;
           }
-          remoteImagesCopied += 1;
+          outcome.referencesCopied += elements.length;
         })(),
       );
     }
     await Promise.all(copyPromises);
 
     return {
-      html: fragments.map((fragment) =>
-        fragment.changed ? fragment.$.html() : fragment.originalHtml,
-      ),
+      html: fragments.map((fragment) => {
+        if (!fragment.changed) return fragment.originalHtml;
+        const rewrittenHtml = fragment.$.html();
+        return replacement === 'pl-figure'
+          ? rewriteImagesAsPlFigure(rewrittenHtml, { display: 'inline' })
+          : rewrittenHtml;
+      }),
       files,
-      remoteImagesCopied,
-      failedImageCount,
-      unattemptedRemoteImageCount,
+      ...outcome,
+      filesCreated: files.size,
     };
   }
 
-  async copyIntoQuestion(question: PLQuestionOutput): Promise<RemoteImageCopyResult> {
+  private async copyIntoQuestion(question: PLQuestionOutput) {
     const result = await this.copyHtml(
       question.questionHtml,
       new Set(question.clientFiles.keys()),
@@ -293,9 +269,9 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
     return result;
   }
 
-  private async copyFeedback(question: IRQuestion): Promise<RemoteImageCopyStats> {
+  private async copyFeedback(question: IRQuestion): Promise<RemoteImageCopyOutcome> {
     const feedback = question.feedback;
-    if (!feedback) return EMPTY_COPY_STATS;
+    if (!feedback) return emptyRemoteImageCopyOutcome();
 
     const html: string[] = [];
     const updateHtml: ((html: string) => void)[] = [];
@@ -303,20 +279,12 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
       html.push(fragment);
       updateHtml.push(update);
     };
-    if (feedback.correct) {
-      addFragment(feedback.correct, (value) => {
-        feedback.correct = value;
-      });
-    }
-    if (feedback.incorrect) {
-      addFragment(feedback.incorrect, (value) => {
-        feedback.incorrect = value;
-      });
-    }
-    if (feedback.general) {
-      addFragment(feedback.general, (value) => {
-        feedback.general = value;
-      });
+    for (const key of ['correct', 'incorrect', 'general'] as const) {
+      if (feedback[key]) {
+        addFragment(feedback[key], (value) => {
+          feedback[key] = value;
+        });
+      }
     }
     const perAnswer = feedback.perAnswer;
     if (perAnswer) {
@@ -326,7 +294,7 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
         });
       }
     }
-    if (html.length === 0) return EMPTY_COPY_STATS;
+    if (html.length === 0) return emptyRemoteImageCopyOutcome();
 
     const existingFiles = new Map<string, Buffer>();
     for (const [filename, asset] of question.assets) {
@@ -352,55 +320,56 @@ export class QtiImportRemoteImageCopier implements ConversionProcessor {
   }
 
   async beforeEmit(itemContainer: IRItemContainer): Promise<void> {
-    const statsByQuestionId = new Map<string, RemoteImageCopyStats>();
-    this.feedbackCopyStats.set(itemContainer, statsByQuestionId);
+    const outcomes = new Map<string, RemoteImageCopyOutcome>();
+    this.feedbackCopyOutcomes.set(itemContainer, outcomes);
     await Promise.all(
       itemContainer.questions.map(async (question) => {
-        statsByQuestionId.set(question.sourceId, await this.copyFeedback(question));
+        outcomes.set(question.sourceId, await this.copyFeedback(question));
       }),
     );
   }
 
   async afterEmit(result: ConversionResult, itemContainer: IRItemContainer): Promise<void> {
-    const feedbackStats = this.feedbackCopyStats.get(itemContainer);
+    const feedbackCopyOutcomes = this.feedbackCopyOutcomes.get(itemContainer) ?? new Map();
     const copyResults = await Promise.all(
-      result.questions.map(async (question) => {
-        const copyResult = await this.copyIntoQuestion(question);
-        addCopyStats(copyResult, feedbackStats?.get(question.sourceId) ?? EMPTY_COPY_STATS);
-        this.questionCopyResults.set(question, copyResult);
-        return copyResult;
-      }),
+      result.questions.map((question) => this.copyIntoQuestion(question)),
     );
 
     for (const [index, copyResult] of copyResults.entries()) {
-      const uncopiedCount = copyResult.failedImageCount + copyResult.unattemptedRemoteImageCount;
-      if (uncopiedCount === 0) continue;
+      const question = result.questions[index];
+      const outcome = combineRemoteImageCopyOutcomes(
+        feedbackCopyOutcomes.get(question.sourceId) ?? emptyRemoteImageCopyOutcome(),
+        copyResult,
+      );
+      if (outcome.referencesFound > 0) {
+        result.reports.push({
+          type: 'remote-image-copy',
+          questionId: question.sourceId,
+          ...outcome,
+        });
+      }
+      if (outcome.referencesLeftRemote === 0) continue;
+
+      const referenceCount = outcome.referencesLeftRemote;
+      const cause =
+        referenceCount === 1
+          ? 'The URL may be invalid or insecure, or the image may be unavailable, too large, or in an unsupported format.'
+          : 'Their URLs may be invalid or insecure, or the images may be unavailable, too large, or in an unsupported format.';
       result.warnings.push({
-        questionId: result.questions[index].sourceId,
-        message: `${uncopiedCount} remote image${uncopiedCount === 1 ? '' : 's'} could not be copied because of ${uncopiedCount === 1 ? 'its URL' : 'their URLs'}, availability, size, or format.`,
+        questionId: question.sourceId,
+        code: 'remote-image-copy-failed',
+        message: `${referenceCount} remote image reference${referenceCount === 1 ? '' : 's'} could not be copied into the course and ${referenceCount === 1 ? 'was' : 'were'} left unchanged. ${cause}`,
       });
     }
   }
+}
 
-  getCopyResult(question: PLQuestionOutput): RemoteImageCopyResult {
-    return (
-      this.questionCopyResults.get(question) ?? {
-        html: question.questionHtml,
-        files: new Map(),
-        ...EMPTY_COPY_STATS,
-      }
-    );
-  }
+function isRemoteImageReference(source: string): boolean {
+  return /^(?:https?:)?\/\/|^:\/\//i.test(source.trim());
 }
 
 function contentDigest(content: Buffer): string {
   return crypto.createHash('sha256').update(content).digest('hex').slice(0, 16);
-}
-
-function addCopyStats(target: RemoteImageCopyStats, source: RemoteImageCopyStats): void {
-  target.remoteImagesCopied += source.remoteImagesCopied;
-  target.failedImageCount += source.failedImageCount;
-  target.unattemptedRemoteImageCount += source.unattemptedRemoteImageCount;
 }
 
 function parseRemoteImageUrl(source: string): URL | null {
@@ -431,12 +400,10 @@ function allocateFilename(preferredFilename: string, existingFilenames: Set<stri
 export async function fetchRemoteImage(
   initialUrl: URL,
   {
-    resolveAddress,
-    fetch = resolveAddress ? createPublicFetch({ resolveAddress }) : publicFetch,
+    fetch = publicFetch,
     consumeBytes,
   }: {
     fetch?: PublicFetch;
-    resolveAddress?: ResolveAddress;
     consumeBytes?: ConsumeBytes;
   } = {},
 ): Promise<FetchedRemoteImage> {

--- a/packages/question-conversion/src/types/ir.ts
+++ b/packages/question-conversion/src/types/ir.ts
@@ -79,15 +79,15 @@ export interface IRRubric {
   criteria: IRRubricCriterion[];
 }
 
-/** Feedback attached to a question. */
+/** HTML feedback fragments shown to a student after their response is graded. */
 export interface IRFeedback {
+  /** Feedback shown when the response is correct. */
   correct?: string;
+  /** Feedback shown when the response is incorrect. */
   incorrect?: string;
-  general?: string;
   /**
-   * Per-answer feedback keyed by the answer display text (matches what PL stores
-   * in data['submitted_answers']). Used for multi-select questions where multiple
-   * feedbacks may need to be concatenated based on which answers were selected.
+   * HTML feedback keyed by the source answer's display text. Emitters use the key to attach the
+   * feedback to the corresponding answer or to compose feedback for the submitted answers.
    */
   perAnswer?: Record<string, string>;
 }

--- a/packages/question-conversion/src/utils/html.ts
+++ b/packages/question-conversion/src/utils/html.ts
@@ -101,7 +101,10 @@ const ABSOLUTE_URL_RE = /^(?:[a-z][a-z0-9+.-]*:|\/\/|:\/\/)/i;
  * The alt and width attributes are preserved; all others (style, class, etc.)
  * are dropped since pl-figure handles its own layout.
  */
-export function rewriteImagesAsPlFigure(html: string): string {
+export function rewriteImagesAsPlFigure(
+  html: string,
+  { display }: { display?: 'inline' } = {},
+): string {
   const $ = loadHtmlFragment(html);
   const mustachePrefix = `${CLIENT_FILES_QUESTION_URL}/`;
   let changed = false;
@@ -126,6 +129,7 @@ export function rewriteImagesAsPlFigure(html: string): string {
     const width = $img.attr('width');
     if (alt) $figure.attr('alt', alt);
     if (width) $figure.attr('width', width);
+    if (display) $figure.attr('display', display);
 
     $img.replaceWith($figure);
     changed = true;


### PR DESCRIPTION
# Description

This is a cleanup follow-up stacked on #15608. It reduces the implementation and test surface while preserving the instructor-facing behavior of copying external images into imported questions.

- Fold the copied-image count into the existing asset summary and describe it to instructors as images copied from external websites.
- Keep `emit()` synchronous and use the async `emitProcessed()` processor boundary for image copying, with processor options remaining optional for ordinary conversions.
- Replace copier-owned side-channel statistics with typed per-question conversion reports and machine-readable failure warnings. Reports retain only the unique client-file count that the application currently uses.
- Normalize the report into a required `copiedExternalImageFileCount` in the QTI review model, defaulting older stored drafts to zero across deployments.
- Narrow `@prairielearn/public-fetch` to its fetch-oriented public API and move the injectable DNS lookup seam into an internal network module.
- Reuse the shared image-to-`pl-figure` rewriting helper and remove redundant implementation-level helpers and tests.

The copied-image count intentionally uses unique client files rather than rewritten HTML references. Repeated references and duplicate content can share one client file, which matches the unit used by the existing asset total.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex produced the majority of the implementation and test changes under human direction and review.

# Testing

Focused behavior-level coverage exercises public-fetch DNS pinning, redirect validation, request methods, bodies, aborts, and connection reuse; prompt and feedback image copying; URL and content deduplication; concurrency and size limits; structured warnings; and report serialization into QTI import drafts.
