### PR TITLE
Allow QTI import without a course instance

### DIFF
--- a/apps/prairielearn/src/components/QuestionsTable.tsx
+++ b/apps/prairielearn/src/components/QuestionsTable.tsx
@@ -36,7 +36,7 @@ import { rankSearchText } from '../lib/client/search.js';
 import {
   QUESTION_TABLE_FILTER_URL_KEYS,
   getAiQuestionGenerationDraftsUrl,
-  getCourseInstanceBaseUrl,
+  getCourseAdminQtiImportUrl,
 } from '../lib/client/url.js';
 import type { QuestionsError } from '../trpc/course/questions.js';
 
@@ -283,10 +283,13 @@ export function QuestionsTable<TQueryKey extends readonly unknown[]>({
   });
 
   const aiGenerateUrl = getAiQuestionGenerationDraftsUrl({ urlPrefix });
-  const importQuestionsUrl =
-    addQuestionUrl && courseInstances.length > 0
-      ? `${getCourseInstanceBaseUrl(currentCourseInstanceId ?? courseInstances[0].id)}/instructor/instance_admin/qti_import?return_to=questions`
-      : undefined;
+  const importQuestionsUrl = addQuestionUrl
+    ? getCourseAdminQtiImportUrl({
+        courseId,
+        courseInstanceId: currentCourseInstanceId,
+        returnTo: 'questions',
+      })
+    : undefined;
 
   const selectedQuestions = table.getFilteredSelectedRowModel().rows.map((row) => row.original);
   const displayedCount = table.getRowModel().rows.length;

--- a/apps/prairielearn/src/lib/client/url.ts
+++ b/apps/prairielearn/src/lib/client/url.ts
@@ -353,6 +353,13 @@ export function getCourseAdminQuestionsUrl(
   return `${baseUrl}?${searchParams.toString()}`;
 }
 
