### PR TITLE
Fix grader guideline Markdown rendering

### DIFF
--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { html } from '@prairielearn/html';
+import { html, unsafeHtml } from '@prairielearn/html';
 import { markdownToHtml } from '@prairielearn/markdown';
 import { run } from '@prairielearn/run';
 
@@ -245,7 +245,9 @@ export function GradingPanel({
           ? html`
               <li class="list-group-item">
                 <div class="mb-1">Guidelines:</div>
-                <p class="my-3" style="white-space: pre-line;">${graderGuidelinesRendered}</p>
+                <p class="my-3" style="white-space: pre-line;" data-testid="grader-guidelines">
+                  ${unsafeHtml(graderGuidelinesRendered)}
+                </p>
               </li>
             `
           : ''}

--- a/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
+++ b/apps/prairielearn/src/pages/instructorAssessmentManualGrading/instanceQuestion/gradingPanel.html.ts
@@ -119,7 +119,7 @@ export function GradingPanel({
   const graderGuidelinesRendered = run(() => {
     if (!graderGuidelines) return null;
     const { rendered, error } = safeMustacheRender(graderGuidelines, mustacheParams);
-    const renderedHtml = markdownToHtml(rendered, { inline: true });
+    const renderedHtml = markdownToHtml(rendered);
     if (!error) return renderedHtml;
     return (
       renderedHtml +
@@ -245,9 +245,9 @@ export function GradingPanel({
           ? html`
               <li class="list-group-item">
                 <div class="mb-1">Guidelines:</div>
-                <p class="my-3" style="white-space: pre-line;" data-testid="grader-guidelines">
+                <div class="markdown-body mt-3" data-testid="grader-guidelines">
                   ${unsafeHtml(graderGuidelinesRendered)}
-                </p>
+                </div>
               </li>
             `
           : ''}

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -903,7 +903,7 @@ describe('Manual Grading', { timeout: 80_000, concurrent: false }, function () {
 
       describe('Changing rubric grader guidelines', () => {
         const grader_guidelines =
-          'Accept answers with an absolute error of at most 0.01. Be lenient when grading arithmetic mistakes.';
+          'Accept answers with an absolute error of at most `0.01`. Be lenient when grading arithmetic mistakes.';
         test('update rubric grader guidelines should succeed', async () => {
           setUser(mockStaff[0]);
           const manualGradingIQPage = await (await fetch(manualGradingIQUrl)).text();
@@ -930,6 +930,14 @@ describe('Manual Grading', { timeout: 80_000, concurrent: false }, function () {
         });
 
         checkSettingsResults(0, -0.5, 0.5, grader_guidelines);
+
+        test('grader guidelines should render Markdown formatting', async () => {
+          const manualGradingIQPage = await (await fetch(manualGradingIQUrl)).text();
+          const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
+          const graderGuidelines = $manualGradingIQPage('[data-testid="grader-guidelines"]');
+
+          assert.equal(graderGuidelines.find('code').text(), '0.01');
+        });
       });
 
       describe('Grading without rubric items', () => {

--- a/apps/prairielearn/src/tests/manualGrading.test.ts
+++ b/apps/prairielearn/src/tests/manualGrading.test.ts
@@ -903,7 +903,7 @@ describe('Manual Grading', { timeout: 80_000, concurrent: false }, function () {
 
       describe('Changing rubric grader guidelines', () => {
         const grader_guidelines =
-          'Accept answers with an absolute error of at most `0.01`. Be lenient when grading arithmetic mistakes.';
+          'Accept answers with an absolute error of at most `0.01`.\n\nBe lenient when grading arithmetic mistakes.';
         test('update rubric grader guidelines should succeed', async () => {
           setUser(mockStaff[0]);
           const manualGradingIQPage = await (await fetch(manualGradingIQUrl)).text();
@@ -936,6 +936,7 @@ describe('Manual Grading', { timeout: 80_000, concurrent: false }, function () {
           const $manualGradingIQPage = cheerio.load(manualGradingIQPage);
           const graderGuidelines = $manualGradingIQPage('[data-testid="grader-guidelines"]');
 
+          assert.equal(graderGuidelines.children('p').length, 2);
           assert.equal(graderGuidelines.find('code').text(), '0.01');
         });
       });


### PR DESCRIPTION
# Description

Grader guidelines were passed through the Markdown parser, but the resulting sanitized HTML was interpolated as a plain string and escaped. Render the sanitized output as HTML so formatting such as inline code appears correctly in the grading panel.

<img width="460" height="226" alt="Screenshot 2026-08-25 at 10 50 49" src="https://github.com/user-attachments/assets/328417c7-6a7f-44bd-85f3-c05b7b2fedb0" />

AI assistance: The majority of the investigation, implementation, and test updates were completed with Codex.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

# Testing

Added integration coverage that saves inline-code Markdown in grader guidelines and verifies that the grading panel renders a `code` element.
