### PR TITLE
Fix incremental chunk invalidation for Git renames

### DIFF
--- a/apps/prairielearn/src/lib/chunks.ts
+++ b/apps/prairielearn/src/lib/chunks.ts
@@ -314,8 +314,10 @@ async function identifyChangedFiles(
   );
   const topLevel = topLevelStdout.trim();
 
+  // Both sides of a rename may belong to independently invalidated chunks. NUL
+  // delimiters keep filenames unambiguous.
   const { stdout: diffStdout } = await util.promisify(child_process.exec)(
-    `git diff --name-only ${oldHash}..${newHash}`,
+    `git diff --no-renames --name-only -z ${oldHash}..${newHash}`,
     {
       cwd: coursePath,
       // This defaults to 1MB of output, however, we've observed in the past that
@@ -326,7 +328,7 @@ async function identifyChangedFiles(
       maxBuffer: 10 * 1024 * 1024,
     },
   );
-  const changedFiles = diffStdout.trim().split('\n');
+  const changedFiles = diffStdout.split('\0').filter((changedFile) => changedFile.length > 0);
 
   // Construct absolute path to all changed files.
   const absoluteChangedFiles = changedFiles.map((changedFile) => path.join(topLevel, changedFile));

--- a/apps/prairielearn/src/tests/chunks.test.ts
+++ b/apps/prairielearn/src/tests/chunks.test.ts
@@ -500,6 +500,7 @@ describe('chunks', () => {
       const newHash = (await execa('git', ['rev-parse', 'HEAD'], { cwd: courseDir })).stdout;
       const { stdout: nameStatus } = await execa(
         'git',
+        // note: find-renames is necessary to override local git configs
         ['diff', '--name-status', '--find-renames=100%', oldHash, newHash],
         { cwd: courseDir },
       );

--- a/apps/prairielearn/src/tests/chunks.test.ts
+++ b/apps/prairielearn/src/tests/chunks.test.ts
@@ -500,7 +500,7 @@ describe('chunks', () => {
       const newHash = (await execa('git', ['rev-parse', 'HEAD'], { cwd: courseDir })).stdout;
       const { stdout: nameStatus } = await execa(
         'git',
-        ['diff', '--name-status', oldHash, newHash],
+        ['diff', '--name-status', '--find-renames=100%', oldHash, newHash],
         { cwd: courseDir },
       );
       assert.equal(nameStatus, 'R100\tquestions/addNumbers/helper.py\tserverFilesCourse/helper.py');

--- a/apps/prairielearn/src/tests/chunks.test.ts
+++ b/apps/prairielearn/src/tests/chunks.test.ts
@@ -467,6 +467,7 @@ describe('chunks', () => {
 
       await fs.writeFile(questionFilePath, 'def get_value():\n    return 42\n');
       await execa('git', ['init'], { cwd: courseDir });
+      await execa('git', ['config', 'diff.renames', 'true'], { cwd: courseDir });
       await execa('git', ['config', 'user.email', 'test@example.com'], { cwd: courseDir });
       await execa('git', ['config', 'user.name', 'Test User'], { cwd: courseDir });
       await execa('git', ['add', '-A'], { cwd: courseDir });
@@ -500,7 +501,6 @@ describe('chunks', () => {
       const newHash = (await execa('git', ['rev-parse', 'HEAD'], { cwd: courseDir })).stdout;
       const { stdout: nameStatus } = await execa(
         'git',
-        // note: find-renames is necessary to override local git configs
         ['diff', '--name-status', '--find-renames=100%', oldHash, newHash],
         { cwd: courseDir },
       );

--- a/apps/prairielearn/src/tests/chunks.test.ts
+++ b/apps/prairielearn/src/tests/chunks.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+import { execa } from 'execa';
 import fs from 'fs-extra';
 import * as tmp from 'tmp-promise';
 import { afterEach, assert, beforeEach, describe, expect, it } from 'vitest';
@@ -453,6 +454,70 @@ describe('chunks', () => {
       assert.isOk(
         await fs.pathExists(path.join(courseRuntimeDir, 'questions', 'subfolder', 'info.json')),
       );
+    });
+
+    it('rebuilds both chunks when a file is renamed across chunk boundaries', async () => {
+      const courseDir = tempTestCourseDir.path;
+      const courseRuntimeDir = chunksLib.getRuntimeDirectoryForCourse({
+        id: course.id,
+        path: courseDir,
+      });
+      const questionFilePath = path.join(courseDir, 'questions', 'addNumbers', 'helper.py');
+      const serverFilePath = path.join(courseDir, 'serverFilesCourse', 'helper.py');
+
+      await fs.writeFile(questionFilePath, 'def get_value():\n    return 42\n');
+      await execa('git', ['init'], { cwd: courseDir });
+      await execa('git', ['config', 'user.email', 'test@example.com'], { cwd: courseDir });
+      await execa('git', ['config', 'user.name', 'Test User'], { cwd: courseDir });
+      await execa('git', ['add', '-A'], { cwd: courseDir });
+      await execa('git', ['commit', '-m', 'Initial course'], { cwd: courseDir });
+      const oldHash = (await execa('git', ['rev-parse', 'HEAD'], { cwd: courseDir })).stdout;
+
+      await chunksLib.updateChunksForCourse({
+        coursePath: courseDir,
+        courseId: course.id,
+        courseData: await courseDB.loadFullCourse(course.id, courseDir),
+      });
+      const chunksToLoad: chunksLib.Chunk[] = [
+        { type: 'question', questionId },
+        { type: 'serverFilesCourse' },
+      ];
+      await chunksLib.ensureChunksForCourseAsync(course.id, chunksToLoad);
+
+      const runtimeQuestionFilePath = path.join(
+        courseRuntimeDir,
+        'questions',
+        'addNumbers',
+        'helper.py',
+      );
+      const runtimeServerFilePath = path.join(courseRuntimeDir, 'serverFilesCourse', 'helper.py');
+      assert.isOk(await fs.pathExists(runtimeQuestionFilePath));
+      assert.isNotOk(await fs.pathExists(runtimeServerFilePath));
+
+      await fs.move(questionFilePath, serverFilePath);
+      await execa('git', ['add', '-A'], { cwd: courseDir });
+      await execa('git', ['commit', '-m', 'Move helper to server files'], { cwd: courseDir });
+      const newHash = (await execa('git', ['rev-parse', 'HEAD'], { cwd: courseDir })).stdout;
+      const { stdout: nameStatus } = await execa(
+        'git',
+        ['diff', '--name-status', oldHash, newHash],
+        { cwd: courseDir },
+      );
+      assert.equal(nameStatus, 'R100\tquestions/addNumbers/helper.py\tserverFilesCourse/helper.py');
+
+      const { logger } = makeMockLogger();
+      await syncDiskToSql(course, logger);
+      await chunksLib.updateChunksForCourse({
+        coursePath: courseDir,
+        courseId: course.id,
+        courseData: await courseDB.loadFullCourse(course.id, courseDir),
+        oldHash,
+        newHash,
+      });
+      await chunksLib.ensureChunksForCourseAsync(course.id, chunksToLoad);
+
+      assert.isOk(await fs.pathExists(runtimeServerFilePath));
+      assert.isNotOk(await fs.pathExists(runtimeQuestionFilePath));
     });
 
     it('deletes chunks that are no longer needed', async () => {


### PR DESCRIPTION
# Description

Incremental chunk updates used Git rename-aware name-only output, which reports only the destination path when Git detects a rename. Moving an unchanged file between independently invalidated chunks therefore rebuilt the destination chunk while leaving stale content in the source runtime chunk.

This disables rename detection for change identification so moves are represented as a deletion plus an addition. It also uses NUL-delimited output to parse filenames safely. The fix is generic across question, course-file, element, and other chunk boundaries.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex produced the majority of the implementation and regression test.

# Testing

Added an integration regression that commits an R100 rename from a question directory to serverFilesCourse, runs the normal sync and chunk-update path, and verifies that the destination runtime chunk gains the file while the rebuilt source question chunk removes it. The regression failed at the stale source-file assertion before the fix and passes afterward. The complete chunk test suite passes with 30 tests.