### PR TITLE
Fix XML whitespace attributes in embedded D2 diagrams

### DIFF
--- a/docs/scripts/d2_svg_file.py
+++ b/docs/scripts/d2_svg_file.py
@@ -31,6 +31,14 @@ def on_config(config: MkDocsConfig) -> MkDocsConfig:
         """
         result, svg, ok = original_render(source, opts, alt)
         if ok:
+            # D2 0.9 uses xml:space for SVG Markdown labels. Python-Markdown
+            # serializes ElementTree's expanded attribute names verbatim, so
+            # restore the XML prefix before the image extension embeds the SVG.
+            xml_space = "{http://www.w3.org/XML/1998/namespace}space"
+            for element in svg.root.iter():
+                if xml_space in element.attrib:
+                    element.set("xml:space", element.attrib.pop(xml_space))
+
             is_file = isinstance(source, Path)
 
             # Check if this diagram should be ignored


### PR DESCRIPTION
# Description

D2 0.9.0, released September 7 and automatically picked up by CI's installer, renders Markdown labels as native SVG with `xml:space="preserve"`. `mkdocs-d2-plugin` parses these attributes into ElementTree's `{http://www.w3.org/XML/1998/namespace}space` form. Python-Markdown then writes those expanded names verbatim into image-embedded SVGs, producing malformed HTML and 37 `tag-pair` errors in the generated question server and developer guide pages.

Restore `xml:space` in the existing D2 documentation hook before Python-Markdown serializes the SVG tree. This preserves whitespace semantics and keeps HTMLHint's validation enabled. No dependency pins or linter exceptions are needed.

Found while checking the unrelated #15738: [failing Python job](https://github.com/PrairieLearn/PrairieLearn/actions/runs/34253340669/job/102152868720). This also reproduces on current `master`. See the [D2 0.9.0 release notes](https://github.com/d2lang/d2/releases/tag/v0.9.0) for the native SVG Markdown change.

- [x] I have disclosed the level of AI assistance used (i.e. none, specific portions, majority of implementation). Codex performed the investigation, implementation, and validation.

# Testing

- With Python 3.13.15, locked dependencies, and D2 0.9.0, reproduced exactly 37 HTMLHint errors in the same two pages before the fix. With the same Python and plugin, the older local D2 renderer produces no expanded XML attributes in the testing lifecycle diagram.
- Both cached and fresh strict documentation builds pass after the fix; HTMLHint scans all 376 files without errors.
- Compared all 14 linked diagrams against the original D2 SVG assets: every text label and all 37 `xml:space` attributes are preserved, along with accessibility labels and SVG download links.
