### PR TITLE
Document model and library responsibilities in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,17 @@ Course content repositories use JSON files like `infoCourse.json`, `infoCourseIn
 
 When working with assessment "groups" / "teams", see the [`groups-and-teams` skill](./.agents/skills/groups-and-teams/SKILL.md).
 
+### Models and libraries
+
+`apps/prairielearn/src/models/` and `apps/prairielearn/src/lib/` are organizational conventions for reusable application code, not strict dependency layers. Choose a location based on the helper's primary responsibility:
+
+- Model modules in `apps/prairielearn/src/models/` should map one-to-one to a primary database table and contain operations centered on that table's entity. Do not create a model without a corresponding primary table. A model may join or update related tables and contain entity-specific business rules, but those operations must remain centered on its primary table.
+- Put cross-entity workflows, orchestration, authorization or context helpers, analytics, and other reusable logic without a corresponding primary database table in `apps/prairielearn/src/lib/`. Library modules may execute SQL or call model functions.
+- Before adding a helper or query, extend an existing model or library module that already owns the responsibility when one exists.
+
 ### SQL query conventions
 
-- Always prefer existing model functions or library helpers over one-off raw SQL queries. Check `apps/prairielearn/src/models/` and existing lib functions before writing any database queries. Only write raw queries when no suitable abstraction exists.
+- Always prefer existing model functions or library helpers over one-off raw SQL queries. Check `apps/prairielearn/src/models/` and `apps/prairielearn/src/lib/` before writing any database queries. Only write raw queries when no suitable abstraction exists.
 - Use `to_jsonb(table.*)` if you need to select all columns from a table as JSON. This is preferred over explicit `jsonb_build_object` calls or returning columns explicitly in a SELECT statement because it automatically includes all columns and stays in sync with schema changes and Zod types.
 - When a query spans multiple tables, model it as a composite object with named canonical `db-types` entities plus any true computed fields, rather than flattening columns or embedding one entity inside another.
 - When writing SQL, get table and column names from `database/tables/` (the source of truth) or from nearby existing queries in the same feature area. Do NOT rely on names found in old migrations, as tables and columns may have been renamed since those migrations were written.


### PR DESCRIPTION
# Description

Document how to choose between `apps/prairielearn/src/models/` and `apps/prairielearn/src/lib/`, including the requirement that every model map one-to-one to a primary database table. The guidance allows entity-centered operations to use related tables while directing cross-entity and table-less reusable logic to `src/lib/`.

The majority of this change was developed with AI assistance.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Not applicable; documentation-only change.
