### PR TITLE
Add filter by course instance to instructor issues page

### DIFF
--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
@@ -334,7 +334,7 @@ function IssueRow({
               {formatDistance(issue.date, now, { addSuffix: true })}
             </span>
           )}{' '}
-          {issue.showUser && (
+          {issue.showUser && issue.user_id != null && (
             <>
               {issue.manually_reported ? 'by' : 'for'} {issue.user_name || '-'} (
               <a href={mailtoLink}>{issue.user_uid || '-'}</a>)

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.html.tsx
@@ -505,6 +505,20 @@ function FilterHelpModal() {
                   <tr>
                     <td>
                       <code>
+                        ci:<em>short_name</em>
+                      </code>
+                    </td>
+                    <td>
+                      Shows all issues associated with a course instance short name like{' '}
+                      <code>short_name</code>; supports <code>*</code> as a wildcard. For example,{' '}
+                      <code>ci:2025F</code> shows all issues associated with the course instance{' '}
+                      <code>2025F</code>, while <code>ci:2025*</code> shows all issues associated
+                      with any course instance that starts with <code>2025</code>.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <code>
                         qid:<em>QID</em>
                       </code>
                     </td>

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -68,6 +68,7 @@ WITH
       )
       AND (
         $filter_not_users::text[] IS NULL
+        OR u.uid IS NULL
         OR u.uid NOT ILIKE ALL ($filter_not_users::text[])
       )
       AND (

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -35,6 +35,7 @@ WITH
       LEFT JOIN questions AS q ON (q.id = i.question_id)
       LEFT JOIN users AS u ON (u.id = i.user_id)
       LEFT JOIN assessments AS a ON (a.id = i.assessment_id)
+      LEFT JOIN course_instances AS ci ON (ci.id = i.course_instance_id)
     WHERE
       i.course_id = $course_id
       AND (
@@ -76,6 +77,14 @@ WITH
       AND (
         $filter_not_assessments::text[] IS NULL
         OR a.tid NOT ILIKE ANY ($filter_not_assessments::text[])
+      )
+      AND (
+        $filter_course_instances::text[] IS NULL
+        OR ci.short_name ILIKE ANY ($filter_course_instances::text[])
+      )
+      AND (
+        $filter_not_course_instances::text[] IS NULL
+        OR ci.short_name NOT ILIKE ANY ($filter_not_course_instances::text[])
       )
       AND (
         -- We only filter by course instance if the user filter has been set,

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.sql
@@ -60,7 +60,7 @@ WITH
       )
       AND (
         $filter_not_qids::text[] IS NULL
-        OR q.qid NOT ILIKE ANY ($filter_not_qids::text[])
+        OR q.qid NOT ILIKE ALL ($filter_not_qids::text[])
       )
       AND (
         $filter_users::text[] IS NULL
@@ -68,7 +68,7 @@ WITH
       )
       AND (
         $filter_not_users::text[] IS NULL
-        OR u.uid NOT ILIKE ANY ($filter_not_users::text[])
+        OR u.uid NOT ILIKE ALL ($filter_not_users::text[])
       )
       AND (
         $filter_assessments::text[] IS NULL
@@ -76,7 +76,8 @@ WITH
       )
       AND (
         $filter_not_assessments::text[] IS NULL
-        OR a.tid NOT ILIKE ANY ($filter_not_assessments::text[])
+        OR a.tid IS NULL
+        OR a.tid NOT ILIKE ALL ($filter_not_assessments::text[])
       )
       AND (
         $filter_course_instances::text[] IS NULL
@@ -84,7 +85,8 @@ WITH
       )
       AND (
         $filter_not_course_instances::text[] IS NULL
-        OR ci.short_name NOT ILIKE ANY ($filter_not_course_instances::text[])
+        OR ci.short_name IS NULL
+        OR ci.short_name NOT ILIKE ALL ($filter_not_course_instances::text[])
       )
       AND (
         -- We only filter by course instance if the user filter has been set,

--- a/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
+++ b/apps/prairielearn/src/pages/instructorIssues/instructorIssues.tsx
@@ -49,6 +49,8 @@ function parseRawQuery(str: string) {
     filter_not_users: null as string[] | null,
     filter_assessments: null as string[] | null,
     filter_not_assessments: null as string[] | null,
+    filter_course_instances: null as string[] | null,
+    filter_not_course_instances: null as string[] | null,
   };
 
   const queryText = parsedQuery.getAllText();
@@ -99,6 +101,15 @@ function parseRawQuery(str: string) {
         } else {
           filters.filter_not_assessments = filters.filter_not_assessments || [];
           filters.filter_not_assessments.push(formatForLikeClause(option.value));
+        }
+        break;
+      case 'ci':
+        if (!option.negated) {
+          filters.filter_course_instances = filters.filter_course_instances || [];
+          filters.filter_course_instances.push(formatForLikeClause(option.value));
+        } else {
+          filters.filter_not_course_instances = filters.filter_not_course_instances || [];
+          filters.filter_not_course_instances.push(formatForLikeClause(option.value));
         }
         break;
     }

--- a/apps/prairielearn/src/tests/e2e/instructorIssues.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/instructorIssues.spec.ts
@@ -58,8 +58,8 @@ interface TestIssueData {
   studentMessage: string;
   manuallyReported: boolean;
   open: boolean;
-  /** Which course instance (if any) the issue's variant should be associated with. */
-  courseInstance?: 'sp15' | 'public';
+  /** Which course instance (if any) the issue should be associated with. */
+  courseInstance?: 'Sp15' | 'public';
 }
 
 const BASE_TEST_ISSUES: TestIssueData[] = [
@@ -98,7 +98,7 @@ const BASE_TEST_ISSUES: TestIssueData[] = [
     studentMessage: 'Issue 6: addNumbers in Sp15 course instance',
     manuallyReported: true,
     open: true,
-    courseInstance: 'sp15',
+    courseInstance: 'Sp15',
   },
   {
     qid: 'addVectors',
@@ -111,12 +111,10 @@ const BASE_TEST_ISSUES: TestIssueData[] = [
 
 async function createTestIssues({
   courseId,
-  sp15CourseInstanceId,
-  publicCourseInstanceId,
+  courseInstanceIdMap,
 }: {
   courseId: string;
-  sp15CourseInstanceId: string;
-  publicCourseInstanceId: string;
+  courseInstanceIdMap: Record<NonNullable<TestIssueData['courseInstance']>, string>;
 }) {
   const user = await getOrCreateUser(TEST_USER);
 
@@ -126,11 +124,6 @@ async function createTestIssues({
   const questionMap: Record<string, { id: string }> = {
     addNumbers: addNumbersQuestion,
     addVectors: addVectorsQuestion,
-  };
-
-  const courseInstanceIdMap: Record<'sp15' | 'public', string> = {
-    sp15: sp15CourseInstanceId,
-    public: publicCourseInstanceId,
   };
 
   for (const issueData of BASE_TEST_ISSUES) {
@@ -181,8 +174,7 @@ test.describe('Instructor issues page', () => {
 
     await createTestIssues({
       courseId: courseInstance.course_id,
-      sp15CourseInstanceId: courseInstance.id,
-      publicCourseInstanceId: publicCourseInstance.id,
+      courseInstanceIdMap: { Sp15: courseInstance.id, public: publicCourseInstance.id },
     });
   });
 

--- a/apps/prairielearn/src/tests/e2e/instructorIssues.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/instructorIssues.spec.ts
@@ -4,6 +4,8 @@ import { IdSchema } from '@prairielearn/zod';
 import { makeAssessmentInstance } from '../../lib/assessment.js';
 import { insertIssue } from '../../lib/issues.js';
 import { selectAssessmentByTid } from '../../models/assessment.js';
+import { selectCourseInstanceByShortName } from '../../models/course-instances.js';
+import { selectCourseByShortName } from '../../models/course.js';
 import { selectQuestionByQid } from '../../models/question.js';
 import { type AuthUser, getOrCreateUser } from '../utils/auth.js';
 
@@ -56,6 +58,8 @@ interface TestIssueData {
   studentMessage: string;
   manuallyReported: boolean;
   open: boolean;
+  /** Which course instance (if any) the issue's variant should be associated with. */
+  courseInstance?: 'sp15' | 'public';
 }
 
 const BASE_TEST_ISSUES: TestIssueData[] = [
@@ -89,9 +93,31 @@ const BASE_TEST_ISSUES: TestIssueData[] = [
     manuallyReported: false,
     open: true,
   },
+  {
+    qid: 'addNumbers',
+    studentMessage: 'Issue 6: addNumbers in Sp15 course instance',
+    manuallyReported: true,
+    open: true,
+    courseInstance: 'sp15',
+  },
+  {
+    qid: 'addVectors',
+    studentMessage: 'Issue 7: addVectors in public course instance',
+    manuallyReported: true,
+    open: true,
+    courseInstance: 'public',
+  },
 ];
 
-async function createTestIssues(courseId: string) {
+async function createTestIssues({
+  courseId,
+  sp15CourseInstanceId,
+  publicCourseInstanceId,
+}: {
+  courseId: string;
+  sp15CourseInstanceId: string;
+  publicCourseInstanceId: string;
+}) {
   const user = await getOrCreateUser(TEST_USER);
 
   const addNumbersQuestion = await selectQuestionByQid({ qid: 'addNumbers', course_id: courseId });
@@ -102,11 +128,19 @@ async function createTestIssues(courseId: string) {
     addVectors: addVectorsQuestion,
   };
 
+  const courseInstanceIdMap: Record<'sp15' | 'public', string> = {
+    sp15: sp15CourseInstanceId,
+    public: publicCourseInstanceId,
+  };
+
   for (const issueData of BASE_TEST_ISSUES) {
     const question = questionMap[issueData.qid];
     const variantId = await insertTestVariant({
       questionId: question.id,
       courseId,
+      courseInstanceId: issueData.courseInstance
+        ? courseInstanceIdMap[issueData.courseInstance]
+        : undefined,
       authnUserId: user.id,
       userId: user.id,
     });
@@ -138,7 +172,18 @@ test.describe('Instructor issues page', () => {
 
   test.beforeAll(async ({ courseInstance }) => {
     issuesUrl = `/pl/course/${courseInstance.course_id}/course_admin/issues`;
-    await createTestIssues(courseInstance.course_id);
+
+    const course = await selectCourseByShortName('QA 101');
+    const publicCourseInstance = await selectCourseInstanceByShortName({
+      course,
+      shortName: 'public',
+    });
+
+    await createTestIssues({
+      courseId: courseInstance.course_id,
+      sp15CourseInstanceId: courseInstance.id,
+      publicCourseInstanceId: publicCourseInstance.id,
+    });
   });
 
   test.describe('View issues list', () => {
@@ -213,6 +258,60 @@ test.describe('Instructor issues page', () => {
 
       const issueItems = page.getByTestId('issue-list-item');
       await expect(issueItems.first()).toBeVisible();
+    });
+
+    test('excluding both known qids returns no issues', async ({ page }) => {
+      await page.goto(issuesUrl);
+
+      const searchInput = page.getByRole('textbox', { name: 'Search all issues' });
+      await searchInput.fill('-qid:addVectors -qid:addNumbers');
+      await searchInput.press('Enter');
+
+      await expect(page.getByTestId('issue-list-item')).toHaveCount(0);
+    });
+
+    test('can search by ci qualifier for a course instance', async ({ page }) => {
+      await page.goto(issuesUrl);
+
+      const searchInput = page.getByRole('textbox', { name: 'Search all issues' });
+      await searchInput.fill('ci:Sp15');
+      await searchInput.press('Enter');
+
+      const issueItems = page.getByTestId('issue-list-item');
+      await expect(issueItems).toHaveCount(1);
+      await expect(issueItems.first()).toContainText('Issue 6:');
+    });
+
+    test('can search with wildcard ci qualifier', async ({ page }) => {
+      await page.goto(issuesUrl);
+
+      const searchInput = page.getByRole('textbox', { name: 'Search all issues' });
+      await searchInput.fill('ci:Sp*');
+      await searchInput.press('Enter');
+
+      const issueItems = page.getByTestId('issue-list-item');
+      await expect(issueItems).toHaveCount(1);
+      await expect(issueItems.first()).toContainText('Issue 6:');
+    });
+
+    test('excluding a course instance includes issues without one or in other course instances', async ({
+      page,
+    }) => {
+      await page.goto(issuesUrl);
+
+      const searchInput = page.getByRole('textbox', { name: 'Search all issues' });
+      await searchInput.fill('-ci:Sp15');
+      await searchInput.press('Enter');
+
+      await expect(page.getByText('Issue 1:', { exact: false })).toBeVisible();
+      await expect(page.getByText('Issue 7:', { exact: false })).toBeVisible();
+
+      const issueItems = page.getByTestId('issue-list-item');
+      const count = await issueItems.count();
+      for (let i = 0; i < count; i++) {
+        const text = await issueItems.nth(i).textContent();
+        expect(text).not.toContain('Issue 6:');
+      }
     });
 
     test('can clear filters', async ({ page }) => {


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

Adds a filter by course instance to the issues page. Resolves #15713. This allows instructors to identify issues associated to a particular section.

Also fixes negation queries with multiple keywords. Previously, a query like `-assessment:HW1 -assessment:HW2` would return all issues, including those associated to assessments HW1 and HW2, because the query used `NOT ILIKE ANY`, and since HW2 does not match HW1 (and vice-versa) they end up being returned anyway. Replaced with `NOT ILIKE ALL` for properly logic, and also included NULL option to return issues not assigned to an assessment or course instance.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: mostly implemented by GPT-5.6 Terra, with human supervision.

# Testing

Tested locally, issues are properly filtered in positive or negative filters, as well as with/without wildcards.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