+export function getCourseAdminQtiImportUrl(
+  parts: CourseAdminUrlParts & { returnTo?: 'questions' | 'assessments' },
+): string {
+  const baseUrl = `${getCourseAdminUrl(parts)}/qti_import`;
+  return parts.returnTo === 'questions' ? `${baseUrl}?return_to=questions` : baseUrl;
+}
+
 export function getQuestionUrl({
   courseInstanceId,
   courseId,

--- a/apps/prairielearn/src/lib/editors.ts
+++ b/apps/prairielearn/src/lib/editors.ts
@@ -2687,20 +2687,23 @@ export interface QtiImportAssessmentData {
 }
 
 export class QtiImportEditor extends Editor {
-  private course_instance: CourseInstance;
+  private course_instance: CourseInstance | null;
   private assessments: QtiImportAssessmentData[];
   private questions: QtiImportQuestionData[];
 
   constructor(
-    params: BaseEditorOptions<{ course_instance: CourseInstance }> & {
+    params: BaseEditorOptions & {
+      course_instance: CourseInstance | null;
       assessments: QtiImportAssessmentData[];
       questions?: QtiImportQuestionData[];
     },
   ) {
-    const { course_instance } = params.locals;
+    const { course_instance } = params;
     super({
       ...params,
-      description: `${course_instance.short_name}: Import QTI content`,
+      description: course_instance
+        ? `${course_instance.short_name}: Import QTI content`
+        : 'Import QTI content',
     });
     this.course_instance = course_instance;
     this.assessments = params.assessments;
@@ -2708,31 +2711,28 @@ export class QtiImportEditor extends Editor {
   }
 
   async write() {
-    assert(this.course_instance.short_name, 'course_instance.short_name is required');
+    const courseInstanceDir = run(() => {
+      if (!this.course_instance) return null;
+      assert(this.course_instance.short_name, 'course_instance.short_name is required');
+      return path.join(this.course.path, 'courseInstances', this.course_instance.short_name);
+    });
 
     // If the course instance is publicly shared, imported assessments and
     // questions must also be marked as shared to avoid a sync error.
-    const ciConfigPath = path.join(
-      this.course.path,
-      'courseInstances',
-      this.course_instance.short_name,
-      'infoCourseInstance.json',
-    );
-    let shareSourcePublicly = false;
-    try {
-      const ciConfig = JSON.parse(await fs.readFile(ciConfigPath, 'utf-8'));
-      shareSourcePublicly = ciConfig.shareSourcePublicly === true;
-    } catch {
-      // Config may not exist yet or may be malformed; default to not sharing.
-    }
+    const shareSourcePublicly = await run(async () => {
+      if (!courseInstanceDir) return false;
+      try {
+        const ciConfig = JSON.parse(
+          await fs.readFile(path.join(courseInstanceDir, 'infoCourseInstance.json'), 'utf-8'),
+        );
+        return ciConfig.shareSourcePublicly === true;
+      } catch {
+        // Config may not exist yet or may be malformed; default to not sharing.
+        return false;
+      }
+    });
 
     const questionsBaseDir = path.join(this.course.path, 'questions');
-    const assessmentsBaseDir = path.join(
-      this.course.path,
-      'courseInstances',
-      this.course_instance.short_name,
-      'assessments',
-    );
 
     // Pre-validate all paths before writing anything to avoid partial state.
     const existingQids = await discoverInfoDirs(questionsBaseDir, 'info.json');
@@ -2791,23 +2791,30 @@ export class QtiImportEditor extends Editor {
       }
     }
 
-    for (const assessment of this.assessments) {
-      const assessmentDir = path.join(assessmentsBaseDir, assessment.directoryName);
-      if (!contains(assessmentsBaseDir, assessmentDir)) {
-        throw new AugmentedError('Invalid assessment folder path', {
-          info: html`
-            <p>The assessment folder path</p>
-            <div class="container">
-              <pre class="bg-dark text-white rounded p-2">${assessmentDir}</pre>
-            </div>
-            <p>must be inside the assessments directory</p>
-            <div class="container">
-              <pre class="bg-dark text-white rounded p-2">${assessmentsBaseDir}</pre>
-            </div>
-          `,
-        });
-      }
-    }
+    const assessmentWrites = run(() => {
+      if (this.assessments.length === 0) return [];
+      // Assessments live under a course instance, so importing any requires one.
+      assert(courseInstanceDir, 'A course instance is required to import assessments');
+      const assessmentsBaseDir = path.join(courseInstanceDir, 'assessments');
+      return this.assessments.map((assessment) => {
+        const assessmentDir = path.join(assessmentsBaseDir, assessment.directoryName);
+        if (!contains(assessmentsBaseDir, assessmentDir)) {
+          throw new AugmentedError('Invalid assessment folder path', {
+            info: html`
+              <p>The assessment folder path</p>
+              <div class="container">
+                <pre class="bg-dark text-white rounded p-2">${assessmentDir}</pre>
+              </div>
+              <p>must be inside the assessments directory</p>
+              <div class="container">
+                <pre class="bg-dark text-white rounded p-2">${assessmentsBaseDir}</pre>
+              </div>
+            `,
+          });
+        }
+        return { assessment, assessmentDir };
+      });
+    });
 
     const pathsToAdd: string[] = [];
 
@@ -2844,9 +2851,7 @@ export class QtiImportEditor extends Editor {
       pathsToAdd.push(qDir);
     }
 
-    for (const assessment of this.assessments) {
-      // Write the assessment (path already validated above).
-      const assessmentDir = path.join(assessmentsBaseDir, assessment.directoryName);
+    for (const { assessment, assessmentDir } of assessmentWrites) {
       const aInfoJson = { ...assessment.infoJson };
       if (shareSourcePublicly) {
         aInfoJson.shareSourcePublicly = true;
@@ -2861,7 +2866,9 @@ export class QtiImportEditor extends Editor {
 
     return {
       pathsToAdd,
-      commitMessage: `${this.course_instance.short_name}: import QTI content`,
+      commitMessage: this.course_instance
+        ? `${this.course_instance.short_name}: import QTI content`
+        : 'import QTI content',
     };
   }
 }

--- a/apps/prairielearn/src/lib/qti-import-drafts.ts
+++ b/apps/prairielearn/src/lib/qti-import-drafts.ts
@@ -10,7 +10,6 @@ const DRAFT_KEY_PREFIX = 'qti-import-drafts/';
 
 const QtiImportDraftDataSchema = z.object({
   courseId: z.string(),
-  courseInstanceId: z.string(),
   userId: z.string(),
   results: z.array(z.unknown()),
 });
@@ -19,7 +18,6 @@ type QtiImportDraftData = z.infer<typeof QtiImportDraftDataSchema>;
 
 interface CreateQtiImportDraftData {
   courseId: string;
-  courseInstanceId: string;
   userId: string;
   results: unknown[];
 }
@@ -43,22 +41,16 @@ export async function createQtiImportDraft(data: CreateQtiImportDraftData): Prom
 export async function readQtiImportDraft({
   draftId,
   courseId,
-  courseInstanceId,
   userId,
 }: {
   draftId: string;
   courseId: string;
-  courseInstanceId: string;
   userId: string;
 }): Promise<QtiImportDraftData> {
   const buffer = await getFromS3(getFileStoreS3Bucket(), draftKey(draftId), true);
   const data = QtiImportDraftDataSchema.parse(JSON.parse(buffer.toString('utf8')));
-  if (
-    data.courseId !== courseId ||
-    data.courseInstanceId !== courseInstanceId ||
-    data.userId !== userId
-  ) {
-    throw new Error('QTI import draft does not belong to this course instance or user');
+  if (data.courseId !== courseId || data.userId !== userId) {
+    throw new Error('QTI import draft does not belong to this course or user');
   }
   return data;
 }

--- a/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.tsx
+++ b/apps/prairielearn/src/pages/instructorAssessments/instructorAssessments.html.tsx
@@ -14,6 +14,7 @@ import { ScorebarHtml } from '../../components/Scorebar.js';
 import { AssessmentShortNameDescription } from '../../components/ShortNameDescriptions.js';
 import { SyncProblemButtonHtml } from '../../components/SyncProblemButton.js';
 import { compiledScriptTag } from '../../lib/assets.js';
+import { getCourseAdminQtiImportUrl } from '../../lib/client/url.js';
 import { type AssessmentModule, type AssessmentSet } from '../../lib/db-types.js';
 import type { ResLocalsForPage } from '../../lib/res-locals.js';
 import { SHORT_NAME_PATTERN } from '../../lib/short-name.js';
@@ -74,7 +75,7 @@ export function InstructorAssessments({
             ? html`
                 <div class="d-flex gap-2 ms-auto">
                   <a
-                    href="${urlPrefix}/instance_admin/qti_import"
+                    href="${getCourseAdminQtiImportUrl({ courseInstanceId: course_instance.id })}"
                     class="btn btn-sm btn-light"
                     aria-label="Import content"
                   >

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
@@ -195,6 +195,7 @@ describe('UploadStep', () => {
         uploading={false}
         processingPhase="idle"
         courseInstances={instances}
+        courseInstancesUrl="/pl/course/1/course_admin/instances"
         selectedCourseInstanceId={instances[0]?.id ?? null}
         onSubmit={() => {}}
         onCourseInstanceChange={() => {}}
@@ -206,6 +207,7 @@ describe('UploadStep', () => {
     const html = render([]);
 
     expect(html).toContain('have any course instances yet');
+    expect(html).toContain('href="/pl/course/1/course_admin/instances"');
     expect(html).not.toContain('Target course instance');
   });
 

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.test.tsx
@@ -1,11 +1,15 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import type { SerializedQuestionOutput } from '../instructorQtiImport.types.js';
+import type {
+  CourseInstanceOption,
+  SerializedQuestionOutput,
+} from '../instructorQtiImport.types.js';
 
 import {
   NonRubricWarnings,
   QuestionBankDeduplicationWarning,
+  UploadStep,
   buildQuestionWarningsByDirectoryName,
   findDuplicateQuestionTitles,
 } from './ImportReviewComponents.js';
@@ -176,5 +180,48 @@ describe('buildQuestionWarningsByDirectoryName', () => {
       'Missing asset file: diagram.png',
       'Unsupported question type "magic_question"',
     ]);
+  });
+});
+
+describe('UploadStep', () => {
+  const courseInstances: CourseInstanceOption[] = [
+    { id: '1', shortName: 'Sp15', longName: 'Spring 2015' },
+    { id: '2', shortName: 'Fa15', longName: 'Fall 2015' },
+  ];
+
+  function render(instances: CourseInstanceOption[]) {
+    return renderToStaticMarkup(
+      <UploadStep
+        uploading={false}
+        processingPhase="idle"
+        courseInstances={instances}
+        selectedCourseInstanceId={instances[0]?.id ?? null}
+        onSubmit={() => {}}
+        onCourseInstanceChange={() => {}}
+      />,
+    );
+  }
+
+  it('explains that quizzes become standalone questions without a course instance', () => {
+    const html = render([]);
+
+    expect(html).toContain('have any course instances yet');
+    expect(html).not.toContain('Target course instance');
+  });
+
+  it('shows the only course instance as read-only text', () => {
+    const html = render(courseInstances.slice(0, 1));
+
+    expect(html).toContain('Target course instance');
+    expect(html).toContain('Sp15: Spring 2015');
+    expect(html).not.toContain('<select');
+  });
+
+  it('lets the user choose between multiple course instances', () => {
+    const html = render(courseInstances);
+
+    expect(html).toContain('<select');
+    expect(html).toContain('Sp15: Spring 2015');
+    expect(html).toContain('Fa15: Fall 2015');
   });
 });

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -338,6 +338,7 @@ export function UploadStep({
   processingPhase,
   onSubmit,
   courseInstances,
+  courseInstancesUrl,
   selectedCourseInstanceId,
   onCourseInstanceChange,
 }: {
@@ -345,6 +346,8 @@ export function UploadStep({
   processingPhase: ProcessingPhase;
   onSubmit: (e: SubmitEvent<HTMLFormElement>) => void;
   courseInstances: CourseInstanceOption[];
+  /** Where to send users who need to create a course instance before importing quizzes. */
+  courseInstancesUrl: string;
   selectedCourseInstanceId: string | null;
   onCourseInstanceChange: (id: string) => void;
 }) {
@@ -361,7 +364,8 @@ export function UploadStep({
         <Alert variant="info" className="mb-3">
           This course doesn't have any course instances yet, so quizzes can't be imported as
           assessments. Their questions will be imported as standalone questions that you can add to
-          assessments after you create a course instance.
+          assessments after you{' '}
+          <Alert.Link href={courseInstancesUrl}>create a course instance</Alert.Link>.
         </Alert>
       )}
       {courseInstances.length === 1 && (

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -207,10 +207,12 @@ export function ImportSummary({
   results,
   strippedAccessRules,
   parseWarnings,
+  canImportAssessments,
 }: {
   results: SerializedConversionResult[];
   strippedAccessRules: StrippedAccessRules | null;
   parseWarnings: ParseWarning[];
+  canImportAssessments: boolean;
 }) {
   const totalAssessments = results.filter((r) => r.sourceType === 'assessment').length;
   const totalQuestionBanks = results.filter((r) => r.sourceType === 'question-bank').length;
@@ -239,6 +241,11 @@ export function ImportSummary({
   const uniqueUnsupported = [...new Set(unsupportedTypes)];
 
   const notImportedItems: string[] = [];
+  if (!canImportAssessments && totalAssessments > 0) {
+    notImportedItems.push(
+      `${totalAssessments} assessment${totalAssessments !== 1 ? 's' : ''} (create a course instance to import them; their questions will still be imported)`,
+    );
+  }
   if (hasRubricIssues) notImportedItems.push('Rubrics (not supported in QTI quiz exports)');
   if (strippedAccessRules?.hasTimeLimits) notImportedItems.push('Time limits');
   if (strippedAccessRules?.hasPasswords) notImportedItems.push('Access passwords');
@@ -265,7 +272,7 @@ export function ImportSummary({
               What can be imported
             </h2>
             <ul className="mb-0">
-              {totalAssessments > 0 && (
+              {canImportAssessments && totalAssessments > 0 && (
                 <li>
                   <strong>{totalAssessments}</strong> assessment
                   {totalAssessments !== 1 ? 's' : ''}
@@ -338,7 +345,7 @@ export function UploadStep({
   processingPhase: ProcessingPhase;
   onSubmit: (e: SubmitEvent<HTMLFormElement>) => void;
   courseInstances: CourseInstanceOption[];
-  selectedCourseInstanceId: string;
+  selectedCourseInstanceId: string | null;
   onCourseInstanceChange: (id: string) => void;
 }) {
   return (
@@ -350,12 +357,19 @@ export function UploadStep({
           Learn more about importing content into PrairieLearn
         </a>
       </p>
+      {courseInstances.length === 0 && (
+        <Alert variant="info" className="mb-3">
+          This course doesn't have any course instances yet, so quizzes can't be imported as
+          assessments. Their questions will be imported as standalone questions that you can add to
+          assessments after you create a course instance.
+        </Alert>
+      )}
       {courseInstances.length > 1 && (
         <div className="mb-3">
           <Form.Label htmlFor="course-instance-select">Target course instance</Form.Label>
           <Form.Select
             id="course-instance-select"
-            value={selectedCourseInstanceId}
+            value={selectedCourseInstanceId ?? ''}
             disabled={uploading}
             onChange={(e) => onCourseInstanceChange(e.target.value)}
           >

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/ImportReviewComponents.tsx
@@ -364,6 +364,18 @@ export function UploadStep({
           assessments after you create a course instance.
         </Alert>
       )}
+      {courseInstances.length === 1 && (
+        <div className="mb-3">
+          <Form.Label htmlFor="course-instance-target">Target course instance</Form.Label>
+          <Form.Control
+            id="course-instance-target"
+            defaultValue={`${courseInstances[0].shortName}: ${courseInstances[0].longName}`}
+            plaintext
+            readOnly
+          />
+          <Form.Text>Assessments will be created in this course instance.</Form.Text>
+        </div>
+      )}
       {courseInstances.length > 1 && (
         <div className="mb-3">
           <Form.Label htmlFor="course-instance-select">Target course instance</Form.Label>

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
@@ -278,6 +278,7 @@ export function QtiImportForm({
   const [selectedCourseInstanceId, setSelectedCourseInstanceId] = useState(initialCourseInstanceId);
   // Assessments live in a course instance, so without one only questions can be imported.
   const canImportAssessments = selectedCourseInstanceId != null;
+  const selectedCourseInstance = courseInstances.find((ci) => ci.id === selectedCourseInstanceId);
   const [trpcClient] = useState(() =>
     createCourseTrpcClient({ csrfToken: csrfTokens.trpc, courseId }),
   );
@@ -743,11 +744,15 @@ export function QtiImportForm({
                 <h2 id="qti-import-assessments-heading" className="h4 mb-1">
                   Assessments
                 </h2>
-                {canImportAssessments ? (
+                {selectedCourseInstance ? (
                   <p className="text-muted mb-3">
-                    Assessments are imported to PrairieLearn with their questions and basic quiz
-                    structure. After import, you can edit their settings, adjust question order and
-                    points, and assign them like any other assessment.
+                    Assessments are imported into{' '}
+                    <strong>
+                      {selectedCourseInstance.shortName}: {selectedCourseInstance.longName}
+                    </strong>{' '}
+                    with their questions and basic quiz structure. After import, you can edit their
+                    settings, adjust question order and points, and assign them like any other
+                    assessment.
                   </p>
                 ) : (
                   <p className="text-muted mb-3">

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
@@ -12,7 +12,9 @@ import { getAppError } from '@prairielearn/trpc/client';
 import { getCourseInstanceBaseUrl } from '../../../lib/client/url.js';
 import { createCourseTrpcClient } from '../../../trpc/course/client.js';
 import type { QtiImportError } from '../../../trpc/course/qti-import.js';
+import { buildImportPayload, getIncludedQuestionCount } from '../instructorQtiImport.payload.js';
 import {
+  type AssessmentOverrides,
   type CourseInstanceOption,
   type ParseWarning,
   QTI_IMPORT_MAX_UPLOAD_BYTES,
@@ -23,7 +25,6 @@ import {
   deduplicateAssessmentZoneQuestions,
   getUnresolvedSourceBankRefs,
   hasCanvasUnresolvedSourceBankRefs,
-  resolveRenamedDir,
 } from '../instructorQtiImport.types.js';
 
 import {
@@ -75,14 +76,6 @@ function useBeforeUnload(enabled: boolean): () => void {
   return () => {
     disabledRef.current = true;
   };
-}
-
-interface AssessmentOverrides {
-  title: string;
-  type: 'Homework' | 'Exam';
-  set: string;
-  number: string;
-  included: boolean;
 }
 
 function deduplicateAssessmentNumbers(
@@ -442,152 +435,18 @@ export function QtiImportForm({
     });
   };
 
-  const getIncludedQuestionCount = (result: SerializedConversionResult) =>
-    result.questions.filter((q) => questionOverrides.get(q.directoryName)?.included !== false)
-      .length;
-
   const handleCreate = async () => {
     setError(null);
     setStep('creating');
 
     try {
-      const includedResults = results
-        .map((result, i) => ({ result, override: overrides[i] }))
-        .filter(
-          ({ result, override }) => override.included && getIncludedQuestionCount(result) > 0,
-        );
-      const includedAssessments = canImportAssessments
-        ? includedResults.filter(
-            (
-              entry,
-            ): entry is typeof entry & {
-              result: Extract<SerializedConversionResult, { sourceType: 'assessment' }>;
-            } => entry.result.sourceType === 'assessment',
-          )
-        : [];
-      // Without a course instance, quiz questions are imported as standalone questions.
-      const standaloneQuestionResults = canImportAssessments
-        ? includedResults.filter(({ result }) => result.sourceType === 'question-bank')
-        : includedResults;
-
-      // Deduplicate assessment directory names so two assessments with the
-      // same title don't overwrite each other.
-      const allocatedAssessmentDirs = new Set<string>();
-      const resolvedAssessmentDirNames = new Map<string, string>();
-      for (const { result } of includedAssessments) {
-        let dirName = result.assessment.directoryName;
-        if (allocatedAssessmentDirs.has(dirName)) {
-          let n = 2;
-          while (allocatedAssessmentDirs.has(`${dirName}-${n}`)) n++;
-          dirName = `${dirName}-${n}`;
-        }
-        allocatedAssessmentDirs.add(dirName);
-        resolvedAssessmentDirNames.set(result.assessment.directoryName, dirName);
-      }
-
-      // Pre-compute final directory names for all renamed questions so that
-      // the same question shared across multiple assessments gets a single
-      // consistent name rather than re-resolving per assessment.
-      const allocatedDirs = new Set(existingDirs);
-      const resolvedDirNames = new Map<string, string>();
-      for (const { result } of includedResults) {
-        for (const q of result.questions) {
-          if (resolvedDirNames.has(q.directoryName)) continue;
-          const qOverride = questionOverrides.get(q.directoryName);
-          if (qOverride?.included === false) continue;
-          let dirName = q.directoryName;
-          if (qOverride?.collides && qOverride.collisionStrategy === 'rename') {
-            dirName = resolveRenamedDir(qOverride.originalDirName, allocatedDirs);
-          }
-          allocatedDirs.add(dirName);
-          resolvedDirNames.set(q.directoryName, dirName);
-        }
-      }
-
-      const questionPayloads = standaloneQuestionResults.flatMap(({ result }) =>
-        result.questions
-          .filter((q) => questionOverrides.get(q.directoryName)?.included !== false)
-          .map((q) => {
-            const qOverride = questionOverrides.get(q.directoryName);
-            const dirName = resolvedDirNames.get(q.directoryName) ?? q.directoryName;
-            return {
-              draftId: q.draftId,
-              originalDirectoryName: q.originalDirectoryName,
-              directoryName: dirName,
-              infoJson: {
-                ...q.infoJson,
-                ...(qOverride && {
-                  title: qOverride.title,
-                  topic: qOverride.topic,
-                  tags: qOverride.tags,
-                }),
-              },
-              overwrite: qOverride?.collides && qOverride.collisionStrategy === 'overwrite',
-            };
-          }),
-      );
-      const questionPayloadsByDirectoryName = new Map(
-        questionPayloads.map((question) => [question.directoryName, question]),
-      );
-
-      const payload = {
+      const payload = buildImportPayload({
+        results,
+        overrides,
+        questionOverrides,
+        existingDirs,
         courseInstanceId: selectedCourseInstanceId,
-        questions: [...questionPayloadsByDirectoryName.values()],
-        assessments: includedAssessments.map(({ result, override }) => {
-          const includedQuestionDirs = new Set<string>();
-
-          const questions = result.questions
-            .filter((q) => questionOverrides.get(q.directoryName)?.included !== false)
-            .map((q) => {
-              const qOverride = questionOverrides.get(q.directoryName);
-              const dirName = resolvedDirNames.get(q.directoryName) ?? q.directoryName;
-              includedQuestionDirs.add(dirName);
-              return {
-                draftId: q.draftId,
-                originalDirectoryName: q.originalDirectoryName,
-                directoryName: dirName,
-                infoJson: {
-                  ...q.infoJson,
-                  ...(qOverride && {
-                    title: qOverride.title,
-                    topic: qOverride.topic,
-                    tags: qOverride.tags,
-                  }),
-                },
-                overwrite: qOverride?.collides && qOverride.collisionStrategy === 'overwrite',
-              };
-            });
-
-          // Rewrite assessment zones to reference the final directory names
-          // and filter out excluded questions.
-          const zones = result.assessment.infoJson.zones
-            .map((zone) => ({
-              ...zone,
-              questions: zone.questions
-                .map((zq) => {
-                  const id = resolvedDirNames.get(zq.id) ?? zq.id;
-                  return includedQuestionDirs.has(id) ? { ...zq, id } : null;
-                })
-                .filter((zq): zq is NonNullable<typeof zq> => zq !== null),
-            }))
-            .filter((zone) => zone.questions.length > 0);
-
-          return {
-            directoryName:
-              resolvedAssessmentDirNames.get(result.assessment.directoryName) ??
-              result.assessment.directoryName,
-            infoJson: {
-              ...result.assessment.infoJson,
-              title: override.title,
-              type: override.type,
-              set: override.set,
-              number: override.number,
-              zones,
-            },
-            questions,
-          };
-        }),
-      };
+      });
 
       const payloadJson = JSON.stringify(payload);
       const payloadBytes = new TextEncoder().encode(payloadJson).length;
@@ -644,7 +503,7 @@ export function QtiImportForm({
         (result, i) =>
           overrides[i]?.included &&
           result.sourceType === 'assessment' &&
-          getIncludedQuestionCount(result) > 0,
+          getIncludedQuestionCount(result, questionOverrides) > 0,
       ).length
     : 0;
   const hasAssessmentResults = results.some((result) => result.sourceType === 'assessment');

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
@@ -704,6 +704,7 @@ export function QtiImportForm({
             uploading={uploading}
             processingPhase={processingPhase}
             courseInstances={courseInstances}
+            courseInstancesUrl={`${urlPrefix}/course_admin/instances`}
             selectedCourseInstanceId={selectedCourseInstanceId}
             onSubmit={handleUpload}
             onCourseInstanceChange={setSelectedCourseInstanceId}

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@prairielearn/question-conversion/trimmer';
 import { getAppError } from '@prairielearn/trpc/client';
 
-import { getCourseInstanceBaseUrl } from '../../../lib/client/url.js';
+import { getCourseAdminQuestionsUrl, getCourseInstanceBaseUrl } from '../../../lib/client/url.js';
 import { createCourseTrpcClient } from '../../../trpc/course/client.js';
 import type { QtiImportError } from '../../../trpc/course/qti-import.js';
 import { buildImportPayload, getIncludedQuestionCount } from '../instructorQtiImport.payload.js';
@@ -461,10 +461,16 @@ export function QtiImportForm({
       await trpcClient.qtiImport.create.mutate(payload);
 
       disableBeforeUnload();
+      // Return to the import target, not the page the user arrived from, so the
+      // questions table shows usage for the instance that just received content.
       window.location.href =
         returnTo === 'assessments' && selectedCourseInstanceId != null
           ? `${getCourseInstanceBaseUrl(selectedCourseInstanceId)}/instructor/instance_admin/assessments`
-          : `${urlPrefix}/course_admin/questions`;
+          : getCourseAdminQuestionsUrl(
+              selectedCourseInstanceId != null
+                ? { courseInstanceId: selectedCourseInstanceId }
+                : { courseId },
+            );
     } catch (err) {
       const appError = getAppError<QtiImportError['Create']>(err);
       if (appError?.code === 'SYNC_JOB_FAILED') {

--- a/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/components/QtiImportForm.tsx
@@ -9,12 +9,9 @@ import {
 } from '@prairielearn/question-conversion/trimmer';
 import { getAppError } from '@prairielearn/trpc/client';
 
-import {
-  getCourseInstanceBaseUrl,
-  getCourseInstanceEditErrorUrl,
-} from '../../../lib/client/url.js';
-import { createCourseInstanceTrpcClient } from '../../../trpc/courseInstance/client.js';
-import type { QtiImportError } from '../../../trpc/courseInstance/qti-import.js';
+import { getCourseInstanceBaseUrl } from '../../../lib/client/url.js';
+import { createCourseTrpcClient } from '../../../trpc/course/client.js';
+import type { QtiImportError } from '../../../trpc/course/qti-import.js';
 import {
   type CourseInstanceOption,
   type ParseWarning,
@@ -270,23 +267,26 @@ function mergeEmbeddedSourceBanks(
 }
 
 export function QtiImportForm({
-  courseInstanceId: initialCourseInstanceId,
+  courseId,
+  urlPrefix,
   courseInstances,
-  csrfTokensByCourseInstance,
+  initialCourseInstanceId,
+  csrfTokens,
   returnTo,
 }: {
-  courseInstanceId: string;
+  courseId: string;
+  urlPrefix: string;
   courseInstances: CourseInstanceOption[];
-  csrfTokensByCourseInstance: Record<string, { upload: string; trpc: string }>;
+  /** Preselected import target; null when the course has no course instances. */
+  initialCourseInstanceId: string | null;
+  csrfTokens: { upload: string; trpc: string };
   returnTo: 'assessments' | 'questions';
 }) {
   const [selectedCourseInstanceId, setSelectedCourseInstanceId] = useState(initialCourseInstanceId);
-  const csrfTokens = csrfTokensByCourseInstance[selectedCourseInstanceId];
-  const [trpcClient, setTrpcClient] = useState(() =>
-    createCourseInstanceTrpcClient({
-      csrfToken: csrfTokens.trpc,
-      courseInstanceId: selectedCourseInstanceId,
-    }),
+  // Assessments live in a course instance, so without one only questions can be imported.
+  const canImportAssessments = selectedCourseInstanceId != null;
+  const [trpcClient] = useState(() =>
+    createCourseTrpcClient({ csrfToken: csrfTokens.trpc, courseId }),
   );
   const [step, setStep] = useState<ImportStep>('upload');
   const [results, setResults] = useState<SerializedConversionResult[]>([]);
@@ -333,9 +333,12 @@ export function QtiImportForm({
     });
     formData.set('file', trimmedFile);
 
+    if (selectedCourseInstanceId != null) {
+      formData.set('course_instance_id', selectedCourseInstanceId);
+    }
+
     setProcessingPhase('uploading');
-    const baseUrl = getCourseInstanceBaseUrl(selectedCourseInstanceId);
-    const response = await fetch(`${baseUrl}/instructor/instance_admin/qti_import/upload`, {
+    const response = await fetch(`${urlPrefix}/course_admin/qti_import/upload`, {
       method: 'POST',
       headers: {
         'X-CSRF-Token': csrfTokens.upload,
@@ -453,16 +456,19 @@ export function QtiImportForm({
         .filter(
           ({ result, override }) => override.included && getIncludedQuestionCount(result) > 0,
         );
-      const includedAssessments = includedResults.filter(
-        (
-          entry,
-        ): entry is typeof entry & {
-          result: Extract<SerializedConversionResult, { sourceType: 'assessment' }>;
-        } => entry.result.sourceType === 'assessment',
-      );
-      const includedQuestionBankResults = includedResults.filter(
-        ({ result }) => result.sourceType === 'question-bank',
-      );
+      const includedAssessments = canImportAssessments
+        ? includedResults.filter(
+            (
+              entry,
+            ): entry is typeof entry & {
+              result: Extract<SerializedConversionResult, { sourceType: 'assessment' }>;
+            } => entry.result.sourceType === 'assessment',
+          )
+        : [];
+      // Without a course instance, quiz questions are imported as standalone questions.
+      const standaloneQuestionResults = canImportAssessments
+        ? includedResults.filter(({ result }) => result.sourceType === 'question-bank')
+        : includedResults;
 
       // Deduplicate assessment directory names so two assessments with the
       // same title don't overwrite each other.
@@ -498,7 +504,7 @@ export function QtiImportForm({
         }
       }
 
-      const questionPayloads = includedQuestionBankResults.flatMap(({ result }) =>
+      const questionPayloads = standaloneQuestionResults.flatMap(({ result }) =>
         result.questions
           .filter((q) => questionOverrides.get(q.directoryName)?.included !== false)
           .map((q) => {
@@ -525,6 +531,7 @@ export function QtiImportForm({
       );
 
       const payload = {
+        courseInstanceId: selectedCourseInstanceId,
         questions: [...questionPayloadsByDirectoryName.values()],
         assessments: includedAssessments.map(({ result, override }) => {
           const includedQuestionDirs = new Set<string>();
@@ -594,12 +601,11 @@ export function QtiImportForm({
 
       await trpcClient.qtiImport.create.mutate(payload);
 
-      const baseUrl = getCourseInstanceBaseUrl(selectedCourseInstanceId);
       disableBeforeUnload();
       window.location.href =
-        returnTo === 'questions'
-          ? `${baseUrl}/instructor/course_admin/questions`
-          : `${baseUrl}/instructor/instance_admin/assessments`;
+        returnTo === 'assessments' && selectedCourseInstanceId != null
+          ? `${getCourseInstanceBaseUrl(selectedCourseInstanceId)}/instructor/instance_admin/assessments`
+          : `${urlPrefix}/course_admin/questions`;
     } catch (err) {
       const appError = getAppError<QtiImportError['Create']>(err);
       if (appError?.code === 'SYNC_JOB_FAILED') {
@@ -633,16 +639,19 @@ export function QtiImportForm({
     [],
   );
 
-  const includedAssessmentCount = results.filter(
-    (result, i) =>
-      overrides[i]?.included &&
-      result.sourceType === 'assessment' &&
-      getIncludedQuestionCount(result) > 0,
-  ).length;
+  const includedAssessmentCount = canImportAssessments
+    ? results.filter(
+        (result, i) =>
+          overrides[i]?.included &&
+          result.sourceType === 'assessment' &&
+          getIncludedQuestionCount(result) > 0,
+      ).length
+    : 0;
   const hasAssessmentResults = results.some((result) => result.sourceType === 'assessment');
   const includedQuestionDirs = new Set<string>();
   for (const [i, result] of results.entries()) {
-    if (!overrides[i]?.included || result.sourceType === 'assessment') continue;
+    if (!overrides[i]?.included) continue;
+    if (canImportAssessments && result.sourceType === 'assessment') continue;
     for (const question of result.questions) {
       if (questionOverrides.get(question.directoryName)?.included !== false) {
         includedQuestionDirs.add(question.directoryName);
@@ -652,7 +661,7 @@ export function QtiImportForm({
   const includedQuestionCount = includedQuestionDirs.size;
   const canImport = includedAssessmentCount > 0 || includedQuestionCount > 0;
   const labelParts: string[] = [];
-  if (includedAssessmentCount > 0 || hasAssessmentResults) {
+  if (canImportAssessments && hasAssessmentResults) {
     labelParts.push(
       `${includedAssessmentCount} assessment${includedAssessmentCount !== 1 ? 's' : ''}`,
     );
@@ -727,7 +736,7 @@ export function QtiImportForm({
       )}
       {overrides[i].included && result.questions.length > 0 && (
         <Card.Body>
-          {result.sourceType === 'assessment' && (
+          {canImportAssessments && result.sourceType === 'assessment' && (
             <div className="row g-3 mb-3">
               <div className="col-md-6">
                 <Form.Label htmlFor={`title-${i}`}>Title</Form.Label>
@@ -809,12 +818,7 @@ export function QtiImportForm({
             {error.jobSequenceId && (
               <>
                 {' '}
-                <Alert.Link
-                  href={getCourseInstanceEditErrorUrl(
-                    selectedCourseInstanceId,
-                    error.jobSequenceId,
-                  )}
-                >
+                <Alert.Link href={`${urlPrefix}/edit_error/${error.jobSequenceId}`}>
                   View sync errors
                 </Alert.Link>
               </>
@@ -836,18 +840,7 @@ export function QtiImportForm({
             courseInstances={courseInstances}
             selectedCourseInstanceId={selectedCourseInstanceId}
             onSubmit={handleUpload}
-            onCourseInstanceChange={(id) => {
-              setSelectedCourseInstanceId(id);
-              const tokens = csrfTokensByCourseInstance[id];
-              // The tRPC proxy is callable, so wrap it to prevent React from treating it
-              // as a functional state update.
-              setTrpcClient(() =>
-                createCourseInstanceTrpcClient({
-                  csrfToken: tokens.trpc,
-                  courseInstanceId: id,
-                }),
-              );
-            }}
+            onCourseInstanceChange={setSelectedCourseInstanceId}
           />
         )}
 
@@ -870,6 +863,7 @@ export function QtiImportForm({
               results={results}
               strippedAccessRules={strippedRules}
               parseWarnings={parseWarnings}
+              canImportAssessments={canImportAssessments}
             />
 
             <UnresolvedBankWarnings results={results} />
@@ -884,11 +878,18 @@ export function QtiImportForm({
                 <h2 id="qti-import-assessments-heading" className="h4 mb-1">
                   Assessments
                 </h2>
-                <p className="text-muted mb-3">
-                  Assessments are imported to PrairieLearn with their questions and basic quiz
-                  structure. After import, you can edit their settings, adjust question order and
-                  points, and assign them like any other assessment.
-                </p>
+                {canImportAssessments ? (
+                  <p className="text-muted mb-3">
+                    Assessments are imported to PrairieLearn with their questions and basic quiz
+                    structure. After import, you can edit their settings, adjust question order and
+                    points, and assign them like any other assessment.
+                  </p>
+                ) : (
+                  <p className="text-muted mb-3">
+                    This course has no course instances yet, so only the questions from these
+                    assessments will be imported.
+                  </p>
+                )}
                 {assessmentResults.map(renderResultCard)}
               </section>
             )}

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.payload.test.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.payload.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildImportPayload, getIncludedQuestionCount } from './instructorQtiImport.payload.js';
+import type {
+  AssessmentOverrides,
+  QuestionOverrides,
+  SerializedConversionResult,
+  SerializedQuestionOutput,
+} from './instructorQtiImport.types.js';
+
+function makeQuestion(directoryName: string, title = directoryName): SerializedQuestionOutput {
+  return {
+    draftId: 'draft',
+    originalDirectoryName: directoryName,
+    directoryName,
+    sourceId: `${directoryName}-source`,
+    infoJson: {
+      uuid: `${directoryName}-uuid`,
+      title,
+      topic: 'Imported',
+      tags: ['imported'],
+      type: 'v3',
+    },
+    questionHtml: '<pl-question-panel></pl-question-panel>',
+    clientFiles: {},
+    skippedVideos: [],
+    copiedExternalImageFileCount: 0,
+  };
+}
+
+function makeAssessment(
+  directoryName: string,
+  questions: SerializedQuestionOutput[],
+): SerializedConversionResult {
+  return {
+    draftId: 'draft',
+    sourceId: `${directoryName}-source`,
+    sourceType: 'assessment',
+    title: directoryName,
+    questions,
+    warnings: [],
+    assessment: {
+      directoryName,
+      infoJson: {
+        uuid: `${directoryName}-uuid`,
+        type: 'Homework',
+        title: directoryName,
+        set: 'Homework',
+        number: '1',
+        allowAccess: [],
+        zones: [
+          {
+            title: 'Questions',
+            questions: questions.map((q) => ({ id: q.directoryName, autoPoints: 1 })),
+          },
+        ],
+      },
+    },
+  };
+}
+
+function makeBank(
+  directoryName: string,
+  questions: SerializedQuestionOutput[],
+): SerializedConversionResult {
+  return {
+    draftId: 'draft',
+    sourceId: `${directoryName}-source`,
+    sourceType: 'question-bank',
+    title: directoryName,
+    questions,
+    warnings: [],
+    directoryName,
+  };
+}
+
+function makeOverride(result: SerializedConversionResult): AssessmentOverrides {
+  return {
+    title: result.title,
+    type: 'Homework',
+    set: 'Homework',
+    number: '1',
+    included: true,
+  };
+}
+
+function makeQuestionOverrides(
+  results: SerializedConversionResult[],
+  edits: Record<string, Partial<QuestionOverrides>> = {},
+): Map<string, QuestionOverrides> {
+  const overrides = new Map<string, QuestionOverrides>();
+  for (const result of results) {
+    for (const q of result.questions) {
+      overrides.set(q.directoryName, {
+        title: q.infoJson.title,
+        topic: q.infoJson.topic,
+        tags: [...q.infoJson.tags],
+        included: true,
+        originalDirName: q.directoryName,
+        collides: false,
+        collisionStrategy: 'overwrite',
+        ...edits[q.directoryName],
+      });
+    }
+  }
+  return overrides;
+}
+
+function build(
+  results: SerializedConversionResult[],
+  {
+    courseInstanceId = '1',
+    edits,
+    existingDirs = new Set<string>(),
+    overrides = results.map(makeOverride),
+  }: {
+    courseInstanceId?: string | null;
+    edits?: Record<string, Partial<QuestionOverrides>>;
+    existingDirs?: Set<string>;
+    overrides?: AssessmentOverrides[];
+  } = {},
+) {
+  return buildImportPayload({
+    results,
+    overrides,
+    questionOverrides: makeQuestionOverrides(results, edits),
+    existingDirs,
+    courseInstanceId,
+  });
+}
+
+const q1 = makeQuestion('imported/quiz/q1', 'Question 1');
+const q2 = makeQuestion('imported/quiz/q2', 'Question 2');
+
+describe('buildImportPayload', () => {
+  it('flattens quizzes into standalone questions without a course instance', () => {
+    const payload = build([makeAssessment('quiz', [q1, q2])], { courseInstanceId: null });
+
+    expect(payload).toEqual({
+      courseInstanceId: null,
+      assessments: [],
+      questions: [
+        {
+          draftId: 'draft',
+          originalDirectoryName: 'imported/quiz/q1',
+          directoryName: 'imported/quiz/q1',
+          infoJson: q1.infoJson,
+          overwrite: false,
+        },
+        {
+          draftId: 'draft',
+          originalDirectoryName: 'imported/quiz/q2',
+          directoryName: 'imported/quiz/q2',
+          infoJson: q2.infoJson,
+          overwrite: false,
+        },
+      ],
+    });
+  });
+
+  it('keeps quizzes as assessments when a course instance is selected', () => {
+    const payload = build([makeAssessment('quiz', [q1, q2])]);
+
+    expect(payload.courseInstanceId).toBe('1');
+    expect(payload.questions).toEqual([]);
+    expect(payload.assessments).toHaveLength(1);
+    expect(payload.assessments?.[0]).toMatchObject({
+      directoryName: 'quiz',
+      infoJson: {
+        title: 'quiz',
+        type: 'Homework',
+        set: 'Homework',
+        number: '1',
+        zones: [
+          {
+            title: 'Questions',
+            questions: [
+              { id: 'imported/quiz/q1', autoPoints: 1 },
+              { id: 'imported/quiz/q2', autoPoints: 1 },
+            ],
+          },
+        ],
+      },
+    });
+    expect(payload.assessments?.[0].questions.map((q) => q.directoryName)).toEqual([
+      'imported/quiz/q1',
+      'imported/quiz/q2',
+    ]);
+  });
+
+  it('imports question bank questions as standalone questions alongside assessments', () => {
+    const bankQuestion = makeQuestion('imported/bank/b1');
+    const payload = build([makeAssessment('quiz', [q1]), makeBank('bank', [bankQuestion])]);
+
+    expect(payload.assessments?.map((a) => a.directoryName)).toEqual(['quiz']);
+    expect(payload.questions?.map((q) => q.directoryName)).toEqual(['imported/bank/b1']);
+  });
+
+  it('deduplicates standalone questions shared across results', () => {
+    const payload = build([makeAssessment('quiz', [q1]), makeBank('bank', [q1])], {
+      courseInstanceId: null,
+    });
+
+    expect(payload.questions?.map((q) => q.directoryName)).toEqual(['imported/quiz/q1']);
+  });
+
+  it('drops excluded questions and results in both branches', () => {
+    const results = [makeAssessment('quiz', [q1, q2]), makeAssessment('empty', [q1])];
+    const overrides = results.map(makeOverride);
+    overrides[1].included = false;
+    const edits = { 'imported/quiz/q2': { included: false } };
+
+    const withInstance = build(results, { overrides, edits });
+    expect(withInstance.assessments?.map((a) => a.directoryName)).toEqual(['quiz']);
+    expect(withInstance.assessments?.[0].questions.map((q) => q.directoryName)).toEqual([
+      'imported/quiz/q1',
+    ]);
+    expect(withInstance.assessments?.[0].infoJson.zones).toEqual([
+      { title: 'Questions', questions: [{ id: 'imported/quiz/q1', autoPoints: 1 }] },
+    ]);
+
+    const withoutInstance = build(results, { overrides, edits, courseInstanceId: null });
+    expect(withoutInstance.assessments).toEqual([]);
+    expect(withoutInstance.questions?.map((q) => q.directoryName)).toEqual(['imported/quiz/q1']);
+  });
+
+  it('applies reviewer edits to assessment and question metadata', () => {
+    const results = [makeAssessment('quiz', [q1])];
+    const overrides: AssessmentOverrides[] = [
+      { title: 'Week 1 Quiz', type: 'Exam', set: 'Exam', number: '3', included: true },
+    ];
+    const edits = {
+      'imported/quiz/q1': { title: 'Renamed', topic: 'Algebra', tags: ['imported', 'week1'] },
+    };
+
+    const payload = build(results, { overrides, edits });
+
+    expect(payload.assessments?.[0].infoJson).toMatchObject({
+      title: 'Week 1 Quiz',
+      type: 'Exam',
+      set: 'Exam',
+      number: '3',
+    });
+    expect(payload.assessments?.[0].questions[0].infoJson).toMatchObject({
+      title: 'Renamed',
+      topic: 'Algebra',
+      tags: ['imported', 'week1'],
+    });
+  });
+
+  it('renames colliding questions consistently across the payload', () => {
+    const existingDirs = new Set(['imported/quiz/q1', 'imported/quiz/q1-2']);
+    const edits = {
+      'imported/quiz/q1': { collides: true, collisionStrategy: 'rename' as const },
+      'imported/quiz/q2': { collides: true, collisionStrategy: 'overwrite' as const },
+    };
+
+    const withInstance = build([makeAssessment('quiz', [q1, q2])], { existingDirs, edits });
+    expect(withInstance.assessments?.[0].questions).toMatchObject([
+      { directoryName: 'imported/quiz/q1-3', overwrite: false },
+      { directoryName: 'imported/quiz/q2', overwrite: true },
+    ]);
+    expect(withInstance.assessments?.[0].infoJson).toMatchObject({
+      zones: [{ questions: [{ id: 'imported/quiz/q1-3' }, { id: 'imported/quiz/q2' }] }],
+    });
+
+    const withoutInstance = build([makeAssessment('quiz', [q1, q2])], {
+      existingDirs,
+      edits,
+      courseInstanceId: null,
+    });
+    expect(withoutInstance.questions).toMatchObject([
+      { directoryName: 'imported/quiz/q1-3', overwrite: false },
+      { directoryName: 'imported/quiz/q2', overwrite: true },
+    ]);
+  });
+
+  it('suffixes assessments that resolve to the same directory name', () => {
+    const payload = build([
+      makeAssessment('quiz', [q1]),
+      makeAssessment('quiz', [makeQuestion('imported/quiz-2/q1')]),
+    ]);
+
+    expect(payload.assessments?.map((a) => a.directoryName)).toEqual(['quiz', 'quiz-2']);
+  });
+});
+
+describe('getIncludedQuestionCount', () => {
+  it('counts questions that are not excluded', () => {
+    const result = makeAssessment('quiz', [q1, q2]);
+    const overrides = makeQuestionOverrides([result], {
+      'imported/quiz/q2': { included: false },
+    });
+
+    expect(getIncludedQuestionCount(result, overrides)).toBe(1);
+    expect(getIncludedQuestionCount(result, new Map())).toBe(2);
+  });
+});

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.payload.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.payload.ts
@@ -1,0 +1,168 @@
+import type { inferRouterInputs } from '@trpc/server';
+
+import type { CourseRouter } from '../../trpc/course/trpc.js';
+
+import {
+  type AssessmentOverrides,
+  type QuestionOverrides,
+  type SerializedConversionResult,
+  type SerializedQuestionOutput,
+  resolveRenamedDir,
+} from './instructorQtiImport.types.js';
+
+export type QtiImportCreateInput = inferRouterInputs<CourseRouter>['qtiImport']['create'];
+
+type AssessmentConversionResult = Extract<SerializedConversionResult, { sourceType: 'assessment' }>;
+
+interface IncludedResult {
+  result: SerializedConversionResult;
+  override: AssessmentOverrides;
+}
+
+export function getIncludedQuestionCount(
+  result: SerializedConversionResult,
+  questionOverrides: Map<string, QuestionOverrides>,
+): number {
+  return result.questions.filter((q) => questionOverrides.get(q.directoryName)?.included !== false)
+    .length;
+}
+
+/**
+ * Builds the `qtiImport.create` mutation input from the reviewed conversion results.
+ *
+ * Assessments can only be created inside a course instance. Without one, every included
+ * result (quizzes included) is flattened into standalone question payloads instead.
+ */
+export function buildImportPayload({
+  results,
+  overrides,
+  questionOverrides,
+  existingDirs,
+  courseInstanceId,
+}: {
+  results: SerializedConversionResult[];
+  overrides: AssessmentOverrides[];
+  questionOverrides: Map<string, QuestionOverrides>;
+  /** Question directories that already exist in the course. */
+  existingDirs: Set<string>;
+  courseInstanceId: string | null;
+}): QtiImportCreateInput {
+  const canImportAssessments = courseInstanceId != null;
+  const isQuestionIncluded = (directoryName: string) =>
+    questionOverrides.get(directoryName)?.included !== false;
+
+  const includedResults: IncludedResult[] = results
+    .map((result, i) => ({ result, override: overrides[i] }))
+    .filter(
+      ({ result, override }) =>
+        override.included && getIncludedQuestionCount(result, questionOverrides) > 0,
+    );
+  const includedAssessments = canImportAssessments
+    ? includedResults.filter(
+        (entry): entry is IncludedResult & { result: AssessmentConversionResult } =>
+          entry.result.sourceType === 'assessment',
+      )
+    : [];
+  const standaloneQuestionResults = canImportAssessments
+    ? includedResults.filter(({ result }) => result.sourceType === 'question-bank')
+    : includedResults;
+
+  // Deduplicate assessment directory names so two assessments with the
+  // same title don't overwrite each other.
+  const allocatedAssessmentDirs = new Set<string>();
+  const resolvedAssessmentDirNames = new Map<string, string>();
+  for (const { result } of includedAssessments) {
+    let dirName = result.assessment.directoryName;
+    if (allocatedAssessmentDirs.has(dirName)) {
+      let n = 2;
+      while (allocatedAssessmentDirs.has(`${dirName}-${n}`)) n++;
+      dirName = `${dirName}-${n}`;
+    }
+    allocatedAssessmentDirs.add(dirName);
+    resolvedAssessmentDirNames.set(result.assessment.directoryName, dirName);
+  }
+
+  // Pre-compute final directory names for all renamed questions so that
+  // the same question shared across multiple assessments gets a single
+  // consistent name rather than re-resolving per assessment.
+  const allocatedDirs = new Set(existingDirs);
+  const resolvedDirNames = new Map<string, string>();
+  for (const { result } of includedResults) {
+    for (const q of result.questions) {
+      if (resolvedDirNames.has(q.directoryName)) continue;
+      const qOverride = questionOverrides.get(q.directoryName);
+      if (qOverride?.included === false) continue;
+      let dirName = q.directoryName;
+      if (qOverride?.collides && qOverride.collisionStrategy === 'rename') {
+        dirName = resolveRenamedDir(qOverride.originalDirName, allocatedDirs);
+      }
+      allocatedDirs.add(dirName);
+      resolvedDirNames.set(q.directoryName, dirName);
+    }
+  }
+
+  const toQuestionPayload = (q: SerializedQuestionOutput) => {
+    const qOverride = questionOverrides.get(q.directoryName);
+    return {
+      draftId: q.draftId,
+      originalDirectoryName: q.originalDirectoryName,
+      directoryName: resolvedDirNames.get(q.directoryName) ?? q.directoryName,
+      infoJson: {
+        ...q.infoJson,
+        ...(qOverride && {
+          title: qOverride.title,
+          topic: qOverride.topic,
+          tags: qOverride.tags,
+        }),
+      },
+      overwrite: qOverride?.collides && qOverride.collisionStrategy === 'overwrite',
+    };
+  };
+
+  const questionPayloads = standaloneQuestionResults.flatMap(({ result }) =>
+    result.questions.filter((q) => isQuestionIncluded(q.directoryName)).map(toQuestionPayload),
+  );
+  const questionPayloadsByDirectoryName = new Map(
+    questionPayloads.map((question) => [question.directoryName, question]),
+  );
+
+  return {
+    courseInstanceId,
+    questions: [...questionPayloadsByDirectoryName.values()],
+    assessments: includedAssessments.map(({ result, override }) => {
+      const questions = result.questions
+        .filter((q) => isQuestionIncluded(q.directoryName))
+        .map(toQuestionPayload);
+      const includedQuestionDirs = new Set(questions.map((q) => q.directoryName));
+
+      // Rewrite assessment zones to reference the final directory names
+      // and filter out excluded questions.
+      const zones = result.assessment.infoJson.zones
+        .map((zone) => ({
+          ...zone,
+          questions: zone.questions
+            .map((zq) => {
+              const id = resolvedDirNames.get(zq.id) ?? zq.id;
+              return includedQuestionDirs.has(id) ? { ...zq, id } : null;
+            })
+            .filter((zq): zq is NonNullable<typeof zq> => zq !== null),
+        }))
+        .filter((zone) => zone.questions.length > 0);
+
+      return {
+        directoryName:
+          resolvedAssessmentDirNames.get(result.assessment.directoryName) ??
+          result.assessment.directoryName,
+        infoJson: {
+          ...result.assessment.infoJson,
+          title: override.title,
+          type: override.type,
+          set: override.set,
+          number: override.number,
+          zones,
+        },
+        questions,
+      };
+    }),
+  };
+}

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.payload.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.payload.ts
@@ -70,7 +70,7 @@ export function buildImportPayload({
   // Deduplicate assessment directory names so two assessments with the
   // same title don't overwrite each other.
   const allocatedAssessmentDirs = new Set<string>();
-  const resolvedAssessmentDirNames = new Map<string, string>();
+  const resolvedAssessmentDirNames = new Map<AssessmentConversionResult, string>();
   for (const { result } of includedAssessments) {
     let dirName = result.assessment.directoryName;
     if (allocatedAssessmentDirs.has(dirName)) {
@@ -79,7 +79,7 @@ export function buildImportPayload({
       dirName = `${dirName}-${n}`;
     }
     allocatedAssessmentDirs.add(dirName);
-    resolvedAssessmentDirNames.set(result.assessment.directoryName, dirName);
+    resolvedAssessmentDirNames.set(result, dirName);
   }
 
   // Pre-compute final directory names for all renamed questions so that
@@ -150,9 +150,7 @@ export function buildImportPayload({
         .filter((zone) => zone.questions.length > 0);
 
       return {
-        directoryName:
-          resolvedAssessmentDirNames.get(result.assessment.directoryName) ??
-          result.assessment.directoryName,
+        directoryName: resolvedAssessmentDirNames.get(result) ?? result.assessment.directoryName,
         infoJson: {
           ...result.assessment.infoJson,
           title: override.title,

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.tsx
@@ -9,6 +9,7 @@ import he from 'he';
 import multer from 'multer';
 import onFinished from 'on-finished';
 import * as tmp from 'tmp-promise';
+import { z } from 'zod';
 
 import { HttpStatusError } from '@prairielearn/error';
 import { html } from '@prairielearn/html';
@@ -32,13 +33,15 @@ import { Hydrate } from '@prairielearn/react/server';
 import { run } from '@prairielearn/run';
 import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
 import { ZipArchiveValidationError, extractZipArchive } from '@prairielearn/utils/zip';
+import { IdSchema, parseRequestBody } from '@prairielearn/zod';
 
 import { PageLayout } from '../../components/PageLayout.js';
 import { nodeModulesAssetPath } from '../../lib/assets.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
-import { getCourseInstanceTrpcUrl } from '../../lib/client/url.js';
+import { getCourseTrpcUrl } from '../../lib/client/url.js';
 import { config } from '../../lib/config.js';
 import { discoverInfoDirs } from '../../lib/discover-info-dirs.js';
+import { idsEqual } from '../../lib/id.js';
 import { createQtiImportDraft } from '../../lib/qti-import-drafts.js';
 import { lintQuestionHtml } from '../../lib/question-html-linter.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
@@ -99,7 +102,7 @@ const qtiImportUploadSingle: RequestHandler = (req, res, next) => {
 
 // Require edit permissions for all routes.
 router.use(
-  typedAsyncHandler<'course-instance'>(async (req, res, next) => {
+  typedAsyncHandler<'course' | 'course-instance'>(async (req, res, next) => {
     const { authz_data: authzData, course } = extractPageContext(res.locals, {
       pageType: 'course',
       accessType: 'instructor',
@@ -116,10 +119,12 @@ router.use(
 
 router.get(
   '/',
-  typedAsyncHandler<'course-instance'>(async (req, res) => {
-    const returnTo = req.query.return_to === 'questions' ? 'questions' : 'assessments';
-
-    const { authz_data: authzData, course } = extractPageContext(res.locals, {
+  typedAsyncHandler<'course' | 'course-instance'>(async (req, res) => {
+    const {
+      authz_data: authzData,
+      course,
+      urlPrefix,
+    } = extractPageContext(res.locals, {
       pageType: 'course',
       accessType: 'instructor',
     });
@@ -128,22 +133,22 @@ router.get(
       authzData,
     });
 
-    // Generate per-CI CSRF tokens so the client can switch target CI without
-    // a page reload. Each CI needs its own upload prefix token and tRPC token.
-    const csrfTokensByCourseInstance: Record<string, { upload: string; trpc: string }> = {};
-    for (const ci of courseInstances) {
-      const uploadBase = `/pl/course_instance/${ci.id}/instructor/instance_admin/qti_import`;
-      csrfTokensByCourseInstance[ci.id] = {
-        upload: generatePrefixCsrfToken(
-          { url: uploadBase, authn_user_id: res.locals.authn_user.id },
-          config.secretKey,
-        ),
-        trpc: generatePrefixCsrfToken(
-          { url: getCourseInstanceTrpcUrl(ci.id), authn_user_id: res.locals.authn_user.id },
-          config.secretKey,
-        ),
-      };
-    }
+    // The assessments page only exists within a course instance.
+    const returnTo =
+      req.query.return_to === 'questions' || !res.locals.course_instance
+        ? 'questions'
+        : 'assessments';
+
+    const csrfTokens = {
+      upload: generatePrefixCsrfToken(
+        { url: `${urlPrefix}/course_admin/qti_import`, authn_user_id: res.locals.authn_user.id },
+        config.secretKey,
+      ),
+      trpc: generatePrefixCsrfToken(
+        { url: getCourseTrpcUrl(course.id), authn_user_id: res.locals.authn_user.id },
+        config.secretKey,
+      ),
+    };
 
     const ciOptions: CourseInstanceOption[] = courseInstances.map((ci) => ({
       id: ci.id,
@@ -171,9 +176,13 @@ router.get(
         content: (
           <Hydrate>
             <QtiImportForm
-              courseInstanceId={res.locals.course_instance.id}
+              courseId={course.id}
+              urlPrefix={urlPrefix}
               courseInstances={ciOptions}
-              csrfTokensByCourseInstance={csrfTokensByCourseInstance}
+              initialCourseInstanceId={
+                res.locals.course_instance?.id ?? courseInstances.at(0)?.id ?? null
+              }
+              csrfTokens={csrfTokens}
               returnTo={returnTo}
             />
           </Hydrate>
@@ -183,10 +192,31 @@ router.get(
   }),
 );
 
+const UploadPostBodySchema = z.object({
+  course_instance_id: IdSchema.optional(),
+});
+
 router.post(
   '/upload',
   qtiImportUploadSingle,
-  typedAsyncHandler<'course-instance'>(async (req, res) => {
+  typedAsyncHandler<'course' | 'course-instance'>(async (req, res) => {
+    const body = parseRequestBody(req, UploadPostBodySchema);
+    const { authz_data: authzData, course } = extractPageContext(res.locals, {
+      pageType: 'course',
+      accessType: 'instructor',
+    });
+
+    const courseInstance = await run(async () => {
+      const courseInstanceId = body.course_instance_id;
+      if (courseInstanceId == null) return null;
+      const courseInstances = await selectCourseInstancesWithStaffAccess({ course, authzData });
+      const courseInstance = courseInstances.find((ci) => idsEqual(ci.id, courseInstanceId));
+      if (!courseInstance) {
+        throw new HttpStatusError(400, 'Invalid course instance');
+      }
+      return courseInstance;
+    });
+
     const file = req.file;
     if (!file) {
       throw new HttpStatusError(400, 'No file uploaded');
@@ -302,13 +332,12 @@ router.post(
       }
 
       const [assessmentSets, assessmentRows] = await Promise.all([
-        selectAssessmentSetsForCourse(res.locals.course.id),
-        selectAssessments({ course_instance_id: res.locals.course_instance.id }),
+        selectAssessmentSetsForCourse(course.id),
+        courseInstance ? selectAssessments({ course_instance_id: courseInstance.id }) : [],
       ]);
 
       const draftId = await createQtiImportDraft({
-        courseId: res.locals.course.id,
-        courseInstanceId: res.locals.course_instance.id,
+        courseId: course.id,
         userId: res.locals.authn_user.id,
         results,
       });

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
@@ -114,6 +114,15 @@ export interface QuestionOverrides {
   collisionStrategy: CollisionStrategy;
 }
 
+/** Reviewer edits to a conversion result, indexed in parallel with the results array. */
+export interface AssessmentOverrides {
+  title: string;
+  type: 'Homework' | 'Exam';
+  set: string;
+  number: string;
+  included: boolean;
+}
+
 export const DUPLICATE_ASSESSMENT_QUESTION_WARNING =
   'This question appears multiple times on the assessment. Only the first occurrence of the question will be imported.';
 

--- a/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
+++ b/apps/prairielearn/src/pages/instructorQtiImport/instructorQtiImport.types.ts
@@ -203,7 +203,7 @@ export interface UploadResponse {
   strippedAccessRules: StrippedAccessRules;
   /** Assessment set names defined in the course's infoCourse.json. */
   assessmentSetNames: string[];
-  /** Existing (set, number) pairs in this course instance, for deduplication. */
+  /** Existing (set, number) pairs in the target course instance, for deduplication. Empty without one. */
   existingAssessmentLabels: { set: string; number: string }[];
   /** Count of unique questions that appeared in more than one question bank and were deduplicated. */
   deduplicatedQuestionBankQuestionCount: number;

--- a/apps/prairielearn/src/server.ts
+++ b/apps/prairielearn/src/server.ts
@@ -60,6 +60,7 @@ import * as cron from './cron/index.js';
 import * as assets from './lib/assets.js';
 import { makeAwsClientConfig } from './lib/aws.js';
 import { canonicalLoggerMiddleware } from './lib/canonical-logger.js';
+import { getCourseAdminQtiImportUrl } from './lib/client/url.js';
 import * as codeCaller from './lib/code-caller/index.js';
 import { DEV_EXECUTION_MODE, config, loadConfig, setLocalsFromConfig } from './lib/config.js';
 import { pullAndUpdateCourse } from './lib/course.js';
@@ -1217,6 +1218,10 @@ export async function initExpress(): Promise<Express> {
     (await import('./pages/instructorQuestions/instructorQuestions.js')).default,
   );
   app.use(
+    '/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/qti_import',
+    (await import('./pages/instructorQtiImport/instructorQtiImport.js')).default,
+  );
+  app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/course_admin/getting_started',
     (
       await import('./pages/instructorCourseAdminGettingStarted/instructorCourseAdminGettingStarted.js')
@@ -1313,9 +1318,19 @@ export async function initExpress(): Promise<Express> {
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_admin/assessments',
     (await import('./pages/instructorAssessments/instructorAssessments.js')).default,
   );
-  app.use(
+  // The QTI importer moved to the course admin area; keep older links working.
+  app.get(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_admin/qti_import',
-    (await import('./pages/instructorQtiImport/instructorQtiImport.js')).default,
+    (req, res) => {
+      res.redirect(
+        url.format({
+          pathname: getCourseAdminQtiImportUrl({
+            courseInstanceId: req.params.course_instance_id,
+          }),
+          search: getSearchParams(req).toString(),
+        }),
+      );
+    },
   );
   app.use(
     '/pl/course_instance/:course_instance_id(\\d+)/instructor/instance_admin/gradebook',
@@ -1707,6 +1722,10 @@ export async function initExpress(): Promise<Express> {
   app.use(
     '/pl/course/:course_id(\\d+)/course_admin/questions',
     (await import('./pages/instructorQuestions/instructorQuestions.js')).default,
+  );
+  app.use(
+    '/pl/course/:course_id(\\d+)/course_admin/qti_import',
+    (await import('./pages/instructorQtiImport/instructorQtiImport.js')).default,
   );
   if (isEnterprise()) {
     app.use(

--- a/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
@@ -5,7 +5,7 @@ import { pipeline } from 'node:stream/promises';
 
 import { ZipArchive } from 'archiver';
 
-import { getCourseAdminQuestionsUrl } from '../../lib/client/url.js';
+import { getCourseAdminQtiImportUrl, getCourseAdminQuestionsUrl } from '../../lib/client/url.js';
 import { deleteQtiImportDraft } from '../../lib/qti-import-drafts.js';
 import type { UploadResponse } from '../../pages/instructorQtiImport/instructorQtiImport.types.js';
 
@@ -386,14 +386,20 @@ async function buildQuestionBankZip(
 
 test.describe('QTI Import', () => {
   test('can navigate to the import page', async ({ page, courseInstance }) => {
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await expect(page).toHaveTitle(/Import QTI content/);
     await page.waitForSelector('.js-hydrated-component');
 
     await expect(page.getByText('Import QTI content')).toBeVisible();
     await expect(page.getByLabel('Export file')).toBeVisible();
+  });
+
+  test('redirects the old instance admin import URL', async ({ page, courseInstance }) => {
+    await page.goto(
+      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import?return_to=questions`,
+    );
+    await expect(page).toHaveURL(/\/instructor\/course_admin\/qti_import\?return_to=questions$/);
+    await expect(page).toHaveTitle(/Import QTI content/);
   });
 
   test('import button appears on assessments page', async ({ page, courseInstance }) => {
@@ -409,7 +415,7 @@ test.describe('QTI Import', () => {
     const link = page.getByRole('link', { name: 'Import questions' });
 
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute('href', /\/instance_admin\/qti_import\?return_to=questions/);
+    await expect(link).toHaveAttribute('href', /\/course_admin\/qti_import\?return_to=questions/);
   });
 
   test('can upload a QTI zip and see the review step', async ({
@@ -420,9 +426,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-test-fixture.zip');
     await buildQtiZip(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -448,9 +452,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-no-manifest-fixture.zip');
     await buildQtiZip(zipPath, { includeManifest: false });
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -468,9 +470,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-unused-asset-fixture.zip');
     await buildQtiZipWithUnusedAsset(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -494,9 +494,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-plain-imsqti-fixture.zip');
     await buildQtiZip(zipPath, { resourceType: 'imsqti_xmlv1p2' });
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -515,9 +513,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-embedded-bank-course-fixture.imscc');
     await buildEmbeddedBankCourseZip(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -540,9 +536,7 @@ test.describe('QTI Import', () => {
     await buildExternalBankAssessmentZip(assessmentZipPath, { includeCourseId: false });
     await buildQuestionBankZip(bankZipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(assessmentZipPath);
@@ -580,9 +574,7 @@ test.describe('QTI Import', () => {
     await buildExternalBankAssessmentZip(assessmentZipPath);
     await buildQuestionBankZip(bankZipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(assessmentZipPath);
@@ -634,9 +626,7 @@ test.describe('QTI Import', () => {
       questionTitle: 'Unmatched Question',
     });
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(assessmentZipPath);
@@ -683,7 +673,7 @@ test.describe('QTI Import', () => {
     const bankUploadStartedPromise = new Promise<void>((resolve) => {
       bankUploadStarted = resolve;
     });
-    await page.route('**/instructor/instance_admin/qti_import/upload', async (route) => {
+    await page.route('**/course_admin/qti_import/upload', async (route) => {
       bankUploadStarted();
       await continueBankUploadPromise;
       await route.fallback();
@@ -702,7 +692,7 @@ test.describe('QTI Import', () => {
     await expect(secondBankUploadButton).not.toContainText('Uploading');
 
     continueBankUpload!();
-    await page.unroute('**/instructor/instance_admin/qti_import/upload');
+    await page.unroute('**/course_admin/qti_import/upload');
 
     await expect(page.getByText('Matched 1 question bank from that upload.')).toBeVisible({
       timeout: 15000,
@@ -729,9 +719,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-test-fixture.zip');
     await buildQtiZip(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     // Upload and review the export before creating the PrairieLearn assessment.
@@ -799,14 +787,12 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-expired-draft-fixture.zip');
     await buildQtiZip(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     const uploadResponsePromise = page.waitForResponse(
       (response) =>
-        response.url().includes('/instructor/instance_admin/qti_import/upload') &&
+        response.url().includes('/course_admin/qti_import/upload') &&
         response.request().method() === 'POST',
     );
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -833,9 +819,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-test-fixture.zip');
     await buildQtiZip(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);
@@ -861,9 +845,7 @@ test.describe('QTI Import', () => {
     await buildQtiZip(zipPath);
 
     // Seed the course with the imported question.
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
     await page.getByLabel('Export file').setInputFiles(zipPath);
     await page.getByRole('button', { name: 'Import content' }).click();
@@ -872,9 +854,7 @@ test.describe('QTI Import', () => {
     await page.waitForURL(/\/instance_admin\/assessments/, { timeout: 30000 });
 
     // Uploading the same export again should surface conflict controls.
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
     await page.getByLabel('Export file').setInputFiles(zipPath);
     await page.getByRole('button', { name: 'Import content' }).click();
@@ -889,9 +869,7 @@ test.describe('QTI Import', () => {
     const zipPath = path.join(testCoursePath, 'qti-test-fixture.zip');
     await buildQtiZip(zipPath);
 
-    await page.goto(
-      `/pl/course_instance/${courseInstance.id}/instructor/instance_admin/qti_import`,
-    );
+    await page.goto(getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id }));
     await page.waitForSelector('.js-hydrated-component');
 
     await page.getByLabel('Export file').setInputFiles(zipPath);

--- a/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
@@ -7,6 +7,8 @@ import { ZipArchive } from 'archiver';
 
 import { getCourseAdminQtiImportUrl, getCourseAdminQuestionsUrl } from '../../lib/client/url.js';
 import { deleteQtiImportDraft } from '../../lib/qti-import-drafts.js';
+import { selectCourseInstanceByShortName } from '../../models/course-instances.js';
+import { selectCourseByShortName } from '../../models/course.js';
 import type { UploadResponse } from '../../pages/instructorQtiImport/instructorQtiImport.types.js';
 
 import { expect, test } from './fixtures.js';
@@ -777,6 +779,45 @@ test.describe('QTI Import', () => {
         },
       ],
     });
+  });
+
+  test('returns to the questions page of the selected course instance', async ({
+    page,
+    courseInstance,
+    testCoursePath,
+  }) => {
+    const zipPath = path.join(testCoursePath, 'qti-target-fixture.zip');
+    await buildQtiZip(zipPath);
+    const course = await selectCourseByShortName('QA 101');
+    const target = await selectCourseInstanceByShortName({ course, shortName: 'public' });
+    const targetQuestionsUrl = getCourseAdminQuestionsUrl({ courseInstanceId: target.id });
+
+    // Start from one instance's questions page but target a different instance.
+    await page.goto(
+      getCourseAdminQtiImportUrl({ courseInstanceId: courseInstance.id, returnTo: 'questions' }),
+    );
+    await page.waitForSelector('.js-hydrated-component');
+    await page.getByLabel('Target course instance').selectOption(target.id);
+    await page.getByLabel('Export file').setInputFiles(zipPath);
+    await page.getByRole('button', { name: 'Import content' }).click();
+    await expect(page.getByRole('button', { name: 'Import 1 assessment' })).toBeEnabled({
+      timeout: 15000,
+    });
+
+    await page.getByRole('button', { name: 'Import 1 assessment' }).click();
+    await page.waitForURL((url) => url.pathname === targetQuestionsUrl, { timeout: 30000 });
+    await expect(page.getByText('1 assessment imported successfully.')).toBeVisible();
+
+    const assessmentInfo = JSON.parse(
+      await readFile(
+        path.join(
+          testCoursePath,
+          'courseInstances/public/assessments/e2e-import-quiz/infoAssessment.json',
+        ),
+        'utf8',
+      ),
+    );
+    expect(assessmentInfo.title).toBe('E2E Import Quiz');
   });
 
   test('shows a clear error when review draft files have expired', async ({

--- a/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
+++ b/apps/prairielearn/src/tests/e2e/qtiImport.spec.ts
@@ -19,13 +19,22 @@ import { expect, test } from './fixtures.js';
  */
 async function buildQtiZip(
   destPath: string,
-  options?: { includeManifest?: boolean; resourceType?: string },
+  options?: {
+    assessmentId?: string;
+    assessmentTitle?: string;
+    includeManifest?: boolean;
+    questionId?: string;
+    resourceType?: string;
+  },
 ): Promise<void> {
+  const assessmentId = options?.assessmentId ?? 'test_assess_1';
+  const assessmentTitle = options?.assessmentTitle ?? 'E2E Import Quiz';
+  const questionId = options?.questionId ?? 'q_mc_1';
   const qtiXml = `<?xml version="1.0" encoding="UTF-8"?>
 <questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2">
-  <assessment ident="test_assess_1" title="E2E Import Quiz">
+  <assessment ident="${assessmentId}" title="${assessmentTitle}">
     <section ident="root_section">
-      <item ident="q_mc_1" title="Sample MC Question">
+      <item ident="${questionId}" title="Sample MC Question">
         <itemmetadata>
           <qtimetadata>
             <qtimetadatafield>
@@ -72,8 +81,8 @@ async function buildQtiZip(
   const manifest = `<?xml version="1.0" encoding="UTF-8"?>
 <manifest identifier="test_manifest" xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
   <resources>
-    <resource identifier="test_assess_1" type="${options?.resourceType ?? 'imsqti_xmlv1p2/imscc_xmlv1p1/assessment'}">
-      <file href="test_assess_1/test_assess_1.xml"/>
+    <resource identifier="${assessmentId}" type="${options?.resourceType ?? 'imsqti_xmlv1p2/imscc_xmlv1p1/assessment'}">
+      <file href="${assessmentId}/${assessmentId}.xml"/>
     </resource>
   </resources>
 </manifest>`;
@@ -82,9 +91,9 @@ async function buildQtiZip(
   const output = createWriteStream(destPath);
   if (options?.includeManifest !== false) {
     archive.append(manifest, { name: 'imsmanifest.xml' });
-    archive.append(qtiXml, { name: 'test_assess_1/test_assess_1.xml' });
+    archive.append(qtiXml, { name: `${assessmentId}/${assessmentId}.xml` });
   } else {
-    archive.append(qtiXml, { name: 'test_assess_1.xml' });
+    archive.append(qtiXml, { name: `${assessmentId}.xml` });
   }
   void archive.finalize();
   await pipeline(archive, output);
@@ -787,7 +796,11 @@ test.describe('QTI Import', () => {
     testCoursePath,
   }) => {
     const zipPath = path.join(testCoursePath, 'qti-target-fixture.zip');
-    await buildQtiZip(zipPath);
+    await buildQtiZip(zipPath, {
+      assessmentId: 'target_assess_1',
+      assessmentTitle: 'E2E Target Quiz',
+      questionId: 'target_q_mc_1',
+    });
     const course = await selectCourseByShortName('QA 101');
     const target = await selectCourseInstanceByShortName({ course, shortName: 'public' });
     const targetQuestionsUrl = getCourseAdminQuestionsUrl({ courseInstanceId: target.id });
@@ -812,12 +825,12 @@ test.describe('QTI Import', () => {
       await readFile(
         path.join(
           testCoursePath,
-          'courseInstances/public/assessments/e2e-import-quiz/infoAssessment.json',
+          'courseInstances/public/assessments/e2e-target-quiz/infoAssessment.json',
         ),
         'utf8',
       ),
     );
-    expect(assessmentInfo.title).toBe('E2E Import Quiz');
+    expect(assessmentInfo.title).toBe('E2E Target Quiz');
   });
 
   test('shows a clear error when review draft files have expired', async ({

--- a/apps/prairielearn/src/tests/qtiImport.test.ts
+++ b/apps/prairielearn/src/tests/qtiImport.test.ts
@@ -162,10 +162,12 @@ describe('QTI import into a course without course instances', { timeout: 60_000 
     );
   });
 
-  it('renders the importer page', async () => {
+  it('renders the importer page with a link to create a course instance', async () => {
     const res = await fetch(`${siteUrl}${importUrl}`);
     assert.equal(res.status, 200);
-    assert.include(await res.text(), 'Import QTI content');
+    const html = await res.text();
+    assert.include(html, 'Import QTI content');
+    assert.include(html, `/pl/course/${COURSE_ID}/course_admin/instances`);
   });
 
   it('rejects an upload that targets an unknown course instance', async () => {

--- a/apps/prairielearn/src/tests/qtiImport.test.ts
+++ b/apps/prairielearn/src/tests/qtiImport.test.ts
@@ -1,0 +1,246 @@
+import { createWriteStream } from 'node:fs';
+import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import { TRPCClientError } from '@trpc/client';
+import { ZipArchive } from 'archiver';
+import { execa } from 'execa';
+import fs from 'fs-extra';
+import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+
+import { generatePrefixCsrfToken } from '@prairielearn/signed-token';
+
+import {
+  getCourseAdminQtiImportUrl,
+  getCourseAdminQuestionsUrl,
+  getCourseTrpcUrl,
+} from '../lib/client/url.js';
+import { config } from '../lib/config.js';
+import { selectOptionalQuestionByQid } from '../models/question.js';
+import type { UploadResponse } from '../pages/instructorQtiImport/instructorQtiImport.types.js';
+import { createCourseTrpcClient } from '../trpc/course/client.js';
+
+import {
+  type CourseRepoFixture,
+  createCourseRepoFixture,
+  updateCourseRepository,
+} from './helperCourse.js';
+import * as helperServer from './helperServer.js';
+
+const siteUrl = `http://localhost:${config.serverPort}`;
+const COURSE_ID = '1';
+const importUrl = getCourseAdminQtiImportUrl({ courseId: COURSE_ID });
+
+async function populateOrigin(originDir: string) {
+  await fs.ensureDir(originDir);
+  await fs.writeJSON(path.join(originDir, 'infoCourse.json'), {
+    uuid: '01234567-89ab-cdef-0123-456789abcdef',
+    name: 'TEST 101',
+    title: 'Test Course',
+    topics: [{ name: 'Test', color: 'gray3', description: 'Test topic' }],
+  });
+}
+
+/** Build a minimal QTI 1.2 quiz export zip with one multiple-choice question. */
+async function buildQtiZip(destPath: string): Promise<void> {
+  const qtiXml = `<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2">
+  <assessment ident="test_assess_1" title="Import Quiz">
+    <section ident="root_section">
+      <item ident="q_mc_1" title="Sample MC Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_choice_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>1.0</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;p&gt;What color is the sky?&lt;/p&gt;</mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="1001">
+                <material><mattext texttype="text/plain">Blue</mattext></material>
+              </response_label>
+              <response_label ident="1002">
+                <material><mattext texttype="text/plain">Green</mattext></material>
+              </response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <varequal respident="response1">1001</varequal>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>`;
+
+  const manifest = `<?xml version="1.0" encoding="UTF-8"?>
+<manifest identifier="test_manifest" xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+  <resources>
+    <resource identifier="test_assess_1" type="imsqti_xmlv1p2/imscc_xmlv1p1/assessment">
+      <file href="test_assess_1/test_assess_1.xml"/>
+    </resource>
+  </resources>
+</manifest>`;
+
+  const archive = new ZipArchive();
+  const output = createWriteStream(destPath);
+  archive.append(manifest, { name: 'imsmanifest.xml' });
+  archive.append(qtiXml, { name: 'test_assess_1/test_assess_1.xml' });
+  void archive.finalize();
+  await pipeline(archive, output);
+}
+
+async function uploadQtiZip(zipPath: string, courseInstanceId?: string): Promise<Response> {
+  const csrfToken = generatePrefixCsrfToken(
+    { url: importUrl, authn_user_id: '1' },
+    config.secretKey,
+  );
+  const formData = new FormData();
+  if (courseInstanceId != null) {
+    formData.set('course_instance_id', courseInstanceId);
+  }
+  formData.set(
+    'file',
+    new Blob([await fs.readFile(zipPath)], { type: 'application/zip' }),
+    path.basename(zipPath),
+  );
+  return await fetch(`${siteUrl}${importUrl}/upload`, {
+    method: 'POST',
+    headers: { 'X-CSRF-Token': csrfToken, Accept: 'application/json' },
+    body: formData,
+  });
+}
+
+function createTrpcClient() {
+  const csrfToken = generatePrefixCsrfToken(
+    { url: getCourseTrpcUrl(COURSE_ID), authn_user_id: '1' },
+    config.secretKey,
+  );
+  return createCourseTrpcClient({ csrfToken, courseId: COURSE_ID, urlBase: siteUrl });
+}
+
+describe('QTI import into a course without course instances', { timeout: 60_000 }, () => {
+  let courseRepo: CourseRepoFixture;
+  let zipPath: string;
+  let uploadResponse: UploadResponse;
+
+  beforeAll(async () => {
+    courseRepo = await createCourseRepoFixture({ populateOrigin });
+    await helperServer.before(courseRepo.courseLiveDir)();
+    await updateCourseRepository({ courseId: COURSE_ID, repository: courseRepo.courseOriginDir });
+
+    zipPath = path.join(courseRepo.baseDir, 'qti-fixture.zip');
+    await buildQtiZip(zipPath);
+  });
+
+  afterAll(helperServer.after);
+
+  it('links to the importer from the questions page', async () => {
+    const res = await fetch(`${siteUrl}${getCourseAdminQuestionsUrl({ courseId: COURSE_ID })}`);
+    assert.equal(res.status, 200);
+    assert.include(
+      await res.text(),
+      getCourseAdminQtiImportUrl({ courseId: COURSE_ID, returnTo: 'questions' }),
+    );
+  });
+
+  it('renders the importer page', async () => {
+    const res = await fetch(`${siteUrl}${importUrl}`);
+    assert.equal(res.status, 200);
+    assert.include(await res.text(), 'Import QTI content');
+  });
+
+  it('rejects an upload that targets an unknown course instance', async () => {
+    const res = await uploadQtiZip(zipPath, '999');
+    assert.equal(res.status, 400);
+  });
+
+  it('accepts an upload without a course instance', async () => {
+    const res = await uploadQtiZip(zipPath);
+    assert.equal(res.status, 200);
+
+    uploadResponse = (await res.json()) as UploadResponse;
+    assert.lengthOf(uploadResponse.results, 1);
+    assert.equal(uploadResponse.results[0].sourceType, 'assessment');
+    assert.lengthOf(uploadResponse.results[0].questions, 1);
+    assert.deepEqual(uploadResponse.existingAssessmentLabels, []);
+  });
+
+  it('refuses to import assessments without a course instance', async () => {
+    const result = uploadResponse.results[0];
+    assert(result.sourceType === 'assessment');
+
+    const error = await createTrpcClient()
+      .qtiImport.create.mutate({
+        courseInstanceId: null,
+        assessments: [
+          {
+            directoryName: result.assessment.directoryName,
+            infoJson: { ...result.assessment.infoJson },
+            questions: result.questions.map((question) => ({
+              draftId: question.draftId,
+              originalDirectoryName: question.originalDirectoryName,
+              directoryName: question.directoryName,
+              infoJson: { ...question.infoJson },
+            })),
+          },
+        ],
+      })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    assert(error instanceof TRPCClientError);
+    assert.equal(error.data?.code, 'BAD_REQUEST');
+  });
+
+  it('imports quiz questions as standalone questions', async () => {
+    const question = uploadResponse.results[0].questions[0];
+
+    await createTrpcClient().qtiImport.create.mutate({
+      courseInstanceId: null,
+      questions: [
+        {
+          draftId: question.draftId,
+          originalDirectoryName: question.originalDirectoryName,
+          directoryName: question.directoryName,
+          infoJson: { ...question.infoJson },
+        },
+      ],
+    });
+
+    const importedQuestion = await selectOptionalQuestionByQid({
+      qid: question.directoryName,
+      course_id: COURSE_ID,
+    });
+    assert.isNotNull(importedQuestion);
+    assert.equal(importedQuestion.title, 'Sample MC Question');
+
+    await execa('git', ['pull'], { cwd: courseRepo.courseDevDir, env: process.env });
+    assert.isTrue(
+      await fs.pathExists(
+        path.join(courseRepo.courseDevDir, 'questions', question.directoryName, 'info.json'),
+      ),
+    );
+    assert.isFalse(await fs.pathExists(path.join(courseRepo.courseDevDir, 'courseInstances')));
+  });
+});

--- a/apps/prairielearn/src/trpc/course/qti-import.ts
+++ b/apps/prairielearn/src/trpc/course/qti-import.ts
@@ -1,19 +1,24 @@
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 import { flash } from '@prairielearn/flash';
+import { run } from '@prairielearn/run';
 import { throwAppError } from '@prairielearn/trpc/server';
+import { IdSchema } from '@prairielearn/zod';
 
 import {
   type QtiImportAssessmentData,
   QtiImportEditor,
   type QtiImportQuestionData,
 } from '../../lib/editors.js';
+import { idsEqual } from '../../lib/id.js';
 import { readQtiImportDraft } from '../../lib/qti-import-drafts.js';
 import { SHORT_NAME_REGEX } from '../../lib/short-name.js';
+import { selectCourseInstancesWithStaffAccess } from '../../models/course-instances.js';
 import { AssessmentJsonSchema } from '../../schemas/infoAssessment.js';
 import { QuestionJsonSchema } from '../../schemas/infoQuestion.js';
 
-import { requireCoursePermissionEdit, t } from './init.js';
+import { requireCoursePermissionEdit, requireNotExampleCourse, t } from './init.js';
 
 const QTI_IMPORT_DRAFT_UNAVAILABLE_MESSAGE =
   'The uploaded course content files are no longer available. Restart the import process and upload the export again.';
@@ -99,17 +104,36 @@ export interface QtiImportError {
 
 const create = t.procedure
   .use(requireCoursePermissionEdit)
+  .use(requireNotExampleCourse)
   .input(
     z
       .object({
+        courseInstanceId: IdSchema.nullable(),
         assessments: z.array(AssessmentDataSchema).default([]),
         questions: z.array(QuestionDataSchema).default([]),
       })
       .refine((data) => data.assessments.length > 0 || data.questions.length > 0, {
         message: 'At least one assessment or question must be included',
+      })
+      .refine((data) => data.assessments.length === 0 || data.courseInstanceId != null, {
+        message: 'A course instance is required to import assessments',
       }),
   )
   .mutation(async ({ input, ctx }) => {
+    const courseInstance = await run(async () => {
+      const { courseInstanceId } = input;
+      if (courseInstanceId == null) return null;
+      const courseInstances = await selectCourseInstancesWithStaffAccess({
+        course: ctx.course,
+        authzData: ctx.authz_data,
+      });
+      const courseInstance = courseInstances.find((ci) => idsEqual(ci.id, courseInstanceId));
+      if (!courseInstance) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid course instance' });
+      }
+      return courseInstance;
+    });
+
     const draftCache = new Map<string, Promise<StoredSerializedConversionResultForHydration[]>>();
     const loadDraft = (draftId: string) => {
       let promise = draftCache.get(draftId);
@@ -117,7 +141,6 @@ const create = t.procedure
         promise = readQtiImportDraft({
           draftId,
           courseId: ctx.course.id,
-          courseInstanceId: ctx.course_instance.id,
           userId: ctx.locals.authn_user.id,
         })
           .then((draft) =>
@@ -179,6 +202,7 @@ const create = t.procedure
 
     const editor = new QtiImportEditor({
       locals: ctx.locals,
+      course_instance: courseInstance,
       assessments,
       questions,
     });

--- a/apps/prairielearn/src/trpc/course/trpc.ts
+++ b/apps/prairielearn/src/trpc/course/trpc.ts
@@ -5,12 +5,14 @@ import { handleTrpcError } from '../../lib/trpc.js';
 import { assessmentModulesRouter } from './assessment-modules.js';
 import { courseStaffRouter } from './course-staff.js';
 import { createContext, t } from './init.js';
+import { qtiImportRouter } from './qti-import.js';
 import { questionsRouter } from './questions.js';
 import { sharingRouter } from './sharing.js';
 
 const courseRouter = t.router({
   assessmentModules: assessmentModulesRouter,
   courseStaff: courseStaffRouter,
+  qtiImport: qtiImportRouter,
   questions: questionsRouter,
   sharing: sharingRouter,
 });

--- a/apps/prairielearn/src/trpc/courseInstance/trpc.ts
+++ b/apps/prairielearn/src/trpc/courseInstance/trpc.ts
@@ -4,11 +4,9 @@ import { handleTrpcError } from '../../lib/trpc.js';
 
 import { createContext, t } from './init.js';
 import { instanceAdminSettingsRouter } from './instance-admin-settings.js';
-import { qtiImportRouter } from './qti-import.js';
 import { studentLabelsRouter } from './student-labels.js';
 
 const courseInstanceRouter = t.router({
-  qtiImport: qtiImportRouter,
   instanceAdminSettings: instanceAdminSettingsRouter,
   studentLabels: studentLabelsRouter,
 });

--- a/docs/importingContent.md
+++ b/docs/importingContent.md
@@ -24,6 +24,8 @@ You can start the QTI importer from either of these pages:
 
 Both entry points use the same importer. If you start from the Questions page, PrairieLearn returns you to the Questions page after the import completes. Otherwise, it returns you to the Assessments page.
 
+Assessments can only be created inside a course instance. If your course has more than one, the importer lets you choose which one receives the imported assessments. You can also import from the Questions page before the course has any course instances; quizzes in the export are then imported as standalone questions that you can add to assessments later.
+
 ## What you can import
 
 The import tool supports individual quiz exports (`.zip` files) and full course exports (`.imscc` files). It handles the following QTI 1.2 question types:
@@ -108,7 +110,7 @@ Other LMS platforms may have similar export features. Look for "QTI export" or "
 8. If an imported question conflicts with an existing question directory, choose **Replace existing question** or **Keep both**. You can also apply overwrite/rename choices to all conflicts in a section.
 9. Click the final **Import** button to create the selected content.
 
-Imported questions are written under `questions/imported/`. Imported assessments are written under the current course instance's `assessments/` directory. After import, you can edit the generated content like any other PrairieLearn question or assessment.
+Imported questions are written under `questions/imported/`. Imported assessments are written under the selected course instance's `assessments/` directory. After import, you can edit the generated content like any other PrairieLearn question or assessment.
 
 ## Tips
 


### PR DESCRIPTION
# Description

> Firas (and other instructors in the past) have noted that QTI import currently requires an existing course instance, and that this is a bit of a pain point. This PR makes QTI import usable in the circumstance where no instance exists.

The QTI importer (page, upload endpoint, and tRPC mutation) lived entirely under the course instance scope, so a course with no course instances had no way to import content: the Questions page hid **Import questions** unless at least one instance existed, and there was no instance URL to send the user to anyway. That's a bad first experience for a new course that wants to start by pulling questions out of Canvas before setting up a term

QTI import now:

- lives in the course admin area at `course_admin/qti_import`, mounted under both the `/pl/course/:id` and `/pl/course_instance/:id/instructor` prefixes, exactly like the Questions page
- treats the course instance as an optional import *target* rather than a scoping requirement; the picker preselects the current instance (or the first accessible one), and the selected id travels with the upload and the `create` mutation
- imports quizzes as standalone questions when the course has no course instances, with an info alert on the upload step and the skipped assessments listed under "What won't be imported" on the review step
- always shows **Import questions** on the Questions page when the user can add questions
- redirects the old `instance_admin/qti_import` URL to the new location, preserving the query string

Implementation notes:

- `course.qtiImport.create` replaces `courseInstance.qtiImport.create`; it takes a nullable `courseInstanceId`, validates it against the staff-accessible instances (same `idsEqual` + `BAD_REQUEST` pattern as `course-staff.ts`), and rejects assessments without one
- `QtiImportEditor` takes `course_instance: CourseInstance | null`; the `shareSourcePublicly` check, assessments directory, job description, and commit message are all conditional on it
- import drafts are keyed by course + user only; drafts written before this change still parse since the extra field is stripped
- the client uses a single course-scoped CSRF token pair instead of a per-instance map, and no longer rebuilds its tRPC client when the target changes
- a new `getCourseAdminQtiImportUrl()` helper backs the links, the redirect, and the tests

Decisions made along the way:

- **Move to course scope vs. add a parallel questions-only route.** Moving keeps one page and one mutation; a parallel route would have duplicated both
- **Questions-only vs. rejecting quizzes when there's no instance.** Rejecting would make the most common Canvas export (a single quiz) useless for a brand-new course
- **No "none" option in the picker when instances exist.** Behavior there is unchanged; users can still uncheck assessments in the review step
- **Redirect the old URL** rather than dropping it, in case the link has been shared or bookmarked

- [x] I have disclosed the level of AI assistance used: The majority of the implementation was completed with assistance by Claude

# Testing

Added an integration test (`tests/qtiImport.test.ts`) that runs the server against a course fixture with zero course instances and covers:

- the Questions page linking to the importer
- the importer page rendering at the course-level URL, including a link to create a course instance
- uploading an export with no `course_instance_id` (quiz parsed, `existingAssessmentLabels` empty)
- rejecting an upload that names an instance the course doesn't have
- `create` rejecting assessments when `courseInstanceId` is `null`
- a questions-only import that writes to the repo, syncs, and leaves no `courseInstances/` directory behind

Updated the e2e spec to the new URLs and added a case for the legacy redirect; every existing case (full import flow, missing banks, conflicts, expired drafts, etc.) passes unchanged otherwise

Follow-ups from review:

- `instructorQtiImport.payload.test.ts` unit-tests the extracted `buildImportPayload()` directly: the no-instance branch that flattens quizzes into standalone questions, exclusion and rename/overwrite handling in both branches, and assessment directory suffixing (which surfaced and fixed a latent bug where two same-named assessments both received the `-2` suffix)
- a new e2e case starts from one instance's Questions page, picks a different target instance, imports, and asserts both the landing URL and that the assessment was written under the target instance
- `ImportReviewComponents.test.tsx` covers the upload step's zero / one / many course instance states, including the read-only target field and the create-instance link
