### PR TITLE
Show institution-provided course access on the homepage

### DIFF
--- a/.agents/skills/express-request-validation/SKILL.md
+++ b/.agents/skills/express-request-validation/SKILL.md
@@ -7,6 +7,7 @@ description: Conventions for validating PrairieLearn Express request parameters,
 
 - Define request schemas at module scope unless they genuinely depend on request-time values. Prefer a static structural schema followed by a semantic check over constructing a schema per request.
 - Parse every request source a handler consumes before database queries or other work. After parsing, use only the parsed values; do not read the corresponding `req.params`, `req.query`, or `req.body` values again.
+- Use `IdSchema` from `@prairielearn/zod` for PrairieLearn database IDs in params, query strings, and bodies. Do not validate them as arbitrary strings or numbers. External-system identifiers that are not PrairieLearn database IDs should use schemas appropriate to those systems.
 - Treat parsed request objects as boundary data, not as parameter bags. Pass explicit fields to database queries, model functions, and other downstream APIs instead of passing `params`, `query`, or `body` wholesale; this keeps each callsite's contract visible and avoids unused-parameter failures when request schemas grow.
 - Use `parseRequest` when validating multiple sources together. Use `parseRequestParams`, `parseRequestQuery`, or `parseRequestBody` when validating only one source.
 - Express cannot verify that a params schema matches the router path. Check the parent mount path as well as the local route and ensure every `ParamsSchema` key matches an actual `:parameter`.

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -387,7 +387,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
-    it('uses every matching candidate for institution UIN invitation access', async () => {
+    it('uses publishing extensions from both the left enrollment and its UIN invitation', async () => {
       const courseInstance = createMockCourseInstance();
       const boundCandidate = createCandidate(
         createMockEnrollment({ id: 'bound', status: 'left' }),

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -220,8 +220,8 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
     classification: Partial<EnrollmentIdentityClassification> = {},
   ): EnrollmentIdentityClassification {
     const resolved = {
-      actionableConventionalInvitation: null,
-      actionableInstitutionRosterInvitation: null,
+      actionableInstitutionUinInvitation: null,
+      actionableUidInvitation: null,
       boundCandidate: null,
       candidates: [],
       ...classification,
@@ -387,15 +387,15 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
-    it('uses every matching candidate for roster invitation access', async () => {
+    it('uses every matching candidate for institution UIN invitation access', async () => {
       const courseInstance = createMockCourseInstance();
       const boundCandidate = createCandidate(
         createMockEnrollment({ id: 'bound', status: 'left' }),
         { boundUser: true },
       );
-      const rosterCandidate = createCandidate(
+      const uinInvitationCandidate = createCandidate(
         createMockEnrollment({
-          id: 'roster',
+          id: 'uin-invitation',
           user_id: null,
           status: 'invited',
           pending_uin: 'uin',
@@ -403,9 +403,9 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         { institutionUin: true },
       );
       mockClassification({
-        actionableInstitutionRosterInvitation: rosterCandidate,
+        actionableInstitutionUinInvitation: uinInvitationCandidate,
         boundCandidate,
-        candidates: [boundCandidate, rosterCandidate],
+        candidates: [boundCandidate, uinInvitationCandidate],
       });
       const extensionSelector = vi
         .spyOn(publishingExtensionsModel, 'selectLatestPublishingExtensionByEnrollmentIds')
@@ -422,7 +422,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         has_student_access_with_enrollment: false,
       });
       assert.deepEqual(extensionSelector.mock.calls, [
-        [{ courseInstance, enrollmentIds: ['bound', 'roster'] }],
+        [{ courseInstance, enrollmentIds: ['bound', 'uin-invitation'] }],
       ]);
     });
 

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -426,23 +426,39 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       ]);
     });
 
-    it('allows access when the request date is before the latest extension end date', async () => {
+    it("does not use a pending invitation's extension after the user has joined", async () => {
       const courseInstance = createMockCourseInstance({
         publishing_start_date: new Date('2025-01-01T00:00:00Z'),
         publishing_end_date: new Date('2025-12-31T23:59:59Z'),
       });
       const reqDate = new Date('2026-02-15T12:00:00Z');
-      const enrollment = createMockEnrollment();
-      const extension = createMockPublishingExtension({
+      const boundCandidate = createCandidate(createMockEnrollment({ id: 'bound' }), {
+        boundUser: true,
+      });
+      const pendingCandidate = createCandidate(
+        createMockEnrollment({
+          id: 'pending',
+          pending_uin: 'uin',
+          status: 'invited',
+          user_id: null,
+        }),
+        { institutionUin: true },
+      );
+      const pendingExtension = createMockPublishingExtension({
         id: 'extension',
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
-      mockBoundEnrollment(enrollment);
+      mockClassification({
+        boundCandidate,
+        candidates: [boundCandidate, pendingCandidate],
+      });
       vi.spyOn(
         publishingExtensionsModel,
         'selectLatestPublishingExtensionByEnrollmentIds',
-      ).mockResolvedValue(extension);
+      ).mockImplementation(({ enrollmentIds }) =>
+        Promise.resolve(enrollmentIds.includes('pending') ? pendingExtension : null),
+      );
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -450,9 +466,8 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         reqDate,
       );
 
-      // Request date is 2026-02-15 12:00:00, latest extension is 2026-02-28 23:59:59
-      assert.isTrue(result.has_student_access);
-      assert.isTrue(result.has_student_access_with_enrollment);
+      assert.isFalse(result.has_student_access);
+      assert.isFalse(result.has_student_access_with_enrollment);
     });
 
     it('forbids access when request date is after all extensions', async () => {

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -5,7 +5,11 @@ import { afterAll, assert, beforeAll, beforeEach, describe, it, vi } from 'vites
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 
 import * as publishingExtensionsModel from '../models/course-instance-publishing-extensions.js';
-import * as enrollmentModel from '../models/enrollment.js';
+import {
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+} from '../models/enrollment-identity.js';
+import * as enrollmentIdentityModel from '../models/enrollment-identity.js';
 import * as helperDb from '../tests/helperDb.js';
 
 import {
@@ -196,6 +200,45 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
     };
   }
 
+  function createCandidate(
+    enrollment: Enrollment,
+    matches: Partial<EnrollmentIdentityCandidate['matches']> = {},
+  ): EnrollmentIdentityCandidate {
+    return {
+      enrollment,
+      matches: {
+        boundUser: false,
+        institutionUin: false,
+        lti13: false,
+        pendingUid: false,
+        ...matches,
+      },
+    };
+  }
+
+  function mockClassification(
+    classification: Partial<EnrollmentIdentityClassification> = {},
+  ): EnrollmentIdentityClassification {
+    const resolved = {
+      actionableConventionalInvitation: null,
+      actionableInstitutionRosterInvitation: null,
+      boundCandidate: null,
+      candidates: [],
+      ...classification,
+    };
+    vi.spyOn(
+      enrollmentIdentityModel,
+      'selectEnrollmentIdentityClassification',
+    ).mockResolvedValue(resolved);
+    return resolved;
+  }
+
+  function mockBoundEnrollment(enrollment: Enrollment | null) {
+    if (enrollment === null) return mockClassification();
+    const candidate = createCandidate(enrollment, { boundUser: true });
+    return mockClassification({ boundCandidate: candidate, candidates: [candidate] });
+  }
+
   describe('no publishing dates', () => {
     it('forbids access when publishing_start_date is null', async () => {
       const courseInstance = createMockCourseInstance({
@@ -204,7 +247,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2025-06-01T12:00:00Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -225,7 +268,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2024-12-31T23:59:59Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -245,7 +288,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2024-12-31T23:59:59Z');
       const enrollment = createMockEnrollment();
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -266,7 +309,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2025-06-01T12:00:00Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -286,7 +329,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2025-06-01T12:00:00Z');
       const enrollment = createMockEnrollment();
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -307,7 +350,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       });
       const reqDate = new Date('2026-01-01T00:00:00Z');
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(null);
+      mockBoundEnrollment(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
         courseInstance,
@@ -327,10 +370,10 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       const reqDate = new Date('2026-01-01T00:00:00Z');
       const enrollment = createMockEnrollment();
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(null);
 
       const result = await calculateModernCourseInstanceStudentAccess(
@@ -345,6 +388,48 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
   });
 
   describe('with publishing extensions', () => {
+    it('uses every matching candidate for roster invitation access', async () => {
+      const courseInstance = createMockCourseInstance();
+      const boundCandidate = createCandidate(
+        createMockEnrollment({ id: 'bound', status: 'left' }),
+        { boundUser: true },
+      );
+      const rosterCandidate = createCandidate(
+        createMockEnrollment({
+          id: 'roster',
+          user_id: null,
+          status: 'invited',
+          pending_uin: 'uin',
+        }),
+        { institutionUin: true },
+      );
+      mockClassification({
+        actionableInstitutionRosterInvitation: rosterCandidate,
+        boundCandidate,
+        candidates: [boundCandidate, rosterCandidate],
+      });
+      const extensionSelector = vi
+        .spyOn(
+          publishingExtensionsModel,
+          'selectLatestPublishingExtensionByEnrollmentIds',
+        )
+        .mockResolvedValue(createMockPublishingExtension());
+
+      const result = await calculateModernCourseInstanceStudentAccess(
+        courseInstance,
+        'test-user-id',
+        new Date('2026-01-15T12:00:00Z'),
+      );
+
+      assert.deepEqual(result, {
+        has_student_access: true,
+        has_student_access_with_enrollment: false,
+      });
+      assert.deepEqual(extensionSelector.mock.calls, [
+        [{ courseInstance, enrollmentIds: ['bound', 'roster'] }],
+      ]);
+    });
+
     it('allows access when the request date is before the latest extension end date', async () => {
       const courseInstance = createMockCourseInstance({
         publishing_start_date: new Date('2025-01-01T00:00:00Z'),
@@ -357,10 +442,10 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(extension);
 
       const result = await calculateModernCourseInstanceStudentAccess(
@@ -386,10 +471,10 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         end_date: new Date('2026-02-28T23:59:59Z'),
       });
 
-      vi.spyOn(enrollmentModel, 'selectOptionalEnrollmentByUserId').mockResolvedValue(enrollment);
+      mockBoundEnrollment(enrollment);
       vi.spyOn(
         publishingExtensionsModel,
-        'selectLatestPublishingExtensionByEnrollment',
+        'selectLatestPublishingExtensionByEnrollmentIds',
       ).mockResolvedValue(extension);
 
       const result = await calculateModernCourseInstanceStudentAccess(

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -5,11 +5,6 @@ import { afterAll, assert, beforeAll, beforeEach, describe, it, vi } from 'vites
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 
 import * as publishingExtensionsModel from '../models/course-instance-publishing-extensions.js';
-import {
-  type EnrollmentIdentityCandidate,
-  type EnrollmentIdentityClassification,
-} from '../models/enrollment-identity.js';
-import * as enrollmentIdentityModel from '../models/enrollment-identity.js';
 import * as helperDb from '../tests/helperDb.js';
 
 import {
@@ -17,6 +12,11 @@ import {
   checkCourseInstanceLegacyAccess,
 } from './authz-data.js';
 import type { CourseInstance, CourseInstancePublishingExtension, Enrollment } from './db-types.js';
+import * as enrollmentIdentityModel from './enrollment/identity.js';
+import {
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+} from './enrollment/identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 

--- a/apps/prairielearn/src/lib/authz-data.test.ts
+++ b/apps/prairielearn/src/lib/authz-data.test.ts
@@ -226,10 +226,9 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
       candidates: [],
       ...classification,
     };
-    vi.spyOn(
-      enrollmentIdentityModel,
-      'selectEnrollmentIdentityClassification',
-    ).mockResolvedValue(resolved);
+    vi.spyOn(enrollmentIdentityModel, 'selectEnrollmentIdentityClassification').mockResolvedValue(
+      resolved,
+    );
     return resolved;
   }
 
@@ -409,10 +408,7 @@ describe('calculateModernCourseInstanceStudentAccess', () => {
         candidates: [boundCandidate, rosterCandidate],
       });
       const extensionSelector = vi
-        .spyOn(
-          publishingExtensionsModel,
-          'selectLatestPublishingExtensionByEnrollmentIds',
-        )
+        .spyOn(publishingExtensionsModel, 'selectLatestPublishingExtensionByEnrollmentIds')
         .mockResolvedValue(createMockPublishingExtension());
 
       const result = await calculateModernCourseInstanceStudentAccess(

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -107,7 +107,11 @@ export async function calculateModernCourseInstanceStudentAccess(
     courseInstanceId: courseInstance.id,
     userId,
   });
-  const isJoined = classification.boundCandidate?.enrollment.status === 'joined';
+  const joinedEnrollment =
+    classification.boundCandidate?.enrollment.status === 'joined'
+      ? classification.boundCandidate.enrollment
+      : null;
+  const isJoined = joinedEnrollment !== null;
 
   // Not published at all.
   if (courseInstance.publishing_start_date == null) {
@@ -130,8 +134,9 @@ export async function calculateModernCourseInstanceStudentAccess(
     };
   }
 
-  // A publishing extension may be assigned to the joined enrollment or to any
-  // row that will be merged when a pending UID or UIN invitation is accepted.
+  // Before admission, any matching row may carry the extension that will be
+  // preserved when those rows are merged. Once the user has joined, pending
+  // rows are not merged automatically and must not extend the joined row's access.
   const hasActionableInvitation =
     classification.actionableUidInvitation !== null ||
     classification.actionableInstitutionUinInvitation !== null;
@@ -141,7 +146,10 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollmentIds({
     courseInstance,
-    enrollmentIds: classification.candidates.map((candidate) => candidate.enrollment.id),
+    enrollmentIds:
+      joinedEnrollment === null
+        ? classification.candidates.map((candidate) => candidate.enrollment.id)
+        : [joinedEnrollment.id],
   });
 
   // Check if we have access via extension.

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -130,8 +130,8 @@ export async function calculateModernCourseInstanceStudentAccess(
     };
   }
 
-  // Joined students and actionable invitations can have an extension on any
-  // enrollment candidate that would participate in admission reconciliation.
+  // A publishing extension may be assigned to the joined enrollment or to any
+  // row that will be merged when a pending UID or UIN invitation is accepted.
   const hasActionableInvitation =
     classification.actionableUidInvitation !== null ||
     classification.actionableInstitutionUinInvitation !== null;

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -7,15 +7,14 @@ import { run } from '@prairielearn/run';
 import { withBrand } from '@prairielearn/utils';
 import { IdSchema } from '@prairielearn/zod';
 
-import { selectLatestPublishingExtensionByEnrollment } from '../models/course-instance-publishing-extensions.js';
-import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
+import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
+import { selectEnrollmentIdentityClassification } from '../models/enrollment-identity.js';
 
 import {
   type ConstructedCourseOrInstanceContext,
   type PlainAuthzData,
   calculateCourseInstanceRolePermissions,
   calculateCourseRolePermissions,
-  dangerousFullSystemAuthz,
 } from './authz-data-lib.js';
 import {
   type CourseInstance,
@@ -104,14 +103,11 @@ export async function calculateModernCourseInstanceStudentAccess(
   // modern publishing configs.
   assert(courseInstance.modern_publishing);
 
-  // We can't trust the authzData to have the correct permissioning,
-  // so we need to use system auth to get the enrollment.
-  const enrollment = await selectOptionalEnrollmentByUserId({
+  const classification = await selectEnrollmentIdentityClassification({
+    courseInstanceId: courseInstance.id,
     userId,
-    requiredRole: ['System'],
-    authzData: dangerousFullSystemAuthz(),
-    courseInstance,
   });
+  const isJoined = classification.boundCandidate?.enrollment.status === 'joined';
 
   // Not published at all.
   if (courseInstance.publishing_start_date == null) {
@@ -130,18 +126,22 @@ export async function calculateModernCourseInstanceStudentAccess(
   if (reqDate < courseInstance.publishing_end_date) {
     return {
       has_student_access: true,
-      has_student_access_with_enrollment: enrollment?.status === 'joined',
+      has_student_access_with_enrollment: isJoined,
     };
   }
 
-  // We are after the end date. We might have access if we have an extension.
-  // Only enrolled students can have extensions.
-  if (enrollment?.status !== 'joined') {
+  // Joined students and actionable invitations can have an extension on any
+  // enrollment candidate that would participate in admission reconciliation.
+  const hasActionableInvitation =
+    classification.actionableConventionalInvitation !== null ||
+    classification.actionableInstitutionRosterInvitation !== null;
+  if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }
 
-  const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollment({
-    enrollment,
+  const latestPublishingExtension = await selectLatestPublishingExtensionByEnrollmentIds({
+    courseInstance,
+    enrollmentIds: classification.candidates.map((candidate) => candidate.enrollment.id),
   });
 
   // Check if we have access via extension.
@@ -150,7 +150,7 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   return {
     has_student_access: hasAccessViaExtension,
-    has_student_access_with_enrollment: hasAccessViaExtension,
+    has_student_access_with_enrollment: hasAccessViaExtension && isJoined,
   };
 }
 

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -8,7 +8,7 @@ import { withBrand } from '@prairielearn/utils';
 import { IdSchema } from '@prairielearn/zod';
 
 import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
-import { selectEnrollmentIdentityClassification } from '../models/enrollment-identity.js';
+
 
 import {
   type ConstructedCourseOrInstanceContext,
@@ -27,6 +27,7 @@ import {
   InstitutionSchema,
   type User,
 } from './db-types.js';
+import { selectEnrollmentIdentityClassification } from './enrollment/identity.js';
 import { ipToMode } from './exam-mode.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -26,7 +26,11 @@ import {
   InstitutionSchema,
   type User,
 } from './db-types.js';
-import { selectEnrollmentIdentityClassification } from './enrollment/identity.js';
+import {
+  type EnrollmentIdentityContext,
+  getEnrollmentAdmissionDecision,
+  selectEnrollmentIdentityClassification,
+} from './enrollment/identity.js';
 import { ipToMode } from './exam-mode.js';
 
 const sql = sqldb.loadSqlEquiv(import.meta.url);
@@ -93,11 +97,13 @@ export async function checkCourseInstanceLegacyAccess({
  * @param courseInstance - The course instance to check access for.
  * @param userId - The ID of the user to check access for.
  * @param reqDate - The date of the request.
+ * @param lti13Identity - Exact link and `sub` from a verified LTI launch, used to find a pending enrollment's publishing extension.
  */
 export async function calculateModernCourseInstanceStudentAccess(
   courseInstance: CourseInstance,
   userId: string,
   reqDate: Date,
+  lti13Identity?: NonNullable<EnrollmentIdentityContext['lti13Identity']>,
 ) {
   // This function should only be called for course instances that are using
   // modern publishing configs.
@@ -105,6 +111,7 @@ export async function calculateModernCourseInstanceStudentAccess(
 
   const classification = await selectEnrollmentIdentityClassification({
     courseInstanceId: courseInstance.id,
+    lti13Identity,
     userId,
   });
   const joinedEnrollment =
@@ -139,7 +146,14 @@ export async function calculateModernCourseInstanceStudentAccess(
   // rows are not merged automatically and must not extend the joined row's access.
   const hasActionableInvitation =
     classification.actionableUidInvitation !== null ||
-    classification.actionableInstitutionUinInvitation !== null;
+    classification.actionableInstitutionUinInvitation !== null ||
+    (lti13Identity !== undefined &&
+      getEnrollmentAdmissionDecision(classification, {
+        type: 'invitation',
+        matchedBy: 'lti13',
+        lti13CourseInstanceId: lti13Identity.lti13CourseInstanceId,
+        sub: lti13Identity.sub,
+      }).allowed);
   if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }
@@ -163,33 +177,34 @@ export async function calculateModernCourseInstanceStudentAccess(
 }
 
 /**
- * Builds the authorization data for a user on a page. The optional parameters are used for effective user overrides,
- * most scenarios should not need to change these parameters.
- *
- * @param params
- * @param params.user - The authenticated user.
- * @param params.course_id - The ID of the course. Inferred from the course instance if null.
- * @param params.course_instance_id - The ID of the course instance.
- * @param params.ip - The IP address of the request.
- * @param params.req_date - The date of the request.
- * @param params.is_administrator - Whether the user is an administrator.
- * @param params.overrides - The overrides to apply to the authorization data.
+ * Builds the authorization data for a user on a page. Most callers should not
+ * need the LTI identity or effective-user overrides.
  */
 export async function constructCourseOrInstanceContext({
   user,
   course_id,
   course_instance_id,
+  lti13Identity,
   ip,
   req_date,
   is_administrator,
   overrides = {},
 }: {
+  /** The authenticated user. */
   user: User;
+  /** The course ID, or `null` to infer it from the course instance. */
   course_id: string | null;
+  /** The course instance ID. */
   course_instance_id: string | null;
+  /** Exact link and `sub` from a verified LTI launch, used when checking publishing extensions. */
+  lti13Identity?: NonNullable<EnrollmentIdentityContext['lti13Identity']>;
+  /** The request IP address. */
   ip: string | null;
+  /** The request date. */
   req_date: Date;
+  /** Whether the authenticated user is an administrator. */
   is_administrator: boolean;
+  /** Effective-user and course-context overrides. */
   overrides?: CourseOrInstanceOverrides;
 }): Promise<ConstructedCourseOrInstanceContext> {
   const resolvedOverrides = {
@@ -273,6 +288,7 @@ export async function constructCourseOrInstanceContext({
                 rawAuthzData.course_instance,
                 user.id,
                 req_date,
+                lti13Identity,
               );
             }
             const courseInstanceIdsWithAccess = await checkCourseInstanceLegacyAccess({

--- a/apps/prairielearn/src/lib/authz-data.ts
+++ b/apps/prairielearn/src/lib/authz-data.ts
@@ -9,7 +9,6 @@ import { IdSchema } from '@prairielearn/zod';
 
 import { selectLatestPublishingExtensionByEnrollmentIds } from '../models/course-instance-publishing-extensions.js';
 
-
 import {
   type ConstructedCourseOrInstanceContext,
   type PlainAuthzData,
@@ -134,8 +133,8 @@ export async function calculateModernCourseInstanceStudentAccess(
   // Joined students and actionable invitations can have an extension on any
   // enrollment candidate that would participate in admission reconciliation.
   const hasActionableInvitation =
-    classification.actionableConventionalInvitation !== null ||
-    classification.actionableInstitutionRosterInvitation !== null;
+    classification.actionableUidInvitation !== null ||
+    classification.actionableInstitutionUinInvitation !== null;
   if (!isJoined && !hasActionableInvitation) {
     return { has_student_access: false, has_student_access_with_enrollment: false };
   }

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -5,15 +5,13 @@ import {
   PotentialEnrollmentStatus,
   checkPotentialEnterpriseEnrollment,
 } from '../../ee/models/enrollment.js';
-import { setEnrollmentStatus } from '../../models/enrollment.js';
 import { selectUserById } from '../../models/user.js';
-import { type AuthzData, hasRole, makePageAuthzData } from '../authz-data-lib.js';
+import { hasRole, makePageAuthzData } from '../authz-data-lib.js';
 import { constructCourseOrInstanceContext } from '../authz-data.js';
 import type { Course, CourseInstance, User } from '../db-types.js';
 import { isEnterprise } from '../license.js';
 import { HttpRedirect } from '../redirect.js';
 
-import { runWithSharedEnrollmentBarrier } from './barrier.js';
 import {
   type EnrollmentIneligibilityReason,
   checkEnrollmentEligibility,
@@ -21,11 +19,9 @@ import {
 } from './eligibility.js';
 import {
   type EnrollmentAdmissionSource,
-  type EnrollmentIdentityCandidate,
   type EnrollmentIdentityClassification,
   selectEnrollmentIdentityClassification,
 } from './identity.js';
-import { lockEnrollments } from './lock.js';
 import {
   EnrollmentAdmissionDeniedError,
   type SelectableEnrollmentAdmissionSource,
@@ -358,62 +354,6 @@ export async function admitUserFromUidInvitation({
       reqDate,
       userId,
     }),
-  });
-}
-
-function selectUidInvitationForRejection(
-  classification: EnrollmentIdentityClassification,
-): EnrollmentIdentityCandidate | null {
-  if (classification.boundCandidate !== null) return null;
-  return (
-    classification.candidates.find(
-      (candidate) =>
-        candidate.enrollment.user_id === null &&
-        (candidate.enrollment.status === 'invited' || candidate.enrollment.status === 'rejected') &&
-        candidate.matches.pendingUid &&
-        candidate.enrollment.pending_lti13_course_instance_id === null,
-    ) ?? null
-  );
-}
-
-/**
- * Rejects a pending UID invitation. This uses the same UID rules as admission,
- * but also treats an already rejected invitation as a successful no-op. The
- * invitation is rechecked after locking so a changed or replacement invitation
- * is left untouched.
- */
-export async function rejectUserFromUidInvitation({
-  authzData,
-  courseInstanceId,
-  userId,
-}: {
-  authzData: AuthzData;
-  courseInstanceId: string;
-  userId: string;
-}): Promise<boolean> {
-  const context = { courseInstanceId, userId };
-
-  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
-    const initialClassification = await selectEnrollmentIdentityClassification(context);
-    const initialInvitation = selectUidInvitationForRejection(initialClassification);
-    if (initialInvitation === null) return false;
-
-    const enrollmentIds = initialClassification.candidates.map(
-      (candidate) => candidate.enrollment.id,
-    );
-    await lockEnrollments(enrollmentIds);
-    const classification = await selectEnrollmentIdentityClassification(context, enrollmentIds);
-    const invitation = selectUidInvitationForRejection(classification);
-    if (invitation?.enrollment.id !== initialInvitation.enrollment.id) return false;
-    if (invitation.enrollment.status === 'rejected') return true;
-
-    await setEnrollmentStatus({
-      enrollment: invitation.enrollment,
-      status: 'rejected',
-      authzData,
-      requiredRole: ['Student'],
-    });
-    return true;
   });
 }
 

--- a/apps/prairielearn/src/lib/enrollment/admission.ts
+++ b/apps/prairielearn/src/lib/enrollment/admission.ts
@@ -211,6 +211,8 @@ function createAdmissionValidator({
       await constructCourseOrInstanceContext({
         course_id: null,
         course_instance_id: courseInstanceId,
+        lti13Identity:
+          source.type === 'invitation' && source.matchedBy === 'lti13' ? source : undefined,
         ip,
         is_administrator: isAdministrator,
         req_date: reqDate,

--- a/apps/prairielearn/src/lib/enrollment/identity.ts
+++ b/apps/prairielearn/src/lib/enrollment/identity.ts
@@ -120,7 +120,7 @@ function allowsUinOrLtiInvitation(
   return boundCandidate.enrollment.status === 'left';
 }
 
-function classifyEnrollmentIdentityCandidates(
+export function classifyEnrollmentIdentityCandidates(
   candidates: readonly EnrollmentIdentityCandidate[],
 ): EnrollmentIdentityClassification {
   const boundCandidates = candidates.filter((candidate) => candidate.matches.boundUser);

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.sql
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.sql
@@ -135,7 +135,7 @@ VALUES
 RETURNING
   *;
 
--- BLOCK reject_uid_invitation
+-- BLOCK reject_invitation
 UPDATE enrollments
 SET
   status = 'rejected'

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.sql
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.sql
@@ -135,6 +135,16 @@ VALUES
 RETURNING
   *;
 
+-- BLOCK reject_conventional_invitation
+UPDATE enrollments
+SET
+  status = 'rejected'
+WHERE
+  id = $enrollment_id
+  AND status = 'invited'
+RETURNING
+  *;
+
 -- BLOCK delete_loser_enrollments
 DELETE FROM enrollments
 WHERE

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.sql
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.sql
@@ -135,7 +135,7 @@ VALUES
 RETURNING
   *;
 
--- BLOCK reject_conventional_invitation
+-- BLOCK reject_uid_invitation
 UPDATE enrollments
 SET
   status = 'rejected'

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -342,11 +342,8 @@ export async function admitUserToCourseInstance(
   });
 }
 
-/**
- * Rejects only the exact actionable UID-matched invitation selected by the
- * caller. UIN and LTI identity matches cannot authorize this mutation.
- */
-export async function rejectUidInvitation({
+async function rejectInvitation({
+  source,
   agentAuthnUserId,
   agentUserId,
   courseInstanceId,
@@ -355,9 +352,12 @@ export async function rejectUidInvitation({
 }: EnrollmentAuditActor & {
   courseInstanceId: string;
   enrollmentId: string;
+  source: Extract<
+    EnrollmentAdmissionSource,
+    { type: 'invitation'; matchedBy: 'institution_uin' | 'uid' }
+  >;
   userId: string;
 }): Promise<Enrollment> {
-  const source: EnrollmentAdmissionSource = { type: 'invitation', matchedBy: 'uid' };
   const context = { courseInstanceId, userId };
 
   return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
@@ -383,7 +383,7 @@ export async function rejectUidInvitation({
 
     const oldEnrollment = decision.invitationCandidate.enrollment;
     const enrollment = await queryRow(
-      sql.reject_uid_invitation,
+      sql.reject_invitation,
       { enrollment_id: oldEnrollment.id },
       EnrollmentSchema,
     );
@@ -398,5 +398,40 @@ export async function rejectUidInvitation({
       agentUserId,
     });
     return enrollment;
+  });
+}
+
+/**
+ * Rejects only the exact actionable UID-matched invitation selected by the
+ * caller. UIN and LTI identity matches cannot authorize this mutation.
+ */
+export async function rejectUidInvitation(
+  options: EnrollmentAuditActor & {
+    courseInstanceId: string;
+    enrollmentId: string;
+    userId: string;
+  },
+): Promise<Enrollment> {
+  return await rejectInvitation({
+    ...options,
+    source: { type: 'invitation', matchedBy: 'uid' },
+  });
+}
+
+/**
+ * Hides institution-provided course access without binding the user or changing
+ * a paired left enrollment. A later roster sync may make the course available
+ * again by reinviting the exact same identity.
+ */
+export async function rejectInstitutionUinInvitation(
+  options: EnrollmentAuditActor & {
+    courseInstanceId: string;
+    enrollmentId: string;
+    userId: string;
+  },
+): Promise<Enrollment> {
+  return await rejectInvitation({
+    ...options,
+    source: { type: 'invitation', matchedBy: 'institution_uin' },
   });
 }

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -237,7 +237,7 @@ export async function admitUserToCourseInstance(
       if (
         decision.reason === 'already_joined' &&
         classification.boundCandidate !== null &&
-        selectedSource.type !== 'pending_uid'
+        !(selectedSource.type === 'invitation' && selectedSource.matchedBy === 'uid')
       ) {
         return classification.boundCandidate.enrollment;
       }
@@ -343,10 +343,10 @@ export async function admitUserToCourseInstance(
 }
 
 /**
- * Rejects only the exact actionable conventional invitation selected by the
- * caller. Roster identity cannot authorize this mutation.
+ * Rejects only the exact actionable UID-matched invitation selected by the
+ * caller. UIN and LTI identity matches cannot authorize this mutation.
  */
-export async function rejectConventionalEnrollmentInvitation({
+export async function rejectUidInvitation({
   agentAuthnUserId,
   agentUserId,
   courseInstanceId,
@@ -357,7 +357,7 @@ export async function rejectConventionalEnrollmentInvitation({
   enrollmentId: string;
   userId: string;
 }): Promise<Enrollment> {
-  const source = { type: 'pending_uid' as const };
+  const source: EnrollmentAdmissionSource = { type: 'invitation', matchedBy: 'uid' };
   const context = { courseInstanceId, userId };
 
   return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
@@ -383,7 +383,7 @@ export async function rejectConventionalEnrollmentInvitation({
 
     const oldEnrollment = decision.invitationCandidate.enrollment;
     const enrollment = await queryRow(
-      sql.reject_conventional_invitation,
+      sql.reject_uid_invitation,
       { enrollment_id: oldEnrollment.id },
       EnrollmentSchema,
     );

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -402,8 +402,8 @@ async function rejectInvitation({
 }
 
 /**
- * Rejects only the exact actionable UID-matched invitation selected by the
- * caller. UIN and LTI identity matches cannot authorize this mutation.
+ * Rejects the pending UID invitation with the ID selected by the caller. A UIN
+ * or LTI match on the same row is not enough to reject it through this method.
  */
 export async function rejectUidInvitation(
   options: EnrollmentAuditActor & {
@@ -419,9 +419,9 @@ export async function rejectUidInvitation(
 }
 
 /**
- * Hides institution-provided course access without binding the user or changing
- * a paired left enrollment. A later roster sync may make the course available
- * again by reinviting the exact same identity.
+ * Hides a pending UIN invitation without binding the user or changing a paired
+ * `left` enrollment. A later import may set the invitation back to `invited`,
+ * making the course appear on the homepage again.
  */
 export async function rejectInstitutionUinInvitation(
   options: EnrollmentAuditActor & {

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -237,7 +237,7 @@ export async function admitUserToCourseInstance(
       if (
         decision.reason === 'already_joined' &&
         classification.boundCandidate !== null &&
-        (selectedSource.type !== 'pending_uid' || expectedInvitationEnrollmentId === undefined)
+        selectedSource.type !== 'pending_uid'
       ) {
         return classification.boundCandidate.enrollment;
       }

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -372,10 +372,7 @@ export async function rejectConventionalEnrollmentInvitation({
     );
     const decision = getEnrollmentAdmissionDecision(classification, source);
 
-    if (
-      !decision.allowed ||
-      decision.invitationCandidate?.enrollment.id !== enrollmentId
-    ) {
+    if (!decision.allowed || decision.invitationCandidate?.enrollment.id !== enrollmentId) {
       throw new EnrollmentAdmissionDeniedError(
         decision.allowed
           ? {

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -237,7 +237,7 @@ export async function admitUserToCourseInstance(
       if (
         decision.reason === 'already_joined' &&
         classification.boundCandidate !== null &&
-        selectedSource.type !== 'pending_uid'
+        (selectedSource.type !== 'pending_uid' || expectedInvitationEnrollmentId === undefined)
       ) {
         return classification.boundCandidate.enrollment;
       }

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -234,7 +234,11 @@ export async function admitUserToCourseInstance(
     const decision = getEnrollmentAdmissionDecision(classification, selectedSource);
 
     if (!decision.allowed) {
-      if (decision.reason === 'already_joined' && classification.boundCandidate !== null) {
+      if (
+        decision.reason === 'already_joined' &&
+        classification.boundCandidate !== null &&
+        selectedSource.type !== 'pending_uid'
+      ) {
         return classification.boundCandidate.enrollment;
       }
       throw new EnrollmentAdmissionDeniedError(decision);
@@ -333,6 +337,71 @@ export async function admitUserToCourseInstance(
       oldSurvivor: survivorCandidate.enrollment,
       newSurvivor: enrollment,
       deletedEnrollments,
+    });
+    return enrollment;
+  });
+}
+
+/**
+ * Rejects only the exact actionable conventional invitation selected by the
+ * caller. Roster identity cannot authorize this mutation.
+ */
+export async function rejectConventionalEnrollmentInvitation({
+  agentAuthnUserId,
+  agentUserId,
+  courseInstanceId,
+  enrollmentId,
+  userId,
+}: EnrollmentAuditActor & {
+  courseInstanceId: string;
+  enrollmentId: string;
+  userId: string;
+}): Promise<Enrollment> {
+  const source = { type: 'pending_uid' as const };
+  const context = { courseInstanceId, userId };
+
+  return await runWithSharedEnrollmentBarrier(courseInstanceId, async () => {
+    const initialClassification = await selectEnrollmentIdentityClassification(context);
+    const enrollmentIds = initialClassification.candidates.map(
+      (candidate) => candidate.enrollment.id,
+    );
+    await lockEnrollments(enrollmentIds);
+    const classification = await selectEnrollmentIdentityClassificationForRevalidation(
+      context,
+      enrollmentIds,
+    );
+    const decision = getEnrollmentAdmissionDecision(classification, source);
+
+    if (
+      !decision.allowed ||
+      decision.invitationCandidate?.enrollment.id !== enrollmentId
+    ) {
+      throw new EnrollmentAdmissionDeniedError(
+        decision.allowed
+          ? {
+              allowed: false,
+              reason: 'no_matching_invitation',
+              source,
+            }
+          : decision,
+      );
+    }
+
+    const oldEnrollment = decision.invitationCandidate.enrollment;
+    const enrollment = await queryRow(
+      sql.reject_conventional_invitation,
+      { enrollment_id: oldEnrollment.id },
+      EnrollmentSchema,
+    );
+    await insertAuditEvent({
+      tableName: 'enrollments',
+      action: 'update',
+      actionDetail: 'invitation_rejected',
+      rowId: enrollment.id,
+      oldRow: oldEnrollment,
+      newRow: enrollment,
+      agentAuthnUserId,
+      agentUserId,
     });
     return enrollment;
   });

--- a/apps/prairielearn/src/lib/enrollment/reconciliation.ts
+++ b/apps/prairielearn/src/lib/enrollment/reconciliation.ts
@@ -366,10 +366,7 @@ export async function rejectConventionalEnrollmentInvitation({
       (candidate) => candidate.enrollment.id,
     );
     await lockEnrollments(enrollmentIds);
-    const classification = await selectEnrollmentIdentityClassificationForRevalidation(
-      context,
-      enrollmentIds,
-    );
+    const classification = await selectEnrollmentIdentityClassification(context, enrollmentIds);
     const decision = getEnrollmentAdmissionDecision(classification, source);
 
     if (!decision.allowed || decision.invitationCandidate?.enrollment.id !== enrollmentId) {

--- a/apps/prairielearn/src/migrations/20260820185253_enrollments__pending_uin__replacement_unique_index.sql
+++ b/apps/prairielearn/src/migrations/20260820185253_enrollments__pending_uin__replacement_unique_index.sql
@@ -1,0 +1,5 @@
+-- prairielearn:migrations NO TRANSACTION
+-- Build the replacement before the constraint swap so writes remain protected throughout the deploy.
+-- Intentionally omit IF NOT EXISTS so a failed concurrent build's invalid index is not silently accepted.
+-- squawk-ignore prefer-robust-stmts
+CREATE UNIQUE INDEX CONCURRENTLY enrollments_pending_uin_course_instance_id_idx ON enrollments (pending_uin, course_instance_id);

--- a/apps/prairielearn/src/migrations/20260820185254_enrollments__pending_uin__replace_unique_constraint.sql
+++ b/apps/prairielearn/src/migrations/20260820185254_enrollments__pending_uin__replace_unique_constraint.sql
@@ -1,0 +1,5 @@
+-- The replacement index was built concurrently, so this swap does not rebuild or scan it.
+ALTER TABLE enrollments
+DROP CONSTRAINT enrollments_course_instance_id_pending_uin_key,
+-- squawk-ignore constraint-missing-not-valid, disallowed-unique-constraint
+ADD CONSTRAINT enrollments_pending_uin_course_instance_id_key UNIQUE USING INDEX enrollments_pending_uin_course_instance_id_idx;

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.sql
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.sql
@@ -13,6 +13,23 @@ ORDER BY
 LIMIT
   1;
 
+-- BLOCK select_latest_publishing_extension_by_enrollment_ids
+SELECT
+  ci_extensions.*
+FROM
+  course_instance_publishing_extensions AS ci_extensions
+  JOIN course_instance_publishing_extension_enrollments AS ci_enrollment_extensions ON (
+    ci_enrollment_extensions.course_instance_publishing_extension_id = ci_extensions.id
+  )
+WHERE
+  ci_extensions.course_instance_id = $course_instance_id
+  AND ci_enrollment_extensions.enrollment_id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  ci_extensions.end_date DESC,
+  ci_extensions.id DESC
+LIMIT
+  1;
+
 -- BLOCK select_publishing_extension_by_id
 SELECT
   *

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
@@ -73,6 +73,29 @@ export async function selectLatestPublishingExtensionByEnrollment({
 }
 
 /**
+ * Finds the latest publishing extension across enrollment identity candidates
+ * for a course instance.
+ */
+export async function selectLatestPublishingExtensionByEnrollmentIds({
+  courseInstance,
+  enrollmentIds,
+}: {
+  courseInstance: CourseInstance;
+  enrollmentIds: readonly string[];
+}) {
+  if (enrollmentIds.length === 0) return null;
+
+  return await queryOptionalRow(
+    sql.select_latest_publishing_extension_by_enrollment_ids,
+    {
+      course_instance_id: courseInstance.id,
+      enrollment_ids: [...enrollmentIds],
+    },
+    CourseInstancePublishingExtensionSchema,
+  );
+}
+
+/**
  * Finds a publishing extension by name within a course instance.
  */
 export async function selectPublishingExtensionByName({

--- a/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
+++ b/apps/prairielearn/src/models/course-instance-publishing-extensions.ts
@@ -73,8 +73,8 @@ export async function selectLatestPublishingExtensionByEnrollment({
 }
 
 /**
- * Finds the latest publishing extension across enrollment identity candidates
- * for a course instance.
+ * Finds the latest publishing extension assigned to any of the supplied
+ * enrollments in this course instance.
  */
 export async function selectLatestPublishingExtensionByEnrollmentIds({
   courseInstance,

--- a/apps/prairielearn/src/models/enrollment.test.ts
+++ b/apps/prairielearn/src/models/enrollment.test.ts
@@ -598,7 +598,7 @@ describe('DB validation of enrollment', () => {
       },
       // pending_uin is unique within a course instance
       {
-        constraint: 'enrollments_course_instance_id_pending_uin_key',
+        constraint: 'enrollments_pending_uin_course_instance_id_key',
         user_id: null,
         status: 'invited',
         created_at: '2025-01-01',

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -21,15 +21,20 @@ export function StudentCoursesCard({
   setShowJoinModal: (value: boolean) => void;
 }) {
   const heading = hasInstructorCourses ? 'Courses with student access' : 'Courses';
-  const [rejectingCourseId, setRejectingCourseId] = useState<string | null>(null);
+  const [rejectingInvitation, setRejectingInvitation] = useState<{
+    courseInstanceId: string;
+    enrollmentId: string;
+  } | null>(null);
   const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
 
-  const invited: StudentHomePageCourse[] = studentCourses.filter(
-    (ci) => ci.enrollment.status === 'invited',
+  const conventionalInvitations = studentCourses.filter(
+    (course): course is StudentHomePageCourse & { access_type: 'conventional_invitation' } =>
+      course.access_type === 'conventional_invitation',
   );
-  const joined: StudentHomePageCourse[] = studentCourses.filter(
-    (ci) => ci.enrollment.status === 'joined',
+  const rosterAvailable = studentCourses.filter(
+    (course) => course.access_type === 'roster_available',
   );
+  const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
   return (
     <div className="card mb-4">
@@ -69,7 +74,7 @@ export function StudentCoursesCard({
         <div className="table-responsive">
           <table className="table table-sm table-hover table-striped" aria-label={heading}>
             <tbody>
-              {invited.map((entry: StudentHomePageCourse) => (
+              {conventionalInvitations.map((entry) => (
                 <tr key={`invite-${entry.course_instance.id}`} className="table-warning">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -86,6 +91,11 @@ export function StudentCoursesCard({
                           <input type="hidden" name="__csrf_token" value={csrfToken} />
                           <input
                             type="hidden"
+                            name="enrollment_id"
+                            value={entry.invitation_enrollment_id}
+                          />
+                          <input
+                            type="hidden"
                             name="course_instance_id"
                             value={entry.course_instance.id}
                           />
@@ -96,11 +106,39 @@ export function StudentCoursesCard({
                         <button
                           type="button"
                           className="btn btn-danger btn-sm"
-                          onClick={() => setRejectingCourseId(entry.course_instance.id)}
+                          onClick={() =>
+                            setRejectingInvitation({
+                              courseInstanceId: entry.course_instance.id,
+                              enrollmentId: entry.invitation_enrollment_id,
+                            })
+                          }
                         >
                           Reject
                         </button>
                       </div>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {rosterAvailable.map((entry) => (
+                <tr key={`roster-${entry.course_instance.id}`} className="table-info">
+                  <td className="align-middle">
+                    <div className="d-flex align-items-center justify-content-between gap-2">
+                      <div>
+                        <span className="fw-semibold">
+                          {entry.course_short_name}: {entry.course_title},{' '}
+                          {entry.course_instance.long_name}
+                        </span>
+                        <span className="ms-2 badge bg-info text-dark">
+                          Available through roster
+                        </span>
+                      </div>
+                      <a
+                        href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}
+                        className="btn btn-primary btn-sm"
+                      >
+                        Open course
+                      </a>
                     </div>
                   </td>
                 </tr>
@@ -130,9 +168,9 @@ export function StudentCoursesCard({
       )}
 
       <Modal
-        show={rejectingCourseId !== null}
+        show={rejectingInvitation !== null}
         backdrop="static"
-        onHide={() => setRejectingCourseId(null)}
+        onHide={() => setRejectingInvitation(null)}
       >
         <Modal.Header closeButton>
           <Modal.Title>Reject invitation</Modal.Title>
@@ -147,14 +185,23 @@ export function StudentCoursesCard({
           <button
             type="button"
             className="btn btn-secondary"
-            onClick={() => setRejectingCourseId(null)}
+            onClick={() => setRejectingInvitation(null)}
           >
             Cancel
           </button>
           <form method="POST">
             <input type="hidden" name="__csrf_token" value={csrfToken} />
             <input type="hidden" name="__action" value="reject_invitation" />
-            <input type="hidden" name="course_instance_id" value={rejectingCourseId ?? ''} />
+            <input
+              type="hidden"
+              name="course_instance_id"
+              value={rejectingInvitation?.courseInstanceId ?? ''}
+            />
+            <input
+              type="hidden"
+              name="enrollment_id"
+              value={rejectingInvitation?.enrollmentId ?? ''}
+            />
             <button type="submit" className="btn btn-danger">
               Reject invitation
             </button>

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -25,16 +25,18 @@ export function StudentCoursesCard({
     courseInstanceId: string;
     enrollmentId: string;
   } | null>(null);
-  const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
+  const [removingCourse, setRemovingCourse] = useState<{
+    courseInstanceId: string;
+    invitationEnrollmentId?: string;
+  } | null>(null);
 
   const uidInvitations = studentCourses.filter(
     (course): course is StudentHomePageCourse & { access_type: 'uid_invitation' } =>
       course.access_type === 'uid_invitation',
   );
-  const institutionUinInvitations = studentCourses.filter(
-    (course) => course.access_type === 'institution_uin_invitation',
+  const accessibleCourses = studentCourses.filter(
+    (course) => course.access_type === 'institution_access' || course.access_type === 'joined',
   );
-  const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
   return (
     <div className="card mb-4">
@@ -120,30 +122,7 @@ export function StudentCoursesCard({
                   </td>
                 </tr>
               ))}
-              {institutionUinInvitations.map((entry) => (
-                <tr key={`institution-invite-${entry.course_instance.id}`} className="table-info">
-                  <td className="align-middle">
-                    <div className="d-flex align-items-center justify-content-between gap-2">
-                      <div>
-                        <span className="fw-semibold">
-                          {entry.course_short_name}: {entry.course_title},{' '}
-                          {entry.course_instance.long_name}
-                        </span>
-                        <span className="ms-2 badge bg-info text-dark">
-                          Available through your institution
-                        </span>
-                      </div>
-                      <a
-                        href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}
-                        className="btn btn-primary btn-sm"
-                      >
-                        Open course
-                      </a>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-              {joined.map((entry) => (
+              {accessibleCourses.map((entry) => (
                 <tr key={entry.course_instance.id}>
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -154,7 +133,14 @@ export function StudentCoursesCard({
                       <button
                         type="button"
                         className="btn btn-danger btn-sm"
-                        onClick={() => setRemovingCourseId(entry.course_instance.id)}
+                        onClick={() =>
+                          setRemovingCourse({
+                            courseInstanceId: entry.course_instance.id,
+                            ...(entry.access_type === 'institution_access'
+                              ? { invitationEnrollmentId: entry.invitation_enrollment_id }
+                              : {}),
+                          })
+                        }
                       >
                         Remove
                       </button>
@@ -210,9 +196,9 @@ export function StudentCoursesCard({
       </Modal>
 
       <Modal
-        show={removingCourseId !== null}
+        show={removingCourse !== null}
         backdrop="static"
-        onHide={() => setRemovingCourseId(null)}
+        onHide={() => setRemovingCourse(null)}
       >
         <Modal.Header closeButton>
           <Modal.Title>Remove course</Modal.Title>
@@ -223,19 +209,41 @@ export function StudentCoursesCard({
             Removing courses here only affects what is visible to you on PrairieLearn. This does not
             change your university course registration.
           </p>
+          {removingCourse?.invitationEnrollmentId !== undefined && (
+            <p>The course may appear again after your institution's enrollment data is updated.</p>
+          )}
         </Modal.Body>
         <Modal.Footer>
           <button
             type="button"
             className="btn btn-secondary"
-            onClick={() => setRemovingCourseId(null)}
+            onClick={() => setRemovingCourse(null)}
           >
             Cancel
           </button>
           <form method="POST">
             <input type="hidden" name="__csrf_token" value={csrfToken} />
-            <input type="hidden" name="__action" value="unenroll" />
-            <input type="hidden" name="course_instance_id" value={removingCourseId ?? ''} />
+            <input
+              type="hidden"
+              name="__action"
+              value={
+                removingCourse?.invitationEnrollmentId === undefined
+                  ? 'unenroll'
+                  : 'remove_institution_access'
+              }
+            />
+            <input
+              type="hidden"
+              name="course_instance_id"
+              value={removingCourse?.courseInstanceId ?? ''}
+            />
+            {removingCourse?.invitationEnrollmentId !== undefined && (
+              <input
+                type="hidden"
+                name="enrollment_id"
+                value={removingCourse.invitationEnrollmentId}
+              />
+            )}
             <button type="submit" className="btn btn-danger">
               Remove course
             </button>

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -27,12 +27,12 @@ export function StudentCoursesCard({
   } | null>(null);
   const [removingCourseId, setRemovingCourseId] = useState<string | null>(null);
 
-  const conventionalInvitations = studentCourses.filter(
-    (course): course is StudentHomePageCourse & { access_type: 'conventional_invitation' } =>
-      course.access_type === 'conventional_invitation',
+  const uidInvitations = studentCourses.filter(
+    (course): course is StudentHomePageCourse & { access_type: 'uid_invitation' } =>
+      course.access_type === 'uid_invitation',
   );
-  const rosterAvailable = studentCourses.filter(
-    (course) => course.access_type === 'roster_available',
+  const institutionUinInvitations = studentCourses.filter(
+    (course) => course.access_type === 'institution_uin_invitation',
   );
   const joined = studentCourses.filter((course) => course.access_type === 'joined');
 
@@ -74,7 +74,7 @@ export function StudentCoursesCard({
         <div className="table-responsive">
           <table className="table table-sm table-hover table-striped" aria-label={heading}>
             <tbody>
-              {conventionalInvitations.map((entry) => (
+              {uidInvitations.map((entry) => (
                 <tr key={`invite-${entry.course_instance.id}`} className="table-warning">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
@@ -120,8 +120,8 @@ export function StudentCoursesCard({
                   </td>
                 </tr>
               ))}
-              {rosterAvailable.map((entry) => (
-                <tr key={`roster-${entry.course_instance.id}`} className="table-info">
+              {institutionUinInvitations.map((entry) => (
+                <tr key={`institution-invite-${entry.course_instance.id}`} className="table-info">
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
                       <div>
@@ -130,7 +130,7 @@ export function StudentCoursesCard({
                           {entry.course_instance.long_name}
                         </span>
                         <span className="ms-2 badge bg-info text-dark">
-                          Available through roster
+                          Available through your institution
                         </span>
                       </div>
                       <a

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -83,7 +83,7 @@ export function StudentCoursesCard({
                     <div className="d-flex align-items-center justify-content-between gap-2">
                       <div>
                         <span className="fw-semibold">
-                          {entry.course_short_name}: {entry.course_title},{' '}
+                          {entry.course.short_name}: {entry.course.title},{' '}
                           {entry.course_instance.long_name}
                         </span>
                         <span className="ms-2 badge bg-warning text-dark">Invitation</span>
@@ -128,7 +128,7 @@ export function StudentCoursesCard({
                   <td className="align-middle">
                     <div className="d-flex align-items-center justify-content-between gap-2">
                       <a href={`${urlPrefix}/course_instance/${entry.course_instance.id}`}>
-                        {entry.course_short_name}: {entry.course_title},{' '}
+                        {entry.course.short_name}: {entry.course.title},{' '}
                         {entry.course_instance.long_name}
                       </a>
                       <button

--- a/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
+++ b/apps/prairielearn/src/pages/home/components/StudentCoursesCard.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
 import { Modal } from 'react-bootstrap';
+
+import { useModalState } from '@prairielearn/ui';
 
 import type { StudentHomePageCourse } from '../home.types.js';
 
@@ -21,14 +22,14 @@ export function StudentCoursesCard({
   setShowJoinModal: (value: boolean) => void;
 }) {
   const heading = hasInstructorCourses ? 'Courses with student access' : 'Courses';
-  const [rejectingInvitation, setRejectingInvitation] = useState<{
+  const rejectInvitationModal = useModalState<{
     courseInstanceId: string;
     enrollmentId: string;
-  } | null>(null);
-  const [removingCourse, setRemovingCourse] = useState<{
+  }>();
+  const removeCourseModal = useModalState<{
     courseInstanceId: string;
     invitationEnrollmentId?: string;
-  } | null>(null);
+  }>();
 
   const uidInvitations = studentCourses.filter(
     (course): course is StudentHomePageCourse & { access_type: 'uid_invitation' } =>
@@ -109,7 +110,7 @@ export function StudentCoursesCard({
                           type="button"
                           className="btn btn-danger btn-sm"
                           onClick={() =>
-                            setRejectingInvitation({
+                            rejectInvitationModal.showWithData({
                               courseInstanceId: entry.course_instance.id,
                               enrollmentId: entry.invitation_enrollment_id,
                             })
@@ -134,7 +135,7 @@ export function StudentCoursesCard({
                         type="button"
                         className="btn btn-danger btn-sm"
                         onClick={() =>
-                          setRemovingCourse({
+                          removeCourseModal.showWithData({
                             courseInstanceId: entry.course_instance.id,
                             ...(entry.access_type === 'institution_access'
                               ? { invitationEnrollmentId: entry.invitation_enrollment_id }
@@ -154,9 +155,10 @@ export function StudentCoursesCard({
       )}
 
       <Modal
-        show={rejectingInvitation !== null}
+        show={rejectInvitationModal.show}
         backdrop="static"
-        onHide={() => setRejectingInvitation(null)}
+        onHide={rejectInvitationModal.onHide}
+        onExited={rejectInvitationModal.onExited}
       >
         <Modal.Header closeButton>
           <Modal.Title>Reject invitation</Modal.Title>
@@ -168,11 +170,7 @@ export function StudentCoursesCard({
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => setRejectingInvitation(null)}
-          >
+          <button type="button" className="btn btn-secondary" onClick={rejectInvitationModal.hide}>
             Cancel
           </button>
           <form method="POST">
@@ -181,12 +179,12 @@ export function StudentCoursesCard({
             <input
               type="hidden"
               name="course_instance_id"
-              value={rejectingInvitation?.courseInstanceId ?? ''}
+              value={rejectInvitationModal.data?.courseInstanceId ?? ''}
             />
             <input
               type="hidden"
               name="enrollment_id"
-              value={rejectingInvitation?.enrollmentId ?? ''}
+              value={rejectInvitationModal.data?.enrollmentId ?? ''}
             />
             <button type="submit" className="btn btn-danger">
               Reject invitation
@@ -196,9 +194,10 @@ export function StudentCoursesCard({
       </Modal>
 
       <Modal
-        show={removingCourse !== null}
+        show={removeCourseModal.show}
         backdrop="static"
-        onHide={() => setRemovingCourse(null)}
+        onHide={removeCourseModal.onHide}
+        onExited={removeCourseModal.onExited}
       >
         <Modal.Header closeButton>
           <Modal.Title>Remove course</Modal.Title>
@@ -209,16 +208,12 @@ export function StudentCoursesCard({
             Removing courses here only affects what is visible to you on PrairieLearn. This does not
             change your university course registration.
           </p>
-          {removingCourse?.invitationEnrollmentId !== undefined && (
+          {removeCourseModal.data?.invitationEnrollmentId !== undefined && (
             <p>The course may appear again after your institution's enrollment data is updated.</p>
           )}
         </Modal.Body>
         <Modal.Footer>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => setRemovingCourse(null)}
-          >
+          <button type="button" className="btn btn-secondary" onClick={removeCourseModal.hide}>
             Cancel
           </button>
           <form method="POST">
@@ -227,7 +222,7 @@ export function StudentCoursesCard({
               type="hidden"
               name="__action"
               value={
-                removingCourse?.invitationEnrollmentId === undefined
+                removeCourseModal.data?.invitationEnrollmentId === undefined
                   ? 'unenroll'
                   : 'remove_institution_access'
               }
@@ -235,13 +230,13 @@ export function StudentCoursesCard({
             <input
               type="hidden"
               name="course_instance_id"
-              value={removingCourse?.courseInstanceId ?? ''}
+              value={removeCourseModal.data?.courseInstanceId ?? ''}
             />
-            {removingCourse?.invitationEnrollmentId !== undefined && (
+            {removeCourseModal.data?.invitationEnrollmentId !== undefined && (
               <input
                 type="hidden"
                 name="enrollment_id"
-                value={removingCourse.invitationEnrollmentId}
+                value={removeCourseModal.data.invitationEnrollmentId}
               />
             )}
             <button type="submit" className="btn btn-danger">

--- a/apps/prairielearn/src/pages/home/home.html.tsx
+++ b/apps/prairielearn/src/pages/home/home.html.tsx
@@ -2,7 +2,6 @@ import { Hydrate } from '@prairielearn/react/server';
 
 import { type StaffInstitution } from '../../lib/client/safe-db-types.js';
 import { type NewsItem } from '../../lib/db-types.js';
-import { computeStatus } from '../../lib/publishing.js';
 
 import { HomeCards } from './components/HomeCards.js';
 import { NewsAlert } from './components/NewsAlert.js';
@@ -33,22 +32,6 @@ export function Home({
   blogUrl: string | null;
   now: Date;
 }) {
-  const listedStudentCourses = studentCourses.filter((ci) => {
-    if (ci.enrollment.status === 'joined') return true;
-    if (ci.enrollment.status === 'invited') {
-      if (!ci.course_instance.modern_publishing) {
-        return false;
-      }
-      return (
-        computeStatus(
-          ci.course_instance.publishing_start_date,
-          ci.course_instance.publishing_end_date,
-        ) === 'published'
-      );
-    }
-    return false;
-  });
-
   return (
     <div className="pt-5 mx-auto" style={{ maxWidth: 960 }}>
       <h1 className="visually-hidden">PrairieLearn Homepage</h1>
@@ -58,7 +41,7 @@ export function Home({
       <InstructorCoursesCard instructorCourses={instructorCourses} urlPrefix={urlPrefix} />
       <Hydrate>
         <HomeCards
-          studentCourses={listedStudentCourses}
+          studentCourses={studentCourses}
           hasInstructorCourses={instructorCourses.length > 0}
           canAddCourses={canAddCourses}
           csrfToken={csrfToken}

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -178,9 +178,7 @@ WITH
       id = $user_id
   )
 SELECT
-  c.id AS course_id,
-  c.short_name AS course_short_name,
-  c.title AS course_title,
+  to_jsonb(c.*) AS course,
   to_jsonb(ci.*) AS course_instance,
   to_jsonb(e.*) AS enrollment,
   CASE

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -267,7 +267,7 @@ ORDER BY
   start_date DESC NULLS LAST,
   end_date DESC NULLS LAST,
   ci.id DESC,
-  e.id;
+  e.id DESC;
 
 -- BLOCK select_admin_institutions
 -- Note that we only consider institutions where the user is explicitly

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -191,11 +191,7 @@ SELECT
   END AS end_date,
   to_jsonb(extension.*) AS latest_publishing_extension,
   coalesce(e.user_id = identity.id, FALSE) AS matches_bound_user,
-  coalesce(
-    e.pending_uid = identity.uid
-    AND e.pending_lti13_course_instance_id IS NULL,
-    FALSE
-  ) AS matches_pending_uid,
+  coalesce(e.pending_uid = identity.uid, FALSE) AS matches_pending_uid,
   coalesce(
     identity.institution_id = c.institution_id
     AND identity.uin IS NOT NULL
@@ -247,10 +243,7 @@ FROM
 WHERE
   (
     e.user_id = identity.id
-    OR (
-      e.pending_uid = identity.uid
-      AND e.pending_lti13_course_instance_id IS NULL
-    )
+    OR e.pending_uid = identity.uid
     OR (
       identity.institution_id = c.institution_id
       AND identity.uin IS NOT NULL

--- a/apps/prairielearn/src/pages/home/home.sql
+++ b/apps/prairielearn/src/pages/home/home.sql
@@ -166,116 +166,108 @@ ORDER BY
 
 -- BLOCK select_student_courses
 WITH
-  -- Base query: all enrollments for this user with course/course_instance data
-  base_enrollments AS (
+  user_identity AS (
     SELECT
-      e.id AS enrollment_id,
-      c.id AS course_id,
-      c.short_name AS course_short_name,
-      c.title AS course_title,
-      ci.id AS course_instance_id,
-      ci.modern_publishing,
-      ci.publishing_start_date,
-      ci.publishing_end_date,
-      to_jsonb(ci) AS course_instance,
-      to_jsonb(e) AS enrollment,
-      u.uid,
-      u.institution_id
+      id,
+      institution_id,
+      uid,
+      uin
     FROM
-      enrollments AS e
-      LEFT JOIN users AS u ON (u.id = e.user_id)
-      JOIN course_instances AS ci ON (
-        ci.id = e.course_instance_id
-        AND ci.deleted_at IS NULL
-      )
-      JOIN courses AS c ON (
-        c.id = ci.course_id
-        AND c.deleted_at IS NULL
-        AND (
-          c.example_course IS FALSE
-          OR $include_example_course_enrollments
-        )
-      )
+      users
     WHERE
-      e.user_id = $user_id
-      OR (
-        e.pending_uid = $pending_uid
-        AND e.pending_lti13_course_instance_id IS NULL
-      )
-  ),
-  -- Legacy courses: use access rules for dates and initial filtering
-  legacy_courses AS (
-    SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      NULL::jsonb AS latest_publishing_extension,
-      NULLIF(d.min_start_date, '-infinity'::timestamptz) AS start_date,
-      NULLIF(d.max_end_date, 'infinity'::timestamptz) AS end_date,
-      be.course_instance_id
-    FROM
-      base_enrollments AS be,
-      LATERAL (
-        SELECT
-          min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
-          max(coalesce(ar.end_date, 'infinity'::timestamptz)) AS max_end_date
-        FROM
-          course_instance_access_rules AS ar
-        WHERE
-          ar.course_instance_id = be.course_instance_id
-      ) AS d
-    WHERE
-      be.modern_publishing IS FALSE
-      AND $req_date BETWEEN d.min_start_date AND d.max_end_date
-  ),
-  -- Modern courses: use publishing dates directly and fetch extension data
-  modern_courses AS (
-    SELECT
-      be.course_id,
-      be.course_short_name,
-      be.course_title,
-      be.course_instance,
-      be.enrollment,
-      to_jsonb(cie) AS latest_publishing_extension,
-      be.publishing_start_date AS start_date,
-      be.publishing_end_date AS end_date,
-      be.course_instance_id
-    FROM
-      base_enrollments AS be
-      LEFT JOIN LATERAL (
-        SELECT
-          cie.*
-        FROM
-          course_instance_publishing_extension_enrollments AS ciee
-          JOIN course_instance_publishing_extensions AS cie ON (
-            cie.id = ciee.course_instance_publishing_extension_id
-          )
-        WHERE
-          ciee.enrollment_id = be.enrollment_id
-        ORDER BY
-          cie.end_date DESC NULLS LAST,
-          cie.id DESC
-        LIMIT
-          1
-      ) AS cie ON TRUE
-    WHERE
-      be.modern_publishing IS TRUE
+      id = $user_id
   )
 SELECT
-  *
+  c.id AS course_id,
+  c.short_name AS course_short_name,
+  c.title AS course_title,
+  to_jsonb(ci.*) AS course_instance,
+  to_jsonb(e.*) AS enrollment,
+  CASE
+    WHEN ci.modern_publishing THEN ci.publishing_start_date
+    ELSE NULLIF(d.min_start_date, '-infinity'::timestamptz)
+  END AS start_date,
+  CASE
+    WHEN ci.modern_publishing THEN ci.publishing_end_date
+    ELSE NULLIF(d.max_end_date, 'infinity'::timestamptz)
+  END AS end_date,
+  to_jsonb(extension.*) AS latest_publishing_extension,
+  coalesce(e.user_id = identity.id, FALSE) AS matches_bound_user,
+  coalesce(
+    e.pending_uid = identity.uid
+    AND e.pending_lti13_course_instance_id IS NULL,
+    FALSE
+  ) AS matches_pending_uid,
+  coalesce(
+    identity.institution_id = c.institution_id
+    AND identity.uin IS NOT NULL
+    AND e.pending_uin = identity.uin,
+    FALSE
+  ) AS matches_institution_uin,
+  FALSE AS matches_lti13
 FROM
-  legacy_courses
-UNION ALL
-SELECT
-  *
-FROM
-  modern_courses
+  enrollments AS e
+  JOIN course_instances AS ci ON (
+    ci.id = e.course_instance_id
+    AND ci.deleted_at IS NULL
+  )
+  JOIN courses AS c ON (
+    c.id = ci.course_id
+    AND c.deleted_at IS NULL
+    AND (
+      c.example_course IS FALSE
+      OR $include_example_course_enrollments
+    )
+  )
+  CROSS JOIN user_identity AS identity
+  CROSS JOIN LATERAL (
+    SELECT
+      min(coalesce(ar.start_date, '-infinity'::timestamptz)) AS min_start_date,
+      max(coalesce(ar.end_date, 'infinity'::timestamptz)) AS max_end_date
+    FROM
+      course_instance_access_rules AS ar
+    WHERE
+      ar.course_instance_id = ci.id
+  ) AS d
+  LEFT JOIN LATERAL (
+    SELECT
+      publishing_extension.*
+    FROM
+      course_instance_publishing_extension_enrollments AS extension_enrollment
+      JOIN course_instance_publishing_extensions AS publishing_extension ON (
+        publishing_extension.id = extension_enrollment.course_instance_publishing_extension_id
+      )
+    WHERE
+      extension_enrollment.enrollment_id = e.id
+      AND publishing_extension.course_instance_id = ci.id
+    ORDER BY
+      publishing_extension.end_date DESC,
+      publishing_extension.id DESC
+    LIMIT
+      1
+  ) AS extension ON ci.modern_publishing
+WHERE
+  (
+    e.user_id = identity.id
+    OR (
+      e.pending_uid = identity.uid
+      AND e.pending_lti13_course_instance_id IS NULL
+    )
+    OR (
+      identity.institution_id = c.institution_id
+      AND identity.uin IS NOT NULL
+      AND e.pending_uin = identity.uin
+    )
+  )
+  AND (
+    ci.modern_publishing
+    OR $req_date BETWEEN d.min_start_date AND d.max_end_date
+  )
 ORDER BY
   start_date DESC NULLS LAST,
   end_date DESC NULLS LAST,
-  course_instance_id DESC;
+  ci.id DESC,
+  e.id;
 
 -- BLOCK select_admin_institutions
 -- Note that we only consider institutions where the user is explicitly

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -97,10 +97,8 @@ function groupStudentCourseCandidates(
     if (group === undefined) {
       group = {
         course: {
-          course_id: row.course_id,
+          course: row.course,
           course_instance: row.course_instance,
-          course_short_name: row.course_short_name,
-          course_title: row.course_title,
           start_date: row.start_date,
           end_date: row.end_date,
           latest_publishing_extension: null,
@@ -187,7 +185,7 @@ router.get(
 
     const visibleStudentCourses = allStudentCourses.filter((entry) => {
       // Filter out courses where user also has instructor access.
-      if (instructorCourses.some((course) => idsEqual(course.id, entry.course_id))) return false;
+      if (instructorCourses.some((course) => idsEqual(course.id, entry.course.id))) return false;
 
       // Legacy courses must be filtered using access rules
       if (!entry.course_instance.modern_publishing) {
@@ -220,13 +218,15 @@ router.get(
     });
 
     const studentCourses = visibleStudentCourses
-      .map(({ classification, ...course }): StudentHomePageCourse | null => {
+      .map(({ classification, course, course_instance }) => {
+        const clientCourse = { course, course_instance };
+
         if (classification.boundCandidate?.enrollment.status === 'joined') {
-          return { ...course, access_type: 'joined' };
+          return { ...clientCourse, access_type: 'joined' };
         }
         if (classification.actionableInstitutionUinInvitation !== null) {
           return {
-            ...course,
+            ...clientCourse,
             access_type: 'institution_access',
             invitation_enrollment_id:
               classification.actionableInstitutionUinInvitation.enrollment.id,
@@ -234,7 +234,7 @@ router.get(
         }
         if (classification.actionableUidInvitation !== null) {
           return {
-            ...course,
+            ...clientCourse,
             access_type: 'uid_invitation',
             invitation_enrollment_id: classification.actionableUidInvitation.enrollment.id,
           };
@@ -322,14 +322,13 @@ router.post(
       is_administrator: res.locals.is_administrator,
     });
 
-    if (authzData === null || courseInstance === null || !hasRole(authzData, ['Student'])) {
+    if (
+      authzData === null ||
+      courseInstance === null ||
+      !hasRole(authzData, ['Student']) ||
+      authzData.course_role !== 'None'
+    ) {
       throw new HttpStatusError(403, 'Access denied');
-    }
-
-    if (!authzData.has_student_access) {
-      flash('error', 'This course instance is not accessible to students');
-      res.redirect(req.originalUrl);
-      return;
     }
 
     switch (body.__action) {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -87,6 +87,7 @@ function groupStudentCourseCandidates(
   const groups = new Map<
     string,
     {
+      boundJoinedPublishingExtension: CourseInstancePublishingExtension | null;
       course: StudentHomePageCourseData;
       candidates: EnrollmentIdentityCandidate[];
     }
@@ -96,6 +97,7 @@ function groupStudentCourseCandidates(
     let group = groups.get(row.course_instance.id);
     if (group === undefined) {
       group = {
+        boundJoinedPublishingExtension: null,
         course: {
           course: row.course,
           course_instance: row.course_instance,
@@ -119,6 +121,9 @@ function groupStudentCourseCandidates(
     });
 
     const extension = row.latest_publishing_extension;
+    if (row.matches_bound_user && row.enrollment.status === 'joined') {
+      group.boundJoinedPublishingExtension = extension;
+    }
     if (
       extension !== null &&
       (group.course.latest_publishing_extension === null ||
@@ -128,10 +133,18 @@ function groupStudentCourseCandidates(
     }
   }
 
-  return [...groups.values()].map((group) => ({
-    ...group.course,
-    classification: classifyEnrollmentIdentityCandidates(group.candidates),
-  }));
+  return [...groups.values()].map((group) => {
+    const classification = classifyEnrollmentIdentityCandidates(group.candidates);
+    return {
+      ...group.course,
+      // Pending rows are merged during admission, but not after the user has joined.
+      latest_publishing_extension:
+        classification.boundCandidate?.enrollment.status === 'joined'
+          ? group.boundJoinedPublishingExtension
+          : group.course.latest_publishing_extension,
+      classification,
+    };
+  });
 }
 
 router.get(

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -6,7 +6,7 @@ import { flash } from '@prairielearn/flash';
 import { loadSqlEquiv, queryRows } from '@prairielearn/postgres';
 import { run } from '@prairielearn/run';
 import { assertNever } from '@prairielearn/utils';
-import { parseRequestBody } from '@prairielearn/zod';
+import { IdSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
@@ -57,17 +57,17 @@ const PostBodySchema = z.discriminatedUnion('__action', [
   z.object({ __action: z.literal('dismiss_news_alert') }),
   z.object({
     __action: z.enum(['accept_invitation', 'reject_invitation']),
-    course_instance_id: z.string().min(1),
-    enrollment_id: z.string().min(1),
+    course_instance_id: IdSchema,
+    enrollment_id: IdSchema,
   }),
   z.object({
     __action: z.literal('unenroll'),
-    course_instance_id: z.string().min(1),
+    course_instance_id: IdSchema,
   }),
   z.object({
     __action: z.literal('remove_institution_access'),
-    course_instance_id: z.string().min(1),
-    enrollment_id: z.string().min(1),
+    course_instance_id: IdSchema,
+    enrollment_id: IdSchema,
   }),
 ]);
 

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -10,6 +10,7 @@ import { parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { redirectToTermsPageIfNeeded } from '../../ee/lib/terms.js';
+import { hasRole } from '../../lib/authz-data-lib.js';
 import {
   checkCourseInstanceLegacyAccess,
   constructCourseOrInstanceContext,
@@ -17,25 +18,36 @@ import {
 import { extractPageContext } from '../../lib/client/page-context.js';
 import { StaffInstitutionSchema } from '../../lib/client/safe-db-types.js';
 import { config } from '../../lib/config.js';
+import type { CourseInstancePublishingExtension } from '../../lib/db-types.js';
+import { admitUserFromUidInvitation } from '../../lib/enrollment/admission.js';
 import {
-  admitUserFromUidInvitation,
-  rejectUserFromUidInvitation,
-} from '../../lib/enrollment/admission.js';
-import { selectEnrollmentAdmissionDecision } from '../../lib/enrollment/identity.js';
-import { EnrollmentAdmissionDeniedError } from '../../lib/enrollment/reconciliation.js';
+  type EnrollmentIdentityCandidate,
+  type EnrollmentIdentityClassification,
+  classifyEnrollmentIdentityCandidates,
+  selectEnrollmentAdmissionDecision,
+} from '../../lib/enrollment/identity.js';
+import {
+  EnrollmentAdmissionDeniedError,
+  rejectConventionalEnrollmentInvitation,
+} from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
-import { computeStatus } from '../../lib/publishing.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import { getUrl } from '../../lib/url.js';
-import { selectOptionalEnrollmentByUid, setEnrollmentStatus } from '../../models/enrollment.js';
+import { selectOptionalEnrollmentByUserId, setEnrollmentStatus } from '../../models/enrollment.js';
 import {
   markNewsItemsAsReadForUser,
   selectUnreadNewsItemsForUser,
 } from '../../models/news-items.js';
 
 import { Home } from './home.html.js';
-import { InstructorHomePageCourseSchema, StudentHomePageCourseSchema } from './home.types.js';
+import {
+  InstructorHomePageCourseSchema,
+  type StudentHomePageCourse,
+  type StudentHomePageCourseCandidateRow,
+  StudentHomePageCourseCandidateRowSchema,
+  type StudentHomePageCourseData,
+} from './home.types.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router();
@@ -43,10 +55,80 @@ const router = Router();
 const PostBodySchema = z.discriminatedUnion('__action', [
   z.object({ __action: z.literal('dismiss_news_alert') }),
   z.object({
-    __action: z.enum(['accept_invitation', 'reject_invitation', 'unenroll']),
+    __action: z.enum(['accept_invitation', 'reject_invitation']),
+    course_instance_id: z.string().min(1),
+    enrollment_id: z.string().min(1),
+  }),
+  z.object({
+    __action: z.literal('unenroll'),
     course_instance_id: z.string().min(1),
   }),
 ]);
+
+function isLaterPublishingExtension(
+  next: CourseInstancePublishingExtension,
+  current: CourseInstancePublishingExtension,
+): boolean {
+  const dateDifference = next.end_date.getTime() - current.end_date.getTime();
+  return dateDifference > 0 || (dateDifference === 0 && BigInt(next.id) > BigInt(current.id));
+}
+
+function groupStudentCourseCandidates(
+  rows: StudentHomePageCourseCandidateRow[],
+): (StudentHomePageCourseData & {
+  classification: EnrollmentIdentityClassification;
+})[] {
+  const groups = new Map<
+    string,
+    {
+      course: StudentHomePageCourseData;
+      candidates: EnrollmentIdentityCandidate[];
+    }
+  >();
+
+  for (const row of rows) {
+    let group = groups.get(row.course_instance.id);
+    if (group === undefined) {
+      group = {
+        course: {
+          course_id: row.course_id,
+          course_instance: row.course_instance,
+          course_short_name: row.course_short_name,
+          course_title: row.course_title,
+          start_date: row.start_date,
+          end_date: row.end_date,
+          latest_publishing_extension: null,
+        },
+        candidates: [],
+      };
+      groups.set(row.course_instance.id, group);
+    }
+
+    group.candidates.push({
+      enrollment: row.enrollment,
+      matches: {
+        boundUser: row.matches_bound_user,
+        institutionUin: row.matches_institution_uin,
+        lti13: row.matches_lti13,
+        pendingUid: row.matches_pending_uid,
+      },
+    });
+
+    const extension = row.latest_publishing_extension;
+    if (
+      extension !== null &&
+      (group.course.latest_publishing_extension === null ||
+        isLaterPublishingExtension(extension, group.course.latest_publishing_extension))
+    ) {
+      group.course.latest_publishing_extension = extension;
+    }
+  }
+
+  return [...groups.values()].map((group) => ({
+    ...group.course,
+    classification: classifyEnrollmentIdentityCandidates(group.candidates),
+  }));
+}
 
 router.get(
   '/',
@@ -71,13 +153,11 @@ router.get(
       InstructorHomePageCourseSchema,
     );
 
-    // Query all student courses (both legacy and modern publishing) in a single query
-    const allStudentCourses = await queryRows(
+    const studentCourseCandidateRows = await queryRows(
       sql.select_student_courses,
       {
         // Use the authenticated user, not the authorized user.
         user_id: res.locals.authn_user.id,
-        pending_uid: res.locals.authn_user.uid,
         // This is a somewhat ugly escape hatch specifically for load testing. In
         // general, we don't want to clutter the home page with example course
         // enrollments, but for load testing we want to enroll a large number of
@@ -87,8 +167,9 @@ router.get(
         include_example_course_enrollments: req.query.include_example_course_enrollments === 'true',
         req_date: res.locals.req_date,
       },
-      StudentHomePageCourseSchema,
+      StudentHomePageCourseCandidateRowSchema,
     );
+    const allStudentCourses = groupStudentCourseCandidates(studentCourseCandidateRows);
 
     const legacyCourseInstancesWithAccess = await checkCourseInstanceLegacyAccess({
       courseInstanceIds: allStudentCourses
@@ -98,7 +179,7 @@ router.get(
       reqDate: res.locals.req_date,
     });
 
-    const studentCourses = allStudentCourses.filter((entry) => {
+    const visibleStudentCourses = allStudentCourses.filter((entry) => {
       // Filter out courses where user also has instructor access.
       if (instructorCourses.some((course) => idsEqual(course.id, entry.course_id))) return false;
 
@@ -131,6 +212,26 @@ router.get(
         res.locals.req_date < endDate
       );
     });
+
+    const studentCourses = visibleStudentCourses
+      .map(({ classification, ...course }): StudentHomePageCourse | null => {
+        if (classification.boundCandidate?.enrollment.status === 'joined') {
+          return { ...course, access_type: 'joined' };
+        }
+        if (classification.actionableInstitutionRosterInvitation !== null) {
+          return { ...course, access_type: 'roster_available' };
+        }
+        if (classification.actionableConventionalInvitation !== null) {
+          return {
+            ...course,
+            access_type: 'conventional_invitation',
+            invitation_enrollment_id:
+              classification.actionableConventionalInvitation.enrollment.id,
+          };
+        }
+        return null;
+      })
+      .filter((entry): entry is StudentHomePageCourse => entry !== null);
 
     const adminInstitutions = await queryRows(
       sql.select_admin_institutions,
@@ -211,28 +312,11 @@ router.post(
       is_administrator: res.locals.is_administrator,
     });
 
-    if (authzData === null || courseInstance === null) {
+    if (authzData === null || courseInstance === null || !hasRole(authzData, ['Student'])) {
       throw new HttpStatusError(403, 'Access denied');
     }
 
-    // Invitations and rejections are only supported for modern publishing courses.
-    if (
-      !courseInstance.modern_publishing &&
-      ['accept_invitation', 'reject_invitation'].includes(body.__action)
-    ) {
-      flash(
-        'error',
-        'Invitations and rejections are only supported for courses using modern publishing.',
-      );
-      res.redirect(req.originalUrl);
-      return;
-    }
-
-    if (
-      courseInstance.modern_publishing &&
-      computeStatus(courseInstance.publishing_start_date, courseInstance.publishing_end_date) !==
-        'published'
-    ) {
+    if (!authzData.has_student_access) {
       flash('error', 'This course instance is not accessible to students');
       res.redirect(req.originalUrl);
       return;
@@ -245,7 +329,11 @@ router.post(
           source: { type: 'invitation', matchedBy: 'uid' },
           userId: res.locals.authn_user.id,
         });
-        if (!decision.allowed || decision.invitationCandidate === null) {
+        if (
+          !decision.allowed ||
+          decision.invitationCandidate === null ||
+          !idsEqual(decision.invitationCandidate.enrollment.id, body.enrollment_id)
+        ) {
           flash('error', 'Failed to accept invitation');
           break;
         }
@@ -266,18 +354,24 @@ router.post(
         break;
       }
       case 'reject_invitation': {
-        const rejected = await rejectUserFromUidInvitation({
-          authzData,
-          courseInstanceId: courseInstance.id,
-          userId: res.locals.authn_user.id,
-        });
-        if (!rejected) flash('error', 'Failed to reject invitation');
+        try {
+          await rejectConventionalEnrollmentInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to reject invitation');
+        }
         break;
       }
       case 'unenroll': {
-        const enrollment = await selectOptionalEnrollmentByUid({
+        const enrollment = await selectOptionalEnrollmentByUserId({
           courseInstance,
-          uid,
+          userId: res.locals.authn_user.id,
           requiredRole: ['Student'],
           authzData,
         });

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -225,8 +225,7 @@ router.get(
           return {
             ...course,
             access_type: 'conventional_invitation',
-            invitation_enrollment_id:
-              classification.actionableConventionalInvitation.enrollment.id,
+            invitation_enrollment_id: classification.actionableConventionalInvitation.enrollment.id,
           };
         }
         return null;

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -312,14 +312,6 @@ router.post(
   typedAsyncHandler<'plain'>(async (req, res) => {
     const body = parseRequestBody(req, PostBodySchema);
 
-    const {
-      authn_user: { uid },
-    } = extractPageContext(res.locals, {
-      pageType: 'plain',
-      accessType: 'student',
-      withAuthzData: false,
-    });
-
     if (body.__action === 'dismiss_news_alert') {
       await markNewsItemsAsReadForUser(res.locals.authn_user);
       res.redirect(req.originalUrl);

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -391,6 +391,10 @@ router.post(
           break;
         }
 
+        // A student may also have a pending UIN invitation for this course. We intentionally do
+        // not reject it here: doing so safely requires locking both enrollment rows in the same
+        // order as reconciliation. The course may therefore reappear using the invitation, which
+        // the student can remove separately.
         await setEnrollmentStatus({
           enrollment,
           status: 'left',

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../lib/enrollment/identity.js';
 import {
   EnrollmentAdmissionDeniedError,
+  rejectInstitutionUinInvitation,
   rejectUidInvitation,
 } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
@@ -62,6 +63,11 @@ const PostBodySchema = z.discriminatedUnion('__action', [
   z.object({
     __action: z.literal('unenroll'),
     course_instance_id: z.string().min(1),
+  }),
+  z.object({
+    __action: z.literal('remove_institution_access'),
+    course_instance_id: z.string().min(1),
+    enrollment_id: z.string().min(1),
   }),
 ]);
 
@@ -219,7 +225,12 @@ router.get(
           return { ...course, access_type: 'joined' };
         }
         if (classification.actionableInstitutionUinInvitation !== null) {
-          return { ...course, access_type: 'institution_uin_invitation' };
+          return {
+            ...course,
+            access_type: 'institution_access',
+            invitation_enrollment_id:
+              classification.actionableInstitutionUinInvitation.enrollment.id,
+          };
         }
         if (classification.actionableUidInvitation !== null) {
           return {
@@ -386,6 +397,21 @@ router.post(
           authzData,
           requiredRole: ['Student'],
         });
+        break;
+      }
+      case 'remove_institution_access': {
+        try {
+          await rejectInstitutionUinInvitation({
+            agentAuthnUserId: res.locals.authn_user.id,
+            agentUserId: res.locals.authn_user.id,
+            courseInstanceId: courseInstance.id,
+            enrollmentId: body.enrollment_id,
+            userId: res.locals.authn_user.id,
+          });
+        } catch (error) {
+          if (!(error instanceof EnrollmentAdmissionDeniedError)) throw error;
+          flash('error', 'Failed to remove course');
+        }
         break;
       }
       default: {

--- a/apps/prairielearn/src/pages/home/home.tsx
+++ b/apps/prairielearn/src/pages/home/home.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../lib/enrollment/identity.js';
 import {
   EnrollmentAdmissionDeniedError,
-  rejectConventionalEnrollmentInvitation,
+  rejectUidInvitation,
 } from '../../lib/enrollment/reconciliation.js';
 import { idsEqual } from '../../lib/id.js';
 import { isEnterprise } from '../../lib/license.js';
@@ -218,14 +218,14 @@ router.get(
         if (classification.boundCandidate?.enrollment.status === 'joined') {
           return { ...course, access_type: 'joined' };
         }
-        if (classification.actionableInstitutionRosterInvitation !== null) {
-          return { ...course, access_type: 'roster_available' };
+        if (classification.actionableInstitutionUinInvitation !== null) {
+          return { ...course, access_type: 'institution_uin_invitation' };
         }
-        if (classification.actionableConventionalInvitation !== null) {
+        if (classification.actionableUidInvitation !== null) {
           return {
             ...course,
-            access_type: 'conventional_invitation',
-            invitation_enrollment_id: classification.actionableConventionalInvitation.enrollment.id,
+            access_type: 'uid_invitation',
+            invitation_enrollment_id: classification.actionableUidInvitation.enrollment.id,
           };
         }
         return null;
@@ -354,7 +354,7 @@ router.post(
       }
       case 'reject_invitation': {
         try {
-          await rejectConventionalEnrollmentInvitation({
+          await rejectUidInvitation({
             agentAuthnUserId: res.locals.authn_user.id,
             agentUserId: res.locals.authn_user.id,
             courseInstanceId: courseInstance.id,

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -23,7 +23,7 @@ export const InstructorHomePageCourseSchema = z.object({
 });
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
-export const StudentHomePageCourseDataSchema = z.object({
+const StudentHomePageCourseDataSchema = z.object({
   course_id: RawStudentCourseSchema.shape.id,
   course_instance: RawStudentCourseInstanceSchema,
   course_short_name: RawStudentCourseSchema.shape.short_name,

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -48,6 +48,6 @@ export type StudentHomePageCourseCandidateRow = z.infer<
 export type StudentHomePageCourse = StudentHomePageCourseData &
   (
     | { access_type: 'joined' }
-    | { access_type: 'conventional_invitation'; invitation_enrollment_id: string }
-    | { access_type: 'roster_available' }
+    | { access_type: 'uid_invitation'; invitation_enrollment_id: string }
+    | { access_type: 'institution_uin_invitation' }
   );

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -24,10 +24,8 @@ export const InstructorHomePageCourseSchema = z.object({
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
 const StudentHomePageCourseDataSchema = z.object({
-  course_id: RawStudentCourseSchema.shape.id,
+  course: RawStudentCourseSchema,
   course_instance: RawStudentCourseInstanceSchema,
-  course_short_name: RawStudentCourseSchema.shape.short_name,
-  course_title: RawStudentCourseSchema.shape.title,
   start_date: DateFromISOString.nullable(),
   end_date: DateFromISOString.nullable(),
   latest_publishing_extension: CourseInstancePublishingExtensionSchema.nullable(),
@@ -45,7 +43,7 @@ export type StudentHomePageCourseCandidateRow = z.infer<
   typeof StudentHomePageCourseCandidateRowSchema
 >;
 
-export type StudentHomePageCourse = StudentHomePageCourseData &
+export type StudentHomePageCourse = Pick<StudentHomePageCourseData, 'course' | 'course_instance'> &
   (
     | { access_type: 'joined' }
     | { access_type: 'uid_invitation'; invitation_enrollment_id: string }

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -49,5 +49,5 @@ export type StudentHomePageCourse = StudentHomePageCourseData &
   (
     | { access_type: 'joined' }
     | { access_type: 'uid_invitation'; invitation_enrollment_id: string }
-    | { access_type: 'institution_uin_invitation' }
+    | { access_type: 'institution_access'; invitation_enrollment_id: string }
   );

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -6,10 +6,7 @@ import {
   RawStudentCourseInstanceSchema,
   RawStudentCourseSchema,
 } from '../../lib/client/safe-db-types.js';
-import {
-  CourseInstancePublishingExtensionSchema,
-  EnrollmentSchema,
-} from '../../lib/db-types.js';
+import { CourseInstancePublishingExtensionSchema, EnrollmentSchema } from '../../lib/db-types.js';
 
 export const InstructorHomePageCourseSchema = z.object({
   id: RawStudentCourseSchema.shape.id,

--- a/apps/prairielearn/src/pages/home/home.types.ts
+++ b/apps/prairielearn/src/pages/home/home.types.ts
@@ -5,9 +5,11 @@ import { DateFromISOString } from '@prairielearn/zod';
 import {
   RawStudentCourseInstanceSchema,
   RawStudentCourseSchema,
-  StudentEnrollmentSchema,
 } from '../../lib/client/safe-db-types.js';
-import { CourseInstancePublishingExtensionSchema } from '../../lib/db-types.js';
+import {
+  CourseInstancePublishingExtensionSchema,
+  EnrollmentSchema,
+} from '../../lib/db-types.js';
 
 export const InstructorHomePageCourseSchema = z.object({
   id: RawStudentCourseSchema.shape.id,
@@ -24,14 +26,31 @@ export const InstructorHomePageCourseSchema = z.object({
 });
 export type InstructorHomePageCourse = z.infer<typeof InstructorHomePageCourseSchema>;
 
-export const StudentHomePageCourseSchema = z.object({
+export const StudentHomePageCourseDataSchema = z.object({
   course_id: RawStudentCourseSchema.shape.id,
   course_instance: RawStudentCourseInstanceSchema,
   course_short_name: RawStudentCourseSchema.shape.short_name,
   course_title: RawStudentCourseSchema.shape.title,
-  enrollment: StudentEnrollmentSchema,
   start_date: DateFromISOString.nullable(),
   end_date: DateFromISOString.nullable(),
   latest_publishing_extension: CourseInstancePublishingExtensionSchema.nullable(),
 });
-export type StudentHomePageCourse = z.infer<typeof StudentHomePageCourseSchema>;
+export type StudentHomePageCourseData = z.infer<typeof StudentHomePageCourseDataSchema>;
+
+export const StudentHomePageCourseCandidateRowSchema = StudentHomePageCourseDataSchema.extend({
+  enrollment: EnrollmentSchema,
+  matches_bound_user: z.boolean(),
+  matches_institution_uin: z.boolean(),
+  matches_lti13: z.boolean(),
+  matches_pending_uid: z.boolean(),
+});
+export type StudentHomePageCourseCandidateRow = z.infer<
+  typeof StudentHomePageCourseCandidateRowSchema
+>;
+
+export type StudentHomePageCourse = StudentHomePageCourseData &
+  (
+    | { access_type: 'joined' }
+    | { access_type: 'conventional_invitation'; invitation_enrollment_id: string }
+    | { access_type: 'roster_available' }
+  );

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -304,6 +304,8 @@ describe('Self-enrollment settings transitions', () => {
 
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
+      const repeatedResponse = await fetch(assessmentsUrl);
+      assert.equal(repeatedResponse.status, 200);
 
       const finalEnrollment = await selectOptionalEnrollmentByUserId({
         userId: invitedUser.id,

--- a/apps/prairielearn/src/tests/enroll.test.ts
+++ b/apps/prairielearn/src/tests/enroll.test.ts
@@ -304,8 +304,6 @@ describe('Self-enrollment settings transitions', () => {
 
       const response = await fetch(assessmentsUrl);
       assert.equal(response.status, 200);
-      const repeatedResponse = await fetch(assessmentsUrl);
-      assert.equal(repeatedResponse.status, 200);
 
       const finalEnrollment = await selectOptionalEnrollmentByUserId({
         userId: invitedUser.id,

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -1,10 +1,11 @@
--- BLOCK create_enrollment_with_status
+-- BLOCK create_enrollment
 INSERT INTO
   enrollments (
     user_id,
     course_instance_id,
     status,
     pending_uid,
+    pending_uin,
     first_joined_at
   )
 VALUES
@@ -13,22 +14,56 @@ VALUES
     $course_instance_id,
     $status,
     $pending_uid,
+    $pending_uin,
     $first_joined_at
   )
 RETURNING
   *;
 
--- BLOCK delete_enrollment_by_course_instance_and_user
+-- BLOCK delete_enrollment_by_id
 DELETE FROM enrollments
 WHERE
-  course_instance_id = $course_instance_id
-  AND user_id = $user_id;
+  id = $enrollment_id;
 
--- BLOCK delete_enrollment_by_course_instance_and_pending_uid
-DELETE FROM enrollments
+-- BLOCK select_enrollments_by_ids
+SELECT
+  *
+FROM
+  enrollments
 WHERE
-  course_instance_id = $course_instance_id
-  AND pending_uid = $pending_uid;
+  id = ANY ($enrollment_ids::bigint[])
+ORDER BY
+  id;
+
+-- BLOCK count_enrollment_audit_events
+SELECT
+  count(*)::integer
+FROM
+  audit_events
+WHERE
+  enrollment_id = ANY ($enrollment_ids::bigint[]);
+
+-- BLOCK create_publishing_extension
+INSERT INTO
+  course_instance_publishing_extensions (course_instance_id, name, end_date)
+VALUES
+  ($course_instance_id, $name, $end_date)
+RETURNING
+  *;
+
+-- BLOCK add_publishing_extension_enrollment
+INSERT INTO
+  course_instance_publishing_extension_enrollments (
+    course_instance_publishing_extension_id,
+    enrollment_id
+  )
+VALUES
+  ($publishing_extension_id, $enrollment_id);
+
+-- BLOCK delete_publishing_extension
+DELETE FROM course_instance_publishing_extensions
+WHERE
+  id = $publishing_extension_id;
 
 -- BLOCK delete_lti13_course_instance
 DELETE FROM lti13_course_instances
@@ -40,5 +75,31 @@ UPDATE course_instances
 SET
   publishing_start_date = $publishing_start_date,
   publishing_end_date = $publishing_end_date
+WHERE
+  id = $course_instance_id;
+
+-- BLOCK create_unrestricted_access_rule
+INSERT INTO
+  course_instance_access_rules (course_instance_id, number, institution)
+SELECT
+  $course_instance_id,
+  coalesce(max(number), 0) + 1,
+  'Any'
+FROM
+  course_instance_access_rules
+WHERE
+  course_instance_id = $course_instance_id
+RETURNING
+  id;
+
+-- BLOCK delete_access_rule
+DELETE FROM course_instance_access_rules
+WHERE
+  id = $access_rule_id;
+
+-- BLOCK update_modern_publishing
+UPDATE course_instances
+SET
+  modern_publishing = $modern_publishing
 WHERE
   id = $course_instance_id;

--- a/apps/prairielearn/src/tests/homepage.test.sql
+++ b/apps/prairielearn/src/tests/homepage.test.sql
@@ -1,39 +1,7 @@
--- BLOCK create_enrollment
-INSERT INTO
-  enrollments (
-    user_id,
-    course_instance_id,
-    status,
-    pending_uid,
-    pending_uin,
-    first_joined_at
-  )
-VALUES
-  (
-    $user_id,
-    $course_instance_id,
-    $status,
-    $pending_uid,
-    $pending_uin,
-    $first_joined_at
-  )
-RETURNING
-  *;
-
 -- BLOCK delete_enrollment_by_id
 DELETE FROM enrollments
 WHERE
   id = $enrollment_id;
-
--- BLOCK select_enrollments_by_ids
-SELECT
-  *
-FROM
-  enrollments
-WHERE
-  id = ANY ($enrollment_ids::bigint[])
-ORDER BY
-  id;
 
 -- BLOCK count_enrollment_audit_events
 SELECT
@@ -42,28 +10,6 @@ FROM
   audit_events
 WHERE
   enrollment_id = ANY ($enrollment_ids::bigint[]);
-
--- BLOCK create_publishing_extension
-INSERT INTO
-  course_instance_publishing_extensions (course_instance_id, name, end_date)
-VALUES
-  ($course_instance_id, $name, $end_date)
-RETURNING
-  *;
-
--- BLOCK add_publishing_extension_enrollment
-INSERT INTO
-  course_instance_publishing_extension_enrollments (
-    course_instance_publishing_extension_id,
-    enrollment_id
-  )
-VALUES
-  ($publishing_extension_id, $enrollment_id);
-
--- BLOCK delete_publishing_extension
-DELETE FROM course_instance_publishing_extensions
-WHERE
-  id = $publishing_extension_id;
 
 -- BLOCK delete_lti13_course_instance
 DELETE FROM lti13_course_instances

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -25,6 +25,10 @@ import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
 import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
+import {
+  createEnrollment as createIdentityEnrollment,
+  createLti13CourseInstance,
+} from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
@@ -114,6 +118,52 @@ describe('Homepage student courses', () => {
       assert.equal(await countAuditEvents([invitation.id]), beforeAuditCount);
     } finally {
       await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
+  });
+
+  it('does not show or reject an LTI invitation that only matches by UID', async () => {
+    const user = await getOrCreateUser({
+      uid: 'lti-uid-only@example.com',
+      name: 'UID-only LTI user',
+      uin: 'different-uin',
+      email: 'lti-uid-only@example.com',
+      institutionId: '1',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
+    const invitation = await createIdentityEnrollment({
+      courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: 'rightful-student-sub',
+      pendingUid: user.uid,
+      pendingUin: 'rightful-student-uin',
+    });
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        assert.lengthOf(
+          page.$(`form:has(input[name="course_instance_id"][value="${courseInstance.id}"])`),
+          0,
+        );
+
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: courseInstance.id,
+            enrollment_id: invitation.id,
+          }),
+        );
+        assertAlert(response.$, 'Failed to reject invitation');
+      });
+
+      const [persistedInvitation] = await selectEnrollments([invitation.id]);
+      assert.equal(persistedInvitation.status, 'invited');
+    } finally {
+      await execute(sql.delete_lti13_course_instance, {
+        lti13_course_instance_id: lti13CourseInstance.id,
+      });
     }
   });
 

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -71,7 +71,7 @@ async function countAuditEvents(ids: string[]) {
   return await queryScalar(sql.count_enrollment_audit_events, { enrollment_ids: ids }, z.number());
 }
 
-describe('Homepage enrollment candidates', () => {
+describe('Homepage student courses', () => {
   beforeAll(async () => {
     await helperServer.before()();
     await helperCourse.syncCourse(EXAMPLE_COURSE_PATH);
@@ -117,7 +117,7 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('groups bound-left and pending UIN candidates once using their maximum extension', async () => {
+  it('shows a left enrollment and matching UIN invitation once with their latest extension', async () => {
     const user = await getOrCreateUser({
       uid: 'grouped-uin-invitation@example.com',
       name: 'Grouped UIN invitation user',
@@ -146,7 +146,7 @@ describe('Homepage enrollment candidates', () => {
       sql.create_publishing_extension,
       {
         course_instance_id: '1',
-        name: 'Homepage expired candidate extension',
+        name: 'Homepage bound enrollment extension',
         end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
       },
       CourseInstancePublishingExtensionSchema,
@@ -155,7 +155,7 @@ describe('Homepage enrollment candidates', () => {
       sql.create_publishing_extension,
       {
         course_instance_id: '1',
-        name: 'Homepage active candidate extension',
+        name: 'Homepage UIN invitation extension',
         end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
       },
       CourseInstancePublishingExtensionSchema,

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -3,17 +3,16 @@ import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
 import { z } from 'zod';
 
-import { execute, loadSqlEquiv, queryRow, queryRows, queryScalar } from '@prairielearn/postgres';
+import { execute, loadSqlEquiv, queryRow, queryScalar } from '@prairielearn/postgres';
 
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import {
-  CourseInstancePublishingExtensionSchema,
-  type Enrollment,
-  EnrollmentSchema,
-  type EnumEnrollmentStatus,
-} from '../lib/db-types.js';
+import { type Enrollment } from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
+import {
+  createPublishingExtensionWithEnrollments,
+  deletePublishingExtension,
+} from '../models/course-instance-publishing-extensions.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
   selectOptionalEnrollmentByPendingUid,
@@ -26,8 +25,9 @@ import * as helperServer from './helperServer.js';
 import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
 import {
-  createEnrollment as createIdentityEnrollment,
+  createEnrollment,
   createLti13CourseInstance,
+  selectEnrollments,
 } from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
@@ -38,37 +38,6 @@ const homeUrl = siteUrl + '/';
 async function postHome(body: URLSearchParams) {
   const response = await fetchCookie(fetch)(homeUrl, { method: 'POST', body });
   return { $: cheerio.load(await response.text()), response };
-}
-
-async function createEnrollment({
-  userId,
-  pendingUid,
-  pendingUin,
-  status,
-}: {
-  userId: string | null;
-  pendingUid?: string | null;
-  pendingUin?: string | null;
-  status: EnumEnrollmentStatus;
-}): Promise<Enrollment> {
-  return await queryRow(
-    sql.create_enrollment,
-    {
-      user_id: userId,
-      course_instance_id: '1',
-      pending_uid: pendingUid,
-      pending_uin: pendingUin,
-      status,
-      first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
-        ? new Date()
-        : null,
-    },
-    EnrollmentSchema,
-  );
-}
-
-async function selectEnrollments(ids: string[]) {
-  return await queryRows(sql.select_enrollments_by_ids, { enrollment_ids: ids }, EnrollmentSchema);
 }
 
 async function countAuditEvents(ids: string[]) {
@@ -86,6 +55,7 @@ describe('Homepage student courses', () => {
   afterAll(helperServer.after);
 
   it('does not discover or mutate a same-UIN invitation from another institution', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const user = await getOrCreateUser({
       uid: 'foreign-uin-invitation@other.example.com',
       name: 'Foreign UIN invitation user',
@@ -94,9 +64,8 @@ describe('Homepage student courses', () => {
       institutionId: '900002',
     });
     const invitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUin: user.uin,
-      status: 'invited',
     });
 
     try {
@@ -131,7 +100,7 @@ describe('Homepage student courses', () => {
     });
     const courseInstance = await selectCourseInstanceById('1');
     const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
-    const invitation = await createIdentityEnrollment({
+    const invitation = await createEnrollment({
       courseInstance,
       pendingLti13CourseInstanceId: lti13CourseInstance.id,
       pendingLti13Sub: 'rightful-student-sub',
@@ -168,6 +137,7 @@ describe('Homepage student courses', () => {
   });
 
   it('shows a left enrollment and matching UIN invitation once with their latest extension', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const user = await getOrCreateUser({
       uid: 'grouped-uin-invitation@example.com',
       name: 'Grouped UIN invitation user',
@@ -176,47 +146,32 @@ describe('Homepage student courses', () => {
       institutionId: '1',
     });
     const boundEnrollment = await createEnrollment({
+      courseInstance,
+      firstJoinedAt: new Date(),
       userId: user.id,
       status: 'left',
     });
     const uinInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUin: user.uin,
-      status: 'invited',
     });
     const uidInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: user.uid,
-      status: 'invited',
     });
     const enrollmentIds = [boundEnrollment.id, uinInvitation.id, uidInvitation.id];
-    const courseInstance = await selectCourseInstanceById('1');
     const now = new Date();
-    const expiredExtension = await queryRow(
-      sql.create_publishing_extension,
-      {
-        course_instance_id: '1',
-        name: 'Homepage bound enrollment extension',
-        end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
-      },
-      CourseInstancePublishingExtensionSchema,
-    );
-    const activeExtension = await queryRow(
-      sql.create_publishing_extension,
-      {
-        course_instance_id: '1',
-        name: 'Homepage UIN invitation extension',
-        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-      },
-      CourseInstancePublishingExtensionSchema,
-    );
-    await execute(sql.add_publishing_extension_enrollment, {
-      publishing_extension_id: expiredExtension.id,
-      enrollment_id: boundEnrollment.id,
+    const expiredExtension = await createPublishingExtensionWithEnrollments({
+      courseInstance,
+      name: 'Homepage bound enrollment extension',
+      endDate: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+      enrollments: [boundEnrollment],
     });
-    await execute(sql.add_publishing_extension_enrollment, {
-      publishing_extension_id: activeExtension.id,
-      enrollment_id: uinInvitation.id,
+    const activeExtension = await createPublishingExtensionWithEnrollments({
+      courseInstance,
+      name: 'Homepage UIN invitation extension',
+      endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      enrollments: [uinInvitation],
     });
     await execute(sql.update_course_instance_publishing, {
       course_instance_id: '1',
@@ -272,11 +227,13 @@ describe('Homepage student courses', () => {
         publishing_start_date: courseInstance.publishing_start_date,
         publishing_end_date: courseInstance.publishing_end_date,
       });
-      await execute(sql.delete_publishing_extension, {
-        publishing_extension_id: activeExtension.id,
+      await deletePublishingExtension({
+        extension: activeExtension,
+        courseInstance,
       });
-      await execute(sql.delete_publishing_extension, {
-        publishing_extension_id: expiredExtension.id,
+      await deletePublishingExtension({
+        extension: expiredExtension,
+        courseInstance,
       });
       for (const enrollmentId of enrollmentIds) {
         await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
@@ -285,6 +242,7 @@ describe('Homepage student courses', () => {
   });
 
   it('does not substitute a new UID invitation for stale accept or reject targets', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const user = await getOrCreateUser({
       uid: 'stale-home-invitation@example.com',
       name: 'Stale homepage invitation user',
@@ -293,9 +251,8 @@ describe('Homepage student courses', () => {
       institutionId: '1',
     });
     const originalInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: user.uid,
-      status: 'invited',
     });
     let replacementInvitation: Enrollment | null = null;
 
@@ -314,9 +271,8 @@ describe('Homepage student courses', () => {
 
       await execute(sql.delete_enrollment_by_id, { enrollment_id: originalInvitation.id });
       replacementInvitation = await createEnrollment({
-        userId: null,
+        courseInstance,
         pendingUid: user.uid,
-        status: 'invited',
       });
 
       await withUser(user, async () => {
@@ -343,7 +299,7 @@ describe('Homepage student courses', () => {
 
       const remainingInvitation = await selectOptionalEnrollmentByPendingUid({
         pendingUid: user.uid,
-        courseInstance: await selectCourseInstanceById('1'),
+        courseInstance,
         requiredRole: ['System'],
         authzData: dangerousFullSystemAuthz(),
       });
@@ -360,6 +316,7 @@ describe('Homepage student courses', () => {
   it.each(['left', 'removed', 'rejected'] as const)(
     'does not treat a %s enrollment as a UID invitation',
     async (status) => {
+      const courseInstance = await selectCourseInstanceById('1');
       const user = await getOrCreateUser({
         uid: `non-actionable-${status}@example.com`,
         name: `Non-actionable ${status} user`,
@@ -368,6 +325,8 @@ describe('Homepage student courses', () => {
         institutionId: '1',
       });
       const enrollment = await createEnrollment({
+        courseInstance,
+        firstJoinedAt: status === 'rejected' ? null : new Date(),
         userId: status === 'rejected' ? null : user.id,
         pendingUid: status === 'rejected' ? user.uid : null,
         status,
@@ -396,6 +355,7 @@ describe('Homepage student courses', () => {
   );
 
   it('accepts and rejects UID invitations for legacy course instances', async () => {
+    const courseInstance = await selectCourseInstanceById('1');
     const acceptingUser = await getOrCreateUser({
       uid: 'legacy-accept@example.com',
       name: 'Legacy accept user',
@@ -411,16 +371,13 @@ describe('Homepage student courses', () => {
       institutionId: '1',
     });
     const acceptingInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: acceptingUser.uid,
-      status: 'invited',
     });
     const rejectingInvitation = await createEnrollment({
-      userId: null,
+      courseInstance,
       pendingUid: rejectingUser.uid,
-      status: 'invited',
     });
-    const courseInstance = await selectCourseInstanceById('1');
     const accessRule = await queryRow(
       sql.create_unrestricted_access_rule,
       { course_instance_id: '1' },

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -81,12 +81,12 @@ describe('Homepage enrollment candidates', () => {
 
   afterAll(helperServer.after);
 
-  it('does not discover or mutate a same-UIN roster invitation from another institution', async () => {
+  it('does not discover or mutate a same-UIN invitation from another institution', async () => {
     const user = await getOrCreateUser({
-      uid: 'foreign-roster@other.example.com',
-      name: 'Foreign roster user',
-      uin: 'shared-roster-uin',
-      email: 'foreign-roster@other.example.com',
+      uid: 'foreign-uin-invitation@other.example.com',
+      name: 'Foreign UIN invitation user',
+      uin: 'shared-invitation-uin',
+      email: 'foreign-uin-invitation@other.example.com',
       institutionId: '900002',
     });
     const invitation = await createEnrollment({
@@ -102,7 +102,7 @@ describe('Homepage enrollment candidates', () => {
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-        assert.notInclude(response.$('body').text(), 'Available through roster');
+        assert.notInclude(response.$('body').text(), 'Available through your institution');
       });
 
       assert.deepEqual(await selectEnrollments([invitation.id]), before);
@@ -112,29 +112,29 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('groups bound-left and pending roster candidates once using their maximum extension', async () => {
+  it('groups bound-left and pending UIN candidates once using their maximum extension', async () => {
     const user = await getOrCreateUser({
-      uid: 'grouped-roster@example.com',
-      name: 'Grouped roster user',
-      uin: 'grouped-roster-uin',
-      email: 'grouped-roster@example.com',
+      uid: 'grouped-uin-invitation@example.com',
+      name: 'Grouped UIN invitation user',
+      uin: 'grouped-invitation-uin',
+      email: 'grouped-uin-invitation@example.com',
       institutionId: '1',
     });
     const boundEnrollment = await createEnrollment({
       userId: user.id,
       status: 'left',
     });
-    const rosterInvitation = await createEnrollment({
+    const uinInvitation = await createEnrollment({
       userId: null,
       pendingUin: user.uin,
       status: 'invited',
     });
-    const conventionalInvitation = await createEnrollment({
+    const uidInvitation = await createEnrollment({
       userId: null,
       pendingUid: user.uid,
       status: 'invited',
     });
-    const enrollmentIds = [boundEnrollment.id, rosterInvitation.id, conventionalInvitation.id];
+    const enrollmentIds = [boundEnrollment.id, uinInvitation.id, uidInvitation.id];
     const courseInstance = await selectCourseInstanceById('1');
     const now = new Date();
     const expiredExtension = await queryRow(
@@ -161,7 +161,7 @@ describe('Homepage enrollment candidates', () => {
     });
     await execute(sql.add_publishing_extension_enrollment, {
       publishing_extension_id: activeExtension.id,
-      enrollment_id: rosterInvitation.id,
+      enrollment_id: uinInvitation.id,
     });
     await execute(sql.update_course_instance_publishing, {
       course_instance_id: '1',
@@ -179,7 +179,7 @@ describe('Homepage enrollment candidates', () => {
           'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
         );
         assert.lengthOf(rows, 1);
-        assert.include(rows.text(), 'Available through roster');
+        assert.include(rows.text(), 'Available through your institution');
         assert.lengthOf(
           rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
           1,
@@ -212,7 +212,7 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('does not substitute a new conventional invitation for stale accept or reject targets', async () => {
+  it('does not substitute a new UID invitation for stale accept or reject targets', async () => {
     const user = await getOrCreateUser({
       uid: 'stale-home-invitation@example.com',
       name: 'Stale homepage invitation user',
@@ -285,7 +285,7 @@ describe('Homepage enrollment candidates', () => {
     }
   });
 
-  it('accepts and rejects conventional invitations for legacy course instances', async () => {
+  it('accepts and rejects UID invitations for legacy course instances', async () => {
     const acceptingUser = await getOrCreateUser({
       uid: 'legacy-accept@example.com',
       name: 'Legacy accept user',

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -138,6 +138,7 @@ describe('Homepage student courses', () => {
 
   it('shows a left enrollment and matching UIN invitation once with their latest extension', async () => {
     const courseInstance = await selectCourseInstanceById('1');
+    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
     const user = await getOrCreateUser({
       uid: 'grouped-uin-invitation@example.com',
       name: 'Grouped UIN invitation user',
@@ -155,11 +156,14 @@ describe('Homepage student courses', () => {
       courseInstance,
       pendingUin: user.uin,
     });
-    const uidInvitation = await createEnrollment({
+    const ltiLinkedUidCandidate = await createEnrollment({
       courseInstance,
+      pendingLti13CourseInstanceId: lti13CourseInstance.id,
+      pendingLti13Sub: 'grouped-lti-sub',
       pendingUid: user.uid,
+      pendingUin: 'grouped-lti-uin',
     });
-    const enrollmentIds = [boundEnrollment.id, uinInvitation.id, uidInvitation.id];
+    const enrollmentIds = [boundEnrollment.id, uinInvitation.id, ltiLinkedUidCandidate.id];
     const now = new Date();
     const expiredExtension = await createPublishingExtensionWithEnrollments({
       courseInstance,
@@ -169,9 +173,9 @@ describe('Homepage student courses', () => {
     });
     const activeExtension = await createPublishingExtensionWithEnrollments({
       courseInstance,
-      name: 'Homepage UIN invitation extension',
+      name: 'Homepage LTI-linked UID candidate extension',
       endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
-      enrollments: [uinInvitation],
+      enrollments: [ltiLinkedUidCandidate],
     });
     await execute(sql.update_course_instance_publishing, {
       course_instance_id: '1',
@@ -215,11 +219,11 @@ describe('Homepage student courses', () => {
         assert.notInclude(response.$('body').text(), 'Failed to remove course');
       });
 
-      const [updatedBoundEnrollment, updatedUinInvitation, updatedUidInvitation] =
+      const [updatedBoundEnrollment, updatedUinInvitation, updatedLtiLinkedUidCandidate] =
         await selectEnrollments(enrollmentIds);
       assert.equal(updatedBoundEnrollment.status, 'left');
       assert.equal(updatedUinInvitation.status, 'rejected');
-      assert.equal(updatedUidInvitation.status, 'invited');
+      assert.equal(updatedLtiLinkedUidCandidate.status, 'invited');
       assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount + 1);
     } finally {
       await execute(sql.update_course_instance_publishing, {
@@ -238,6 +242,61 @@ describe('Homepage student courses', () => {
       for (const enrollmentId of enrollmentIds) {
         await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
       }
+      await execute(sql.delete_lti13_course_instance, {
+        lti13_course_instance_id: lti13CourseInstance.id,
+      });
+    }
+  });
+
+  it("does not use a pending invitation's extension after the user has joined", async () => {
+    const courseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const user = await getOrCreateUser({
+      uid: 'joined-with-pending-invitation@example.com',
+      name: 'Joined with pending invitation user',
+      uin: 'joined-with-pending-invitation-uin',
+      email: 'joined-with-pending-invitation@example.com',
+      institutionId: '1',
+    });
+    const joinedEnrollment = await createEnrollment({
+      courseInstance,
+      firstJoinedAt: new Date(),
+      userId: user.id,
+      status: 'joined',
+    });
+    const pendingInvitation = await createEnrollment({
+      courseInstance,
+      pendingUin: user.uin,
+    });
+    const extension = await createPublishingExtensionWithEnrollments({
+      courseInstance,
+      name: 'Homepage stale pending invitation extension',
+      endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      enrollments: [pendingInvitation],
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: courseInstance.id,
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const rows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(rows, 0);
+      });
+    } finally {
+      await execute(sql.update_course_instance_publishing, {
+        course_instance_id: courseInstance.id,
+        publishing_start_date: courseInstance.publishing_start_date,
+        publishing_end_date: courseInstance.publishing_end_date,
+      });
+      await deletePublishingExtension({ extension, courseInstance });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: joinedEnrollment.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: pendingInvitation.id });
     }
   });
 

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -102,7 +102,12 @@ describe('Homepage enrollment candidates', () => {
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-        assert.notInclude(response.$('body').text(), 'Available through your institution');
+        assert.lengthOf(
+          response.$(
+            'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+          ),
+          0,
+        );
       });
 
       assert.deepEqual(await selectEnrollments([invitation.id]), before);
@@ -179,21 +184,38 @@ describe('Homepage enrollment candidates', () => {
           'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
         );
         assert.lengthOf(rows, 1);
-        assert.include(rows.text(), 'Available through your institution');
-        assert.lengthOf(
-          rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
-          1,
-        );
+        assert.lengthOf(rows.find(`a[href="/pl/course_instance/${courseInstance.id}"]`), 1);
+        assert.notInclude(rows.text(), 'Available through your institution');
+        assert.notInclude(rows.text(), 'Open course');
         assert.lengthOf(rows.find('input[name="__action"][value="accept_invitation"]'), 0);
         assert.lengthOf(rows.find('input[name="__action"][value="reject_invitation"]'), 0);
         assert.lengthOf(
           rows.find('button').filter((_, el) => response.$(el).text().trim() === 'Remove'),
-          0,
+          1,
         );
       });
 
       assert.deepEqual(await selectEnrollments(enrollmentIds), before);
       assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount);
+
+      await withUser(user, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'remove_institution_access',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: courseInstance.id,
+            enrollment_id: uinInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to remove course');
+      });
+
+      const [updatedBoundEnrollment, updatedUinInvitation, updatedUidInvitation] =
+        await selectEnrollments(enrollmentIds);
+      assert.equal(updatedBoundEnrollment.status, 'left');
+      assert.equal(updatedUinInvitation.status, 'rejected');
+      assert.equal(updatedUidInvitation.status, 'invited');
+      assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount + 1);
     } finally {
       await execute(sql.update_course_instance_publishing, {
         course_instance_id: '1',

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -1,12 +1,18 @@
 import * as cheerio from 'cheerio';
 import fetchCookie from 'fetch-cookie';
 import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+import { z } from 'zod';
 
-import { execute, loadSqlEquiv, queryRow } from '@prairielearn/postgres';
+import { execute, loadSqlEquiv, queryRow, queryRows, queryScalar } from '@prairielearn/postgres';
 
 import { dangerousFullSystemAuthz } from '../lib/authz-data-lib.js';
 import { config } from '../lib/config.js';
-import { type Enrollment, EnrollmentSchema, type EnumEnrollmentStatus } from '../lib/db-types.js';
+import {
+  CourseInstancePublishingExtensionSchema,
+  type Enrollment,
+  EnrollmentSchema,
+  type EnumEnrollmentStatus,
+} from '../lib/db-types.js';
 import { EXAMPLE_COURSE_PATH } from '../lib/paths.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import {
@@ -17,38 +23,38 @@ import {
 import { assertAlert, fetchCheerio } from './helperClient.js';
 import * as helperCourse from './helperCourse.js';
 import * as helperServer from './helperServer.js';
-import { getOrCreateUser, withUser } from './utils/auth.js';
+import { createInstitution, getOrCreateUser, withUser } from './utils/auth.js';
 import { getCsrfToken } from './utils/csrf.js';
-import {
-  createEnrollment,
-  createLti13CourseInstance,
-  selectEnrollments,
-} from './utils/enrollment-identity.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
 const siteUrl = 'http://localhost:' + config.serverPort;
 const homeUrl = siteUrl + '/';
 
-/** Helper function to create enrollments with specific statuses for testing */
-async function createEnrollmentWithStatus({
+async function postHome(body: URLSearchParams) {
+  const response = await fetchCookie(fetch)(homeUrl, { method: 'POST', body });
+  return { $: cheerio.load(await response.text()), response };
+}
+
+async function createEnrollment({
   userId,
-  courseInstanceId,
-  status,
   pendingUid,
+  pendingUin,
+  status,
 }: {
   userId: string | null;
-  courseInstanceId: string;
-  status: EnumEnrollmentStatus;
   pendingUid?: string | null;
+  pendingUin?: string | null;
+  status: EnumEnrollmentStatus;
 }): Promise<Enrollment> {
   return await queryRow(
-    sql.create_enrollment_with_status,
+    sql.create_enrollment,
     {
       user_id: userId,
-      course_instance_id: courseInstanceId,
-      status,
+      course_instance_id: '1',
       pending_uid: pendingUid,
+      pending_uin: pendingUin,
+      status,
       first_joined_at: ['joined', 'left', 'removed', 'blocked'].includes(status)
         ? new Date()
         : null,
@@ -57,478 +63,320 @@ async function createEnrollmentWithStatus({
   );
 }
 
-describe('Homepage enrollment actions', () => {
+async function selectEnrollments(ids: string[]) {
+  return await queryRows(sql.select_enrollments_by_ids, { enrollment_ids: ids }, EnrollmentSchema);
+}
+
+async function countAuditEvents(ids: string[]) {
+  return await queryScalar(
+    sql.count_enrollment_audit_events,
+    { enrollment_ids: ids },
+    z.number(),
+  );
+}
+
+describe('Homepage enrollment candidates', () => {
   beforeAll(async () => {
     await helperServer.before()();
     await helperCourse.syncCourse(EXAMPLE_COURSE_PATH);
-
-    // Set uid_regexp for the default institution to allow @example.com UIDs
     await execute("UPDATE institutions SET uid_regexp = '@example\\.com$' WHERE id = 1");
+    await createInstitution('900002', 'other.example.com', 'Other institution');
   });
 
   afterAll(helperServer.after);
 
-  it('handles double accept invitation (no-op)', async () => {
+  it('does not discover or mutate a same-UIN roster invitation from another institution', async () => {
     const user = await getOrCreateUser({
-      uid: 'invited1@example.com',
-      name: 'Invited User 1',
-      uin: 'invited1',
-      email: 'invited1@example.com',
-      institutionId: '1',
+      uid: 'foreign-roster@other.example.com',
+      name: 'Foreign roster user',
+      uin: 'shared-roster-uin',
+      email: 'foreign-roster@other.example.com',
+      institutionId: '900002',
     });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First accept
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now joined
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'joined');
-
-      // Second accept (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still joined
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
-
-  it('handles double reject invitation (no-op)', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited2@example.com',
-      name: 'Invited User 2',
-      uin: 'invited2',
-      email: 'invited2@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
-      userId: null,
-      courseInstanceId: '1',
-      status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First reject
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now rejected
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'rejected');
-
-      // Second reject (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still rejected
-      const finalEnrollment = await selectOptionalEnrollmentByPendingUid({
-        pendingUid: user.uid,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'rejected');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
-      course_instance_id: '1',
-      pending_uid: user.uid,
-    });
-  });
-
-  it('does not show or reject an LTI invitation that only matches by UID', async () => {
-    const user = await getOrCreateUser({
-      uid: 'lti-uid-only@example.com',
-      name: 'UID-only LTI user',
-      uin: 'different-uin',
-      email: 'lti-uid-only@example.com',
-      institutionId: '1',
-    });
-    const courseInstance = await selectCourseInstanceById('1');
-    const lti13CourseInstance = await createLti13CourseInstance(courseInstance);
     const invitation = await createEnrollment({
-      courseInstance,
-      pendingLti13CourseInstanceId: lti13CourseInstance.id,
-      pendingLti13Sub: 'rightful-student-sub',
-      pendingUid: user.uid,
-      pendingUin: 'rightful-student-uin',
-    });
-
-    try {
-      await withUser(user, async () => {
-        const page = await fetchCheerio(homeUrl);
-        assert.lengthOf(
-          page.$(`form:has(input[name="course_instance_id"][value="${courseInstance.id}"])`),
-          0,
-        );
-
-        const response = await fetchCookie(fetch)(homeUrl, {
-          method: 'POST',
-          body: new URLSearchParams({
-            __action: 'reject_invitation',
-            course_instance_id: courseInstance.id,
-            __csrf_token: await getCsrfToken(homeUrl),
-          }),
-        });
-        assert.equal(response.status, 200);
-        assertAlert(cheerio.load(await response.text()), 'Failed to reject invitation');
-      });
-
-      const enrollments = await selectEnrollments([invitation.id]);
-      assert.lengthOf(enrollments, 1);
-      assert.equal(enrollments[0].status, 'invited');
-    } finally {
-      await execute(sql.delete_lti13_course_instance, {
-        lti13_course_instance_id: lti13CourseInstance.id,
-      });
-    }
-  });
-
-  it('shows error when rejecting after accepting invitation', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited3@example.com',
-      name: 'Invited User 3',
-      uin: 'invited3',
-      email: 'invited3@example.com',
-      institutionId: '1',
-    });
-
-    // Create an invited enrollment
-    await createEnrollmentWithStatus({
       userId: null,
-      courseInstanceId: '1',
+      pendingUin: user.uin,
       status: 'invited',
-      pendingUid: user.uid,
-    });
-
-    await withUser(user, async () => {
-      const fetchWithCookies = fetchCookie(fetch);
-
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First accept the invitation
-      const acceptResponse = await fetchWithCookies(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'accept_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(acceptResponse.status, 200);
-      assert.equal(acceptResponse.url, homeUrl);
-
-      // Now try to reject (should fail with error)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const rejectResponse = await fetchWithCookies(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'reject_invitation',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(rejectResponse.status, 200);
-      assert.equal(rejectResponse.url, homeUrl);
-
-      // Get the HTML to check for flash message
-      const rejectResponseText = await rejectResponse.text();
-      const $ = cheerio.load(rejectResponseText);
-
-      // Verify error message is shown
-      assertAlert($, 'Failed to reject invitation');
-
-      // Verify enrollment is still joined
-      const courseInstance = await selectCourseInstanceById('1');
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'joined');
-    });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
-      course_instance_id: '1',
-      user_id: user.id,
-    });
-  });
-
-  it.each(['left', 'removed', 'rejected'] as const)(
-    'does not treat a %s enrollment as an invitation',
-    async (status) => {
-      const user = await getOrCreateUser({
-        uid: `non-actionable-${status}@example.com`,
-        name: `Non-actionable ${status} user`,
-        uin: `non-actionable-${status}`,
-        email: `non-actionable-${status}@example.com`,
-        institutionId: '1',
-      });
-      const isPending = status === 'rejected';
-      await createEnrollmentWithStatus({
-        userId: isPending ? null : user.id,
-        courseInstanceId: '1',
-        status,
-        pendingUid: isPending ? user.uid : null,
-      });
-
-      try {
-        await withUser(user, async () => {
-          const fetchWithCookies = fetchCookie(fetch);
-          const response = await fetchWithCookies(homeUrl, {
-            method: 'POST',
-            body: new URLSearchParams({
-              __action: 'accept_invitation',
-              course_instance_id: '1',
-              __csrf_token: await getCsrfToken(homeUrl),
-            }),
-          });
-          assert.equal(response.status, 200);
-          const $ = cheerio.load(await response.text());
-          assertAlert($, 'Failed to accept invitation');
-
-          const courseInstance = await selectCourseInstanceById('1');
-          const enrollment = isPending
-            ? await selectOptionalEnrollmentByPendingUid({
-                pendingUid: user.uid,
-                courseInstance,
-                requiredRole: ['System'],
-                authzData: dangerousFullSystemAuthz(),
-              })
-            : await selectOptionalEnrollmentByUserId({
-                userId: user.id,
-                courseInstance,
-                requiredRole: ['System'],
-                authzData: dangerousFullSystemAuthz(),
-              });
-          assert.isNotNull(enrollment);
-          assert.equal(enrollment.status, status);
-        });
-      } finally {
-        if (isPending) {
-          await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
-            course_instance_id: '1',
-            pending_uid: user.uid,
-          });
-        } else {
-          await execute(sql.delete_enrollment_by_course_instance_and_user, {
-            course_instance_id: '1',
-            user_id: user.id,
-          });
-        }
-      }
-    },
-  );
-
-  it('does not show invited course that is not published', async () => {
-    const user = await getOrCreateUser({
-      uid: 'invited5@example.com',
-      name: 'Invited User 5',
-      uin: 'invited5',
-      email: 'invited5@example.com',
-      institutionId: '1',
-    });
-
-    const futureStart = new Date();
-    futureStart.setFullYear(futureStart.getFullYear() + 1);
-    const futureEnd = new Date();
-    futureEnd.setFullYear(futureEnd.getFullYear() + 2);
-
-    const existingCourseInstance = await selectCourseInstanceById('1');
-    assert.isNotNull(existingCourseInstance);
-    assert.equal(existingCourseInstance.modern_publishing, true);
-    assert.isNotNull(existingCourseInstance.publishing_start_date);
-    assert.isNotNull(existingCourseInstance.publishing_end_date);
-
-    await execute(sql.update_course_instance_publishing, {
-      course_instance_id: '1',
-      publishing_start_date: futureStart,
-      publishing_end_date: futureEnd,
     });
 
     try {
-      // Create an invited enrollment
-      await createEnrollmentWithStatus({
-        userId: null,
-        courseInstanceId: '1',
-        status: 'invited',
-        pendingUid: user.uid,
-      });
+      const before = await selectEnrollments([invitation.id]);
+      const beforeAuditCount = await countAuditEvents([invitation.id]);
 
       await withUser(user, async () => {
         const response = await fetchCheerio(homeUrl);
         assert.equal(response.status, 200);
-
-        const studentCoursesTable = response.$(
-          'table[aria-label="Courses with student access"], table[aria-label="Courses"]',
-        );
-
-        const studentRows = studentCoursesTable.find('tr');
-        assert.equal(studentRows.length, 0, 'No course rows should be visible');
+        assert.notInclude(response.$('body').text(), 'Available through roster');
       });
+
+      assert.deepEqual(await selectEnrollments([invitation.id]), before);
+      assert.equal(await countAuditEvents([invitation.id]), beforeAuditCount);
     } finally {
-      await execute(sql.delete_enrollment_by_course_instance_and_pending_uid, {
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: invitation.id });
+    }
+  });
+
+  it('groups bound-left and pending roster candidates once using their maximum extension', async () => {
+    const user = await getOrCreateUser({
+      uid: 'grouped-roster@example.com',
+      name: 'Grouped roster user',
+      uin: 'grouped-roster-uin',
+      email: 'grouped-roster@example.com',
+      institutionId: '1',
+    });
+    const boundEnrollment = await createEnrollment({
+      userId: user.id,
+      status: 'left',
+    });
+    const rosterInvitation = await createEnrollment({
+      userId: null,
+      pendingUin: user.uin,
+      status: 'invited',
+    });
+    const conventionalInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    const enrollmentIds = [
+      boundEnrollment.id,
+      rosterInvitation.id,
+      conventionalInvitation.id,
+    ];
+    const courseInstance = await selectCourseInstanceById('1');
+    const now = new Date();
+    const expiredExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
         course_instance_id: '1',
-        pending_uid: user.uid,
+        name: 'Homepage expired candidate extension',
+        end_date: new Date(now.getTime() - 12 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    const activeExtension = await queryRow(
+      sql.create_publishing_extension,
+      {
+        course_instance_id: '1',
+        name: 'Homepage active candidate extension',
+        end_date: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+      },
+      CourseInstancePublishingExtensionSchema,
+    );
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: expiredExtension.id,
+      enrollment_id: boundEnrollment.id,
+    });
+    await execute(sql.add_publishing_extension_enrollment, {
+      publishing_extension_id: activeExtension.id,
+      enrollment_id: rosterInvitation.id,
+    });
+    await execute(sql.update_course_instance_publishing, {
+      course_instance_id: '1',
+      publishing_start_date: new Date(now.getTime() - 48 * 60 * 60 * 1000),
+      publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+
+    try {
+      const before = await selectEnrollments(enrollmentIds);
+      const beforeAuditCount = await countAuditEvents(enrollmentIds);
+
+      await withUser(user, async () => {
+        const response = await fetchCheerio(homeUrl);
+        const rows = response.$(
+          'table[aria-label="Courses with student access"] tr, table[aria-label="Courses"] tr',
+        );
+        assert.lengthOf(rows, 1);
+        assert.include(rows.text(), 'Available through roster');
+        assert.lengthOf(
+          rows.find('a').filter((_, el) => response.$(el).text().trim() === 'Open course'),
+          1,
+        );
+        assert.lengthOf(rows.find('input[name="__action"][value="accept_invitation"]'), 0);
+        assert.lengthOf(rows.find('input[name="__action"][value="reject_invitation"]'), 0);
+        assert.lengthOf(
+          rows.find('button').filter((_, el) => response.$(el).text().trim() === 'Remove'),
+          0,
+        );
       });
 
+      assert.deepEqual(await selectEnrollments(enrollmentIds), before);
+      assert.equal(await countAuditEvents(enrollmentIds), beforeAuditCount);
+    } finally {
       await execute(sql.update_course_instance_publishing, {
         course_instance_id: '1',
-        publishing_start_date: existingCourseInstance.publishing_start_date,
-        publishing_end_date: existingCourseInstance.publishing_end_date,
+        publishing_start_date: courseInstance.publishing_start_date,
+        publishing_end_date: courseInstance.publishing_end_date,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: activeExtension.id,
+      });
+      await execute(sql.delete_publishing_extension, {
+        publishing_extension_id: expiredExtension.id,
+      });
+      for (const enrollmentId of enrollmentIds) {
+        await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollmentId });
+      }
+    }
+  });
+
+  it('does not substitute a new conventional invitation for stale accept or reject targets', async () => {
+    const user = await getOrCreateUser({
+      uid: 'stale-home-invitation@example.com',
+      name: 'Stale homepage invitation user',
+      uin: 'stale-home-invitation-uin',
+      email: 'stale-home-invitation@example.com',
+      institutionId: '1',
+    });
+    const originalInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: user.uid,
+      status: 'invited',
+    });
+    let replacementInvitation: Enrollment | null = null;
+
+    try {
+      await withUser(user, async () => {
+        const page = await fetchCheerio(homeUrl);
+        const invitationIdInput = page.$(
+          `input[name="enrollment_id"][value="${originalInvitation.id}"]`,
+        );
+        assert.lengthOf(invitationIdInput, 1);
+        assert.equal(
+          invitationIdInput.closest('form').find('input[name="__action"]').attr('value'),
+          'accept_invitation',
+        );
+      });
+
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: originalInvitation.id });
+      replacementInvitation = await createEnrollment({
+        userId: null,
+        pendingUid: user.uid,
+        status: 'invited',
+      });
+
+      await withUser(user, async () => {
+        const acceptResponse = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(acceptResponse.$, 'Failed to accept invitation');
+
+        const rejectResponse = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: originalInvitation.id,
+          }),
+        );
+        assertAlert(rejectResponse.$, 'Failed to reject invitation');
+      });
+
+      const remainingInvitation = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: user.uid,
+        courseInstance: await selectCourseInstanceById('1'),
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(remainingInvitation);
+      assert.equal(remainingInvitation.id, replacementInvitation.id);
+      assert.equal(remainingInvitation.status, 'invited');
+    } finally {
+      await execute(sql.delete_enrollment_by_id, {
+        enrollment_id: replacementInvitation?.id ?? originalInvitation.id,
       });
     }
   });
 
-  it('handles double unenroll (no-op)', async () => {
-    const user = await getOrCreateUser({
-      uid: 'joined1@example.com',
-      name: 'Joined User 1',
-      uin: 'joined1',
-      email: 'joined1@example.com',
+  it('accepts and rejects conventional invitations for legacy course instances', async () => {
+    const acceptingUser = await getOrCreateUser({
+      uid: 'legacy-accept@example.com',
+      name: 'Legacy accept user',
+      uin: 'legacy-accept-uin',
+      email: 'legacy-accept@example.com',
       institutionId: '1',
     });
-
-    // Create a joined enrollment
-    await createEnrollmentWithStatus({
-      userId: user.id,
-      courseInstanceId: '1',
-      status: 'joined',
+    const rejectingUser = await getOrCreateUser({
+      uid: 'legacy-reject@example.com',
+      name: 'Legacy reject user',
+      uin: 'legacy-reject-uin',
+      email: 'legacy-reject@example.com',
+      institutionId: '1',
     });
-
-    await withUser(user, async () => {
-      const csrfToken = await getCsrfToken(homeUrl);
-
-      // First unenroll
-      const firstResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'unenroll',
-          course_instance_id: '1',
-          __csrf_token: csrfToken,
-        }),
-      });
-      assert.equal(firstResponse.status, 200);
-      assert.equal(firstResponse.url, homeUrl);
-
-      // Verify enrollment is now left
-      const courseInstance = await selectCourseInstanceById('1');
-      const enrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(enrollment);
-      assert.equal(enrollment.status, 'left');
-
-      // Second unenroll (should be a no-op)
-      const csrfToken2 = await getCsrfToken(homeUrl);
-      const secondResponse = await fetchCheerio(homeUrl, {
-        method: 'POST',
-        body: new URLSearchParams({
-          __action: 'unenroll',
-          course_instance_id: '1',
-          __csrf_token: csrfToken2,
-        }),
-      });
-      assert.equal(secondResponse.status, 200);
-      assert.equal(secondResponse.url, homeUrl);
-
-      // Verify enrollment is still left
-      const finalEnrollment = await selectOptionalEnrollmentByUserId({
-        userId: user.id,
-        courseInstance,
-        requiredRole: ['System'],
-        authzData: dangerousFullSystemAuthz(),
-      });
-      assert.isNotNull(finalEnrollment);
-      assert.equal(finalEnrollment.status, 'left');
+    const acceptingInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: acceptingUser.uid,
+      status: 'invited',
     });
-
-    await execute(sql.delete_enrollment_by_course_instance_and_user, {
+    const rejectingInvitation = await createEnrollment({
+      userId: null,
+      pendingUid: rejectingUser.uid,
+      status: 'invited',
+    });
+    const courseInstance = await selectCourseInstanceById('1');
+    const accessRule = await queryRow(
+      sql.create_unrestricted_access_rule,
+      { course_instance_id: '1' },
+      z.object({ id: z.string() }),
+    );
+    await execute(sql.update_modern_publishing, {
       course_instance_id: '1',
-      user_id: user.id,
+      modern_publishing: false,
     });
+
+    try {
+      await withUser(acceptingUser, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'accept_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: acceptingInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to accept invitation');
+      });
+      const acceptedEnrollment = await selectOptionalEnrollmentByUserId({
+        userId: acceptingUser.id,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(acceptedEnrollment);
+      assert.equal(acceptedEnrollment.status, 'joined');
+
+      await withUser(rejectingUser, async () => {
+        const response = await postHome(
+          new URLSearchParams({
+            __action: 'reject_invitation',
+            __csrf_token: await getCsrfToken(homeUrl),
+            course_instance_id: '1',
+            enrollment_id: rejectingInvitation.id,
+          }),
+        );
+        assert.notInclude(response.$('body').text(), 'Failed to reject invitation');
+      });
+      const rejectedEnrollment = await selectOptionalEnrollmentByPendingUid({
+        pendingUid: rejectingUser.uid,
+        courseInstance,
+        requiredRole: ['System'],
+        authzData: dangerousFullSystemAuthz(),
+      });
+      assert.isNotNull(rejectedEnrollment);
+      assert.equal(rejectedEnrollment.status, 'rejected');
+    } finally {
+      await execute(sql.update_modern_publishing, {
+        course_instance_id: '1',
+        modern_publishing: courseInstance.modern_publishing,
+      });
+      await execute(sql.delete_access_rule, { access_rule_id: accessRule.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: acceptingInvitation.id });
+      await execute(sql.delete_enrollment_by_id, { enrollment_id: rejectingInvitation.id });
+    }
   });
 });

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -68,11 +68,7 @@ async function selectEnrollments(ids: string[]) {
 }
 
 async function countAuditEvents(ids: string[]) {
-  return await queryScalar(
-    sql.count_enrollment_audit_events,
-    { enrollment_ids: ids },
-    z.number(),
-  );
+  return await queryScalar(sql.count_enrollment_audit_events, { enrollment_ids: ids }, z.number());
 }
 
 describe('Homepage enrollment candidates', () => {
@@ -138,11 +134,7 @@ describe('Homepage enrollment candidates', () => {
       pendingUid: user.uid,
       status: 'invited',
     });
-    const enrollmentIds = [
-      boundEnrollment.id,
-      rosterInvitation.id,
-      conventionalInvitation.id,
-    ];
+    const enrollmentIds = [boundEnrollment.id, rosterInvitation.id, conventionalInvitation.id];
     const courseInstance = await selectCourseInstanceById('1');
     const now = new Date();
     const expiredExtension = await queryRow(

--- a/apps/prairielearn/src/tests/homepage.test.ts
+++ b/apps/prairielearn/src/tests/homepage.test.ts
@@ -307,6 +307,44 @@ describe('Homepage student courses', () => {
     }
   });
 
+  it.each(['left', 'removed', 'rejected'] as const)(
+    'does not treat a %s enrollment as a UID invitation',
+    async (status) => {
+      const user = await getOrCreateUser({
+        uid: `non-actionable-${status}@example.com`,
+        name: `Non-actionable ${status} user`,
+        uin: `non-actionable-${status}`,
+        email: `non-actionable-${status}@example.com`,
+        institutionId: '1',
+      });
+      const enrollment = await createEnrollment({
+        userId: status === 'rejected' ? null : user.id,
+        pendingUid: status === 'rejected' ? user.uid : null,
+        status,
+      });
+
+      try {
+        await withUser(user, async () => {
+          const response = await postHome(
+            new URLSearchParams({
+              __action: 'accept_invitation',
+              __csrf_token: await getCsrfToken(homeUrl),
+              course_instance_id: '1',
+              enrollment_id: enrollment.id,
+            }),
+          );
+          assertAlert(response.$, 'Failed to accept invitation');
+        });
+
+        const [persistedEnrollment] = await selectEnrollments([enrollment.id]);
+        assert.equal(persistedEnrollment.status, status);
+        assert.equal(persistedEnrollment.user_id, status === 'rejected' ? null : user.id);
+      } finally {
+        await execute(sql.delete_enrollment_by_id, { enrollment_id: enrollment.id });
+      }
+    },
+  );
+
   it('accepts and rejects UID invitations for legacy course instances', async () => {
     const acceptingUser = await getOrCreateUser({
       uid: 'legacy-accept@example.com',

--- a/apps/prairielearn/src/tests/lti13Linking.test.ts
+++ b/apps/prairielearn/src/tests/lti13Linking.test.ts
@@ -37,6 +37,7 @@ import {
   Lti13CourseInstanceSchema,
 } from '../lib/db-types.js';
 import { createServerJob, selectJobsByJobSequenceId } from '../lib/server-jobs.js';
+import { createPublishingExtensionWithEnrollments } from '../models/course-instance-publishing-extensions.js';
 import { selectCourseInstanceById } from '../models/course-instances.js';
 import { selectOptionalEnrollmentByUserId } from '../models/enrollment.js';
 import { selectOptionalUserByUid, selectOrInsertUserByUid } from '../models/user.js';
@@ -399,10 +400,14 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         selfEnrollmentUseEnrollmentCode: false,
         restrictToInstitution: false,
       });
+      await execute(
+        "UPDATE course_instances SET publishing_end_date = $publishing_end_date WHERE id = '1'",
+        { publishing_end_date: courseInstance.publishing_end_date },
+      );
       await execute("UPDATE course_instances SET enrollment_limit = NULL WHERE id = '1'");
     });
 
-    test('admits only the exact link and sub from the fresh launch', async () => {
+    test('admits an exact link and sub using its publishing extension', async () => {
       await updateCourseInstanceSettings('1', {
         selfEnrollmentEnabled: false,
         selfEnrollmentUseEnrollmentCode: true,
@@ -417,6 +422,17 @@ describe('LTI 1.3 course instance linking', { concurrent: false }, () => {
         pendingUin: 'exact-invitation-unmatched-uin',
         status: 'invited',
       });
+      const now = new Date();
+      await createPublishingExtensionWithEnrollments({
+        courseInstance,
+        name: 'Exact LTI invitation extension',
+        endDate: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+        enrollments: [invitation],
+      });
+      await execute(
+        "UPDATE course_instances SET publishing_end_date = $publishing_end_date WHERE id = '1'",
+        { publishing_end_date: new Date(now.getTime() - 24 * 60 * 60 * 1000) },
+      );
       const fetchWithCookies = fetchCookie(fetch);
       const targetLinkUri = `${siteUrl}/pl/lti13_instance/1/course_navigation`;
       const executor = await makeLoginExecutor({

--- a/database/tables/enrollments.pg
+++ b/database/tables/enrollments.pg
@@ -15,9 +15,9 @@ columns
 
 indexes
     enrollments_pkey: PRIMARY KEY (id) USING btree (id)
-    enrollments_course_instance_id_pending_uin_key: UNIQUE (course_instance_id, pending_uin) USING btree (course_instance_id, pending_uin)
     enrollments_pending_lti13_ciid_sub_course_instance_id_key: UNIQUE (pending_lti13_course_instance_id, pending_lti13_sub, course_instance_id) USING btree (pending_lti13_course_instance_id, pending_lti13_sub, course_instance_id)
     enrollments_pending_uid_course_instance_id_key: UNIQUE (pending_uid, course_instance_id) USING btree (pending_uid, course_instance_id)
+    enrollments_pending_uin_course_instance_id_key: UNIQUE (pending_uin, course_instance_id) USING btree (pending_uin, course_instance_id)
     enrollments_user_id_course_instance_id_key: UNIQUE (user_id, course_instance_id) USING btree (user_id, course_instance_id)
     enrollments_course_instance_id_idx: USING btree (course_instance_id)
 


### PR DESCRIPTION
# Description

This replaces #15519. GitHub closed that PR during stacked merge-queue processing after deleting a merged parent branch; the failure matches [github/gh-stack#443](https://github.com/github/gh-stack/issues/443). The already-reviewed fifth-layer commits were rebased unchanged onto `master` after prerequisite PRs #15509, #15510, #15511, and #15518 merged.

Implements the fifth and final review slice for [PrairieLearnInc/planning#51](https://github.com/PrairieLearnInc/planning/issues/51).

Uses one homepage query to find enrollments bound to the user and invitations matching the user's UID or institution-scoped UIN, then groups all matching rows once per course instance with the shared classifier. A bound `left` row plus a pending UIN invitation appears once as institution-provided access rather than as a joined enrollment, and the effective publishing extension is the latest extension assigned to any matching row.

Presents institution-provided access with the same linked course row and Remove control as a joined course, while UID invitations retain their explicit Accept and Reject controls. Following the course link uses the normal checked-admission path. Remove rejects the displayed pending UIN invitation by ID without binding the user or changing a paired `left` enrollment, and a later institutional import may make the course available again. Homepage GET remains read-only, and UID invitation POST actions require both a currently actionable invitation and the same enrollment ID rendered in the form.

Modern course authorization recognizes a live extension across the same matching rows only for joined users or pending UID, institution-scoped UIN, and exact LTI invitations that can currently be accepted. `has_student_access_with_enrollment` remains true only for joined users, so extension-backed invitations still pass through checked admission before course access.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance disclosure: Codex produced the majority of the implementation and tests under human-directed design, manager inspection, and independent adversarial review.

# Testing

Focused homepage integration coverage verifies cross-institution UIN isolation, bound-left and pending-UIN grouping, the latest extension across matching rows, no mutation on GET, unified joined/institution-provided presentation, removal of only the displayed UIN invitation, stale UID-form denial, non-invitation `left`/`removed`/`rejected` posts, and UID invitation Accept/Reject behavior. Authorization coverage verifies that invitation extensions allow navigation without claiming that the user is already joined, including an expired course entered through an exact LTI invitation with its own publishing extension.

Recovery verification compared the original and rebased 21-commit ranges with `git range-diff`; every patch matched exactly, and the replacement retains the original 21-file `+1104/-737` diff.
