### PR TITLE
Show current IP address in user settings

### DIFF
--- a/apps/prairielearn/src/lib/client-ip.ts
+++ b/apps/prairielearn/src/lib/client-ip.ts
@@ -3,5 +3,5 @@ import type { Request } from 'express';
 export function getClientIpAddress(req: Request): string | undefined {
   // Node may represent IPv4 client addresses as IPv4-mapped IPv6 addresses.
   const ipAddress = req.ip;
-  return ipAddress?.startsWith('::ffff:') ? ipAddress.slice(7) : ipAddress;
+  return ipAddress?.toLowerCase().startsWith('::ffff:') ? ipAddress.slice(7) : ipAddress;
 }

--- a/apps/prairielearn/src/lib/client-ip.ts
+++ b/apps/prairielearn/src/lib/client-ip.ts
@@ -1,0 +1,7 @@
+import type { Request } from 'express';
+
+export function getClientIpAddress(req: Request): string | undefined {
+  // Node may represent IPv4 client addresses as IPv4-mapped IPv6 addresses.
+  const ipAddress = req.ip;
+  return ipAddress?.startsWith('::ffff:') ? ipAddress.slice(7) : ipAddress;
+}

--- a/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
+++ b/apps/prairielearn/src/pages/instructorEffectiveUser/instructorEffectiveUser.ts
@@ -4,6 +4,7 @@ import { Router } from 'express';
 import { HttpStatusError } from '@prairielearn/error';
 import { loadSqlEquiv, queryRow } from '@prairielearn/postgres';
 
+import { getClientIpAddress } from '../../lib/client-ip.js';
 import { clearCookie, setCookie } from '../../lib/cookie.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 
@@ -28,13 +29,13 @@ router.get(
       CourseRolesSchema,
     );
 
-    let ipAddress = req.ip;
-    // Trim out IPv6 wrapper on IPv4 addresses
-    if (ipAddress?.slice(0, 7) === '::ffff:') {
-      ipAddress = ipAddress.slice(7);
-    }
-
-    res.send(InstructorEffectiveUser({ resLocals: res.locals, ipAddress, courseRoles }));
+    res.send(
+      InstructorEffectiveUser({
+        resLocals: res.locals,
+        ipAddress: getClientIpAddress(req),
+        courseRoles,
+      }),
+    );
   }),
 );
 

--- a/apps/prairielearn/src/pages/userSettings/components/UserSettingsPage.tsx
+++ b/apps/prairielearn/src/pages/userSettings/components/UserSettingsPage.tsx
@@ -26,6 +26,7 @@ interface UserSettingsPageProps {
     short_name: string;
   };
   authnProviderName: string;
+  ipAddress: string | undefined;
   accessTokens: UserAccessToken[];
   newAccessTokens: string[];
   isExamMode: boolean;
