### PR TITLE
Invalidate assessment statistics after restoration

### DIFF
--- a/apps/prairielearn/src/sprocs/sync_assessments.sql
+++ b/apps/prairielearn/src/sprocs/sync_assessments.sql
@@ -95,7 +95,15 @@ BEGIN
     ),
     update_matched_dest_rows AS (
         UPDATE assessments AS dest
-        SET tid = src_tid, uuid = src_uuid, deleted_at = NULL
+        SET
+            tid = src_tid,
+            uuid = src_uuid,
+            deleted_at = NULL,
+            -- Statistics may have become stale while the assessment was deleted.
+            statistics_last_updated_at = CASE
+                WHEN dest.deleted_at IS NOT NULL THEN now() - interval '100 years'
+                ELSE dest.statistics_last_updated_at
+            END
         FROM matched_rows
         WHERE dest.id = dest_id AND dest.course_instance_id = syncing_course_instance_id
     ),


### PR DESCRIPTION
# Description

When a soft-deleted assessment is restored during sync, its cached statistics may no longer be current. Mark the statistics timestamp deliberately stale only during restoration so the normal statistics update path recomputes them, while preserving the timestamp for assessments that were already live.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: The majority of the implementation and pull request preparation was completed with Codex under Nathan's direction.

# Testing

- Ran the assessment-sync integration suite (168 tests).
