### PR TITLE
Harden file reads in workspaces and external graders

### DIFF
--- a/apps/grader-host/src/index.ts
+++ b/apps/grader-host/src/index.ts
@@ -620,23 +620,24 @@ async function runJob(
     // Now that the job has completed, let's extract the results
     // First up: results.json
     if (results.succeeded) {
-      let data: Buffer;
-      try {
-        data = await readFileWithinDirectory(tempDir, 'results/results.json', 1024 * 1024);
-      } catch (err) {
+      const data = await readFileWithinDirectory(
+        tempDir,
+        'results/results.json',
+        1024 * 1024,
+      ).catch((err: unknown) => {
+        results.succeeded = false;
         if (err instanceof FileSizeLimitError) {
-          results.succeeded = false;
           results.message =
             'The grading results were larger than 1MB. ' +
             'If the problem persists, please contact course staff or a proctor.';
-          return;
+        } else {
+          logger.error('Could not read results.json', err);
+          results.message = 'Could not read grading results.';
         }
+        return null;
+      });
 
-        logger.error('Could not read results.json', err);
-        results.succeeded = false;
-        results.message = 'Could not read grading results.';
-        return;
-      }
+      if (data === null) return;
 
       try {
         const parsedResults = JSON.parse(data.toString());

--- a/apps/grader-host/src/index.ts
+++ b/apps/grader-host/src/index.ts
@@ -18,7 +18,7 @@ import * as tmp from 'tmp-promise';
 import z from 'zod';
 
 import { DockerName, setupDockerAuth } from '@prairielearn/docker-utils';
-import { contains } from '@prairielearn/path-utils';
+import { FileSizeLimitError, contains, readFileWithinDirectory } from '@prairielearn/path-utils';
 import * as sqldb from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { sanitizeObject } from '@prairielearn/sanitize';
@@ -620,33 +620,33 @@ async function runJob(
     // Now that the job has completed, let's extract the results
     // First up: results.json
     if (results.succeeded) {
-      await fs.readFile(path.join(tempDir, 'results', 'results.json')).then(
-        (data) => {
-          if (Buffer.byteLength(data) > 1024 * 1024) {
-            // Cap output at 1MB
-            results.succeeded = false;
-            results.message =
-              'The grading results were larger than 1MB. ' +
-              'If the problem persists, please contact course staff or a proctor.';
-            return;
-          }
-
-          try {
-            const parsedResults = JSON.parse(data.toString());
-            results.results = sanitizeObject(parsedResults);
-            results.succeeded = true;
-          } catch (e) {
-            logger.error('Could not parse results.json:', e);
-            results.succeeded = false;
-            results.message = 'Could not parse the grading results.';
-          }
-        },
-        (err) => {
-          logger.error('Could not read results.json', err);
+      let data: Buffer;
+      try {
+        data = await readFileWithinDirectory(tempDir, 'results/results.json', 1024 * 1024);
+      } catch (err) {
+        if (err instanceof FileSizeLimitError) {
           results.succeeded = false;
-          results.message = 'Could not read grading results.';
-        },
-      );
+          results.message =
+            'The grading results were larger than 1MB. ' +
+            'If the problem persists, please contact course staff or a proctor.';
+          return;
+        }
+
+        logger.error('Could not read results.json', err);
+        results.succeeded = false;
+        results.message = 'Could not read grading results.';
+        return;
+      }
+
+      try {
+        const parsedResults = JSON.parse(data.toString());
+        results.results = sanitizeObject(parsedResults);
+        results.succeeded = true;
+      } catch (e) {
+        logger.error('Could not parse results.json:', e);
+        results.succeeded = false;
+        results.message = 'Could not parse the grading results.';
+      }
     } else {
       if (results.timedOut) {
         results.message = `Your grading job did not complete within the time limit of ${timeout} seconds.\nPlease fix your code before submitting again.`;

--- a/apps/prairielearn/src/lib/externalGraderLocal.ts
+++ b/apps/prairielearn/src/lib/externalGraderLocal.ts
@@ -200,22 +200,22 @@ export class ExternalGraderLocal implements Grader {
 
       // Now that the job has completed, let's extract the results from `results.json`.
       if (results.succeeded) {
-        let data: Buffer | undefined;
-        try {
-          data = await readFileWithinDirectory(dir, 'results/results.json', 1024 * 1024);
-        } catch (err) {
-          results.succeeded = false;
-          if (err instanceof FileSizeLimitError) {
-            results.message =
-              'The grading results were larger than 1MB. ' +
-              'If the problem persists, please contact course staff or a proctor.';
-          } else {
-            logger.error('Could not read results.json', err);
-            results.message = 'Could not read grading results.';
-          }
-        }
+        const data = await readFileWithinDirectory(dir, 'results/results.json', 1024 * 1024).catch(
+          (err: unknown) => {
+            results.succeeded = false;
+            if (err instanceof FileSizeLimitError) {
+              results.message =
+                'The grading results were larger than 1MB. ' +
+                'If the problem persists, please contact course staff or a proctor.';
+            } else {
+              logger.error('Could not read results.json', err);
+              results.message = 'Could not read grading results.';
+            }
+            return null;
+          },
+        );
 
-        if (data != null) {
+        if (data !== null) {
           try {
             results.results = JSON.parse(data.toString('utf8'));
             results.succeeded = true;

--- a/apps/prairielearn/src/lib/externalGraderLocal.ts
+++ b/apps/prairielearn/src/lib/externalGraderLocal.ts
@@ -5,11 +5,10 @@ import * as path from 'path';
 import byline from 'byline';
 import Docker from 'dockerode';
 import { execa } from 'execa';
-import fs from 'fs-extra';
 import * as shlex from 'shlex';
 
 import { logger } from '@prairielearn/logger';
-import { contains } from '@prairielearn/path-utils';
+import { FileSizeLimitError, contains, readFileWithinDirectory } from '@prairielearn/path-utils';
 import * as sqldb from '@prairielearn/postgres';
 
 import { config } from './config.js';
@@ -201,26 +200,29 @@ export class ExternalGraderLocal implements Grader {
 
       // Now that the job has completed, let's extract the results from `results.json`.
       if (results.succeeded) {
-        const data = await fs.readFile(path.join(dir, 'results', 'results.json'));
+        let data: Buffer | undefined;
         try {
-          if (Buffer.byteLength(data) > 1024 * 1024) {
-            // Cap data size at 1MB
-            results.succeeded = false;
+          data = await readFileWithinDirectory(dir, 'results/results.json', 1024 * 1024);
+        } catch (err) {
+          results.succeeded = false;
+          if (err instanceof FileSizeLimitError) {
             results.message =
               'The grading results were larger than 1MB. ' +
               'If the problem persists, please contact course staff or a proctor.';
           } else {
-            try {
-              results.results = JSON.parse(data.toString('utf8'));
-              results.succeeded = true;
-            } catch {
-              results.succeeded = false;
-              results.message = 'Could not parse the grading results.';
-            }
+            logger.error('Could not read results.json', err);
+            results.message = 'Could not read grading results.';
           }
-        } catch {
-          logger.error('Could not read results.json');
-          results.succeeded = false;
+        }
+
+        if (data != null) {
+          try {
+            results.results = JSON.parse(data.toString('utf8'));
+            results.succeeded = true;
+          } catch {
+            results.succeeded = false;
+            results.message = 'Could not parse the grading results.';
+          }
         }
       } else {
         results.results = null;

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -1,12 +1,11 @@
-import { promises as fsPromises } from 'fs';
 import { ok as assert } from 'node:assert';
+import { promises as fsPromises } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 import * as path from 'path';
 
 import { ZipArchive } from 'archiver';
 import * as async from 'async';
 import debugfn from 'debug';
-import type { Entry } from 'fast-glob';
 import fs from 'fs-extra';
 import klaw from 'klaw';
 import mustache from 'mustache';
@@ -731,41 +730,34 @@ async function getGradedFilesFromFileSystem(workspace_id: string): Promise<strin
   const remoteName = `workspace-${workspace_id}-${workspace_version}`;
   const remoteDir = path.join(config.workspaceHomeDirRoot, remoteName, 'current');
 
-  let gradedFiles: Entry[];
-  try {
-    gradedFiles = await workspaceUtils.getWorkspaceGradedFiles(
-      remoteDir,
-      workspace_graded_files ?? [],
-      {
-        maxFiles: config.workspaceMaxGradedFilesCount,
-        maxSize: config.workspaceMaxGradedFilesSize,
-      },
-    );
-  } catch (err: any) {
-    // Turn any error into a `SubmissionFormatError` so that it is handled correctly.
-    throw new SubmissionFormatError(err.message);
-  }
+  await using gradedFiles = await workspaceUtils
+    .openWorkspaceGradedFiles(remoteDir, workspace_graded_files ?? [], {
+      maxFiles: config.workspaceMaxGradedFilesCount,
+      maxSize: config.workspaceMaxGradedFilesSize,
+    })
+    .catch((err: Error) => {
+      // Turn any error into a `SubmissionFormatError` so that it is handled correctly.
+      throw new SubmissionFormatError(err.message);
+    });
 
-  // Zip files from filesystem to zip file
-  gradedFiles.forEach((file) => {
-    const remotePath = path.join(remoteDir, file.path);
-    debug(`Zipping graded file ${remotePath} into ${zipPath}`);
-    archive.file(remotePath, { name: file.path });
-  });
-
-  // Write zip file to disk
   const stream = fs.createWriteStream(zipPath);
-  await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     archive.on('error', (err) => reject(err));
 
     stream
       .on('error', (err) => reject(err))
       .on('finish', () => {
         debug(`Zipped graded files as ${zipPath} (${archive.pointer()} total bytes)`);
-        resolve(zipPath);
+        resolve();
       });
 
     archive.pipe(stream);
+
+    for (const file of gradedFiles) {
+      debug(`Zipping graded file ${path.join(remoteDir, file.path)} into ${zipPath}`);
+      archive.append(file.createReadStream(), { name: file.path });
+    }
+
     archive.finalize().catch((err) => reject(err));
   });
   return zipPath;

--- a/apps/prairielearn/src/lib/workspace.ts
+++ b/apps/prairielearn/src/lib/workspace.ts
@@ -1,5 +1,6 @@
 import { ok as assert } from 'node:assert';
 import { promises as fsPromises } from 'node:fs';
+import { pipeline } from 'node:stream/promises';
 import { setTimeout as sleep } from 'node:timers/promises';
 import * as path from 'path';
 
@@ -726,7 +727,6 @@ async function getGradedFilesFromFileSystem(workspace_id: string): Promise<strin
   );
   const zipPath = await tmp.tmpName({ postfix: '.zip' });
 
-  const archive = new ZipArchive();
   const remoteName = `workspace-${workspace_id}-${workspace_version}`;
   const remoteDir = path.join(config.workspaceHomeDirRoot, remoteName, 'current');
 
@@ -740,26 +740,16 @@ async function getGradedFilesFromFileSystem(workspace_id: string): Promise<strin
       throw new SubmissionFormatError(err.message);
     });
 
-  const stream = fs.createWriteStream(zipPath);
-  await new Promise<void>((resolve, reject) => {
-    archive.on('error', (err) => reject(err));
+  const archive = new ZipArchive();
+  const archiveCompleted = pipeline(archive, fs.createWriteStream(zipPath));
 
-    stream
-      .on('error', (err) => reject(err))
-      .on('finish', () => {
-        debug(`Zipped graded files as ${zipPath} (${archive.pointer()} total bytes)`);
-        resolve();
-      });
+  for (const file of gradedFiles) {
+    debug(`Zipping graded file ${path.join(remoteDir, file.path)} into ${zipPath}`);
+    archive.append(file.createReadStream(), { name: file.path });
+  }
 
-    archive.pipe(stream);
-
-    for (const file of gradedFiles) {
-      debug(`Zipping graded file ${path.join(remoteDir, file.path)} into ${zipPath}`);
-      archive.append(file.createReadStream(), { name: file.path });
-    }
-
-    archive.finalize().catch((err) => reject(err));
-  });
+  await Promise.all([archive.finalize(), archiveCompleted]);
+  debug(`Zipped graded files as ${zipPath} (${archive.pointer()} total bytes)`);
   return zipPath;
 }
 

--- a/apps/workspace-host/package.json
+++ b/apps/workspace-host/package.json
@@ -53,7 +53,6 @@
     "@types/node": "^24.13.3",
     "@typescript/native-preview": "beta",
     "@vitest/coverage-v8": "^4.1.10",
-    "fast-glob": "^3.3.3",
     "tsx": "^4.23.11",
     "typescript-cp": "^0.1.11",
     "vitest": "^4.1.10"

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -5,6 +5,7 @@ import * as http from 'node:http';
 import * as net from 'node:net';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
 import { ECRClient } from '@aws-sdk/client-ecr';
 import { S3 } from '@aws-sdk/client-s3';
@@ -1169,25 +1170,14 @@ async function sendGradedFilesArchive(workspace_id: string | number, res: Respon
   // Stream the archive back to the client as it's generated.
   res.attachment(zipName).status(200);
   const archive = new ZipArchive();
-  archive.pipe(res);
-
-  archive.on('error', (err) => {
-    logger.error('Error creating archive', err);
-    Sentry.captureException(err);
-
-    // Since we've probably already sent some data to the client, we can't do
-    // anything to gracefully let them know that we encountered an error.
-    // Instead, we'll just destroy the socket so that they pick up an error
-    // and handle that however they want.
-    res.socket?.destroy();
-  });
+  const archiveCompleted = pipeline(archive, res);
 
   for (const file of gradedFiles) {
     archive.append(file.createReadStream(), { name: file.path });
     debug(`Sending ${file.path}`);
   }
 
-  await archive.finalize();
+  await Promise.all([archive.finalize(), archiveCompleted]);
 }
 
 async function sendLogs(workspaceId: string | number, res: Response) {

--- a/apps/workspace-host/src/interface.ts
+++ b/apps/workspace-host/src/interface.ts
@@ -17,7 +17,6 @@ import debugfn from 'debug';
 import Docker from 'dockerode';
 import express, { type Response } from 'express';
 import asyncHandler from 'express-async-handler';
-import { type Entry } from 'fast-glob';
 import minimist from 'minimist';
 import * as shlex from 'shlex';
 import { z } from 'zod';
@@ -1156,20 +1155,16 @@ async function sendGradedFilesArchive(workspace_id: string | number, res: Respon
   const zipName = `${workspace.remote_name}-${timestamp}.zip`;
   const workspaceDir = path.join(config.workspaceHostHomeDirRoot, workspace.remote_name, 'current');
 
-  let gradedFiles: Entry[] | undefined;
-  try {
-    gradedFiles = await workspaceUtils.getWorkspaceGradedFiles(
-      workspaceDir,
-      workspace_graded_files,
-      {
-        maxFiles: config.workspaceMaxGradedFilesCount,
-        maxSize: config.workspaceMaxGradedFilesSize,
-      },
-    );
-  } catch (err: any) {
-    res.status(500).send(err.message);
-    return;
-  }
+  await using gradedFiles = await workspaceUtils
+    .openWorkspaceGradedFiles(workspaceDir, workspace_graded_files, {
+      maxFiles: config.workspaceMaxGradedFilesCount,
+      maxSize: config.workspaceMaxGradedFilesSize,
+    })
+    .catch((err: Error) => {
+      res.status(500).send(err.message);
+      return null;
+    });
+  if (gradedFiles == null) return;
 
   // Stream the archive back to the client as it's generated.
   res.attachment(zipName).status(200);
@@ -1188,14 +1183,8 @@ async function sendGradedFilesArchive(workspace_id: string | number, res: Respon
   });
 
   for (const file of gradedFiles) {
-    try {
-      const filePath = path.join(workspaceDir, file.path);
-      archive.file(filePath, { name: file.path });
-      debug(`Sending ${file.path}`);
-    } catch {
-      logger.warn(`Graded file ${file.path} does not exist.`);
-      continue;
-    }
+    archive.append(file.createReadStream(), { name: file.path });
+    debug(`Sending ${file.path}`);
   }
 
   await archive.finalize();

--- a/packages/path-utils/src/index.test.ts
+++ b/packages/path-utils/src/index.test.ts
@@ -1,6 +1,20 @@
-import { assert, describe, it } from 'vitest';
+import fs, { mkdtempDisposable } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
-import { contains, isContainedRelativePath } from './index.js';
+import { assert, describe, expect, it } from 'vitest';
+
+import {
+  FileSizeLimitError,
+  contains,
+  isContainedRelativePath,
+  openFileWithinDirectory,
+  readFileWithinDirectory,
+} from './index.js';
+
+function makeTempDirectory() {
+  return mkdtempDisposable(path.join(os.tmpdir(), 'prairielearn-path-utils-'));
+}
 
 describe('File paths', () => {
   describe('contains function', () => {
@@ -64,6 +78,67 @@ describe('File paths', () => {
       assert.notOk(isContainedRelativePath('/PrairieLearn'));
       assert.notOk(isContainedRelativePath('../PrairieLearn'));
       assert.notOk(isContainedRelativePath('PrairieLearn/../../etc'));
+    });
+  });
+
+  describe('openFileWithinDirectory function', () => {
+    it('opens a regular file within the directory', async () => {
+      await using directory = await makeTempDirectory();
+      await fs.mkdir(path.join(directory.path, 'results'));
+      await fs.writeFile(path.join(directory.path, 'results', 'results.json'), '{"score": 1}');
+
+      await using file = await openFileWithinDirectory(directory.path, 'results/results.json');
+      const contents = await file.readFile();
+
+      assert.equal(contents.toString(), '{"score": 1}');
+    });
+
+    it('rejects a symbolic link to a file outside the directory', async () => {
+      await using directory = await makeTempDirectory();
+      await using outsideDirectory = await makeTempDirectory();
+      const outsideFile = path.join(outsideDirectory.path, 'secret.json');
+      await fs.mkdir(path.join(directory.path, 'results'));
+      await fs.writeFile(outsideFile, '{"secret": true}');
+      await fs.symlink(outsideFile, path.join(directory.path, 'results', 'results.json'));
+
+      await expect(openFileWithinDirectory(directory.path, 'results/results.json')).rejects.toThrow(
+        'File is outside the allowed directory.',
+      );
+    });
+
+    it('rejects a symbolic link to a directory outside the allowed directory', async () => {
+      await using directory = await makeTempDirectory();
+      await using outsideDirectory = await makeTempDirectory();
+      await fs.writeFile(path.join(outsideDirectory.path, 'results.json'), '{"secret": true}');
+      await fs.symlink(outsideDirectory.path, path.join(directory.path, 'results'));
+
+      await expect(openFileWithinDirectory(directory.path, 'results/results.json')).rejects.toThrow(
+        'File is outside the allowed directory.',
+      );
+    });
+
+    it('rejects non-regular files', async () => {
+      await using directory = await makeTempDirectory();
+      await fs.mkdir(path.join(directory.path, 'results.json'));
+
+      await expect(openFileWithinDirectory(directory.path, 'results.json')).rejects.toThrow(
+        'Path is not a regular file.',
+      );
+    });
+  });
+
+  describe('readFileWithinDirectory function', () => {
+    it('reads files within the limit and rejects larger files', async () => {
+      await using directory = await makeTempDirectory();
+      await fs.writeFile(path.join(directory.path, 'results.json'), '12345');
+
+      assert.equal(
+        (await readFileWithinDirectory(directory.path, 'results.json', 5)).toString(),
+        '12345',
+      );
+      await expect(readFileWithinDirectory(directory.path, 'results.json', 4)).rejects.toThrow(
+        FileSizeLimitError,
+      );
     });
   });
 });

--- a/packages/path-utils/src/index.ts
+++ b/packages/path-utils/src/index.ts
@@ -1,4 +1,14 @@
-import path from 'path';
+import { constants } from 'node:fs';
+import fs, { type FileHandle } from 'node:fs/promises';
+import path from 'node:path';
+import { buffer } from 'node:stream/consumers';
+
+export class FileSizeLimitError extends Error {
+  constructor(maxSize: number) {
+    super(`File exceeds size limit of ${maxSize} bytes.`);
+    this.name = 'FileSizeLimitError';
+  }
+}
 
 /**
  * Returns true if the parent path contains the child path. Used to allow code
@@ -36,4 +46,73 @@ export function isContainedRelativePath(relPath: string, includeSelf = true): bo
   relPath = path.normalize(relPath);
   if (relPath === '.') return includeSelf;
   return !(relPath.split(path.sep)[0] === '..' || path.isAbsolute(relPath));
+}
+
+/**
+ * Opens a regular file whose resolved path is contained within the given directory.
+ *
+ * `O_NOFOLLOW` protects against replacement of the final path component after resolution, while
+ * `O_NONBLOCK` prevents a special file from blocking before it can be rejected. On Linux, resolving
+ * the opened descriptor also detects replacement of a parent directory. The caller is responsible
+ * for closing the returned file handle.
+ */
+export async function openFileWithinDirectory(
+  directoryPath: string,
+  filePath: string,
+): Promise<FileHandle> {
+  const [resolvedDirectoryPath, resolvedFilePath] = await Promise.all([
+    fs.realpath(directoryPath),
+    fs.realpath(path.resolve(directoryPath, filePath)),
+  ]);
+
+  if (!contains(resolvedDirectoryPath, resolvedFilePath, false)) {
+    throw new Error('File is outside the allowed directory.');
+  }
+
+  const file = await fs.open(
+    resolvedFilePath,
+    constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+  );
+  try {
+    if (process.platform === 'linux') {
+      // `O_NOFOLLOW` only protects the final path component. Resolving the opened descriptor lets
+      // us detect if a concurrently replaced parent directory redirected the open outside the root.
+      const openedFilePath = await fs.realpath(`/proc/self/fd/${file.fd}`);
+      if (!contains(resolvedDirectoryPath, openedFilePath, false)) {
+        throw new Error('File is outside the allowed directory.');
+      }
+    }
+
+    const stats = await file.stat();
+    if (!stats.isFile()) {
+      throw new Error('Path is not a regular file.');
+    }
+    return file;
+  } catch (error) {
+    await file.close();
+    throw error;
+  }
+}
+
+/**
+ * Reads a contained regular file while limiting the number of bytes read into memory.
+ */
+export async function readFileWithinDirectory(
+  directoryPath: string,
+  filePath: string,
+  maxSize: number,
+): Promise<Buffer> {
+  await using file = await openFileWithinDirectory(directoryPath, filePath);
+  const data = await buffer(
+    file.createReadStream({
+      autoClose: false,
+      start: 0,
+      // `end` is inclusive, so this reads at most `maxSize + 1` bytes.
+      end: maxSize,
+    }),
+  );
+  if (data.length > maxSize) {
+    throw new FileSizeLimitError(maxSize);
+  }
+  return data;
 }

--- a/packages/workspace-utils/package.json
+++ b/packages/workspace-utils/package.json
@@ -14,7 +14,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsgo && tscp",
-    "dev": "tsgo --watch --preserveWatchOutput & tscp --watch"
+    "dev": "tsgo --watch --preserveWatchOutput & tscp --watch",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "@prairielearn/path-utils": "workspace:^",
@@ -30,6 +31,8 @@
     "@prairielearn/tsconfig": "workspace:^",
     "@types/node": "^24.13.3",
     "@typescript/native-preview": "beta",
-    "typescript-cp": "^0.1.11"
+    "@vitest/coverage-v8": "^4.1.10",
+    "typescript-cp": "^0.1.11",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/workspace-utils/src/graded-files.ts
+++ b/packages/workspace-utils/src/graded-files.ts
@@ -1,0 +1,104 @@
+import { Readable } from 'node:stream';
+
+import fg from 'fast-glob';
+import { filesize } from 'filesize';
+
+import { isContainedRelativePath, openFileWithinDirectory } from '@prairielearn/path-utils';
+
+interface GradedFilesLimits {
+  maxFiles: number;
+  maxSize: number;
+}
+
+export interface WorkspaceGradedFile {
+  path: string;
+  createReadStream(): Readable;
+}
+
+interface OpenedWorkspaceGradedFile extends WorkspaceGradedFile {
+  close(): Promise<void>;
+}
+
+export type OpenedWorkspaceGradedFiles = Iterable<WorkspaceGradedFile> & AsyncDisposable;
+
+async function closeWorkspaceGradedFiles(files: OpenedWorkspaceGradedFile[]): Promise<void> {
+  await Promise.allSettled(files.map((file) => file.close()));
+}
+
+export async function openWorkspaceGradedFiles(
+  workspaceDir: string,
+  gradedFiles: string[],
+  limits: GradedFilesLimits,
+): Promise<OpenedWorkspaceGradedFiles> {
+  const matchedPaths = (
+    await fg(gradedFiles, {
+      cwd: workspaceDir,
+      ...workspaceFastGlobDefaultOptions,
+    })
+  ).filter((filePath) => isContainedRelativePath(filePath, false));
+
+  // We generally use `archiver` downstream of this, which does not elegantly
+  // handle file names with backslashes:
+  // https://github.com/archiverjs/node-archiver/issues/743
+  // To prevent downstream issues, we disallow any files with backslashes in
+  // their paths. We fail hard rather than silently dropping these files so
+  // that it's clear to the user what's happening.
+  const backslashPaths = matchedPaths.filter((filePath) => filePath.includes('\\'));
+  if (backslashPaths.length > 0) {
+    const paths = backslashPaths.join(', ');
+    throw new Error(`Cannot submit files with paths that contain backslashes: ${paths}`);
+  }
+
+  if (matchedPaths.length > limits.maxFiles) {
+    throw new Error(`Cannot submit more than ${limits.maxFiles} files from the workspace.`);
+  }
+
+  const files: OpenedWorkspaceGradedFile[] = [];
+  try {
+    let totalSize = 0;
+    for (const matchedPath of matchedPaths) {
+      const fileHandle = await openFileWithinDirectory(workspaceDir, matchedPath);
+      let size: number;
+      try {
+        size = (await fileHandle.stat()).size;
+      } catch (error) {
+        await fileHandle.close();
+        throw error;
+      }
+
+      files.push({
+        path: matchedPath,
+        createReadStream: () =>
+          size === 0 ? Readable.from([]) : fileHandle.createReadStream({ start: 0, end: size - 1 }),
+        close: () => fileHandle.close(),
+      });
+      totalSize += size;
+
+      if (totalSize > limits.maxSize) {
+        throw new Error(
+          `Workspace files exceed limit of ${filesize(limits.maxSize, {
+            base: 2,
+          })}.`,
+        );
+      }
+    }
+
+    return {
+      [Symbol.iterator]: () => files[Symbol.iterator](),
+      // eslint-disable-next-line unicorn/no-nonstandard-builtin-properties -- Supported in Node 24.
+      [Symbol.asyncDispose]: () => closeWorkspaceGradedFiles(files),
+    };
+  } catch (error) {
+    await closeWorkspaceGradedFiles(files);
+    throw error;
+  }
+}
+
+/**
+ * Default options for calls to `fast-glob`.
+ */
+export const workspaceFastGlobDefaultOptions = {
+  extglob: false,
+  braceExpansion: false,
+  followSymbolicLinks: false,
+};

--- a/packages/workspace-utils/src/index.test.ts
+++ b/packages/workspace-utils/src/index.test.ts
@@ -1,0 +1,58 @@
+import fs, { mkdtempDisposable } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { buffer } from 'node:stream/consumers';
+
+import { assert, describe, it } from 'vitest';
+
+import { openWorkspaceGradedFiles } from './index.js';
+
+function makeTempDirectory() {
+  return mkdtempDisposable(path.join(os.tmpdir(), 'prairielearn-workspace-utils-'));
+}
+
+describe('openWorkspaceGradedFiles', () => {
+  const limits = {
+    maxFiles: 10,
+    maxSize: 1024,
+  };
+
+  it('returns regular graded files', async () => {
+    await using workspaceDirectory = await makeTempDirectory();
+    await fs.writeFile(path.join(workspaceDirectory.path, 'answer.py'), 'print("hello")');
+
+    await using files = await openWorkspaceGradedFiles(workspaceDirectory.path, ['*.py'], limits);
+
+    const [file] = [...files];
+    assert.equal(file.path, 'answer.py');
+    await fs.appendFile(path.join(workspaceDirectory.path, 'answer.py'), '\nprint("goodbye")');
+    assert.equal((await buffer(file.createReadStream())).toString(), 'print("hello")');
+  });
+
+  it('does not follow a symbolic link to a file', async () => {
+    await using workspaceDirectory = await makeTempDirectory();
+    await using outsideDirectory = await makeTempDirectory();
+    const outsideFile = path.join(outsideDirectory.path, 'secret.py');
+    await fs.writeFile(outsideFile, 'secret');
+    await fs.symlink(outsideFile, path.join(workspaceDirectory.path, 'answer.py'));
+
+    await using files = await openWorkspaceGradedFiles(workspaceDirectory.path, ['*.py'], limits);
+
+    assert.isEmpty([...files]);
+  });
+
+  it('does not traverse a symbolic link to a directory', async () => {
+    await using workspaceDirectory = await makeTempDirectory();
+    await using outsideDirectory = await makeTempDirectory();
+    await fs.writeFile(path.join(outsideDirectory.path, 'secret.py'), 'secret');
+    await fs.symlink(outsideDirectory.path, path.join(workspaceDirectory.path, 'linked'));
+
+    await using files = await openWorkspaceGradedFiles(
+      workspaceDirectory.path,
+      ['**/*.py'],
+      limits,
+    );
+
+    assert.isEmpty([...files]);
+  });
+});

--- a/packages/workspace-utils/src/index.ts
+++ b/packages/workspace-utils/src/index.ts
@@ -3,14 +3,18 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import type { Emitter as SocketIOEmitter } from '@socket.io/redis-emitter';
-import fg, { type Entry } from 'fast-glob';
-import { filesize } from 'filesize';
 import type { Server as SocketIOServer } from 'socket.io';
 import { z } from 'zod';
 
-import { contains } from '@prairielearn/path-utils';
 import { execute, loadSqlEquiv, queryRow, queryScalar } from '@prairielearn/postgres';
 import { IdSchema, IntervalSchema } from '@prairielearn/zod';
+
+export {
+  openWorkspaceGradedFiles,
+  type OpenedWorkspaceGradedFiles,
+  type WorkspaceGradedFile,
+  workspaceFastGlobDefaultOptions,
+} from './graded-files.js';
 
 const WorkspaceVersionSchema = z.object({
   id: IdSchema,
@@ -87,52 +91,6 @@ export async function updateWorkspaceState(
   });
 }
 
-interface GradedFilesLimits {
-  maxFiles: number;
-  maxSize: number;
-}
-
-export async function getWorkspaceGradedFiles(
-  workspaceDir: string,
-  gradedFiles: string[],
-  limits: GradedFilesLimits,
-): Promise<Entry[]> {
-  const files = (
-    await fg(gradedFiles, {
-      cwd: workspaceDir,
-      stats: true,
-      ...workspaceFastGlobDefaultOptions,
-    })
-  ).filter((file) => contains(workspaceDir, path.join(workspaceDir, file.path)));
-
-  // We generally use `archiver` downstream of this, which does not elegantly
-  // handle file names with backslashes:
-  // https://github.com/archiverjs/node-archiver/issues/743
-  // To prevent downstream issues, we disallow any files with backslashes in
-  // their paths. We fail hard rather than silently dropping these files so
-  // that it's clear to the user what's happening.
-  const backslashPaths = files.filter((file) => file.path.includes('\\'));
-  if (backslashPaths.length > 0) {
-    const paths = backslashPaths.map((file) => file.path).join(', ');
-    throw new Error(`Cannot submit files with paths that contain backslashes: ${paths}`);
-  }
-
-  if (files.length > limits.maxFiles) {
-    throw new Error(`Cannot submit more than ${limits.maxFiles} files from the workspace.`);
-  }
-
-  const totalSize = files.reduce((acc, file) => acc + (file.stats?.size ?? 0), 0);
-  if (totalSize > limits.maxSize) {
-    throw new Error(
-      `Workspace files exceed limit of ${filesize(limits.maxSize, {
-        base: 2,
-      })}.`,
-    );
-  }
-
-  return files;
-}
-
 /**
  * Updates the disk usage of a workspace. This is computed as the sum of the
  * sizes of all versions of the workspace. The result is stored in the
@@ -204,14 +162,6 @@ async function getWorkspaceFiles(dir: string): Promise<Dirent[]> {
     throw e;
   }
 }
-
-/**
- * Default options for calls to `fast-glob`.
- */
-export const workspaceFastGlobDefaultOptions = {
-  extglob: false,
-  braceExpansion: false,
-};
 
 /**
  * Update the course instance usages for workspace usage.

--- a/packages/workspace-utils/vitest.config.ts
+++ b/packages/workspace-utils/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    dir: `${import.meta.dirname}/src`,
+    coverage: {
+      reporter: ['html', 'text-summary', 'cobertura'],
+      include: ['src/**/*.{ts,tsx}'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1472,9 +1472,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
       tsx:
         specifier: ^4.23.11
         version: 4.23.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2911,9 +2911,15 @@ importers:
       '@typescript/native-preview':
         specifier: beta
         version: 7.0.0-dev.20260421.2
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       typescript-cp:
         specifier: ^0.1.11
         version: 0.1.11(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/zod:
     dependencies:


### PR DESCRIPTION
# Description

This PR improves the safety and consistency of file collection for workspace submissions and external graders. Files are now opened through a shared path utility that verifies regular files remain within their expected directories, applies size limits during reads, and keeps validated file handles open while archives are streamed.

These changes won't impact normal workspace and grader behavior. Files that don't satisfy the expected path and file-type constraints are rejected rather than collected.

# Testing

I added focused unit coverage for in-directory reads, bounded reads, non-regular files, symbolic links to files and directories, and workspace graded-file collection.