@@ -38,6 +39,7 @@ export function UserSettingsPage({
   user,
   institution,
   authnProviderName,
+  ipAddress,
   accessTokens,
   newAccessTokens,
   isExamMode,
@@ -57,6 +59,7 @@ export function UserSettingsPage({
           user={user}
           institution={institution}
           authnProviderName={authnProviderName}
+          ipAddress={ipAddress}
         />
 
         <UserSettingsCard initialEnableSingleKeyShortcuts={initialEnableSingleKeyShortcuts} />
@@ -80,10 +83,12 @@ function UserProfileCard({
   user,
   institution,
   authnProviderName,
+  ipAddress,
 }: {
   user: UserSettingsPageProps['user'];
   institution: UserSettingsPageProps['institution'];
   authnProviderName: string;
+  ipAddress: string | undefined;
 }) {
   return (
     <div className="card mb-4">
@@ -121,6 +126,10 @@ function UserProfileCard({
             <tr>
               <th>Authentication method</th>
               <td>{authnProviderName}</td>
+            </tr>
+            <tr>
+              <th>IP address</th>
+              <td>{ipAddress ?? <em>Unknown</em>}</td>
             </tr>
           </tbody>
         </table>

--- a/apps/prairielearn/src/pages/userSettings/userSettings.tsx
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.tsx
@@ -87,6 +87,7 @@ router.get(
                   short_name: authn_institution.short_name,
                 }}
                 authnProviderName={res.locals.authn_provider_name}
+                ipAddress={req.ip}
                 accessTokens={isExamMode ? [] : UserAccessTokenSchema.array().parse(accessTokens)}
                 newAccessTokens={isExamMode ? [] : newAccessTokens}
                 isExamMode={isExamMode}

--- a/apps/prairielearn/src/pages/userSettings/userSettings.tsx
+++ b/apps/prairielearn/src/pages/userSettings/userSettings.tsx
@@ -13,6 +13,7 @@ import { UserSettingsPurchasesCard } from '../../ee/lib/billing/components/UserS
 import { getPurchasesForUser } from '../../ee/lib/billing/purchases.js';
 import { UserAccessTokenSchema } from '../../lib/client/safe-db-types.js';
 import { getUserTrpcUrl } from '../../lib/client/url.js';
+import { getClientIpAddress } from '../../lib/client-ip.js';
 import { config } from '../../lib/config.js';
 import { AccessTokenSchema, InstitutionSchema, UserSchema } from '../../lib/db-types.js';
 import { ipToMode } from '../../lib/exam-mode.js';
@@ -87,7 +88,7 @@ router.get(
                   short_name: authn_institution.short_name,
                 }}
                 authnProviderName={res.locals.authn_provider_name}
-                ipAddress={req.ip}
+                ipAddress={getClientIpAddress(req)}
                 accessTokens={isExamMode ? [] : UserAccessTokenSchema.array().parse(accessTokens)}
                 newAccessTokens={isExamMode ? [] : newAccessTokens}
                 isExamMode={isExamMode}

--- a/apps/prairielearn/src/tests/userSettings.test.ts
+++ b/apps/prairielearn/src/tests/userSettings.test.ts
@@ -9,17 +9,18 @@ import { selectUserSettings } from '../models/user-settings.js';
 import { createUserTrpcClient } from '../trpc/user/client.js';
 
 import * as helperServer from './helperServer.js';
+import { withConfig } from './utils/config.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
-const originalTrustProxy = config.trustProxy;
 
 describe('User settings', { timeout: 60_000, concurrent: false }, () => {
   let trpcClient: ReturnType<typeof createUserTrpcClient>;
 
-  beforeAll(() => {
-    config.trustProxy = true;
+  beforeAll(async () => {
+    await withConfig({ trustProxy: true }, async () => {
+      await helperServer.before()();
+    });
   });
-  beforeAll(helperServer.before());
   beforeAll(() => {
     trpcClient = createUserTrpcClient({
       csrfToken: generatePrefixCsrfToken(
@@ -30,9 +31,6 @@ describe('User settings', { timeout: 60_000, concurrent: false }, () => {
     });
   });
   afterAll(helperServer.after);
-  afterAll(() => {
-    config.trustProxy = originalTrustProxy;
-  });
 
   test('shows the current IP address in the user profile', async () => {
     const response = await fetch(`${siteUrl}/pl/settings`, {

--- a/apps/prairielearn/src/tests/userSettings.test.ts
+++ b/apps/prairielearn/src/tests/userSettings.test.ts
@@ -1,3 +1,4 @@
+import * as cheerio from 'cheerio';
 import { afterAll, assert, beforeAll, describe, test } from 'vitest';
 
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
@@ -10,10 +11,14 @@ import { createUserTrpcClient } from '../trpc/user/client.js';
 import * as helperServer from './helperServer.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
+const originalTrustProxy = config.trustProxy;
 
 describe('User settings', { timeout: 60_000, concurrent: false }, () => {
   let trpcClient: ReturnType<typeof createUserTrpcClient>;
 
+  beforeAll(() => {
+    config.trustProxy = true;
+  });
   beforeAll(helperServer.before());
   beforeAll(() => {
     trpcClient = createUserTrpcClient({
@@ -25,6 +30,23 @@ describe('User settings', { timeout: 60_000, concurrent: false }, () => {
     });
   });
   afterAll(helperServer.after);
+  afterAll(() => {
+    config.trustProxy = originalTrustProxy;
+  });
+
+  test('shows the current IP address in the user profile', async () => {
+    const response = await fetch(`${siteUrl}/pl/settings`, {
+      headers: { 'X-Forwarded-For': '203.0.113.42' },
+    });
+    assert(response.ok);
+
+    const $ = cheerio.load(await response.text());
+    const ipAddressRow = $('table[aria-label="User profile information"] tr').filter(
+      (_, element) => $(element).find('th').text().trim() === 'IP address',
+    );
+    assert.lengthOf(ipAddressRow, 1);
+    assert.equal(ipAddressRow.find('td').text().trim(), '203.0.113.42');
+  });
 
   test('updates settings for the authenticated user', async () => {
     const updatedSettings = await trpcClient.settings.update.mutate({

--- a/apps/prairielearn/src/tests/userSettings.test.ts
+++ b/apps/prairielearn/src/tests/userSettings.test.ts
@@ -32,19 +32,25 @@ describe('User settings', { timeout: 60_000, concurrent: false }, () => {
   });
   afterAll(helperServer.after);
 
-  test('shows the current IP address in the user profile', async () => {
-    const response = await fetch(`${siteUrl}/pl/settings`, {
-      headers: { 'X-Forwarded-For': '203.0.113.42' },
-    });
-    assert(response.ok);
+  test.each([
+    { forwardedIp: '::ffff:203.0.113.42', displayedIp: '203.0.113.42' },
+    { forwardedIp: '2001:db8::1', displayedIp: '2001:db8::1' },
+  ])(
+    'shows $forwardedIp as $displayedIp in the user profile',
+    async ({ forwardedIp, displayedIp }) => {
+      const response = await fetch(`${siteUrl}/pl/settings`, {
+        headers: { 'X-Forwarded-For': forwardedIp },
+      });
+      assert(response.ok);
 
-    const $ = cheerio.load(await response.text());
-    const ipAddressRow = $('table[aria-label="User profile information"] tr').filter(
-      (_, element) => $(element).find('th').text().trim() === 'IP address',
-    );
-    assert.lengthOf(ipAddressRow, 1);
-    assert.equal(ipAddressRow.find('td').text().trim(), '203.0.113.42');
-  });
+      const $ = cheerio.load(await response.text());
+      const ipAddressRow = $('table[aria-label="User profile information"] tr').filter(
+        (_, element) => $(element).find('th').text().trim() === 'IP address',
+      );
+      assert.lengthOf(ipAddressRow, 1);
+      assert.equal(ipAddressRow.find('td').text().trim(), displayedIp);
+    },
+  );
 
   test('updates settings for the authenticated user', async () => {
     const updatedSettings = await trpcClient.settings.update.mutate({

--- a/apps/prairielearn/src/tests/userSettings.test.ts
+++ b/apps/prairielearn/src/tests/userSettings.test.ts
@@ -34,6 +34,7 @@ describe('User settings', { timeout: 60_000, concurrent: false }, () => {
 
   test.each([
     { forwardedIp: '::ffff:203.0.113.42', displayedIp: '203.0.113.42' },
+    { forwardedIp: '::FFFF:203.0.113.42', displayedIp: '203.0.113.42' },
     { forwardedIp: '2001:db8::1', displayedIp: '2001:db8::1' },
   ])(
     'shows $forwardedIp as $displayedIp in the user profile',


### PR DESCRIPTION
# Description

Adds the user's current IP address to the User profile card on `/pl/settings`.

The displayed address is derived from `req.ip`, which is also used on this page to determine whether the user is in Exam or Public mode. IPv4-mapped IPv6 addresses are displayed as plain IPv4 addresses, consistent with the Effective User page. This gives students a concrete value to share with instructors and administrators when diagnosing PrairieTest location network-filter mismatches.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Added integration coverage that configures a trusted proxy and verifies that the User profile table removes the IPv6 wrapper from an IPv4-mapped address while preserving a native IPv6 address.
