### PR TITLE
Use fixed version of d2 to build docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -184,8 +184,10 @@ jobs:
           sudo apt-get install -y graphviz libgraphviz-dev
 
       - name: Install additional dependencies
+        # We use the explicit d2 version 0.8.2 because the latest version of d2 (0.9.0)
+        # has a bug that causes our lint to fail.
         run: |-
-          sudo curl -fsSL https://d2lang.com/install.sh | sh -s --
+          sudo curl -fsSL https://d2lang.com/install.sh | sh -s -- --version 0.8.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Python

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,9 @@ build:
     install:
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --frozen --group docs
     pre_build:
-      - curl -fsSL https://d2lang.com/install.sh | sh -s --
+      # We use the explicit d2 version 0.8.2 because the latest version of d2 (0.9.0)
+      # has a bug that causes our lint to fail.
+      - curl -fsSL https://d2lang.com/install.sh | sh -s -- --version 0.8.2
       - cp $HOME/.local/bin/d2 $READTHEDOCS_VIRTUALENV_PATH/bin/d2
 
 mkdocs:


### PR DESCRIPTION
<!--

Etiquette and expectations for contributions can be found here:
https://docs.prairielearn.com/contributing

-->

# Description

d2 version 0.9.0 (released yesterday) is causing issues with the HTML linter. This PR sets the d2 installer to use version 0.8.2, which works as expected.

I haven't updated the docs to fix a version there, but I can if it's deemed important.

<!--
- Summarize your changes and explain *why* these changes are necessary (even if it seems obvious).
- Include any relevant context from Slack, meetings, or other discussions.
- If there were discussions about key decisions, alternative designs, or implementation choices, summarize the alternatives considered, the pros/cons of each, and the reasons for the eventual choices.
- If this change is resolving a specific issue, include a link to the issue (e.g. "closes #1234").
- If applicable, include screenshots and/or videos.
-->

- [x] I have disclosed the level of AI assistance used: none.

# Testing

Clearing cache, building docs and running lint:

```sh
rm -rf .cache/ site/
make build-docs lint-html
```

Causes lint errors on master, and succeeds in this branch.

<!--

- Share how you tested your changes.
- If you're fixing a bug, explain how to reproduce the original issue.
- If applicable, make sure you've authored unit and/or integration tests.
- If applicable, provide instructions for a reviewer to test the changes for themselves.
- If applicable, mention any accessibility testing that was done.

If you re-test your PR after significant changes, please add a comment to the PR saying so.

Self-reviews with GitHub's review UI are encouraged to point out the following:

- Explanations for code or design decisions that may confuse reviewers.
- Particularly important or core changes.
- Items that may need further discussion.
- Changes that may warrant additional testing.

Thank you for contributing to PrairieLearn!

-->
