### PR TITLE
Add Python helper to dependabot update settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -156,6 +156,7 @@ updates:
     patterns: ['*']
     directories:
       - '/'
+      - '/apps/prairielearn/python'
       - '/docs'
       - '/graders/c'
       - '/graders/python'


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

#15223 added support for a Python helper package, with a custom pyproject.toml file that is expected to be maintained in sync with the versions of the repository root dependencies. Since dependabot is unaware of these changes, it doesn't update both files in sync, as seen in #15712. This PR includes the new pyproject directory to the dependabot settings to ensure they are updated in sync.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Relying on dependabot/CI to test it.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
