### PR TITLE
Clarify in docs/UI that invitations don't email students

### DIFF
--- a/apps/prairielearn/src/pages/instructorStudents/components/InviteStudentsModal.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/components/InviteStudentsModal.tsx
@@ -17,11 +17,13 @@ const MAX_UIDS = 1000;
 export function InviteStudentsModal({
   show,
   courseInstance,
+  selfEnrollLink,
   onHide,
   onSubmit,
 }: {
   show: boolean;
   courseInstance: StaffCourseInstance;
+  selfEnrollLink: string;
   onHide: () => void;
   onSubmit: (uids: string[]) => Promise<void>;
 }) {
@@ -122,7 +124,16 @@ export function InviteStudentsModal({
               </div>
             )}
             <div className="form-text" id="invite-uids-help">
-              One UID per line, or comma/space separated.
+              One UID per line, or comma/space separated. Students are not notified about the
+              invitation: you must instruct them to visit{' '}
+              <a href="/" target="_blank" rel="noopener noreferrer">
+                the PrairieLearn homepage
+              </a>{' '}
+              or{' '}
+              <a href={selfEnrollLink} target="_blank" rel="noopener noreferrer">
+                the course instance enrollment link
+              </a>{' '}
+              to accept the invitation.
             </div>
           </div>
         </Modal.Body>

--- a/apps/prairielearn/src/pages/instructorStudents/components/SyncStudentsModal.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/components/SyncStudentsModal.tsx
@@ -55,12 +55,14 @@ export function SyncStudentsModal({
   show,
   courseInstance,
   students,
+  selfEnrollLink,
   onHide,
   onSubmit,
 }: {
   show: boolean;
   courseInstance: StaffCourseInstance;
   students: StudentRow[];
+  selfEnrollLink: string;
   onHide: () => void;
   onSubmit: (toInvite: string[], toCancelInvitation: string[], toRemove: string[]) => Promise<void>;
 }) {
@@ -243,7 +245,16 @@ export function SyncStudentsModal({
                   </div>
                 )}
                 <div className="form-text" id="sync-uids-help">
-                  One UID per line, or comma/space/semicolon separated.
+                  One UID per line, or comma/space/semicolon separated. Students are not notified
+                  about the invitation: you must instruct them to visit{' '}
+                  <a href="/" target="_blank" rel="noopener noreferrer">
+                    the PrairieLearn homepage
+                  </a>{' '}
+                  or{' '}
+                  <a href={selfEnrollLink} target="_blank" rel="noopener noreferrer">
+                    the course instance enrollment link
+                  </a>{' '}
+                  to accept the invitation.
                 </div>
               </div>
             </form>

--- a/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
+++ b/apps/prairielearn/src/pages/instructorStudents/instructorStudents.html.tsx
@@ -873,12 +873,14 @@ function StudentsCard({
       <InviteStudentsModal
         show={showInvite}
         courseInstance={courseInstance}
+        selfEnrollLink={selfEnrollLink}
         onHide={() => setShowInvite(false)}
         onSubmit={inviteStudents}
       />
       <SyncStudentsModal
         show={showSync}
         courseInstance={courseInstance}
+        selfEnrollLink={selfEnrollLink}
         students={students}
         onHide={() => setShowSync(false)}
         onSubmit={syncStudents}

--- a/docs/courseInstance/index.md
+++ b/docs/courseInstance/index.md
@@ -220,7 +220,7 @@ If you want to disable self-enrollment after a certain date, you can set the `be
 
 #### Completely disabling self-enrollment
 
-If you want to disable self-enrollment completely, you can set the `enabled` property to `false` in the `selfEnrollment` section of `infoCourseInstance.json`. This will mean that only invited students can enroll in the course instance, not via a direct link or enrollment code.
+If you want to disable self-enrollment completely, you can set the `enabled` property to `false` in the `selfEnrollment` section of `infoCourseInstance.json`. This will mean that only invited students can enroll in the course instance, and a direct link or enrollment code is not sufficient to enroll.
 
 ```json title="infoCourseInstance.json"
 {

--- a/docs/courseInstance/index.md
+++ b/docs/courseInstance/index.md
@@ -240,6 +240,8 @@ If you want to disable self-enrollment completely, you can set the `enabled` pro
 
 Students can be invited to a course instance by an instructor. Instructors can invite students to a course instance by visiting the "Students" tab of the course instance and clicking the "Invite" button. Invites will show up on the student's PrairieLearn homepage. If a student rejects an invitation, they can still join via a link to the course. However, the invitation will not show up on their homepage until they are re-invited. If an invited student accesses any link to the course (regardless of the current self-enrollment settings), they will automatically join the course.
 
+Note that invited students are not notified of their invitations. Instructors need to notify students using their own communication channels (e.g., email, LMS announcements, etc.), instructing students to visit PrairieLearn or the course instance self-enrollment link and accept the invitation.
+
 #### Blocking students
 
 If you want to remove students from a course instance, you can do this by visiting the individual student page and clicking the "Block" button. They will immediately be removed from the course instance and will no longer be able to enroll themselves in the course instance. If you later click "Unblock" on their page, they will be immediately re-enrolled in the course instance.


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

When students are added to a course instance by the instructor, the system uses the term "invite", which can have the connotation of communication. However PL does not currently send any email or other communication in the invitation process. This PR adds a note on both the invitation modals and the docs, clarifying that it is still the responsibility of the instructor to communicate with students about the invitation.

Based on question from a new user on Slack.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: minimal (auto-complete).

# Testing

Modals show the updated text.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
