### PR TITLE
Generalize prefix CSRF token claims

### DIFF
--- a/.changeset/generalize-prefix-token-claims.md
+++ b/.changeset/generalize-prefix-token-claims.md
@@ -2,4 +2,4 @@
 '@prairielearn/signed-token': minor
 ---
 
-Allow prefix-based CSRF tokens to authenticate against multiple exactly matched claims.
+Allow prefix-based CSRF tokens to authenticate against caller-defined identity claims.

--- a/.changeset/generalize-prefix-token-claims.md
+++ b/.changeset/generalize-prefix-token-claims.md
@@ -2,4 +2,4 @@
 '@prairielearn/signed-token': minor
 ---
 
-Allow prefix-based CSRF tokens to authenticate against caller-defined identity claims.
+Allow prefix-based CSRF tokens to authenticate against caller-defined claims.

--- a/.changeset/generalize-prefix-token-claims.md
+++ b/.changeset/generalize-prefix-token-claims.md
@@ -1,0 +1,5 @@
+---
+'@prairielearn/signed-token': minor
+---
+
+Allow prefix-based CSRF tokens to authenticate against multiple exactly matched claims.

--- a/.changeset/generalize-prefix-token-claims.md
+++ b/.changeset/generalize-prefix-token-claims.md
@@ -1,5 +1,5 @@
 ---
-'@prairielearn/signed-token': minor
+'@prairielearn/signed-token': major
 ---
 
 Allow prefix-based CSRF tokens to authenticate against caller-defined claims.

--- a/packages/signed-token/README.md
+++ b/packages/signed-token/README.md
@@ -6,9 +6,11 @@ A package for generating signed tokens. Useful for CSRF tokens or generally to r
 
 ```ts
 import {
+  checkSignedToken,
+  checkSignedTokenPrefix,
+  generatePrefixCsrfToken,
   generateSignedToken,
   getCheckedSignedTokenData,
-  checkSignedToken,
 } from '@prairielearn/signed-token';
 
 const token = generateSignedToken({ foo: 'bar' }, 'SECRET_KEY');
@@ -34,4 +36,23 @@ console.log(checkSignedToken(token, { foo: 'bar' }, 'NEW_SECRET_KEY'));
 
 console.log(getCheckedSignedTokenData(oldToken, ['NEW_SECRET_KEY', 'OLD_SECRET_KEY']));
 // { foo: 'bar' }
+```
+
+Prefix-based CSRF tokens allow a token to cover a URL and all of its sub-routes. Any additional
+properties are treated as claims and must match exactly during validation:
+
+```ts
+const token = generatePrefixCsrfToken(
+  { url: '/api/trpc', user_id: '123', authentication: { provider: 'saml' } },
+  'SECRET_KEY',
+);
+
+console.log(
+  checkSignedTokenPrefix(
+    token,
+    { url: '/api/trpc/users.list', user_id: '123', authentication: { provider: 'saml' } },
+    'SECRET_KEY',
+  ),
+);
+// true
 ```

