### PR TITLE
Allow SAML login when names are missing

### DIFF
--- a/apps/prairielearn/src/ee/auth/saml/router.test.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.test.ts
@@ -1,11 +1,12 @@
 import { assert, describe, it } from 'vitest';
 
-import { resolveSamlAttributes } from './router.js';
+import { resolveSamlAttributes, validateSamlAttributes } from './router.js';
 
 function makeProvider(
-  overrides: Partial<Parameters<typeof resolveSamlAttributes>[0]> = {},
-): Parameters<typeof resolveSamlAttributes>[0] {
+  overrides: Partial<Parameters<typeof validateSamlAttributes>[0]> = {},
+): Parameters<typeof validateSamlAttributes>[0] {
   return {
+    allow_missing_name: false,
     uid_attribute: null,
     uin_attribute: null,
     name_attribute: null,
@@ -202,5 +203,59 @@ describe('resolveSamlAttributes', () => {
       assert.isNull(result.uid);
       assert.isNull(result.email);
     });
+  });
+});
+
+describe('validateSamlAttributes', () => {
+  const requiredMappings = {
+    uid_attribute: 'uid',
+    uin_attribute: 'uin',
+    name_attribute: 'displayName',
+  };
+
+  it('rejects a missing name by default', () => {
+    const provider = makeProvider(requiredMappings);
+    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
+
+    assert.throws(
+      () => validateSamlAttributes(provider, resolved),
+      /Missing values for the following SAML attributes: name \(displayName\)/,
+    );
+  });
+
+  it('allows a missing name when configured', () => {
+    const provider = makeProvider({ ...requiredMappings, allow_missing_name: true });
+    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
+
+    assert.deepEqual(validateSamlAttributes(provider, resolved), {
+      uid: 'user@example.com',
+      uin: '123',
+      name: null,
+      email: null,
+    });
+  });
+
+  it('still rejects missing UID and UIN values when names are optional', () => {
+    const provider = makeProvider({ ...requiredMappings, allow_missing_name: true });
+    const resolved = resolveSamlAttributes(provider, {});
+
+    assert.throws(
+      () => validateSamlAttributes(provider, resolved),
+      /Missing values for the following SAML attributes: uid \(uid\), uin \(uin\)/,
+    );
+  });
+
+  it('still requires a name mapping when names are optional', () => {
+    const provider = makeProvider({
+      uid_attribute: 'uid',
+      uin_attribute: 'uin',
+      allow_missing_name: true,
+    });
+    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
+
+    assert.throws(
+      () => validateSamlAttributes(provider, resolved),
+      /Missing one or more SAML attribute mappings/,
+    );
   });
 });

--- a/apps/prairielearn/src/ee/auth/saml/router.test.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.test.ts
@@ -1,11 +1,13 @@
 import { assert, describe, it } from 'vitest';
 
-import { resolveSamlAttributes } from './router.js';
+import { resolveSamlAttributes, validateSamlAttributes } from './router.js';
 
-function makeProvider(
-  overrides: Partial<Parameters<typeof resolveSamlAttributes>[0]> = {},
-): Parameters<typeof resolveSamlAttributes>[0] {
+type TestProvider = Parameters<typeof resolveSamlAttributes>[0] &
+  Parameters<typeof validateSamlAttributes>[0];
+
+function makeProvider(overrides: Partial<TestProvider> = {}): TestProvider {
   return {
+    allow_missing_name: false,
     uid_attribute: null,
     uin_attribute: null,
     name_attribute: null,
@@ -202,5 +204,59 @@ describe('resolveSamlAttributes', () => {
       assert.isNull(result.uid);
       assert.isNull(result.email);
     });
+  });
+});
+
+describe('validateSamlAttributes', () => {
+  const requiredMappings = {
+    uid_attribute: 'uid',
+    uin_attribute: 'uin',
+    name_attribute: 'displayName',
+  };
+
+  it('rejects a missing name by default', () => {
+    const provider = makeProvider(requiredMappings);
+    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
+
+    assert.throws(
+      () => validateSamlAttributes(provider, resolved),
+      /Missing values for the following SAML attributes: name \(displayName\)/,
+    );
+  });
+
+  it('allows a missing name when configured', () => {
+    const provider = makeProvider({ ...requiredMappings, allow_missing_name: true });
+    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
+
+    assert.deepEqual(validateSamlAttributes(provider, resolved), {
+      uid: 'user@example.com',
+      uin: '123',
+      name: null,
+      email: null,
+    });
+  });
+
+  it('still rejects missing UID and UIN values when names are optional', () => {
+    const provider = makeProvider({ ...requiredMappings, allow_missing_name: true });
+    const resolved = resolveSamlAttributes(provider, {});
+
+    assert.throws(
+      () => validateSamlAttributes(provider, resolved),
+      /Missing values for the following SAML attributes: uid \(uid\), uin \(uin\)/,
+    );
+  });
+
+  it('still requires a name mapping when names are optional', () => {
+    const provider = makeProvider({
+      uid_attribute: 'uid',
+      uin_attribute: 'uin',
+      allow_missing_name: true,
+    });
+    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
+
+    assert.throws(
+      () => validateSamlAttributes(provider, resolved),
+      /Missing one or more SAML attribute mappings/,
+    );
   });
 });

--- a/apps/prairielearn/src/ee/auth/saml/router.test.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.test.ts
@@ -1,12 +1,11 @@
 import { assert, describe, it } from 'vitest';
 
