### PR TITLE
Fix automatic expansion of file previews after rendering

### DIFF
--- a/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
+++ b/apps/prairielearn/elements/pl-file-upload/pl-file-upload.js
@@ -356,6 +356,7 @@
       const renderFileListEntry = (fileName, isOptional = false, isWildcard = false) => {
         const isExpanded = expandedFiles.includes(fileName);
         const fileData = this.getSubmittedFileContents(fileName);
+        let shouldExpandPreview = false;
 
         const $file = $(
           `<li class="list-group-item" data-file="${escapeFileName(fileName)}"></li>`,
@@ -478,7 +479,7 @@
               }
               $codePreview.removeClass('d-none');
             }
-            this.expandPreviewForFile(fileName);
+            shouldExpandPreview = true;
           } catch {
             const url = this.b64ToBlobUrl(fileData);
             $imgPreview
@@ -505,6 +506,9 @@
         }
 
         $fileList.append($file);
+        if (shouldExpandPreview) {
+          this.expandPreviewForFile(fileName);
+        }
         index++;
       };
 


### PR DESCRIPTION
# Description

Fixes the ordering bug in `PLFileUpload.renderFileList` where `expandPreviewForFile(fileName)` was called before the newly rendered file entry was appended to the file list. Because the DOM query inside `expandPreviewForFile` looks up `li[data-file="..."]`, it could not find the entry that had not yet been appended, so PDF and text previews remained collapsed after rendering.

The expansion is now deferred until after `$fileList.append($file)`, using a `shouldExpandPreview` flag that is only set for the PDF/text (non-image) path. The image path is unchanged: it still expands on the `load` event.

Closes #15618.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Reproduction: upload (or load a previous submission of) a PDF or text file in a `pl-file-upload` question. Before this change the preview stayed collapsed after rendering; after the change it expands automatically.

I was unable to run the project's lint/typecheck tooling locally (this environment has Node 22 / pnpm 10, while the repo requires Node >= 24 / pnpm 11.19), so this change has not been verified in a running instance.