--- a/packages/signed-token/README.md
+++ b/packages/signed-token/README.md
@@ -39,20 +39,14 @@ console.log(getCheckedSignedTokenData(oldToken, ['NEW_SECRET_KEY', 'OLD_SECRET_K
 ```
 
 Prefix-based CSRF tokens allow a token to cover a URL and all of its sub-routes. Any additional
-properties are treated as claims and must match exactly during validation:
+properties are treated as identity claims and must match exactly during validation. At least one
+identity claim is required:
 
 ```ts
-const token = generatePrefixCsrfToken(
-  { url: '/api/trpc', user_id: '123', authentication: { provider: 'saml' } },
-  'SECRET_KEY',
-);
+const token = generatePrefixCsrfToken({ url: '/api/trpc', user_id: '123' }, 'SECRET_KEY');
 
 console.log(
-  checkSignedTokenPrefix(
-    token,
-    { url: '/api/trpc/users.list', user_id: '123', authentication: { provider: 'saml' } },
-    'SECRET_KEY',
-  ),
+  checkSignedTokenPrefix(token, { url: '/api/trpc/users.list', user_id: '123' }, 'SECRET_KEY'),
 );
 // true
 ```

--- a/packages/signed-token/README.md
+++ b/packages/signed-token/README.md
@@ -39,8 +39,8 @@ console.log(getCheckedSignedTokenData(oldToken, ['NEW_SECRET_KEY', 'OLD_SECRET_K
 ```
 
 Prefix-based CSRF tokens allow a token to cover a URL and all of its sub-routes. Any additional
-properties are treated as claims and must match exactly during validation. At least one claim is
-required, and the internal `type` property is reserved:
+properties are treated as claims and must match exactly during validation. At least one defined
+claim is required, and the internal `type` property is reserved:
 
 ```ts
 const token = generatePrefixCsrfToken({ url: '/api/trpc', user_id: '123' }, 'SECRET_KEY');

--- a/packages/signed-token/README.md
+++ b/packages/signed-token/README.md
@@ -39,8 +39,8 @@ console.log(getCheckedSignedTokenData(oldToken, ['NEW_SECRET_KEY', 'OLD_SECRET_K
 ```
 
 Prefix-based CSRF tokens allow a token to cover a URL and all of its sub-routes. Any additional
-properties are treated as identity claims and must match exactly during validation. At least one
-identity claim is required:
+properties are treated as claims and must match exactly during validation. At least one claim is
+required, and the internal `type` property is reserved:
 
 ```ts
 const token = generatePrefixCsrfToken({ url: '/api/trpc', user_id: '123' }, 'SECRET_KEY');

--- a/packages/signed-token/src/index.test.ts
+++ b/packages/signed-token/src/index.test.ts
@@ -127,8 +127,6 @@ describe('checkSignedTokenPrefix', () => {
   it('validates token when request URL starts with prefix', () => {
     const token = generatePrefixCsrfToken(TEST_DATA, SECRET_KEY);
 
-    // We allow the route itself, both with and without a trailing slash.
-    assert.isTrue(checkSignedTokenPrefix(token, { ...TEST_DATA, url: '/test' }, SECRET_KEY));
     assert.isTrue(checkSignedTokenPrefix(token, { ...TEST_DATA, url: '/test/' }, SECRET_KEY));
 
     // We allow deeply nested routes as well.
@@ -158,8 +156,6 @@ describe('checkSignedTokenPrefix', () => {
         SECRET_KEY,
       ),
     );
-    // @ts-expect-error Testing runtime validation for JavaScript callers.
-    assert.isFalse(checkSignedTokenPrefix(token, { url: '/test' }, SECRET_KEY));
     assert.isFalse(
       checkSignedTokenPrefix(
         token,

--- a/packages/signed-token/src/index.test.ts
+++ b/packages/signed-token/src/index.test.ts
@@ -87,17 +87,32 @@ describe('generatePrefixCsrfToken', () => {
     assert.equal(tokenData.user_id, TEST_DATA_WITH_ALTERNATE_CLAIM.user_id);
   });
 
-  it('rejects data without an identity claim', () => {
+  it('rejects data without a claim', () => {
     assert.throws(
       // @ts-expect-error Testing runtime validation for JavaScript callers.
       () => generatePrefixCsrfToken({ url: '/test' }, SECRET_KEY),
-      'Prefix CSRF token data must contain at least one identity claim',
+      'Prefix CSRF token data must contain at least one claim',
+    );
+  });
+
+  it('rejects the reserved type claim', () => {
+    assert.throws(
+      () =>
+        generatePrefixCsrfToken(
+          {
+            ...TEST_DATA_WITH_ALTERNATE_CLAIM,
+            // @ts-expect-error Testing runtime validation for JavaScript callers.
+            type: 'custom',
+          },
+          SECRET_KEY,
+        ),
+      'Prefix CSRF token data cannot contain the reserved "type" claim',
     );
   });
 });
 
 describe('checkSignedTokenPrefix', () => {
-  it('validates an alternate identity claim', () => {
+  it('validates an alternate claim', () => {
     const token = generatePrefixCsrfToken(TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY);
 
     assert.isTrue(checkSignedTokenPrefix(token, TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY));
@@ -154,11 +169,27 @@ describe('checkSignedTokenPrefix', () => {
     );
   });
 
-  it('rejects a prefix token without an identity claim', () => {
+  it('rejects a prefix token without a claim', () => {
     const token = generateSignedToken({ url: '/test', type: 'prefix' }, SECRET_KEY);
 
     // @ts-expect-error Testing runtime validation for JavaScript callers.
     assert.isFalse(checkSignedTokenPrefix(token, { url: '/test' }, SECRET_KEY));
+  });
+
+  it('rejects the reserved type claim in request data', () => {
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY);
+
+    assert.isFalse(
+      checkSignedTokenPrefix(
+        token,
+        {
+          ...TEST_DATA_WITH_ALTERNATE_CLAIM,
+          // @ts-expect-error Testing runtime validation for JavaScript callers.
+          type: 'prefix',
+        },
+        SECRET_KEY,
+      ),
+    );
   });
 
   it('rejects non-prefix tokens', () => {

--- a/packages/signed-token/src/index.test.ts
+++ b/packages/signed-token/src/index.test.ts
@@ -11,10 +11,7 @@ import {
 const SECRET_KEY = 'test-secret-key';
 const OLD_SECRET_KEY = 'old-test-secret-key';
 const TEST_DATA = { url: '/test', authn_user_id: '123' };
-const TEST_DATA_WITH_MULTIPLE_CLAIMS = {
-  ...TEST_DATA,
-  authentication: { provider: 'saml', institution_id: '456' },
-};
+const TEST_DATA_WITH_ALTERNATE_CLAIM = { url: '/test', user_id: '123' };
 
 describe('generateSignedToken', () => {
   it('generates a token that can be validated', () => {
@@ -82,21 +79,28 @@ describe('getCheckedSignedTokenData', () => {
 
 describe('generatePrefixCsrfToken', () => {
   it('generates a token with type prefix', () => {
-    const token = generatePrefixCsrfToken(TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY);
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY);
 
     const tokenData = getCheckedSignedTokenData(token, SECRET_KEY);
     assert.equal(tokenData.type, 'prefix');
-    assert.equal(tokenData.url, TEST_DATA_WITH_MULTIPLE_CLAIMS.url);
-    assert.equal(tokenData.authn_user_id, TEST_DATA_WITH_MULTIPLE_CLAIMS.authn_user_id);
-    assert.deepEqual(tokenData.authentication, TEST_DATA_WITH_MULTIPLE_CLAIMS.authentication);
+    assert.equal(tokenData.url, TEST_DATA_WITH_ALTERNATE_CLAIM.url);
+    assert.equal(tokenData.user_id, TEST_DATA_WITH_ALTERNATE_CLAIM.user_id);
+  });
+
+  it('rejects data without an identity claim', () => {
+    assert.throws(
+      // @ts-expect-error Testing runtime validation for JavaScript callers.
+      () => generatePrefixCsrfToken({ url: '/test' }, SECRET_KEY),
+      'Prefix CSRF token data must contain at least one identity claim',
+    );
   });
 });
 
 describe('checkSignedTokenPrefix', () => {
-  it('validates multiple claims', () => {
-    const token = generatePrefixCsrfToken(TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY);
+  it('validates an alternate identity claim', () => {
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY);
 
-    assert.isTrue(checkSignedTokenPrefix(token, TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY));
+    assert.isTrue(checkSignedTokenPrefix(token, TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY));
   });
 
   it('validates token when request URL matches prefix exactly', () => {
@@ -130,34 +134,31 @@ describe('checkSignedTokenPrefix', () => {
   });
 
   it('rejects token when claims do not match exactly', () => {
-    const token = generatePrefixCsrfToken(TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY);
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_ALTERNATE_CLAIM, SECRET_KEY);
 
     assert.isFalse(
       checkSignedTokenPrefix(
         token,
-        { ...TEST_DATA_WITH_MULTIPLE_CLAIMS, authn_user_id: '456' },
+        { ...TEST_DATA_WITH_ALTERNATE_CLAIM, user_id: '456' },
         SECRET_KEY,
       ),
     );
+    // @ts-expect-error Testing runtime validation for JavaScript callers.
+    assert.isFalse(checkSignedTokenPrefix(token, { url: '/test' }, SECRET_KEY));
     assert.isFalse(
       checkSignedTokenPrefix(
         token,
-        {
-          ...TEST_DATA_WITH_MULTIPLE_CLAIMS,
-          authentication: { provider: 'oidc', institution_id: '456' },
-        },
+        { ...TEST_DATA_WITH_ALTERNATE_CLAIM, role: 'student' },
         SECRET_KEY,
       ),
     );
-    const { authentication: _authentication, ...missingClaimData } = TEST_DATA_WITH_MULTIPLE_CLAIMS;
-    assert.isFalse(checkSignedTokenPrefix(token, missingClaimData, SECRET_KEY));
-    assert.isFalse(
-      checkSignedTokenPrefix(
-        token,
-        { ...TEST_DATA_WITH_MULTIPLE_CLAIMS, role: 'student' },
-        SECRET_KEY,
-      ),
-    );
+  });
+
+  it('rejects a prefix token without an identity claim', () => {
+    const token = generateSignedToken({ url: '/test', type: 'prefix' }, SECRET_KEY);
+
+    // @ts-expect-error Testing runtime validation for JavaScript callers.
+    assert.isFalse(checkSignedTokenPrefix(token, { url: '/test' }, SECRET_KEY));
   });
 
   it('rejects non-prefix tokens', () => {

--- a/packages/signed-token/src/index.test.ts
+++ b/packages/signed-token/src/index.test.ts
@@ -11,6 +11,10 @@ import {
 const SECRET_KEY = 'test-secret-key';
 const OLD_SECRET_KEY = 'old-test-secret-key';
 const TEST_DATA = { url: '/test', authn_user_id: '123' };
+const TEST_DATA_WITH_MULTIPLE_CLAIMS = {
+  ...TEST_DATA,
+  authentication: { provider: 'saml', institution_id: '456' },
+};
 
 describe('generateSignedToken', () => {
   it('generates a token that can be validated', () => {
@@ -78,16 +82,23 @@ describe('getCheckedSignedTokenData', () => {
 
 describe('generatePrefixCsrfToken', () => {
   it('generates a token with type prefix', () => {
-    const token = generatePrefixCsrfToken(TEST_DATA, SECRET_KEY);
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY);
 
     const tokenData = getCheckedSignedTokenData(token, SECRET_KEY);
     assert.equal(tokenData.type, 'prefix');
-    assert.equal(tokenData.url, TEST_DATA.url);
-    assert.equal(tokenData.authn_user_id, TEST_DATA.authn_user_id);
+    assert.equal(tokenData.url, TEST_DATA_WITH_MULTIPLE_CLAIMS.url);
+    assert.equal(tokenData.authn_user_id, TEST_DATA_WITH_MULTIPLE_CLAIMS.authn_user_id);
+    assert.deepEqual(tokenData.authentication, TEST_DATA_WITH_MULTIPLE_CLAIMS.authentication);
   });
 });
 
 describe('checkSignedTokenPrefix', () => {
+  it('validates multiple claims', () => {
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY);
+
+    assert.isTrue(checkSignedTokenPrefix(token, TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY));
+  });
+
   it('validates token when request URL matches prefix exactly', () => {
     const token = generatePrefixCsrfToken(TEST_DATA, SECRET_KEY);
 
@@ -118,11 +129,34 @@ describe('checkSignedTokenPrefix', () => {
     assert.isFalse(checkSignedTokenPrefix(token, { ...TEST_DATA, url: '/testy' }, SECRET_KEY));
   });
 
-  it('rejects token when user ID does not match', () => {
-    const token = generatePrefixCsrfToken(TEST_DATA, SECRET_KEY);
+  it('rejects token when claims do not match exactly', () => {
+    const token = generatePrefixCsrfToken(TEST_DATA_WITH_MULTIPLE_CLAIMS, SECRET_KEY);
 
     assert.isFalse(
-      checkSignedTokenPrefix(token, { ...TEST_DATA, authn_user_id: '456' }, SECRET_KEY),
+      checkSignedTokenPrefix(
+        token,
+        { ...TEST_DATA_WITH_MULTIPLE_CLAIMS, authn_user_id: '456' },
+        SECRET_KEY,
+      ),
+    );
+    assert.isFalse(
+      checkSignedTokenPrefix(
+        token,
+        {
+          ...TEST_DATA_WITH_MULTIPLE_CLAIMS,
+          authentication: { provider: 'oidc', institution_id: '456' },
+        },
+        SECRET_KEY,
+      ),
+    );
+    const { authentication: _authentication, ...missingClaimData } = TEST_DATA_WITH_MULTIPLE_CLAIMS;
+    assert.isFalse(checkSignedTokenPrefix(token, missingClaimData, SECRET_KEY));
+    assert.isFalse(
+      checkSignedTokenPrefix(
+        token,
+        { ...TEST_DATA_WITH_MULTIPLE_CLAIMS, role: 'student' },
+        SECRET_KEY,
+      ),
     );
   });
 

--- a/packages/signed-token/src/index.test.ts
+++ b/packages/signed-token/src/index.test.ts
@@ -87,11 +87,15 @@ describe('generatePrefixCsrfToken', () => {
     assert.equal(tokenData.user_id, TEST_DATA_WITH_ALTERNATE_CLAIM.user_id);
   });
 
-  it('rejects data without a claim', () => {
+  it('rejects data without a defined claim', () => {
     assert.throws(
       // @ts-expect-error Testing runtime validation for JavaScript callers.
       () => generatePrefixCsrfToken({ url: '/test' }, SECRET_KEY),
-      'Prefix CSRF token data must contain at least one claim',
+      'Prefix CSRF token data must contain at least one defined claim',
+    );
+    assert.throws(
+      () => generatePrefixCsrfToken({ url: '/test', user_id: undefined }, SECRET_KEY),
+      'Prefix CSRF token data must contain at least one defined claim',
     );
   });
 
@@ -165,11 +169,10 @@ describe('checkSignedTokenPrefix', () => {
     );
   });
 
-  it('rejects a prefix token without a claim', () => {
+  it('rejects a prefix token without a defined claim', () => {
     const token = generateSignedToken({ url: '/test', type: 'prefix' }, SECRET_KEY);
 
-    // @ts-expect-error Testing runtime validation for JavaScript callers.
-    assert.isFalse(checkSignedTokenPrefix(token, { url: '/test' }, SECRET_KEY));
+    assert.isFalse(checkSignedTokenPrefix(token, { url: '/test', user_id: undefined }, SECRET_KEY));
   });
 
   it('rejects the reserved type claim in request data', () => {

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -23,7 +23,9 @@ type RequireClaim<Data extends PrefixCsrfTokenData> =
   Exclude<keyof Data, 'url' | 'type'> extends never ? never : Data;
 
 function hasClaim(data: PrefixCsrfTokenData): boolean {
-  return Object.keys(data).some((key) => key !== 'url' && key !== 'type');
+  return Object.entries(data).some(
+    ([key, value]) => key !== 'url' && key !== 'type' && value !== undefined,
+  );
 }
 
 function getSecretKeys(secretKey: SecretKey): readonly [string, ...string[]] {
@@ -157,8 +159,8 @@ export function checkSignedToken(
  * Generates a CSRF token that is valid for a URL prefix instead of an exact URL.
  * This is useful for tRPC and similar APIs where a single token should be valid
  * for all sub-routes under a prefix (e.g., `/foo/bar/trpc` is valid for
- * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`). At least one claim is
- * required to prevent claimless tokens.
+ * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`). At least one defined
+ * claim is required to prevent claimless tokens.
  */
 export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
   data: RequireClaim<Data>,
@@ -168,7 +170,7 @@ export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
     throw new Error('Prefix CSRF token data cannot contain the reserved "type" claim');
   }
   if (!hasClaim(data)) {
-    throw new Error('Prefix CSRF token data must contain at least one claim');
+    throw new Error('Prefix CSRF token data must contain at least one defined claim');
   }
   return generateSignedToken({ ...data, type: 'prefix' }, secretKey);
 }
@@ -176,7 +178,8 @@ export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
 /**
  * Validates a prefix-based CSRF token. The token's URL must be a prefix of the
  * request URL for validation to succeed. All claims other than the URL must
- * exactly match the claims in the token, and at least one claim must be present.
+ * exactly match the claims in the token, and at least one defined claim must be
+ * present.
  *
  * @param token - The CSRF token to validate
  * @param requestData - The request URL and claims to validate

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -13,6 +13,11 @@ interface CheckOptions {
 
 export type SecretKey = string | readonly [string, ...string[]];
 
+interface PrefixCsrfTokenData {
+  url: string;
+  [claim: string]: unknown;
+}
+
 function getSecretKeys(secretKey: SecretKey): readonly [string, ...string[]] {
   if (typeof secretKey === 'string') {
     return [secretKey];
@@ -146,28 +151,25 @@ export function checkSignedToken(
  * for all sub-routes under a prefix (e.g., `/foo/bar/trpc` is valid for
  * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`).
  */
-export function generatePrefixCsrfToken(
-  data: { url: string; authn_user_id: string },
-  secretKey: SecretKey,
-) {
+export function generatePrefixCsrfToken(data: PrefixCsrfTokenData, secretKey: SecretKey) {
   return generateSignedToken({ ...data, type: 'prefix' }, secretKey);
 }
 
 /**
  * Validates a prefix-based CSRF token. The token's URL must be a prefix of the
- * request URL for validation to succeed.
+ * request URL for validation to succeed. All claims other than the URL must
+ * exactly match the claims in the token.
  *
  * @param token - The CSRF token to validate
- * @param requestData - The request URL and authenticated user ID
+ * @param requestData - The request URL and claims to validate
  * @param requestData.url - The request URL to validate against
- * @param requestData.authn_user_id - The authenticated user ID to validate against
  * @param secretKey - The secret key used for signing
  * @param options - Optional settings like maxAge
  * @returns true if the token is valid, false otherwise
  */
 export function checkSignedTokenPrefix(
   token: string,
-  requestData: { url: string; authn_user_id: string },
+  requestData: PrefixCsrfTokenData,
   secretKey: SecretKey,
   options: CheckOptions = {},
 ): boolean {
@@ -177,23 +179,24 @@ export function checkSignedTokenPrefix(
   const tokenData = getCheckedSignedTokenData(token, secretKey, options);
   if (tokenData == null) return false;
 
+  const { type, url: prefixUrl, ...tokenClaims } = tokenData;
+
   // Verify this is a prefix token (prevents token type confusion)
-  if (tokenData.type !== 'prefix') {
+  if (type !== 'prefix') {
     debug('checkSignedTokenPrefix(): FAIL - token type is not prefix');
     return false;
   }
 
-  // Verify user ID matches exactly
-  if (tokenData.authn_user_id !== requestData.authn_user_id) {
-    debug('checkSignedTokenPrefix(): FAIL - authn_user_id mismatch');
+  const { url: requestUrl, ...requestClaims } = requestData;
+
+  if (!isEqual(tokenClaims, requestClaims)) {
+    debug('checkSignedTokenPrefix(): FAIL - claims mismatch');
     return false;
   }
 
   // Verify the request URL starts with the token's prefix URL.
   // We treat the prefix as implicitly ending with a trailing slash, so
   // `/test` matches `/test`, `/test/`, and `/test/nested`, but NOT `/testy`.
-  const prefixUrl = tokenData.url;
-  const requestUrl = requestData.url;
   const normalizedPrefix = prefixUrl.endsWith('/') ? prefixUrl : prefixUrl + '/';
   if (requestUrl !== prefixUrl && !requestUrl.startsWith(normalizedPrefix)) {
     debug(

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -19,10 +19,10 @@ interface PrefixCsrfTokenData {
   [claim: string]: unknown;
 }
 
-type RequireIdentityClaim<Data extends PrefixCsrfTokenData> =
+type RequireClaim<Data extends PrefixCsrfTokenData> =
   Exclude<keyof Data, 'url' | 'type'> extends never ? never : Data;
 
-function hasIdentityClaim(data: PrefixCsrfTokenData): boolean {
+function hasClaim(data: PrefixCsrfTokenData): boolean {
   return Object.keys(data).some((key) => key !== 'url' && key !== 'type');
 }
 
@@ -157,15 +157,18 @@ export function checkSignedToken(
  * Generates a CSRF token that is valid for a URL prefix instead of an exact URL.
  * This is useful for tRPC and similar APIs where a single token should be valid
  * for all sub-routes under a prefix (e.g., `/foo/bar/trpc` is valid for
- * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`). At least one identity
- * claim is required to prevent tokens from being valid for every user.
+ * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`). At least one claim is
+ * required to prevent unbound tokens.
  */
 export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
-  data: RequireIdentityClaim<Data>,
+  data: RequireClaim<Data>,
   secretKey: SecretKey,
 ) {
-  if (!hasIdentityClaim(data)) {
-    throw new Error('Prefix CSRF token data must contain at least one identity claim');
+  if (Object.hasOwn(data, 'type')) {
+    throw new Error('Prefix CSRF token data cannot contain the reserved "type" claim');
+  }
+  if (!hasClaim(data)) {
+    throw new Error('Prefix CSRF token data must contain at least one claim');
   }
   return generateSignedToken({ ...data, type: 'prefix' }, secretKey);
 }
@@ -173,8 +176,7 @@ export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
 /**
  * Validates a prefix-based CSRF token. The token's URL must be a prefix of the
  * request URL for validation to succeed. All claims other than the URL must
- * exactly match the claims in the token, and at least one identity claim must
- * be present.
+ * exactly match the claims in the token, and at least one claim must be present.
  *
  * @param token - The CSRF token to validate
  * @param requestData - The request URL and claims to validate
@@ -185,7 +187,7 @@ export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
  */
 export function checkSignedTokenPrefix<const Data extends PrefixCsrfTokenData>(
   token: string,
-  requestData: RequireIdentityClaim<Data>,
+  requestData: RequireClaim<Data>,
   secretKey: SecretKey,
   options: CheckOptions = {},
 ): boolean {
@@ -203,10 +205,15 @@ export function checkSignedTokenPrefix<const Data extends PrefixCsrfTokenData>(
     return false;
   }
 
+  if (Object.hasOwn(requestData, 'type')) {
+    debug('checkSignedTokenPrefix(): FAIL - request data contains reserved type claim');
+    return false;
+  }
+
   const { url: requestUrl, ...requestClaims } = requestData;
 
-  if (!hasIdentityClaim(requestData)) {
-    debug('checkSignedTokenPrefix(): FAIL - no identity claims');
+  if (!hasClaim(requestData)) {
+    debug('checkSignedTokenPrefix(): FAIL - no claims');
     return false;
   }
 

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -15,7 +15,15 @@ export type SecretKey = string | readonly [string, ...string[]];
 
 interface PrefixCsrfTokenData {
   url: string;
+  type?: never;
   [claim: string]: unknown;
+}
+
+type RequireIdentityClaim<Data extends PrefixCsrfTokenData> =
+  Exclude<keyof Data, 'url' | 'type'> extends never ? never : Data;
+
+function hasIdentityClaim(data: PrefixCsrfTokenData): boolean {
+  return Object.keys(data).some((key) => key !== 'url' && key !== 'type');
 }
 
 function getSecretKeys(secretKey: SecretKey): readonly [string, ...string[]] {
@@ -149,16 +157,24 @@ export function checkSignedToken(
  * Generates a CSRF token that is valid for a URL prefix instead of an exact URL.
  * This is useful for tRPC and similar APIs where a single token should be valid
  * for all sub-routes under a prefix (e.g., `/foo/bar/trpc` is valid for
- * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`).
+ * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`). At least one identity
+ * claim is required to prevent tokens from being valid for every user.
  */
-export function generatePrefixCsrfToken(data: PrefixCsrfTokenData, secretKey: SecretKey) {
+export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
+  data: RequireIdentityClaim<Data>,
+  secretKey: SecretKey,
+) {
+  if (!hasIdentityClaim(data)) {
+    throw new Error('Prefix CSRF token data must contain at least one identity claim');
+  }
   return generateSignedToken({ ...data, type: 'prefix' }, secretKey);
 }
 
 /**
  * Validates a prefix-based CSRF token. The token's URL must be a prefix of the
  * request URL for validation to succeed. All claims other than the URL must
- * exactly match the claims in the token.
+ * exactly match the claims in the token, and at least one identity claim must
+ * be present.
  *
  * @param token - The CSRF token to validate
  * @param requestData - The request URL and claims to validate
@@ -167,9 +183,9 @@ export function generatePrefixCsrfToken(data: PrefixCsrfTokenData, secretKey: Se
  * @param options - Optional settings like maxAge
  * @returns true if the token is valid, false otherwise
  */
-export function checkSignedTokenPrefix(
+export function checkSignedTokenPrefix<const Data extends PrefixCsrfTokenData>(
   token: string,
-  requestData: PrefixCsrfTokenData,
+  requestData: RequireIdentityClaim<Data>,
   secretKey: SecretKey,
   options: CheckOptions = {},
 ): boolean {
@@ -188,6 +204,11 @@ export function checkSignedTokenPrefix(
   }
 
   const { url: requestUrl, ...requestClaims } = requestData;
+
+  if (!hasIdentityClaim(requestData)) {
+    debug('checkSignedTokenPrefix(): FAIL - no identity claims');
+    return false;
+  }
 
   if (!isEqual(tokenClaims, requestClaims)) {
     debug('checkSignedTokenPrefix(): FAIL - claims mismatch');

--- a/packages/signed-token/src/index.ts
+++ b/packages/signed-token/src/index.ts
@@ -158,7 +158,7 @@ export function checkSignedToken(
  * This is useful for tRPC and similar APIs where a single token should be valid
  * for all sub-routes under a prefix (e.g., `/foo/bar/trpc` is valid for
  * `/foo/bar/trpc/getUser` and `/foo/bar/trpc/updateUser`). At least one claim is
- * required to prevent unbound tokens.
+ * required to prevent claimless tokens.
  */
 export function generatePrefixCsrfToken<const Data extends PrefixCsrfTokenData>(
   data: RequireClaim<Data>,


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Generalize prefix-based CSRF token helpers to accept caller-defined claims, allowing PrairieLearn to continue using `authn_user_id` while PrairieTest uses `user_id` directly. The helpers require at least one defined non-URL claim, reserve the internal `type` property, and exact-match all supplied claims to prevent claimless tokens.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Added unit coverage for alternate claim names, exact matching, claimless and undefined-only claim sets, and caller use of the reserved `type` property.