### PR TITLE
Fix deletion of AI grading results for large IDs

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
@@ -115,7 +115,10 @@ WITH
       gj.submission_id = s.id
       AND gj.grading_method = 'AI'
       AND gj.deleted_at IS NULL
-      AND iq.assessment_question_id = ANY ($assessment_question_ids::bigint[])
+      AND iq.assessment_question_id IN (
+        SELECT
+          unnest($assessment_question_ids::bigint[])
+      )
     RETURNING
       gj.id AS grading_job_id,
       gj.submission_id,

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
@@ -115,10 +115,7 @@ WITH
       gj.submission_id = s.id
       AND gj.grading_method = 'AI'
       AND gj.deleted_at IS NULL
-      AND iq.assessment_question_id IN (
-        SELECT
-          unnest($assessment_question_ids::int[])
-      )
+      AND iq.assessment_question_id = ANY ($assessment_question_ids::bigint[])
     RETURNING
       gj.id AS grading_job_id,
       gj.submission_id,


### PR DESCRIPTION
# Description

The Delete all AI grading results action cast assessment question IDs to PostgreSQL integer arrays, causing IDs above 2,147,483,647 to fail with an out-of-range error. Use a bigint array to match the assessment_questions ID type.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance was used for the investigation and implementation.

# Testing

Not run at the request of the maintainer; this is a SQL type-cast correction.