-import { resolveSamlAttributes, validateSamlAttributes } from './router.js';
+import { resolveSamlAttributes } from './router.js';
 
 function makeProvider(
-  overrides: Partial<Parameters<typeof validateSamlAttributes>[0]> = {},
-): Parameters<typeof validateSamlAttributes>[0] {
+  overrides: Partial<Parameters<typeof resolveSamlAttributes>[0]> = {},
+): Parameters<typeof resolveSamlAttributes>[0] {
   return {
-    allow_missing_name: false,
     uid_attribute: null,
     uin_attribute: null,
     name_attribute: null,
@@ -203,59 +202,5 @@ describe('resolveSamlAttributes', () => {
       assert.isNull(result.uid);
       assert.isNull(result.email);
     });
-  });
-});
-
-describe('validateSamlAttributes', () => {
-  const requiredMappings = {
-    uid_attribute: 'uid',
-    uin_attribute: 'uin',
-    name_attribute: 'displayName',
-  };
-
-  it('rejects a missing name by default', () => {
-    const provider = makeProvider(requiredMappings);
-    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
-
-    assert.throws(
-      () => validateSamlAttributes(provider, resolved),
-      /Missing values for the following SAML attributes: name \(displayName\)/,
-    );
-  });
-
-  it('allows a missing name when configured', () => {
-    const provider = makeProvider({ ...requiredMappings, allow_missing_name: true });
-    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
-
-    assert.deepEqual(validateSamlAttributes(provider, resolved), {
-      uid: 'user@example.com',
-      uin: '123',
-      name: null,
-      email: null,
-    });
-  });
-
-  it('still rejects missing UID and UIN values when names are optional', () => {
-    const provider = makeProvider({ ...requiredMappings, allow_missing_name: true });
-    const resolved = resolveSamlAttributes(provider, {});
-
-    assert.throws(
-      () => validateSamlAttributes(provider, resolved),
-      /Missing values for the following SAML attributes: uid \(uid\), uin \(uin\)/,
-    );
-  });
-
-  it('still requires a name mapping when names are optional', () => {
-    const provider = makeProvider({
-      uid_attribute: 'uid',
-      uin_attribute: 'uin',
-      allow_missing_name: true,
-    });
-    const resolved = resolveSamlAttributes(provider, { uid: 'user@example.com', uin: '123' });
-
-    assert.throws(
-      () => validateSamlAttributes(provider, resolved),
-      /Missing one or more SAML attribute mappings/,
-    );
   });
 });

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -56,6 +56,46 @@ export function resolveSamlAttributes(
   return { uid, uin, name, givenName, familyName, email, hasNameMapping };
 }
 
