### PR TITLE
Return 404 for invalid legacy node_modules paths

### DIFF
--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -37,7 +37,7 @@ import passport from 'passport';
 import favicon from 'serve-favicon';
 
 import { cache } from '@prairielearn/cache';
-import { generateErrorId } from '@prairielearn/error';
+import { HttpStatusError, generateErrorId } from '@prairielearn/error';
 import { flashMiddleware } from '@prairielearn/flash';
 import { addFileLogging, logger, reopenFileLogging } from '@prairielearn/logger';
 import * as migrations from '@prairielearn/migrations';
@@ -401,10 +401,14 @@ export async function initExpress(): Promise<Express> {
 
   // For backwards compatibility, we redirect requests for the old `node_modules`
   // route to the new `cacheable_node_modules` route.
-  app.use('/node_modules', (req, res) => {
+  app.use('/node_modules', (req, res, next) => {
     // Strip the leading slash.
     const assetPath = req.url.slice(1);
-    res.redirect(assets.nodeModulesAssetPath(assetPath));
+    try {
+      res.redirect(assets.nodeModulesAssetPath(assetPath));
+    } catch {
+      next(new HttpStatusError(404, 'Not Found'));
+    }
   });
 
   // Support legacy use of ace by v2 questions

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -406,8 +406,12 @@ export async function initExpress(): Promise<Express> {
     const assetPath = req.url.slice(1);
     try {
       res.redirect(assets.nodeModulesAssetPath(assetPath));
-    } catch {
-      next(new HttpStatusError(404, 'Not Found'));
+    } catch (err) {
+      if (err instanceof Error && 'code' in err && err.code === 'MODULE_NOT_FOUND') {
+        next(new HttpStatusError(404, 'Not Found'));
+      } else {
+        next(err);
+      }
     }
   });
 

--- a/apps/prairielearn/src/tests/assets.test.ts
+++ b/apps/prairielearn/src/tests/assets.test.ts
@@ -37,6 +37,23 @@ describe('Static assets', () => {
   beforeAll(helperServer.before());
   afterAll(helperServer.after);
 
+  it('returns 404 for pnpm-internal paths through the legacy node_modules route', async () => {
+    const res = await fetch(
+      `${SITE_URL}/node_modules/.pnpm/superjson@2.2.6/node_modules/superjson/src/util.ts`,
+      { redirect: 'manual' },
+    );
+
+    assert.equal(res.status, 404);
+  });
+
+  it('redirects valid paths through the legacy node_modules route', async () => {
+    const assetPath = 'superjson/dist/index.js';
+    const res = await fetch(`${SITE_URL}/node_modules/${assetPath}`, { redirect: 'manual' });
+
+    assert.equal(res.status, 302);
+    assert.equal(res.headers.get('location'), assets.nodeModulesAssetPath(assetPath));
+  });
+
   it('serves all element node_modules assets', async () => {
     const elementsInfo = await getOrLoadElementsInfo();
 


### PR DESCRIPTION
This should fix the load balancer alerts we got today.

# Description

Requests for pnpm-internal or otherwise unresolvable paths can reach the legacy `/node_modules` redirect route. The route passes the path to `nodeModulesAssetPath()`, which tries to resolve a package version and can throw `MODULE_NOT_FOUND`; the global error handler then turns that request into a 500.

Convert failures from that legacy HTTP route to a 404 while preserving the existing redirect for resolvable package paths. The handling remains route-scoped so trusted internal callers of `nodeModulesAssetPath()` continue to surface programming or configuration errors.

This change does not alter source-map publication, infrastructure, alarms, or production state.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

AI assistance: Codex performed the majority of implementation and validation from the supplied incident diagnosis.

# Testing

The asset integration suite now covers the reported `.pnpm/superjson@2.2.6/.../src/util.ts` request returning 404 and confirms that a valid `superjson` legacy path still returns the expected redirect.