### PR TITLE
Show enrollment and billing status in course instance settings

### DIFF
--- a/apps/prairielearn/src/ee/models/enrollment.ts
+++ b/apps/prairielearn/src/ee/models/enrollment.ts
@@ -96,6 +96,69 @@ export async function getEnrollmentCountsForCourseInstance(
   };
 }
 
+interface EnrollmentContext {
+  institution: Institution;
+  course: Course;
+  courseInstance: CourseInstance;
+}
+
+export interface EnrollmentCapacity {
+  limit: number;
+  used: number;
+  remaining: number;
+  annualLimitSource: 'course' | 'institution' | null;
+}
+
+export function getCourseInstanceEnrollmentLimit({
+  institution,
+  course,
+  courseInstance,
+}: EnrollmentContext): number {
+  return (
+    courseInstance.enrollment_limit ??
+    course.course_instance_enrollment_limit ??
+    institution.course_instance_enrollment_limit
+  );
+}
+
+/** Returns free enrollment capacity, including shared limits over the past year. */
+export async function getEnrollmentCapacity({
+  institution,
+  course,
+  courseInstance,
+}: EnrollmentContext): Promise<EnrollmentCapacity> {
+  const institutionEnrollmentCounts = await getEnrollmentCountsForInstitution({
+    institution_id: institution.id,
+    created_since: '1 year',
+  });
+  const courseEnrollmentCounts = await getEnrollmentCountsForCourse({
+    course_id: course.id,
+    created_since: '1 year',
+  });
+  const courseInstanceEnrollmentCounts = await getEnrollmentCountsForCourseInstance(
+    courseInstance.id,
+  );
+
+  const limit = getCourseInstanceEnrollmentLimit({ institution, course, courseInstance });
+  const used = courseInstanceEnrollmentCounts.free;
+  const instanceRemaining = limit - used;
+  const institutionRemaining =
+    institution.yearly_enrollment_limit - institutionEnrollmentCounts.free;
+  // The institution's annual limit always applies, even with a course override.
+  const courseRemaining =
+    (course.yearly_enrollment_limit ?? institution.yearly_enrollment_limit) -
+    courseEnrollmentCounts.free;
+  const remaining = Math.max(0, Math.min(instanceRemaining, institutionRemaining, courseRemaining));
+  const annualLimitSource =
+    Math.min(institutionRemaining, courseRemaining) < instanceRemaining
+      ? institutionRemaining <= courseRemaining
+        ? 'institution'
+        : 'course'
+      : null;
+
+  return { limit, used, remaining, annualLimitSource };
+}
+
 export enum PotentialEnrollmentStatus {
   ALLOWED = 'allowed',
   LIMIT_EXCEEDED = 'limit_exceeded',
@@ -161,44 +224,8 @@ export async function checkPotentialEnterpriseEnrollment({
   // exceeded by one or two users. Future enrollments will still be blocked,
   // which will prompt course/institution staff to seek an increase in their
   // enrollment limit.
-  const institutionEnrollmentCounts = await getEnrollmentCountsForInstitution({
-    institution_id: institution.id,
-    created_since: '1 year',
-  });
-  const courseEnrollmentCounts = await getEnrollmentCountsForCourse({
-    course_id: courseInstance.course_id,
-    created_since: '1 year',
-  });
-  const courseInstanceEnrollmentCounts = await getEnrollmentCountsForCourseInstance(
-    courseInstance.id,
-  );
-
-  const freeInstitutionEnrollmentCount = institutionEnrollmentCounts.free;
-  const freeCourseEnrollmentCount = courseEnrollmentCounts.free;
-  const freeCourseInstanceEnrollmentCount = courseInstanceEnrollmentCounts.free;
-
-  // If both an institutional and course yearly enrollment limit are defined, we'll
-  // always enforce both of them. That is, the institutional yearly enrollment limit
-  // always applies, and the course yearly enrollment can only serve as a tighter
-  // bound on that.
-  //
-  // If a course yearly enrollment limit is not defined, we'll use the institutional
-  // enrollment limit as the upper bound, as the number of enrollments in the course
-  // must by definition be less than or equal to the number of enrollments in the
-  // institution as a whole.
-  const institutionYearlyEnrollmentLimit = institution.yearly_enrollment_limit;
-  const courseYearlyEnrollmentLimit =
-    course.yearly_enrollment_limit ?? institutionYearlyEnrollmentLimit;
-  const courseInstanceEnrollmentLimit =
-    courseInstance.enrollment_limit ??
-    course.course_instance_enrollment_limit ??
-    institution.course_instance_enrollment_limit;
-
-  if (
-    freeInstitutionEnrollmentCount + 1 > institutionYearlyEnrollmentLimit ||
-    freeCourseEnrollmentCount + 1 > courseYearlyEnrollmentLimit ||
-    freeCourseInstanceEnrollmentCount + 1 > courseInstanceEnrollmentLimit
-  ) {
+  const capacity = await getEnrollmentCapacity({ institution, course, courseInstance });
+  if (capacity.remaining === 0) {
     return PotentialEnrollmentStatus.LIMIT_EXCEEDED;
   }
 

--- a/apps/prairielearn/src/ee/models/enrollment.ts
+++ b/apps/prairielearn/src/ee/models/enrollment.ts
@@ -96,12 +96,6 @@ export async function getEnrollmentCountsForCourseInstance(
   };
 }
 
-interface EnrollmentContext {
-  institution: Institution;
-  course: Course;
-  courseInstance: CourseInstance;
-}
-
 export interface EnrollmentCapacity {
   limit: number;
   used: number;
@@ -109,24 +103,16 @@ export interface EnrollmentCapacity {
   annualLimitSource: 'course' | 'institution' | null;
 }
 
-export function getCourseInstanceEnrollmentLimit({
-  institution,
-  course,
-  courseInstance,
-}: EnrollmentContext): number {
-  return (
-    courseInstance.enrollment_limit ??
-    course.course_instance_enrollment_limit ??
-    institution.course_instance_enrollment_limit
-  );
-}
-
 /** Returns free enrollment capacity, including shared limits over the past year. */
 export async function getEnrollmentCapacity({
   institution,
   course,
   courseInstance,
-}: EnrollmentContext): Promise<EnrollmentCapacity> {
+}: {
+  institution: Institution;
+  course: Course;
+  courseInstance: CourseInstance;
+}): Promise<EnrollmentCapacity> {
   const institutionEnrollmentCounts = await getEnrollmentCountsForInstitution({
     institution_id: institution.id,
     created_since: '1 year',
@@ -139,7 +125,10 @@ export async function getEnrollmentCapacity({
     courseInstance.id,
   );
 
-  const limit = getCourseInstanceEnrollmentLimit({ institution, course, courseInstance });
+  const limit =
+    courseInstance.enrollment_limit ??
+    course.course_instance_enrollment_limit ??
+    institution.course_instance_enrollment_limit;
   const used = courseInstanceEnrollmentCounts.free;
   const instanceRemaining = limit - used;
   const institutionRemaining =
@@ -224,8 +213,44 @@ export async function checkPotentialEnterpriseEnrollment({
   // exceeded by one or two users. Future enrollments will still be blocked,
   // which will prompt course/institution staff to seek an increase in their
   // enrollment limit.
-  const capacity = await getEnrollmentCapacity({ institution, course, courseInstance });
-  if (capacity.remaining === 0) {
+  const institutionEnrollmentCounts = await getEnrollmentCountsForInstitution({
+    institution_id: institution.id,
+    created_since: '1 year',
+  });
+  const courseEnrollmentCounts = await getEnrollmentCountsForCourse({
+    course_id: courseInstance.course_id,
+    created_since: '1 year',
+  });
+  const courseInstanceEnrollmentCounts = await getEnrollmentCountsForCourseInstance(
+    courseInstance.id,
+  );
+
+  const freeInstitutionEnrollmentCount = institutionEnrollmentCounts.free;
+  const freeCourseEnrollmentCount = courseEnrollmentCounts.free;
+  const freeCourseInstanceEnrollmentCount = courseInstanceEnrollmentCounts.free;
+
+  // If both an institutional and course yearly enrollment limit are defined, we'll
+  // always enforce both of them. That is, the institutional yearly enrollment limit
+  // always applies, and the course yearly enrollment can only serve as a tighter
+  // bound on that.
+  //
+  // If a course yearly enrollment limit is not defined, we'll use the institutional
+  // enrollment limit as the upper bound, as the number of enrollments in the course
+  // must by definition be less than or equal to the number of enrollments in the
+  // institution as a whole.
+  const institutionYearlyEnrollmentLimit = institution.yearly_enrollment_limit;
+  const courseYearlyEnrollmentLimit =
+    course.yearly_enrollment_limit ?? institutionYearlyEnrollmentLimit;
+  const courseInstanceEnrollmentLimit =
+    courseInstance.enrollment_limit ??
+    course.course_instance_enrollment_limit ??
+    institution.course_instance_enrollment_limit;
+
+  if (
+    freeInstitutionEnrollmentCount + 1 > institutionYearlyEnrollmentLimit ||
+    freeCourseEnrollmentCount + 1 > courseYearlyEnrollmentLimit ||
+    freeCourseInstanceEnrollmentCount + 1 > courseInstanceEnrollmentLimit
+  ) {
     return PotentialEnrollmentStatus.LIMIT_EXCEEDED;
   }
 

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/EnrollmentAndBillingCard.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/components/EnrollmentAndBillingCard.tsx
@@ -1,0 +1,80 @@
+import { Alert, Card } from 'react-bootstrap';
+
+import type { EnrollmentCapacity } from '../../../ee/models/enrollment.js';
+
+export interface EnrollmentAndBillingCardProps {
+  studentBillingEnabled: boolean;
+  studentComputeBillingEnabled: boolean;
+  enrollmentCount: number;
+  capacity: EnrollmentCapacity | null;
+}
+
+export function EnrollmentAndBillingCard({
+  studentBillingEnabled,
+  studentComputeBillingEnabled,
+  enrollmentCount,
+  capacity,
+}: EnrollmentAndBillingCardProps) {
+  // Large limits are operational safeguards, not instructor-facing allowances.
+  const showAllowance = capacity !== null && capacity.limit < 10_000;
+
+  return (
+    <Card aria-labelledby="enrollment-and-billing-heading">
+      <Card.Body>
+        <h2 id="enrollment-and-billing-heading" className="h5 card-title mb-3">
+          Enrollment and billing
+        </h2>
+        <h3 className="h6">
+          {studentBillingEnabled
+            ? 'Student billing enabled'
+            : studentComputeBillingEnabled
+              ? 'Student billing for compute features'
+              : 'Student payment not required'}
+        </h3>
+        {studentBillingEnabled ? (
+          <p className="mb-0">Students pay for access to this course instance.</p>
+        ) : !studentComputeBillingEnabled ? (
+          <p className="mb-0">Students can enroll without paying for course access.</p>
+        ) : null}
+        {studentComputeBillingEnabled && (
+          <p className="mb-0">Students pay for external grading and workspaces.</p>
+        )}
+        {studentBillingEnabled && (
+          <p className="mt-3 mb-0">
+            {enrollmentCount.toLocaleString('en-US')}{' '}
+            {enrollmentCount === 1 ? 'enrollment' : 'enrollments'}
+          </p>
+        )}
+        {showAllowance && (
+          <div className="mt-3">
+            <h3 className="h6">Enrollment allowance</h3>
+            <p className="mb-0">
+              {capacity.used.toLocaleString('en-US')} of {capacity.limit.toLocaleString('en-US')}{' '}
+              enrollments used{' · '}
+              <strong>{capacity.remaining.toLocaleString('en-US')} remaining</strong>
+            </p>
+            {capacity.annualLimitSource && (
+              <p className="mt-2 mb-0">
+                Remaining capacity is limited by the {capacity.annualLimitSource}'s shared
+                enrollment limit over the past year.
+              </p>
+            )}
+            {enrollmentCount > capacity.used && (
+              <p className="small text-muted mt-2 mb-0">
+                Students with individually purchased or sponsored course access do not use this
+                allowance.
+              </p>
+            )}
+          </div>
+        )}
+        {capacity?.remaining === 0 && (
+          <Alert variant="warning" className="mt-3 mb-0">
+            {showAllowance
+              ? 'The enrollment allowance has been reached. Contact support to increase it.'
+              : 'An enrollment limit has been reached. Contact support to enable additional enrollments.'}
+          </Alert>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -12,7 +12,6 @@ import { type Timezone, formatTimezone } from '@prairielearn/utils/timezone';
 import { GitHubButton } from '../../components/GitHubButton.js';
 import { ShareSourcePubliclyCard } from '../../components/ShareSourcePubliclyCard.js';
 import { CourseInstanceShortNameDescription } from '../../components/ShortNameDescriptions.js';
-import type { EnrollmentCapacity } from '../../ee/models/enrollment.js';
 import type { PageContext } from '../../lib/client/page-context.js';
 import { getAssessmentSettingsUrl } from '../../lib/client/url.js';
 import { validateShortName } from '../../lib/short-name.js';
@@ -20,6 +19,10 @@ import { createCourseInstanceTrpcClient } from '../../trpc/courseInstance/client
 import { TRPCProvider } from '../../trpc/courseInstance/context.js';
 
 import { CopyCourseInstanceModal } from './components/CopyCourseInstanceModal.js';
+import {
+  EnrollmentAndBillingCard,
+  type EnrollmentAndBillingCardProps,
+} from './components/EnrollmentAndBillingCard.js';
 import { SelfEnrollmentSettings } from './components/SelfEnrollmentSettings.js';
 import type { SettingsFormValues } from './instructorInstanceAdminSettings.types.js';
 
@@ -41,7 +44,7 @@ interface InstructorInstanceAdminSettingsProps {
   nonPublicAssessmentsInCourseInstance: { id: string; tid: string }[];
   questionSharingEnabled: boolean;
   accessControlMigrationNeeded: boolean;
-  enrollmentCapacity: EnrollmentCapacity | null;
+  enrollmentAndBilling: EnrollmentAndBillingCardProps | null;
 }
 
 export function InstructorInstanceAdminSettings({
@@ -85,7 +88,7 @@ function InstructorInstanceAdminSettingsInner({
   nonPublicAssessmentsInCourseInstance,
   questionSharingEnabled,
   accessControlMigrationNeeded,
-  enrollmentCapacity,
+  enrollmentAndBilling,
 }: Omit<InstructorInstanceAdminSettingsProps, 'trpcCsrfToken'>) {
   const [showCopyModal, setShowCopyModal] = useState(false);
 
@@ -272,31 +275,7 @@ function InstructorInstanceAdminSettingsInner({
             </div>
           </div>
 
-          {enrollmentCapacity && (
-            <div className="card" aria-labelledby="enrollment-capacity-heading">
-              <div className="card-body">
-                <h2 id="enrollment-capacity-heading" className="h5 card-title mb-3">
-                  Enrollment capacity
-                </h2>
-                <p className="mb-2">
-                  {enrollmentCapacity.used.toLocaleString('en-US')} of{' '}
-                  {enrollmentCapacity.limit.toLocaleString('en-US')} free enrollments used
-                  {' · '}
-                  <strong>{enrollmentCapacity.remaining.toLocaleString('en-US')} remaining</strong>
-                </p>
-                {enrollmentCapacity.annualLimitSource && (
-                  <p className="mb-2">
-                    Remaining capacity is limited by the{' '}
-                    {enrollmentCapacity.annualLimitSource === 'course' ? 'course' : 'institution'}
-                    's shared enrollment limit over the past year.
-                  </p>
-                )}
-                <p className="small text-muted mb-0">
-                  Paid enrollments do not count toward these limits.
-                </p>
-              </div>
-            </div>
-          )}
+          {enrollmentAndBilling && <EnrollmentAndBillingCard {...enrollmentAndBilling} />}
 
           <div className="card">
             <div className="card-body">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.html.tsx
@@ -12,6 +12,7 @@ import { type Timezone, formatTimezone } from '@prairielearn/utils/timezone';
 import { GitHubButton } from '../../components/GitHubButton.js';
 import { ShareSourcePubliclyCard } from '../../components/ShareSourcePubliclyCard.js';
 import { CourseInstanceShortNameDescription } from '../../components/ShortNameDescriptions.js';
+import type { EnrollmentCapacity } from '../../ee/models/enrollment.js';
 import type { PageContext } from '../../lib/client/page-context.js';
 import { getAssessmentSettingsUrl } from '../../lib/client/url.js';
 import { validateShortName } from '../../lib/short-name.js';
@@ -40,6 +41,7 @@ interface InstructorInstanceAdminSettingsProps {
   nonPublicAssessmentsInCourseInstance: { id: string; tid: string }[];
   questionSharingEnabled: boolean;
   accessControlMigrationNeeded: boolean;
+  enrollmentCapacity: EnrollmentCapacity | null;
 }
 
 export function InstructorInstanceAdminSettings({
@@ -83,6 +85,7 @@ function InstructorInstanceAdminSettingsInner({
   nonPublicAssessmentsInCourseInstance,
   questionSharingEnabled,
   accessControlMigrationNeeded,
+  enrollmentCapacity,
 }: Omit<InstructorInstanceAdminSettingsProps, 'trpcCsrfToken'>) {
   const [showCopyModal, setShowCopyModal] = useState(false);
 
@@ -268,6 +271,32 @@ function InstructorInstanceAdminSettingsInner({
               </div>
             </div>
           </div>
+
+          {enrollmentCapacity && (
+            <div className="card" aria-labelledby="enrollment-capacity-heading">
+              <div className="card-body">
+                <h2 id="enrollment-capacity-heading" className="h5 card-title mb-3">
+                  Enrollment capacity
+                </h2>
+                <p className="mb-2">
+                  {enrollmentCapacity.used.toLocaleString('en-US')} of{' '}
+                  {enrollmentCapacity.limit.toLocaleString('en-US')} free enrollments used
+                  {' · '}
+                  <strong>{enrollmentCapacity.remaining.toLocaleString('en-US')} remaining</strong>
+                </p>
+                {enrollmentCapacity.annualLimitSource && (
+                  <p className="mb-2">
+                    Remaining capacity is limited by the{' '}
+                    {enrollmentCapacity.annualLimitSource === 'course' ? 'course' : 'institution'}
+                    's shared enrollment limit over the past year.
+                  </p>
+                )}
+                <p className="small text-muted mb-0">
+                  Paid enrollments do not count toward these limits.
+                </p>
+              </div>
+            </div>
+          )}
 
           <div className="card">
             <div className="card-body">

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -16,9 +16,11 @@ import { parseRequestBody } from '@prairielearn/zod';
 import { DeleteCourseInstanceModal } from '../../components/DeleteCourseInstanceModal.js';
 import { PageLayout } from '../../components/PageLayout.js';
 import {
-  getCourseInstanceEnrollmentLimit,
-  getEnrollmentCapacity,
-} from '../../ee/models/enrollment.js';
+  getPlanGrantsForPartialContexts,
+  getRequiredPlansForCourseInstance,
+  planGrantsMatchFeatures,
+} from '../../ee/lib/billing/plans.js';
+import { getEnrollmentCapacity } from '../../ee/models/enrollment.js';
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import {
@@ -54,6 +56,7 @@ import { insertCourseInstancePermissions } from '../../models/course-permissions
 import type { CourseInstanceJsonInput } from '../../schemas/index.js';
 import { uniqueEnrollmentCode } from '../../sync/fromDisk/courseInstances.js';
 
+import type { EnrollmentAndBillingCardProps } from './components/EnrollmentAndBillingCard.js';
 import { InstructorInstanceAdminSettings } from './instructorInstanceAdminSettings.html.js';
 import { SettingsFormBodySchema } from './instructorInstanceAdminSettings.types.js';
 
@@ -85,17 +88,34 @@ router.get(
       { course_instance_id: courseInstance.id },
       z.number(),
     );
-    // Annual limits are server-only fields omitted from the client page context.
-    const enrollmentContext = {
-      institution: res.locals.institution,
-      course: res.locals.course,
-      courseInstance,
-    };
-    // Large limits are operational defaults, so only show capacity for smaller limits.
-    const enrollmentCapacity =
-      isEnterprise() && getCourseInstanceEnrollmentLimit(enrollmentContext) < 10_000
-        ? await getEnrollmentCapacity(enrollmentContext)
-        : null;
+    let enrollmentAndBilling: EnrollmentAndBillingCardProps | null = null;
+    if (isEnterprise()) {
+      const requiredPlans = await getRequiredPlansForCourseInstance(courseInstance.id);
+      const studentBillingEnabled = requiredPlans.includes('basic');
+      const studentComputeBillingEnabled =
+        requiredPlans.includes('compute') &&
+        !planGrantsMatchFeatures(
+          await getPlanGrantsForPartialContexts({
+            institution_id: institution.id,
+            course_instance_id: courseInstance.id,
+          }),
+          ['external-grading', 'workspaces'],
+        );
+      // Annual limits are server-only fields omitted from the client page context.
+      const capacity = studentBillingEnabled
+        ? null
+        : await getEnrollmentCapacity({
+            institution: res.locals.institution,
+            course: res.locals.course,
+            courseInstance,
+          });
+      enrollmentAndBilling = {
+        studentBillingEnabled,
+        studentComputeBillingEnabled,
+        enrollmentCount,
+        capacity,
+      };
+    }
     const host = getCanonicalHost(req);
     const studentLink = new URL(`/pl/course_instance/${courseInstance.id}`, host).href;
     const publicLink = new URL(`/pl/public/course_instance/${courseInstance.id}/assessments`, host)
@@ -186,7 +206,7 @@ router.get(
                 nonPublicAssessmentsInCourseInstance={nonPublicAssessmentsInCourseInstance}
                 questionSharingEnabled={questionSharingEnabled}
                 accessControlMigrationNeeded={accessControlMigrationNeeded}
-                enrollmentCapacity={enrollmentCapacity}
+                enrollmentAndBilling={enrollmentAndBilling}
               />
             </Hydrate>
             <Hydrate>

--- a/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
+++ b/apps/prairielearn/src/pages/instructorInstanceAdminSettings/instructorInstanceAdminSettings.tsx
@@ -15,6 +15,10 @@ import { parseRequestBody } from '@prairielearn/zod';
 
 import { DeleteCourseInstanceModal } from '../../components/DeleteCourseInstanceModal.js';
 import { PageLayout } from '../../components/PageLayout.js';
+import {
+  getCourseInstanceEnrollmentLimit,
+  getEnrollmentCapacity,
+} from '../../ee/models/enrollment.js';
 import { b64EncodeUnicode } from '../../lib/base64-util.js';
 import { extractPageContext } from '../../lib/client/page-context.js';
 import {
@@ -36,6 +40,7 @@ import {
 } from '../../lib/editors.js';
 import { courseRepoContentUrl } from '../../lib/github.js';
 import { getPaths } from '../../lib/instructorFiles.js';
+import { isEnterprise } from '../../lib/license.js';
 import { formatJsonWithPrettier } from '../../lib/prettier.js';
 import { typedAsyncHandler } from '../../lib/res-locals.js';
 import {
@@ -80,6 +85,17 @@ router.get(
       { course_instance_id: courseInstance.id },
       z.number(),
     );
+    // Annual limits are server-only fields omitted from the client page context.
+    const enrollmentContext = {
+      institution: res.locals.institution,
+      course: res.locals.course,
+      courseInstance,
+    };
+    // Large limits are operational defaults, so only show capacity for smaller limits.
+    const enrollmentCapacity =
+      isEnterprise() && getCourseInstanceEnrollmentLimit(enrollmentContext) < 10_000
+        ? await getEnrollmentCapacity(enrollmentContext)
+        : null;
     const host = getCanonicalHost(req);
     const studentLink = new URL(`/pl/course_instance/${courseInstance.id}`, host).href;
     const publicLink = new URL(`/pl/public/course_instance/${courseInstance.id}/assessments`, host)
@@ -170,6 +186,7 @@ router.get(
                 nonPublicAssessmentsInCourseInstance={nonPublicAssessmentsInCourseInstance}
                 questionSharingEnabled={questionSharingEnabled}
                 accessControlMigrationNeeded={accessControlMigrationNeeded}
+                enrollmentCapacity={enrollmentCapacity}
               />
             </Hydrate>
             <Hydrate>

--- a/apps/prairielearn/src/tests/instructorInstanceAdminSettings.test.sql
+++ b/apps/prairielearn/src/tests/instructorInstanceAdminSettings.test.sql
@@ -1,0 +1,44 @@
+-- BLOCK update_institution_limits
+UPDATE institutions
+SET
+  course_instance_enrollment_limit = $institutionLimit,
+  yearly_enrollment_limit = $institutionYearlyLimit
+WHERE
+  id = 1;
+
+-- BLOCK update_course_limits
+UPDATE courses
+SET
+  course_instance_enrollment_limit = $courseLimit,
+  yearly_enrollment_limit = $courseYearlyLimit
+WHERE
+  id = 1;
+
+-- BLOCK update_instance_limit
+UPDATE course_instances
+SET
+  enrollment_limit = $instanceLimit
+WHERE
+  id = 1;
+
+-- BLOCK mark_enrollment_removed
+UPDATE enrollments
+SET
+  status = 'removed'
+WHERE
+  course_instance_id = 1
+  AND user_id = (
+    SELECT
+      id
+    FROM
+      users
+    WHERE
+      uid = 'student2@example.com'
+  );
+
+-- BLOCK age_enrollments
+UPDATE enrollments
+SET
+  created_at = now() - interval '2 years'
+WHERE
+  course_instance_id = 1;

--- a/apps/prairielearn/src/tests/instructorInstanceAdminSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorInstanceAdminSettings.test.ts
@@ -5,6 +5,11 @@ import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, test } fr
 
 import { execute, loadSqlEquiv } from '@prairielearn/postgres';
 
+import {
+  reconcilePlanGrantsForCourseInstance,
+  reconcilePlanGrantsForInstitution,
+  updateRequiredPlansForCourseInstance,
+} from '../ee/lib/billing/plans.js';
 import { ensurePlanGrant } from '../ee/models/plan-grants.js';
 import { enableEnterpriseEdition, withoutEnterpriseEdition } from '../ee/tests/ee-helpers.js';
 import { config } from '../lib/config.js';
@@ -178,7 +183,7 @@ describe('Updating a course instance ID', { concurrent: false }, () => {
   });
 });
 
-describe('Course instance enrollment capacity', () => {
+describe('Course instance enrollment and billing', () => {
   enableEnterpriseEdition();
   beforeEach(helperServer.before());
   afterEach(helperServer.after);
@@ -205,13 +210,18 @@ describe('Course instance enrollment capacity', () => {
   }
 
   test.each([10_000, 10_001])(
-    'hides capacity for a limit of %i after enrollment',
+    'shows payment status without an allowance for a limit of %i',
     async (limit) => {
       await setLimits({ institutionLimit: limit });
       await enrollRandomUsers('1', 1);
       const { $, status } = await fetchCheerio(pageUrl);
       assert.equal(status, 200);
-      assert.lengthOf($('#enrollment-capacity-heading'), 0);
+      assert.lengthOf($('#enrollment-and-billing-heading'), 1);
+      const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+      assert.include(summary, 'Student payment not required');
+      assert.include(summary, 'Students can enroll without paying for course access.');
+      assert.notInclude(summary, 'Enrollment allowance');
+      assert.notInclude(summary, 'remaining');
     },
   );
 
@@ -225,8 +235,8 @@ describe('Course instance enrollment capacity', () => {
     await enrollRandomUsers('1', 2);
     const { $, status } = await fetchCheerio(pageUrl);
     assert.equal(status, 200);
-    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
-    assert.include(summary, `2 of ${expected.toLocaleString('en-US')} free enrollments used`);
+    const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+    assert.include(summary, `2 of ${expected.toLocaleString('en-US')} enrollments used`);
     assert.include(summary, `${(expected - 2).toLocaleString('en-US')} remaining`);
     assert.notInclude(summary, 'shared enrollment limit');
   });
@@ -236,7 +246,7 @@ describe('Course instance enrollment capacity', () => {
     await withoutEnterpriseEdition(async () => {
       const { $, status } = await fetchCheerio(pageUrl);
       assert.equal(status, 200);
-      assert.lengthOf($('#enrollment-capacity-heading'), 0);
+      assert.lengthOf($('#enrollment-and-billing-heading'), 0);
     });
   });
 
@@ -245,9 +255,13 @@ describe('Course instance enrollment capacity', () => {
     await setLimits({ instanceLimit: limit });
     const { $, status } = await fetchCheerio(pageUrl);
     assert.equal(status, 200);
-    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
-    assert.include(summary, `2 of ${limit} free enrollments used`);
+    const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+    assert.include(summary, `2 of ${limit} enrollments used`);
     assert.include(summary, '0 remaining');
+    assert.include(
+      summary,
+      'The enrollment allowance has been reached. Contact support to increase it.',
+    );
   });
 
   test.each([
@@ -258,8 +272,8 @@ describe('Course instance enrollment capacity', () => {
     await setLimits({ instanceLimit: 20, ...limits });
     const { $, status } = await fetchCheerio(pageUrl);
     assert.equal(status, 200);
-    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
-    assert.include(summary, '2 of 20 free enrollments used');
+    const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+    assert.include(summary, '2 of 20 enrollments used');
     assert.include(summary, '1 remaining');
     assert.include(summary, `${source}'s shared enrollment limit over the past year`);
   });
@@ -285,8 +299,12 @@ describe('Course instance enrollment capacity', () => {
     await setLimits({ instanceLimit: 20, institutionYearlyLimit: 2 });
     const { $, status } = await fetchCheerio(pageUrl);
     assert.equal(status, 200);
-    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
-    assert.include(summary, '1 of 20 free enrollments used');
+    const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+    assert.include(summary, '1 of 20 enrollments used');
+    assert.include(
+      summary,
+      'Students with individually purchased or sponsored course access do not use this allowance.',
+    );
     assert.include(summary, '1 remaining');
   });
 
@@ -296,8 +314,85 @@ describe('Course instance enrollment capacity', () => {
     await setLimits({ instanceLimit: 20, institutionYearlyLimit: 3 });
     const { $, status } = await fetchCheerio(pageUrl);
     assert.equal(status, 200);
-    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
-    assert.include(summary, '2 of 20 free enrollments used');
+    const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+    assert.include(summary, '2 of 20 enrollments used');
     assert.include(summary, '3 remaining');
   });
+
+  test.each([false, true])(
+    'shows student billing instead of an allowance (compute: %s)',
+    async (compute) => {
+      await enrollRandomUsers('1', 2);
+      await setLimits({ instanceLimit: 0, institutionYearlyLimit: 0, courseYearlyLimit: 0 });
+      await updateRequiredPlansForCourseInstance(
+        '1',
+        compute ? ['basic', 'compute'] : ['basic'],
+        '1',
+      );
+      const { $, status } = await fetchCheerio(pageUrl);
+      assert.equal(status, 200);
+      const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+      assert.include(summary, 'Student billing enabled');
+      assert.include(summary, 'Students pay for access to this course instance.');
+      assert.include(summary, '2 enrollments');
+      assert.equal(summary.includes('Students pay for external grading and workspaces.'), compute);
+      assert.notInclude(summary, 'Enrollment allowance');
+      assert.notInclude(summary, 'remaining');
+      assert.notInclude(summary, 'Contact support');
+      assert.notInclude(summary, 'Student payment not required');
+    },
+  );
+
+  test('keeps the enrollment allowance when students pay only for compute', async () => {
+    await enrollRandomUsers('1', 2);
+    await setLimits({ instanceLimit: 20 });
+    await updateRequiredPlansForCourseInstance('1', ['compute'], '1');
+    const { $, status } = await fetchCheerio(pageUrl);
+    assert.equal(status, 200);
+    const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+    assert.include(summary, 'Student billing for compute features');
+    assert.include(summary, 'Students pay for external grading and workspaces.');
+    assert.include(summary, '2 of 20 enrollments used');
+    assert.include(summary, '18 remaining');
+    assert.notInclude(summary, 'Student payment not required');
+  });
+
+  test.each(['institution', 'course instance'])(
+    'does not advertise student payment for compute covered by the %s',
+    async (source) => {
+      await setLimits({ instanceLimit: 20 });
+      await updateRequiredPlansForCourseInstance('1', ['compute'], '1');
+      const reconcile =
+        source === 'institution'
+          ? reconcilePlanGrantsForInstitution
+          : reconcilePlanGrantsForCourseInstance;
+      await reconcile('1', [{ plan: 'everything', grantType: 'invoice' }], '1');
+      const { $, status } = await fetchCheerio(pageUrl);
+      assert.equal(status, 200);
+      const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+      assert.include(summary, 'Student payment not required');
+      assert.include(summary, '0 of 20 enrollments used');
+      assert.notInclude(summary, 'Students pay for external grading and workspaces.');
+    },
+  );
+
+  test.each(['course', 'institution'])(
+    'shows a support warning when a shared %s limit blocks a large-cap instance',
+    async (source) => {
+      await enrollRandomUsers('1', 2);
+      await setLimits(
+        source === 'course' ? { courseYearlyLimit: 2 } : { institutionYearlyLimit: 2 },
+      );
+      const { $, status } = await fetchCheerio(pageUrl);
+      assert.equal(status, 200);
+      const summary = $('[aria-labelledby="enrollment-and-billing-heading"]').text();
+      assert.include(
+        summary,
+        'An enrollment limit has been reached. Contact support to enable additional enrollments.',
+      );
+      assert.notInclude(summary, 'Enrollment allowance');
+      assert.notInclude(summary, '10,000');
+      assert.notInclude(summary, 'remaining');
+    },
+  );
 });

--- a/apps/prairielearn/src/tests/instructorInstanceAdminSettings.test.ts
+++ b/apps/prairielearn/src/tests/instructorInstanceAdminSettings.test.ts
@@ -1,8 +1,12 @@
 import * as path from 'path';
 
 import fs from 'fs-extra';
-import { afterAll, assert, beforeAll, describe, test } from 'vitest';
+import { afterAll, afterEach, assert, beforeAll, beforeEach, describe, test } from 'vitest';
 
+import { execute, loadSqlEquiv } from '@prairielearn/postgres';
+
+import { ensurePlanGrant } from '../ee/models/plan-grants.js';
+import { enableEnterpriseEdition, withoutEnterpriseEdition } from '../ee/tests/ee-helpers.js';
 import { config } from '../lib/config.js';
 import { features } from '../lib/features/index.js';
 
@@ -14,6 +18,8 @@ import {
   updateCourseRepository,
 } from './helperCourse.js';
 import * as helperServer from './helperServer.js';
+import { getOrCreateUser } from './utils/auth.js';
+import { enrollRandomUsers } from './utils/enrollments.js';
 
 const siteUrl = `http://localhost:${config.serverPort}`;
 const courseTemplateDir = path.join(import.meta.dirname, 'testFileEditor', 'courseTemplate');
@@ -169,5 +175,129 @@ describe('Updating a course instance ID', { concurrent: false }, () => {
     } finally {
       await setSharingFilesPublic(false);
     }
+  });
+});
+
+describe('Course instance enrollment capacity', () => {
+  enableEnterpriseEdition();
+  beforeEach(helperServer.before());
+  afterEach(helperServer.after);
+
+  const sql = loadSqlEquiv(import.meta.url);
+  const pageUrl = `${siteUrl}/pl/course_instance/1/instructor/instance_admin/settings`;
+
+  async function setLimits({
+    institutionLimit = 10_000,
+    courseLimit = null,
+    instanceLimit = null,
+    institutionYearlyLimit = 100_000,
+    courseYearlyLimit = null,
+  }: {
+    institutionLimit?: number;
+    courseLimit?: number | null;
+    instanceLimit?: number | null;
+    institutionYearlyLimit?: number;
+    courseYearlyLimit?: number | null;
+  }) {
+    await execute(sql.update_institution_limits, { institutionLimit, institutionYearlyLimit });
+    await execute(sql.update_course_limits, { courseLimit, courseYearlyLimit });
+    await execute(sql.update_instance_limit, { instanceLimit });
+  }
+
+  test.each([10_000, 10_001])(
+    'hides capacity for a limit of %i after enrollment',
+    async (limit) => {
+      await setLimits({ institutionLimit: limit });
+      await enrollRandomUsers('1', 1);
+      const { $, status } = await fetchCheerio(pageUrl);
+      assert.equal(status, 200);
+      assert.lengthOf($('#enrollment-capacity-heading'), 0);
+    },
+  );
+
+  test.each([
+    { institutionLimit: 20, expected: 20 },
+    { institutionLimit: 20, courseLimit: 30, expected: 30 },
+    { institutionLimit: 20, courseLimit: 30, instanceLimit: 40, expected: 40 },
+    { instanceLimit: 9999, expected: 9999 },
+  ])('shows the effective limit: $expected', async ({ expected, ...limits }) => {
+    await setLimits(limits);
+    await enrollRandomUsers('1', 2);
+    const { $, status } = await fetchCheerio(pageUrl);
+    assert.equal(status, 200);
+    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
+    assert.include(summary, `2 of ${expected.toLocaleString('en-US')} free enrollments used`);
+    assert.include(summary, `${(expected - 2).toLocaleString('en-US')} remaining`);
+    assert.notInclude(summary, 'shared enrollment limit');
+  });
+
+  test('hides capacity without enterprise enrollment enforcement', async () => {
+    await setLimits({ instanceLimit: 20 });
+    await withoutEnterpriseEdition(async () => {
+      const { $, status } = await fetchCheerio(pageUrl);
+      assert.equal(status, 200);
+      assert.lengthOf($('#enrollment-capacity-heading'), 0);
+    });
+  });
+
+  test.each([0, 1, 2])('shows zero remaining for an exhausted limit of %i', async (limit) => {
+    await enrollRandomUsers('1', 2);
+    await setLimits({ instanceLimit: limit });
+    const { $, status } = await fetchCheerio(pageUrl);
+    assert.equal(status, 200);
+    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
+    assert.include(summary, `2 of ${limit} free enrollments used`);
+    assert.include(summary, '0 remaining');
+  });
+
+  test.each([
+    { institutionYearlyLimit: 3, courseYearlyLimit: 10, source: 'institution' },
+    { institutionYearlyLimit: 10, courseYearlyLimit: 3, source: 'course' },
+  ])('accounts for the shared $source annual limit', async ({ source, ...limits }) => {
+    await enrollRandomUsers('1', 2);
+    await setLimits({ instanceLimit: 20, ...limits });
+    const { $, status } = await fetchCheerio(pageUrl);
+    assert.equal(status, 200);
+    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
+    assert.include(summary, '2 of 20 free enrollments used');
+    assert.include(summary, '1 remaining');
+    assert.include(summary, `${source}'s shared enrollment limit over the past year`);
+  });
+
+  test('excludes paid and non-joined enrollments from capacity', async () => {
+    await enrollRandomUsers('1', 3);
+    const paidUser = await getOrCreateUser({
+      uid: 'student1@example.com',
+      name: 'Paid Student',
+      uin: 'student-0',
+    });
+    await ensurePlanGrant({
+      plan_grant: {
+        institution_id: '1',
+        course_instance_id: '1',
+        user_id: paidUser.id,
+        plan_name: 'basic',
+        type: 'stripe',
+      },
+      authn_user_id: '1',
+    });
+    await execute(sql.mark_enrollment_removed);
+    await setLimits({ instanceLimit: 20, institutionYearlyLimit: 2 });
+    const { $, status } = await fetchCheerio(pageUrl);
+    assert.equal(status, 200);
+    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
+    assert.include(summary, '1 of 20 free enrollments used');
+    assert.include(summary, '1 remaining');
+  });
+
+  test('counts older enrollments toward the instance limit but not annual limits', async () => {
+    await enrollRandomUsers('1', 2);
+    await execute(sql.age_enrollments);
+    await setLimits({ instanceLimit: 20, institutionYearlyLimit: 3 });
+    const { $, status } = await fetchCheerio(pageUrl);
+    assert.equal(status, 200);
+    const summary = $('[aria-labelledby="enrollment-capacity-heading"]').text();
+    assert.include(summary, '2 of 20 free enrollments used');
+    assert.include(summary, '3 remaining');
   });
 });


### PR DESCRIPTION
# Description

Course instance Settings currently gives instructors no summary of enrollment capacity or who pays for access. Add an **Enrollment and billing** card beside the self-enrollment controls to show the student payment status and any meaningful enrollment allowance.

Student billing takes precedence over numeric capacity. Otherwise, show allowances only when the effective configured instance limit is below 10,000; the threshold applies to the configured limit, not the remaining count. Resolve the limit from the instance, course, and institution in that order. Large limits are treated as operational safeguards and remain hidden unless exhausted, when a support warning is shown.

The display uses payment configuration rather than inferring a commercial plan: the existing data does not reliably distinguish an institutional contract, post-paid course, or free tier. In particular, a small custom allowance is not necessarily the standard free tier, and a 10,000 safety cap is not a promise of unlimited access.

## Scenarios

All enterprise instances show a card titled **Enrollment and billing**. Numeric examples below assume 12 counted enrollments and an effective limit of 20 unless stated otherwise.

| Scenario | Status and explanation | Capacity display |
| --- | --- | --- |
| Institutional contract with no student billing and a large safety cap | **Student payment not required** — “Students can enroll without paying for course access.” | No allowance or remaining count. |
| Post-paid course with no student billing and a large safety cap | Same student payment status as above. | No allowance or remaining count. |
| Standard small allowance, including a 20-enrollment free configuration | **Student payment not required** — “Students can enroll without paying for course access.” | **Enrollment allowance**; “12 of 20 enrollments used · **8 remaining**”. |
| Custom instance, course, or institution allowance below 10,000 | Same payment status, unless students pay for compute features as described below. | Use the actual inherited or overridden limit; do not assume 20 or label it a free tier. |
| Student-paid course access (`basic` required), regardless of underlying caps | **Student billing enabled** — “Students pay for access to this course instance.” | Total joined enrollment count, e.g. “12 enrollments”; no allowance, remaining count, or capacity warning. |
| Student-paid course access and compute (`basic` and uncovered `compute` required) | Same student billing status, plus “Students pay for external grading and workspaces.” | Total joined enrollment count; no numeric allowance. |
| Students pay only for compute features | **Student billing for compute features** — “Students pay for external grading and workspaces.” | Keep the normal allowance rules: compute-only payment does not remove enrollment caps. |
| Required compute access is already covered by institution or instance grants | Omit the student compute-payment message. Show **Student payment not required**, or **Student billing enabled** if course access still requires student payment. | Follow the usual rules for course-access billing and the effective limit. |
| A shared annual limit is tighter than a displayed instance allowance | Keep the payment status and add “Remaining capacity is limited by the course's [or institution's] shared enrollment limit over the past year.” | Show the smaller remaining capacity, e.g. “12 of 20 enrollments used · **3 remaining**”. |
| A displayed allowance is exhausted, including by a shared annual limit | Add warning: “The enrollment allowance has been reached. Contact support to increase it.” | **0 remaining**; never show a negative count. |
| A hidden large cap or its shared annual limit is exhausted, without student-paid course access | Add warning: “An enrollment limit has been reached. Contact support to enable additional enrollments.” | Continue hiding the large allowance and remaining count. |
| Some joined students have individually purchased or sponsored course access | When displaying an allowance, add “Students with individually purchased or sponsored course access do not use this allowance.” | Exclude these students from the allowance usage. |
| Enterprise enrollment enforcement is disabled | No card. | None. |

Remaining capacity includes both the institution's rolling one-year limit and any course annual limit. Usage counts joined enrollment records, not unique students; removed enrollments and individual paid/sponsored basic grants do not consume the allowance. The instance count spans its lifetime, while the annual counts use enrollment creation times in the past year.

This PR does not change enrollment admission behavior. The pre-existing basic-plus-compute bypass bug is handled independently in #15746.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation).

Codex wrote the implementation and tests.

## Screenshots

Settings with a 20-enrollment allowance:

![Course instance Settings with enrollment and billing status and eight enrollments remaining](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-desktop.png)

<details>
<summary>Other billing states, shared limits, and mobile layout</summary>

No student payment required, with the large safety cap hidden:

![No student payment required](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-funded.png)

Student-paid course access and compute:

![Student billing enabled with the total joined enrollment count](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-student-paid.png)

Compute-only student billing:

![Compute billing with an enrollment allowance](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-compute.png)

Shared annual limit:

![Annual institution limit reduces remaining capacity](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-annual.png)

Exhausted allowance:

![Exhausted enrollment allowance with a support warning](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-exhausted.png)

Mobile settings:

![Enrollment and billing card at mobile width](https://raw.githubusercontent.com/PrairieLearn/PrairieLearn/b7c44d437f41ae11fb31c26bb34525d7815f5a1f/enrollment-billing-mobile.png)

</details>

# Testing

- Integration coverage exercises inherited and custom limits, the 10,000 threshold, zero and exhausted caps, course/institution annual constraints, older enrollments, paid and removed enrollments, student billing with and without compute, compute-only billing, and institution/instance compute coverage. All 24 settings tests pass.
- Visually verified the rendered page in Chrome at desktop and mobile widths. A temporary Playwright harness verified and captured the allowance, hidden safety cap, student-paid, compute-only, shared annual-limit, and exhausted-capacity states shown above.