+export function validateSamlAttributes(
+  provider: Pick<
+    SamlProvider,
+    | 'allow_missing_name'
+    | 'uid_attribute'
+    | 'uin_attribute'
+    | 'name_attribute'
+    | 'given_name_attribute'
+    | 'family_name_attribute'
+    | 'email_attribute'
+  >,
+  resolved: ReturnType<typeof resolveSamlAttributes>,
+): {
+  uid: string;
+  uin: string;
+  name: string | null;
+  email: string | null;
+} {
+  if (!provider.uid_attribute || !provider.uin_attribute || !resolved.hasNameMapping) {
+    throw new Error('Missing one or more SAML attribute mappings');
+  }
+
+  const { uid, uin, name, email } = resolved;
+  if (!uid || !uin || (!name && !provider.allow_missing_name)) {
+    const nameAttributeDescription =
+      provider.name_attribute ||
+      `${provider.given_name_attribute} + ${provider.family_name_attribute}`;
+    const missingAttributes = [
+      ...(!uid ? [`uid (${provider.uid_attribute})`] : []),
+      ...(!uin ? [`uin (${provider.uin_attribute})`] : []),
+      ...(!name && !provider.allow_missing_name ? [`name (${nameAttributeDescription})`] : []),
+    ];
+    throw new Error(
+      `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
+    );
+  }
+
+  return { uid, uin, name, email };
+}
+
 const router = Router({ mergeParams: true });
 
 router.get('/login', (req, res, next) => {
@@ -137,33 +177,9 @@ router.post(
       return;
     }
 
-    // Only perform validation if we aren't rendering the above test page.
-    //
-    // We cannot safely require emails for users. For some categories of users,
-    // such as FERPA-suppressed students, an IdP may not pass an email address.
-    // So even if an email attribute is configured and we get it for the vast
-    // majority of users, there may be some for which it is not present.
-    if (
-      !institutionSamlProvider.uid_attribute ||
-      !institutionSamlProvider.uin_attribute ||
-      !resolved.hasNameMapping
-    ) {
-      throw new Error('Missing one or more SAML attribute mappings');
-    }
-    const { uid, uin, name, email } = resolved;
-    if (!uid || !uin || !name) {
-      const nameAttributeDescription =
-        institutionSamlProvider.name_attribute ||
-        `${institutionSamlProvider.given_name_attribute} + ${institutionSamlProvider.family_name_attribute}`;
-      const missingAttributes = [
-        ...(!uid ? [`uid (${institutionSamlProvider.uid_attribute})`] : []),
-        ...(!uin ? [`uin (${institutionSamlProvider.uin_attribute})`] : []),
-        ...(!name ? [`name (${nameAttributeDescription})`] : []),
-      ];
-      throw new Error(
-        `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
-      );
-    }
+    // Only perform validation if we aren't rendering the above test page. Email is always optional,
+    // and institutions can opt in to allowing missing names. UID and UIN remain required.
+    const { uid, uin, name, email } = validateSamlAttributes(institutionSamlProvider, resolved);
 
     const authnParams = {
       uid,

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -56,46 +56,6 @@ export function resolveSamlAttributes(
   return { uid, uin, name, givenName, familyName, email, hasNameMapping };
 }
 
-export function validateSamlAttributes(
-  provider: Pick<
-    SamlProvider,
-    | 'allow_missing_name'
-    | 'uid_attribute'
-    | 'uin_attribute'
-    | 'name_attribute'
-    | 'given_name_attribute'
-    | 'family_name_attribute'
-    | 'email_attribute'
-  >,
-  resolved: ReturnType<typeof resolveSamlAttributes>,
-): {
-  uid: string;
-  uin: string;
-  name: string | null;
-  email: string | null;
-} {
-  if (!provider.uid_attribute || !provider.uin_attribute || !resolved.hasNameMapping) {
-    throw new Error('Missing one or more SAML attribute mappings');
-  }
-
-  const { uid, uin, name, email } = resolved;
-  if (!uid || !uin || (!name && !provider.allow_missing_name)) {
-    const nameAttributeDescription =
-      provider.name_attribute ||
-      `${provider.given_name_attribute} + ${provider.family_name_attribute}`;
-    const missingAttributes = [
-      ...(!uid ? [`uid (${provider.uid_attribute})`] : []),
-      ...(!uin ? [`uin (${provider.uin_attribute})`] : []),
-      ...(!name && !provider.allow_missing_name ? [`name (${nameAttributeDescription})`] : []),
-    ];
-    throw new Error(
-      `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
-    );
-  }
-
-  return { uid, uin, name, email };
-}
-
 const router = Router({ mergeParams: true });
 
 router.get('/login', (req, res, next) => {
@@ -177,9 +137,36 @@ router.post(
       return;
     }
 
-    // Only perform validation if we aren't rendering the above test page. Email is always optional,
-    // and institutions can opt in to allowing missing names. UID and UIN remain required.
-    const { uid, uin, name, email } = validateSamlAttributes(institutionSamlProvider, resolved);
+    // Only perform validation if we aren't rendering the above test page.
+    //
+    // We cannot safely require emails for users. For some categories of users,
+    // such as FERPA-suppressed students, an IdP may not pass an email address.
+    // So even if an email attribute is configured and we get it for the vast
+    // majority of users, there may be some for which it is not present.
+    // Institutions can also explicitly allow users with missing names.
+    if (
+      !institutionSamlProvider.uid_attribute ||
+      !institutionSamlProvider.uin_attribute ||
+      !resolved.hasNameMapping
+    ) {
+      throw new Error('Missing one or more SAML attribute mappings');
+    }
+    const { uid, uin, name, email } = resolved;
+    if (!uid || !uin || (!name && !institutionSamlProvider.allow_missing_name)) {
+      const nameAttributeDescription =
+        institutionSamlProvider.name_attribute ||
+        `${institutionSamlProvider.given_name_attribute} + ${institutionSamlProvider.family_name_attribute}`;
+      const missingAttributes = [
+        ...(!uid ? [`uid (${institutionSamlProvider.uid_attribute})`] : []),
+        ...(!uin ? [`uin (${institutionSamlProvider.uin_attribute})`] : []),
+        ...(!name && !institutionSamlProvider.allow_missing_name
+          ? [`name (${nameAttributeDescription})`]
+          : []),
+      ];
+      throw new Error(
+        `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
+      );
+    }
 
     const authnParams = {
       uid,

--- a/apps/prairielearn/src/ee/auth/saml/router.ts
+++ b/apps/prairielearn/src/ee/auth/saml/router.ts
@@ -56,6 +56,50 @@ export function resolveSamlAttributes(
   return { uid, uin, name, givenName, familyName, email, hasNameMapping };
 }
 
+export function validateSamlAttributes(
+  provider: Pick<
+    SamlProvider,
+    | 'allow_missing_name'
+    | 'uid_attribute'
+    | 'uin_attribute'
+    | 'name_attribute'
+    | 'given_name_attribute'
+    | 'family_name_attribute'
+  >,
+  resolved: ReturnType<typeof resolveSamlAttributes>,
+): {
+  uid: string;
+  uin: string;
+  name: string | null;
+  email: string | null;
+} {
+  if (!provider.uid_attribute || !provider.uin_attribute || !resolved.hasNameMapping) {
+    throw new Error('Missing one or more SAML attribute mappings');
+  }
+
+  const { uid, uin, name, email } = resolved;
+
+  // Email is intentionally optional because some IdPs omit it for some users even when an email
+  // attribute is configured.
+  if (!uid || !uin || (!name && !provider.allow_missing_name)) {
+    const nameAttributeDescription =
+      provider.name_attribute ||
+      `${provider.given_name_attribute} + ${provider.family_name_attribute}`;
+
+    const missingAttributes = [
+      ...(!uid ? [`uid (${provider.uid_attribute})`] : []),
+      ...(!uin ? [`uin (${provider.uin_attribute})`] : []),
+      ...(!name && !provider.allow_missing_name ? [`name (${nameAttributeDescription})`] : []),
+    ];
+
+    throw new Error(
+      `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
+    );
+  }
+
+  return { uid, uin, name, email };
+}
+
 const router = Router({ mergeParams: true });
 
 router.get('/login', (req, res, next) => {
@@ -138,35 +182,7 @@ router.post(
     }
 
     // Only perform validation if we aren't rendering the above test page.
-    //
-    // We cannot safely require emails for users. For some categories of users,
-    // such as FERPA-suppressed students, an IdP may not pass an email address.
-    // So even if an email attribute is configured and we get it for the vast
-    // majority of users, there may be some for which it is not present.
-    // Institutions can also explicitly allow users with missing names.
-    if (
-      !institutionSamlProvider.uid_attribute ||
-      !institutionSamlProvider.uin_attribute ||
-      !resolved.hasNameMapping
-    ) {
-      throw new Error('Missing one or more SAML attribute mappings');
-    }
-    const { uid, uin, name, email } = resolved;
-    if (!uid || !uin || (!name && !institutionSamlProvider.allow_missing_name)) {
-      const nameAttributeDescription =
-        institutionSamlProvider.name_attribute ||
-        `${institutionSamlProvider.given_name_attribute} + ${institutionSamlProvider.family_name_attribute}`;
-      const missingAttributes = [
-        ...(!uid ? [`uid (${institutionSamlProvider.uid_attribute})`] : []),
-        ...(!uin ? [`uin (${institutionSamlProvider.uin_attribute})`] : []),
-        ...(!name && !institutionSamlProvider.allow_missing_name
-          ? [`name (${nameAttributeDescription})`]
-          : []),
-      ];
-      throw new Error(
-        `Missing values for the following SAML attributes: ${missingAttributes.join(', ')}`,
-      );
-    }
+    const { uid, uin, name, email } = validateSamlAttributes(institutionSamlProvider, resolved);
 
     const authnParams = {
       uid,

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.html.ts
@@ -329,6 +329,26 @@ ${samlProvider?.certificate ?? '-----BEGIN CERTIFICATE-----\n-----END CERTIFICAT
           </small>
         </div>
 
+        <div class="mb-3 form-check">
+          <input
+            type="checkbox"
+            class="form-check-input"
+            id="allow_missing_name"
+            name="allow_missing_name"
+            value="1"
+            ${samlProvider?.allow_missing_name ? 'checked' : ''}
+            aria-describedby="allowMissingNameHelp"
+          />
+          <label class="form-check-label" for="allow_missing_name">
+            Allow login without a name
+          </label>
+          <div id="allowMissingNameHelp" class="small text-muted">
+            Allow users to log in when the configured name attributes are missing from their SAML
+            response. Existing names will be preserved; users without a stored name will be shown
+            using their UID until a name becomes available.
+          </div>
+        </div>
+
         <div class="mb-3">
           <label class="form-label" for="uid_attribute">UID attribute</label>
           <input

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.sql
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.sql
@@ -23,6 +23,7 @@ WITH
         name_attribute,
         given_name_attribute,
         family_name_attribute,
+        allow_missing_name,
         email_attribute,
         public_key,
         private_key
@@ -41,6 +42,7 @@ WITH
         $name_attribute,
         $given_name_attribute,
         $family_name_attribute,
+        $allow_missing_name,
         $email_attribute,
         COALESCE($public_key, ''),
         COALESCE($private_key, '')
@@ -58,6 +60,7 @@ WITH
       name_attribute = EXCLUDED.name_attribute,
       given_name_attribute = EXCLUDED.given_name_attribute,
       family_name_attribute = EXCLUDED.family_name_attribute,
+      allow_missing_name = EXCLUDED.allow_missing_name,
       email_attribute = EXCLUDED.email_attribute,
       public_key = COALESCE($public_key, saml_providers.public_key),
       private_key = COALESCE($private_key, saml_providers.private_key)

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 
 import { HttpStatusError } from '@prairielearn/error';
 import { execute, loadSqlEquiv, runInTransactionAsync } from '@prairielearn/postgres';
-import { IdSchema, parseRequest, parseRequestParams } from '@prairielearn/zod';
 
 import {
   lockInstitutionForIdentityConfiguration,
@@ -34,36 +33,6 @@ import {
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });
 
-const ParamsSchema = z.object({ institution_id: IdSchema });
-
-const PostRequestSchemas = {
-  params: ParamsSchema,
-  body: z.discriminatedUnion('__action', [
-    z.object({
-      __action: z.literal('save'),
-      sso_login_url: z.string(),
-      issuer: z.string().optional(),
-      certificate: z.string(),
-      validate_audience: z.literal('1').optional(),
-      want_assertions_signed: z.literal('1').optional(),
-      want_authn_response_signed: z.literal('1').optional(),
-      uid_attribute: z.string(),
-      uin_attribute: z.string().optional(),
-      name_attribute: z.string(),
-      given_name_attribute: z.string(),
-      family_name_attribute: z.string(),
-      allow_missing_name: z.literal('1').optional(),
-      email_attribute: z.string(),
-    }),
-    z.object({ __action: z.literal('delete') }),
-    z.object({
-      __action: z.literal('decode_assertion'),
-      strict_mode: z.literal('1').optional(),
-      encoded_assertion: z.string(),
-    }),
-  ]),
-};
-
 function createCertificate(
   options: pem.CertificateCreationOptions,
 ): Promise<pem.CertificateCreationResult> {
@@ -78,13 +47,14 @@ function createCertificate(
 router.get(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const { institution_id } = parseRequestParams(req, ParamsSchema);
-    const institution = await getInstitution(institution_id);
-    const samlProvider = await getInstitutionSamlProvider(institution_id);
-    const institutionAuthenticationProviders =
-      await getInstitutionAuthenticationProviders(institution_id);
-    const lti13InstancesWithRosterSyncAllowed =
-      await selectLti13InstancesWithRosterSyncAllowed(institution_id);
+    const institution = await getInstitution(req.params.institution_id);
+    const samlProvider = await getInstitutionSamlProvider(req.params.institution_id);
+    const institutionAuthenticationProviders = await getInstitutionAuthenticationProviders(
+      req.params.institution_id,
+    );
+    const lti13InstancesWithRosterSyncAllowed = await selectLti13InstancesWithRosterSyncAllowed(
+      req.params.institution_id,
+    );
 
     res.send(
       AdministratorInstitutionSaml({
@@ -102,136 +72,129 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const { params, body } = parseRequest(req, PostRequestSchemas);
+    if (req.body.__action === 'save') {
+      await runInTransactionAsync(async () => {
+        await lockInstitutionForIdentityConfiguration(req.params.institution_id);
 
-    switch (body.__action) {
-      case 'save': {
-        await runInTransactionAsync(async () => {
-          await lockInstitutionForIdentityConfiguration(params.institution_id);
+        // Check if there's an existing SAML provider configured. We'll use
+        // that to determine if we need to create a new keypair. That is, we'll
+        // only create a new keypair if there's no existing provider.
+        const samlProvider = await getInstitutionSamlProvider(req.params.institution_id);
+        const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
+          req.params.institution_id,
+        );
+        // Disabled inputs are omitted from form submissions, so preserve locked values.
+        const issuer = z.string().parse(req.body.issuer ?? samlProvider?.issuer);
+        const uinAttribute = normalizeUinAttribute(
+          req.body.uin_attribute ?? samlProvider?.uin_attribute,
+        );
 
-          // Check if there's an existing SAML provider configured. We'll use
-          // that to determine if we need to create a new keypair. That is, we'll
-          // only create a new keypair if there's no existing provider.
-          const samlProvider = await getInstitutionSamlProvider(params.institution_id);
-          const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
-            params.institution_id,
+        if (
+          identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed &&
+          (uinAttribute !== normalizeUinAttribute(samlProvider?.uin_attribute) ||
+            issuer !== samlProvider?.issuer)
+        ) {
+          throw new HttpStatusError(
+            400,
+            'Disallow roster syncing for all affected LTI 1.3 instances before changing the SAML issuer or UIN attribute',
           );
-          // Disabled inputs are omitted from form submissions, so preserve locked values.
-          const issuer = z.string().parse(body.issuer ?? samlProvider?.issuer);
-          const uinAttribute = normalizeUinAttribute(
-            body.uin_attribute ?? samlProvider?.uin_attribute,
-          );
-
-          if (
-            identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed &&
-            (uinAttribute !== normalizeUinAttribute(samlProvider?.uin_attribute) ||
-              issuer !== samlProvider?.issuer)
-          ) {
-            throw new HttpStatusError(
-              400,
-              'Disallow roster syncing for all affected LTI 1.3 instances before changing the SAML issuer or UIN attribute',
-            );
-          }
-
-          let publicKey, privateKey;
-          if (!samlProvider) {
-            // No existing provider; create a new keypair with OpenSSL.
-            const keys = await createCertificate({
-              selfSigned: true,
-              // Make certificate valid for 30 years.
-              // TODO: persist expiry time in database so that in the future,
-              // we can automatically warn users about expiring certificates.
-              days: 265 * 30,
-              // We use the host header as a shortcut to avoid the need to know
-              // a given installation's domain name.
-              commonName: req.headers.host,
-            });
-            publicKey = keys.certificate;
-            privateKey = keys.serviceKey;
-          }
-
-          await execute(sql.insert_institution_saml_provider, {
-            institution_id: params.institution_id,
-            sso_login_url: body.sso_login_url,
-            issuer,
-            certificate: body.certificate,
-            validate_audience: body.validate_audience === '1',
-            want_assertions_signed: body.want_assertions_signed === '1',
-            want_authn_response_signed: body.want_authn_response_signed === '1',
-            // Normalize empty strings to `null`.
-            uin_attribute: uinAttribute,
-            uid_attribute: body.uid_attribute || null,
-            name_attribute: body.name_attribute || null,
-            given_name_attribute: body.given_name_attribute || null,
-            family_name_attribute: body.family_name_attribute || null,
-            allow_missing_name: body.allow_missing_name === '1',
-            email_attribute: body.email_attribute || null,
-            // The upsert query is configured to ignore these values if they're null.
-            public_key: publicKey,
-            private_key: privateKey,
-            // For audit logs
-            authn_user_id: res.locals.authn_user.id,
-          });
-        });
-        res.redirect(req.originalUrl);
-        return;
-      }
-      case 'delete': {
-        await runInTransactionAsync(async () => {
-          await lockInstitutionForIdentityConfiguration(params.institution_id);
-          const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
-            params.institution_id,
-          );
-          if (identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed) {
-            throw new HttpStatusError(
-              400,
-              'Disallow roster syncing for all affected LTI 1.3 instances before deleting the SAML configuration',
-            );
-          }
-
-          await execute(sql.delete_institution_saml_provider, {
-            institution_id: params.institution_id,
-            // For audit logs
-            authn_user_id: res.locals.authn_user.id,
-          });
-        });
-        res.redirect(req.originalUrl);
-        return;
-      }
-      case 'decode_assertion': {
-        const samlConfig = await getSamlOptions({
-          institution_id: params.institution_id,
-          host: req.headers.host,
-          strictMode: body.strict_mode === '1',
-        });
-        const saml = new SAML({
-          ...samlConfig,
-          // Disable clock skew checking; we might be testing with a very old SAML response.
-          acceptedClockSkewMs: -1,
-        });
-
-        let xml: string;
-        try {
-          // @ts-expect-error https://github.com/chrisbottin/xml-formatter/issues/72
-          xml = formatXml(Buffer.from(body.encoded_assertion, 'base64').toString('utf8'));
-        } catch (err: any) {
-          res.send(DecodedAssertion({ xml: err.message, profile: '' }));
-          return;
         }
 
-        const profile = await saml
-          .validatePostResponseAsync({
-            SAMLResponse: body.encoded_assertion,
-          })
-          .catch((err) => {
-            return {
-              error: err.message,
-            };
+        let publicKey, privateKey;
+        if (!samlProvider) {
+          // No existing provider; create a new keypair with OpenSSL.
+          const keys = await createCertificate({
+            selfSigned: true,
+            // Make certificate valid for 30 years.
+            // TODO: persist expiry time in database so that in the future,
+            // we can automatically warn users about expiring certificates.
+            days: 265 * 30,
+            // We use the host header as a shortcut to avoid the need to know
+            // a given installation's domain name.
+            commonName: req.headers.host,
           });
+          publicKey = keys.certificate;
+          privateKey = keys.serviceKey;
+        }
 
-        res.send(DecodedAssertion({ xml, profile: JSON.stringify(profile, null, 2) }));
+        await execute(sql.insert_institution_saml_provider, {
+          institution_id: req.params.institution_id,
+          sso_login_url: req.body.sso_login_url,
+          issuer,
+          certificate: req.body.certificate,
+          validate_audience: req.body.validate_audience === '1',
+          want_assertions_signed: req.body.want_assertions_signed === '1',
+          want_authn_response_signed: req.body.want_authn_response_signed === '1',
+          // Normalize empty strings to `null`.
+          uin_attribute: uinAttribute,
+          uid_attribute: req.body.uid_attribute || null,
+          name_attribute: req.body.name_attribute || null,
+          given_name_attribute: req.body.given_name_attribute || null,
+          family_name_attribute: req.body.family_name_attribute || null,
+          allow_missing_name: req.body.allow_missing_name === '1',
+          email_attribute: req.body.email_attribute || null,
+          // The upsert query is configured to ignore these values if they're null.
+          public_key: publicKey,
+          private_key: privateKey,
+          // For audit logs
+          authn_user_id: res.locals.authn_user.id,
+        });
+      });
+      res.redirect(req.originalUrl);
+    } else if (req.body.__action === 'delete') {
+      await runInTransactionAsync(async () => {
+        await lockInstitutionForIdentityConfiguration(req.params.institution_id);
+        const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
+          req.params.institution_id,
+        );
+        if (identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed) {
+          throw new HttpStatusError(
+            400,
+            'Disallow roster syncing for all affected LTI 1.3 instances before deleting the SAML configuration',
+          );
+        }
+
+        await execute(sql.delete_institution_saml_provider, {
+          institution_id: req.params.institution_id,
+          // For audit logs
+          authn_user_id: res.locals.authn_user.id,
+        });
+      });
+      res.redirect(req.originalUrl);
+    } else if (req.body.__action === 'decode_assertion') {
+      const samlConfig = await getSamlOptions({
+        institution_id: req.params.institution_id,
+        host: req.headers.host,
+        strictMode: req.body.strict_mode === '1',
+      });
+      const saml = new SAML({
+        ...samlConfig,
+        // Disable clock skew checking; we might be testing with a very old SAML response.
+        acceptedClockSkewMs: -1,
+      });
+
+      let xml: string;
+      try {
+        // @ts-expect-error https://github.com/chrisbottin/xml-formatter/issues/72
+        xml = formatXml(Buffer.from(req.body.encoded_assertion, 'base64').toString('utf8'));
+      } catch (err: any) {
+        res.send(DecodedAssertion({ xml: err.message, profile: '' }));
         return;
       }
+
+      const profile = await saml
+        .validatePostResponseAsync({
+          SAMLResponse: req.body.encoded_assertion,
+        })
+        .catch((err) => {
+          return {
+            error: err.message,
+          };
+        });
+
+      res.send(DecodedAssertion({ xml, profile: JSON.stringify(profile, null, 2) }));
+    } else {
+      throw new HttpStatusError(400, `unknown __action: ${req.body.__action}`);
     }
   }),
 );

--- a/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
+++ b/apps/prairielearn/src/ee/pages/administratorInstitutionSaml/administratorInstitutionSaml.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 
 import { HttpStatusError } from '@prairielearn/error';
 import { execute, loadSqlEquiv, runInTransactionAsync } from '@prairielearn/postgres';
+import { IdSchema, parseRequest, parseRequestParams } from '@prairielearn/zod';
 
 import {
   lockInstitutionForIdentityConfiguration,
@@ -33,6 +34,36 @@ import {
 const sql = loadSqlEquiv(import.meta.url);
 const router = Router({ mergeParams: true });
 
+const ParamsSchema = z.object({ institution_id: IdSchema });
+
+const PostRequestSchemas = {
+  params: ParamsSchema,
+  body: z.discriminatedUnion('__action', [
+    z.object({
+      __action: z.literal('save'),
+      sso_login_url: z.string(),
+      issuer: z.string().optional(),
+      certificate: z.string(),
+      validate_audience: z.literal('1').optional(),
+      want_assertions_signed: z.literal('1').optional(),
+      want_authn_response_signed: z.literal('1').optional(),
+      uid_attribute: z.string(),
+      uin_attribute: z.string().optional(),
+      name_attribute: z.string(),
+      given_name_attribute: z.string(),
+      family_name_attribute: z.string(),
+      allow_missing_name: z.literal('1').optional(),
+      email_attribute: z.string(),
+    }),
+    z.object({ __action: z.literal('delete') }),
+    z.object({
+      __action: z.literal('decode_assertion'),
+      strict_mode: z.literal('1').optional(),
+      encoded_assertion: z.string(),
+    }),
+  ]),
+};
+
 function createCertificate(
   options: pem.CertificateCreationOptions,
 ): Promise<pem.CertificateCreationResult> {
@@ -47,14 +78,13 @@ function createCertificate(
 router.get(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    const institution = await getInstitution(req.params.institution_id);
-    const samlProvider = await getInstitutionSamlProvider(req.params.institution_id);
-    const institutionAuthenticationProviders = await getInstitutionAuthenticationProviders(
-      req.params.institution_id,
-    );
-    const lti13InstancesWithRosterSyncAllowed = await selectLti13InstancesWithRosterSyncAllowed(
-      req.params.institution_id,
-    );
+    const { institution_id } = parseRequestParams(req, ParamsSchema);
+    const institution = await getInstitution(institution_id);
+    const samlProvider = await getInstitutionSamlProvider(institution_id);
+    const institutionAuthenticationProviders =
+      await getInstitutionAuthenticationProviders(institution_id);
+    const lti13InstancesWithRosterSyncAllowed =
+      await selectLti13InstancesWithRosterSyncAllowed(institution_id);
 
     res.send(
       AdministratorInstitutionSaml({
@@ -72,128 +102,136 @@ router.get(
 router.post(
   '/',
   typedAsyncHandler<'plain'>(async (req, res) => {
-    if (req.body.__action === 'save') {
-      await runInTransactionAsync(async () => {
-        await lockInstitutionForIdentityConfiguration(req.params.institution_id);
+    const { params, body } = parseRequest(req, PostRequestSchemas);
 
-        // Check if there's an existing SAML provider configured. We'll use
-        // that to determine if we need to create a new keypair. That is, we'll
-        // only create a new keypair if there's no existing provider.
-        const samlProvider = await getInstitutionSamlProvider(req.params.institution_id);
-        const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
-          req.params.institution_id,
-        );
-        // Disabled inputs are omitted from form submissions, so preserve locked values.
-        const issuer = z.string().parse(req.body.issuer ?? samlProvider?.issuer);
-        const uinAttribute = normalizeUinAttribute(
-          req.body.uin_attribute ?? samlProvider?.uin_attribute,
-        );
+    switch (body.__action) {
+      case 'save': {
+        await runInTransactionAsync(async () => {
+          await lockInstitutionForIdentityConfiguration(params.institution_id);
 
-        if (
-          identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed &&
-          (uinAttribute !== normalizeUinAttribute(samlProvider?.uin_attribute) ||
-            issuer !== samlProvider?.issuer)
-        ) {
-          throw new HttpStatusError(
-            400,
-            'Disallow roster syncing for all affected LTI 1.3 instances before changing the SAML issuer or UIN attribute',
+          // Check if there's an existing SAML provider configured. We'll use
+          // that to determine if we need to create a new keypair. That is, we'll
+          // only create a new keypair if there's no existing provider.
+          const samlProvider = await getInstitutionSamlProvider(params.institution_id);
+          const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
+            params.institution_id,
           );
-        }
+          // Disabled inputs are omitted from form submissions, so preserve locked values.
+          const issuer = z.string().parse(body.issuer ?? samlProvider?.issuer);
+          const uinAttribute = normalizeUinAttribute(
+            body.uin_attribute ?? samlProvider?.uin_attribute,
+          );
 
-        let publicKey, privateKey;
-        if (!samlProvider) {
-          // No existing provider; create a new keypair with OpenSSL.
-          const keys = await createCertificate({
-            selfSigned: true,
-            // Make certificate valid for 30 years.
-            // TODO: persist expiry time in database so that in the future,
-            // we can automatically warn users about expiring certificates.
-            days: 265 * 30,
-            // We use the host header as a shortcut to avoid the need to know
-            // a given installation's domain name.
-            commonName: req.headers.host,
+          if (
+            identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed &&
+            (uinAttribute !== normalizeUinAttribute(samlProvider?.uin_attribute) ||
+              issuer !== samlProvider?.issuer)
+          ) {
+            throw new HttpStatusError(
+              400,
+              'Disallow roster syncing for all affected LTI 1.3 instances before changing the SAML issuer or UIN attribute',
+            );
+          }
+
+          let publicKey, privateKey;
+          if (!samlProvider) {
+            // No existing provider; create a new keypair with OpenSSL.
+            const keys = await createCertificate({
+              selfSigned: true,
+              // Make certificate valid for 30 years.
+              // TODO: persist expiry time in database so that in the future,
+              // we can automatically warn users about expiring certificates.
+              days: 265 * 30,
+              // We use the host header as a shortcut to avoid the need to know
+              // a given installation's domain name.
+              commonName: req.headers.host,
+            });
+            publicKey = keys.certificate;
+            privateKey = keys.serviceKey;
+          }
+
+          await execute(sql.insert_institution_saml_provider, {
+            institution_id: params.institution_id,
+            sso_login_url: body.sso_login_url,
+            issuer,
+            certificate: body.certificate,
+            validate_audience: body.validate_audience === '1',
+            want_assertions_signed: body.want_assertions_signed === '1',
+            want_authn_response_signed: body.want_authn_response_signed === '1',
+            // Normalize empty strings to `null`.
+            uin_attribute: uinAttribute,
+            uid_attribute: body.uid_attribute || null,
+            name_attribute: body.name_attribute || null,
+            given_name_attribute: body.given_name_attribute || null,
+            family_name_attribute: body.family_name_attribute || null,
+            allow_missing_name: body.allow_missing_name === '1',
+            email_attribute: body.email_attribute || null,
+            // The upsert query is configured to ignore these values if they're null.
+            public_key: publicKey,
+            private_key: privateKey,
+            // For audit logs
+            authn_user_id: res.locals.authn_user.id,
           });
-          publicKey = keys.certificate;
-          privateKey = keys.serviceKey;
-        }
-
-        await execute(sql.insert_institution_saml_provider, {
-          institution_id: req.params.institution_id,
-          sso_login_url: req.body.sso_login_url,
-          issuer,
-          certificate: req.body.certificate,
-          validate_audience: req.body.validate_audience === '1',
-          want_assertions_signed: req.body.want_assertions_signed === '1',
-          want_authn_response_signed: req.body.want_authn_response_signed === '1',
-          // Normalize empty strings to `null`.
-          uin_attribute: uinAttribute,
-          uid_attribute: req.body.uid_attribute || null,
-          name_attribute: req.body.name_attribute || null,
-          given_name_attribute: req.body.given_name_attribute || null,
-          family_name_attribute: req.body.family_name_attribute || null,
-          email_attribute: req.body.email_attribute || null,
-          // The upsert query is configured to ignore these values if they're null.
-          public_key: publicKey,
-          private_key: privateKey,
-          // For audit logs
-          authn_user_id: res.locals.authn_user.id,
         });
-      });
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'delete') {
-      await runInTransactionAsync(async () => {
-        await lockInstitutionForIdentityConfiguration(req.params.institution_id);
-        const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
-          req.params.institution_id,
-        );
-        if (identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed) {
-          throw new HttpStatusError(
-            400,
-            'Disallow roster syncing for all affected LTI 1.3 instances before deleting the SAML configuration',
-          );
-        }
-
-        await execute(sql.delete_institution_saml_provider, {
-          institution_id: req.params.institution_id,
-          // For audit logs
-          authn_user_id: res.locals.authn_user.id,
-        });
-      });
-      res.redirect(req.originalUrl);
-    } else if (req.body.__action === 'decode_assertion') {
-      const samlConfig = await getSamlOptions({
-        institution_id: req.params.institution_id,
-        host: req.headers.host,
-        strictMode: req.body.strict_mode === '1',
-      });
-      const saml = new SAML({
-        ...samlConfig,
-        // Disable clock skew checking; we might be testing with a very old SAML response.
-        acceptedClockSkewMs: -1,
-      });
-
-      let xml: string;
-      try {
-        // @ts-expect-error https://github.com/chrisbottin/xml-formatter/issues/72
-        xml = formatXml(Buffer.from(req.body.encoded_assertion, 'base64').toString('utf8'));
-      } catch (err: any) {
-        res.send(DecodedAssertion({ xml: err.message, profile: '' }));
+        res.redirect(req.originalUrl);
         return;
       }
+      case 'delete': {
+        await runInTransactionAsync(async () => {
+          await lockInstitutionForIdentityConfiguration(params.institution_id);
+          const identityConfigurationStatus = await selectInstitutionIdentityConfigurationStatus(
+            params.institution_id,
+          );
+          if (identityConfigurationStatus.has_lti13_instance_with_roster_sync_allowed) {
+            throw new HttpStatusError(
+              400,
+              'Disallow roster syncing for all affected LTI 1.3 instances before deleting the SAML configuration',
+            );
+          }
 
-      const profile = await saml
-        .validatePostResponseAsync({
-          SAMLResponse: req.body.encoded_assertion,
-        })
-        .catch((err) => {
-          return {
-            error: err.message,
-          };
+          await execute(sql.delete_institution_saml_provider, {
+            institution_id: params.institution_id,
+            // For audit logs
+            authn_user_id: res.locals.authn_user.id,
+          });
+        });
+        res.redirect(req.originalUrl);
+        return;
+      }
+      case 'decode_assertion': {
+        const samlConfig = await getSamlOptions({
+          institution_id: params.institution_id,
+          host: req.headers.host,
+          strictMode: body.strict_mode === '1',
+        });
+        const saml = new SAML({
+          ...samlConfig,
+          // Disable clock skew checking; we might be testing with a very old SAML response.
+          acceptedClockSkewMs: -1,
         });
 
-      res.send(DecodedAssertion({ xml, profile: JSON.stringify(profile, null, 2) }));
-    } else {
-      throw new HttpStatusError(400, `unknown __action: ${req.body.__action}`);
+        let xml: string;
+        try {
+          // @ts-expect-error https://github.com/chrisbottin/xml-formatter/issues/72
+          xml = formatXml(Buffer.from(body.encoded_assertion, 'base64').toString('utf8'));
+        } catch (err: any) {
+          res.send(DecodedAssertion({ xml: err.message, profile: '' }));
+          return;
+        }
+
+        const profile = await saml
+          .validatePostResponseAsync({
+            SAMLResponse: body.encoded_assertion,
+          })
+          .catch((err) => {
+            return {
+              error: err.message,
+            };
+          });
+
+        res.send(DecodedAssertion({ xml, profile: JSON.stringify(profile, null, 2) }));
+        return;
+      }
     }
   }),
 );

--- a/apps/prairielearn/src/lib/db-types.ts
+++ b/apps/prairielearn/src/lib/db-types.ts
@@ -1509,6 +1509,7 @@ export const RubricItemSchema = z.object({
 export type RubricItem = z.infer<typeof RubricItemSchema>;
 
 export const SamlProviderSchema = z.object({
+  allow_missing_name: z.boolean(),
   certificate: z.string(),
   email_attribute: z.string().nullable(),
   family_name_attribute: z.string().nullable(),

--- a/apps/prairielearn/src/migrations/20260902233611_saml_providers__allow_missing_name__add.sql
+++ b/apps/prairielearn/src/migrations/20260902233611_saml_providers__allow_missing_name__add.sql
@@ -1,0 +1,2 @@
+ALTER TABLE saml_providers
+ADD COLUMN allow_missing_name BOOLEAN NOT NULL DEFAULT FALSE;

--- a/apps/prairielearn/src/pages/instructorStudentDetail/components/OverviewCard.tsx
+++ b/apps/prairielearn/src/pages/instructorStudentDetail/components/OverviewCard.tsx
@@ -77,7 +77,7 @@ export function OverviewCard({
       <div className="card-body">
         <div className="d-flex flex-column flex-md-row mb-2 mb-md-0 align-items-md-center justify-content-between">
           <h2 className="d-flex align-items-center">
-            {user?.name ?? enrollment.pending_uid}
+            {user?.name ?? user?.uid ?? enrollment.pending_uid}
             {enrollment.status !== 'joined' && (
               <EnrollmentStatusIcon type="badge" className="ms-2 fs-6" status={enrollment.status} />
             )}

--- a/apps/prairielearn/src/tests/institutionLti13Guardrails.test.ts
+++ b/apps/prairielearn/src/tests/institutionLti13Guardrails.test.ts
@@ -52,6 +52,7 @@ function getSamlSaveBody(page: CheerioResponse): URLSearchParams {
     'validate_audience',
     'want_assertions_signed',
     'want_authn_response_signed',
+    'allow_missing_name',
   ]) {
     if (form.find(`[name=${name}]`).is(':checked')) body.set(name, '1');
   }
@@ -217,10 +218,13 @@ describe('institution LTI 1.3 roster syncing guardrails', { concurrent: false },
 
     const safeSamlChange = getSamlSaveBody(samlPage);
     safeSamlChange.set('certificate', 'replacement certificate');
-    assert.equal(
-      (await fetchCheerio(samlPage.url, { method: 'POST', body: safeSamlChange })).status,
-      200,
-    );
+    safeSamlChange.set('allow_missing_name', '1');
+    const safeSamlResponse = await fetchCheerio(samlPage.url, {
+      method: 'POST',
+      body: safeSamlChange,
+    });
+    assert.equal(safeSamlResponse.status, 200);
+    assert.isTrue(safeSamlResponse.$('input[name=allow_missing_name]').is(':checked'));
 
     const changedIssuer = getSamlSaveBody(await fetchCheerio(samlPage.url));
     changedIssuer.set('issuer', 'https://replacement.example.com/saml');

--- a/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.ts
+++ b/apps/prairielearn/src/tests/sprocs/users_select_or_insert.test.ts
@@ -23,7 +23,7 @@ async function getUserParams(user_id: string | null) {
 }
 
 async function usersSelectOrInsert(
-  user: { uid: string; name: string; uin?: string | null; email?: string | null },
+  user: { uid: string; name: string | null; uin?: string | null; email?: string | null },
   authn_provider_name: string | null = null,
   institution_id: string | null = null,
 ) {
@@ -73,6 +73,14 @@ describe('sproc users_select_or_insert tests', { concurrent: false }, () => {
 
     const fromdb = await getUserParams(user_id);
     assert.deepEqual(user, fromdb);
+  });
+
+  test('user 1 preserves name when login omits it', async () => {
+    const { user_id } = await usersSelectOrInsert({ ...baseUser, name: null });
+    assert.equal(user_id, '1');
+
+    const fromdb = await getUserParams(user_id);
+    assert.deepEqual({ ...baseUser, name: 'J.R. User' }, fromdb);
   });
 
   test('add an institution for host.com', async () => {

--- a/database/tables/saml_providers.pg
+++ b/database/tables/saml_providers.pg
@@ -1,4 +1,5 @@
 columns
+    allow_missing_name: boolean not null default false
     certificate: text not null
     email_attribute: text
     family_name_attribute: text


### PR DESCRIPTION
# Description

Some SAML identity providers intentionally omit name attributes for certain users. PrairieLearn currently rejects those users after successful SAML authentication, even though UID and UIN are sufficient to identify the account and the users table supports a NULL name.

- Add an allow_missing_name option to each SAML provider, defaulting to false.
- When enabled, continue requiring configured name mappings plus nonempty UID and UIN values, but allow the resolved name value to be absent.
- Pass the missing name through as NULL so existing stored names are preserved and a later non-NULL SAML name can populate the record.
- Add an institution-administrator checkbox explaining that users without a stored name are displayed using their UID.
- Fall back to the user's UID in the student detail heading when their name is missing.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Codex produced the majority of the implementation and tests under human direction.

# Testing

- Added focused coverage for strict-by-default name validation, the opt-in behavior, mandatory UID/UIN values, and mandatory name mappings.
- Extended the institution SAML administration integration coverage to save and reload the new option while LTI roster syncing is enabled.
- Added stored-procedure coverage confirming that a NULL incoming name preserves an existing user name.
- Verified the migration and generated database description remain consistent.

