### PR TITLE
Fix score upload for deleted groups

### DIFF
--- a/apps/prairielearn/src/lib/score-upload.sql
+++ b/apps/prairielearn/src/lib/score-upload.sql
@@ -47,6 +47,8 @@ WHERE
     s.id = $submission_id
     OR (
       $submission_id IS NULL
+      -- Exact submission IDs can reference retained work from deleted groups, but
+      -- name-based lookups must exclude deleted groups because names can be reused.
       AND g.deleted_at IS NULL
       AND COALESCE(g.name, u.uid) = $uid_or_group
       AND ai.number = $ai_number

--- a/apps/prairielearn/src/lib/score-upload.sql
+++ b/apps/prairielearn/src/lib/score-upload.sql
@@ -37,10 +37,7 @@ FROM
   JOIN questions AS q ON (q.id = aq.question_id)
   JOIN courses AS c ON (c.id = q.course_id)
   JOIN assessment_instances AS ai ON (ai.id = iq.assessment_instance_id)
-  LEFT JOIN teams AS g ON (
-    g.id = ai.team_id
-    AND g.deleted_at IS NULL
-  )
+  LEFT JOIN teams AS g ON (g.id = ai.team_id)
   LEFT JOIN users AS u ON (u.id = ai.user_id)
   LEFT JOIN variants AS v ON (v.instance_question_id = iq.id)
   LEFT JOIN submissions AS s ON (s.variant_id = v.id)
@@ -50,6 +47,7 @@ WHERE
     s.id = $submission_id
     OR (
       $submission_id IS NULL
+      AND g.deleted_at IS NULL
       AND COALESCE(g.name, u.uid) = $uid_or_group
       AND ai.number = $ai_number
       AND q.qid = $qid


### PR DESCRIPTION
# Description

Allow instance-question score uploads with an exact submission ID to resolve retained historical work after its group is soft-deleted. The deleted-team predicate now applies only to name-based fallback lookup, which continues to exclude deleted groups and avoids ambiguity when group names are reused.

Deleting a group retains its assessment instances and submissions, and historical manual-grading and submission exports continue to include that work. This allows instructors to round-trip exported rows using the exact submission ID, even though deleted groups remain hidden from normal assessment-instance listings and name-based lookup.

Previously, filtering the team in the join erased its identity before the exact-ID branch ran, so the retained submission could not pass score-upload identity validation.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: The majority of the implementation and analysis used Codex.

# Testing

No behavior test was added because the existing score-upload integration flow covers individual work and does not naturally exercise retained submissions from soft-deleted groups. The changed SQL file passes formatting and SQL linting.
