### PR TITLE
Fix instructor file browser dotfile downloads

### DIFF
--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
@@ -14,13 +14,12 @@ const contexts = [
   { navPage: 'instance_admin', directory: 'courseInstances/Fa18' },
   { navPage: 'assessment', directory: 'courseInstances/Fa18/assessments/HW1' },
   { navPage: 'question', directory: 'questions/test/question' },
-] as const;
-
+];
 const contents = 'options(repos = c(CRAN = "https://cran.rstudio.com"))\n';
 let temporaryPath: string;
 let coursePath: string;
 
-function createApp(navPage: string, hasViewPermission = true) {
+function createApp(navPage = 'course_admin', hasViewPermission = true) {
   const app = express();
   app.use((_req, res, next) => {
     res.locals.course = { id: '1', path: coursePath };
@@ -29,22 +28,18 @@ function createApp(navPage: string, hasViewPermission = true) {
     res.locals.question = { id: '1', qid: 'test/question' };
     res.locals.navPage = navPage;
     res.locals.urlPrefix = '/pl/course/1';
-    res.locals.authz_data = {
-      has_course_permission_view: hasViewPermission,
-      has_course_permission_edit: false,
-    };
+    res.locals.authz_data = { has_course_permission_view: hasViewPermission };
     next();
   });
   app.use('/file_download', router);
   app.use(((err, _req, res, _next) => {
-    const httpError = err as Error & { status?: number };
-    res.status(httpError.status ?? 500).send('<h1>Error processing request</h1>');
+    res.status((err as Error & { status?: number }).status ?? 500).send('<h1>Error</h1>');
   }) satisfies ErrorRequestHandler);
   return app;
 }
 
 function downloadUrl(url: string, filename: string) {
-  // Encode slashes as well so fetch does not normalize traversal attempts before sending them.
+  // Encode slashes so fetch does not normalize traversal attempts before sending them.
   return `${url}/file_download/${encodeURIComponent(filename)}`;
 }
 
@@ -53,166 +48,108 @@ async function assertErrorResponse(response: Response, status: number) {
   assert.isNull(response.headers.get('Content-Disposition'));
   assert.isNull(response.headers.get('Content-Range'));
   assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8');
-  assert.equal(await response.text(), '<h1>Error processing request</h1>');
+  assert.equal(await response.text(), '<h1>Error</h1>');
 }
 
 describe('Instructor file downloads', () => {
   beforeAll(async () => {
     temporaryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'instructor-file-download-'));
     coursePath = path.join(temporaryPath, 'course');
+    // Exercise both a symlink above the question root and a symlinked excluded directory.
+    await fs.mkdir(path.join(coursePath, 'questionSources'), { recursive: true });
+    await fs.symlink('questionSources', path.join(coursePath, 'questions'));
     for (const { directory } of contexts) {
       const root = path.join(coursePath, directory);
-      await fs.mkdir(path.join(root, '.config'), { recursive: true });
-      await fs.mkdir(path.join(root, '.git'), { recursive: true });
+      await fs.mkdir(root, { recursive: true });
       await fs.writeFile(path.join(root, '.Rprofile'), contents);
-      await fs.writeFile(path.join(root, 'submission.R'), contents);
-      await fs.writeFile(path.join(root, '.config', 'profile.R'), contents);
-      await fs.writeFile(path.join(root, '.git', 'config'), 'repository internals');
     }
+    await fs.mkdir(path.join(coursePath, '.config/.git'), { recursive: true });
+    await fs.writeFile(path.join(coursePath, '.config/.git/config'), 'repository internals');
+    await fs.writeFile(path.join(coursePath, '.config/profile.R'), contents);
+    await fs.writeFile(path.join(coursePath, 'submission.R'), contents);
     await fs.writeFile(path.join(temporaryPath, 'outside.R'), 'outside course');
-    await fs.mkdir(path.join(coursePath, 'questions/test/question-sibling'), { recursive: true });
-    await fs.writeFile(
-      path.join(coursePath, 'questions/test/question-sibling/.Rprofile'),
-      contents,
-    );
     await fs.symlink('.Rprofile', path.join(coursePath, '.profile-link'));
-    await fs.symlink('.git', path.join(coursePath, '.repository-link'));
+    await fs.symlink('.config/.git', path.join(coursePath, '.repository-link'));
     await fs.symlink('../outside.R', path.join(coursePath, '.outside-link'));
     await fs.symlink(
       '../../../.Rprofile',
       path.join(coursePath, 'questions/test/question/.course-link'),
     );
-    await fs.symlink('questions', path.join(coursePath, '.questions-link'));
   });
 
   afterAll(async () => {
     await fs.rm(temporaryPath, { recursive: true, force: true });
   });
 
-  describe.each(contexts)('$navPage', ({ navPage, directory }) => {
-    it.each(['.Rprofile', 'submission.R', '.config/profile.R'])(
-      'downloads the actual contents of %s for a course viewer',
-      async (filename) => {
-        await withServer(createApp(navPage), async ({ url }) => {
-          const response = await fetch(
-            `${downloadUrl(url, path.join(directory, filename))}?attachment=${encodeURIComponent(path.basename(filename))}`,
-          );
-          assert.equal(response.status, 200);
-          assert.equal(
-            response.headers.get('Content-Disposition'),
-            `attachment; filename="${path.basename(filename)}"`,
-          );
-          assert.equal(await response.text(), contents);
-        });
-      },
-    );
-
-    it.each(['.Rprofile', 'submission.R'])(
-      'requires course view permission for %s',
-      async (filename) => {
-        await withServer(createApp(navPage, false), async ({ url }) => {
-          await assertErrorResponse(
-            await fetch(
-              `${downloadUrl(url, path.join(directory, filename))}?attachment=profile.R&type=application/pdf`,
-            ),
-            403,
-          );
-        });
-      },
-    );
-
-    it('rejects repository internals', async () => {
-      await withServer(createApp(navPage), async ({ url }) => {
-        const response = await fetch(downloadUrl(url, path.join(directory, '.git/config')));
-        await assertErrorResponse(response, navPage === 'course_admin' ? 500 : 404);
-      });
+  it.each([
+    ...contexts.map(({ navPage, directory }) => [navPage, path.join(directory, '.Rprofile')]),
+    ...['submission.R', '.config/profile.R', '.profile-link'].map((filename) => [
+      'course_admin',
+      filename,
+    ]),
+  ])('downloads %s: %s', async (navPage, filename) => {
+    await withServer(createApp(navPage), async ({ url }) => {
+      const response = await fetch(`${downloadUrl(url, filename)}?attachment=profile.R`);
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get('Content-Disposition'), 'attachment; filename="profile.R"');
+      assert.equal(await response.text(), contents);
     });
   });
 
-  it('supports inline previews and successful partial downloads', async () => {
-    await withServer(createApp('question'), async ({ url }) => {
-      const fileUrl = downloadUrl(url, 'questions/test/question/.Rprofile');
+  it.each([
+    ['course_admin', '../outside.R', 500],
+    ['course_admin', 'questions/test/question/.Rprofile', 500],
+    ['course_admin', 'questionSources/test/question/.Rprofile', 404],
+    ['instance_admin', 'courseInstances/Fa18/assessments/HW1/.Rprofile', 500],
+    ['question', 'questions/test/question/../../../.Rprofile', 500],
+    ['question', 'questions/test/question/.course-link', 404],
+    ['course_admin', '.config/.git/config', 404],
+    ['course_admin', '.repository-link/config', 404],
+    ['course_admin', '.outside-link', 404],
+    ['course_admin', '.missing', 404],
+    ['course_admin', '.config', 404],
+    ['course_admin', 'submission.R/child', 404],
+  ] as const)('rejects %s: %s', async (navPage, filename, status) => {
+    await withServer(createApp(navPage), async ({ url }) => {
+      await assertErrorResponse(
+        await fetch(`${downloadUrl(url, filename)}?attachment=error.pdf&type=application/pdf`),
+        status,
+      );
+    });
+  });
+
+  it('requires course Viewer permission', async () => {
+    await withServer(createApp('course_admin', false), async ({ url }) => {
+      await assertErrorResponse(
+        await fetch(`${downloadUrl(url, '.Rprofile')}?attachment=profile.R`),
+        403,
+      );
+    });
+  });
+
+  it('supports previews and ranges, and clears download headers on range errors', async () => {
+    await withServer(createApp(), async ({ url }) => {
+      const fileUrl = downloadUrl(url, '.Rprofile');
       const preview = await fetch(`${fileUrl}?type=text/plain`);
       assert.equal(preview.status, 200);
       assert.isNull(preview.headers.get('Content-Disposition'));
       assert.equal(preview.headers.get('Content-Type'), 'text/plain; charset=utf-8');
       assert.equal(await preview.text(), contents);
 
-      const partial = await fetch(`${fileUrl}?attachment=.Rprofile`, {
-        headers: { Range: 'bytes=0-6' },
-      });
+      const partial = await fetch(fileUrl, { headers: { Range: 'bytes=0-6' } });
       assert.equal(partial.status, 206);
       assert.equal(
         partial.headers.get('Content-Range'),
         `bytes 0-6/${Buffer.byteLength(contents)}`,
       );
       assert.equal(await partial.text(), contents.slice(0, 7));
-    });
-  });
 
-  it.each(['missing.R', '.missing', '.config', 'submission.R/child'])(
-    'renders a normal error response for %s',
-    async (filename) => {
-      await withServer(createApp('question'), async ({ url }) => {
-        await assertErrorResponse(
-          await fetch(
-            `${downloadUrl(url, `questions/test/question/${filename}`)}?attachment=error.pdf&type=application/pdf`,
-          ),
-          404,
-        );
-      });
-    },
-  );
-
-  it('clears download headers when sendFile rejects an unsatisfiable range', async () => {
-    await withServer(createApp('question'), async ({ url }) => {
       await assertErrorResponse(
-        await fetch(
-          `${downloadUrl(url, 'questions/test/question/.Rprofile')}?attachment=error.pdf&type=application/pdf`,
-          {
-            headers: { Range: 'bytes=10000-' },
-          },
-        ),
+        await fetch(`${fileUrl}?attachment=error.pdf&type=application/pdf`, {
+          headers: { Range: 'bytes=10000-' },
+        }),
         416,
       );
-    });
-  });
-
-  it.each([
-    { navPage: 'course_admin', filename: '../outside.R' },
-    { navPage: 'course_admin', filename: 'questions/test/question/.Rprofile' },
-    { navPage: 'course_admin', filename: 'courseInstances/Fa18/.Rprofile' },
-    { navPage: 'instance_admin', filename: 'courseInstances/Fa18/assessments/HW1/.Rprofile' },
-    { navPage: 'instance_admin', filename: '.Rprofile' },
-    { navPage: 'assessment', filename: 'courseInstances/Fa18/.Rprofile' },
-    { navPage: 'question', filename: 'questions/test/question-sibling/.Rprofile' },
-    { navPage: 'question', filename: 'questions/test/question/../../../.Rprofile' },
-    { navPage: 'question', filename: 'questions/test/question/../../../../outside.R' },
-  ])('rejects $filename in $navPage', async ({ navPage, filename }) => {
-    await withServer(createApp(navPage), async ({ url }) => {
-      await assertErrorResponse(
-        await fetch(`${downloadUrl(url, filename)}?attachment=.Rprofile`),
-        500,
-      );
-    });
-  });
-
-  it('allows symlinks within the same file browser context', async () => {
-    await withServer(createApp('course_admin'), async ({ url }) => {
-      const response = await fetch(downloadUrl(url, '.profile-link'));
-      assert.equal(response.status, 200);
-      assert.equal(await response.text(), contents);
-    });
-  });
-
-  it.each([
-    { navPage: 'course_admin', filename: '.repository-link/config' },
-    { navPage: 'course_admin', filename: '.outside-link' },
-    { navPage: 'course_admin', filename: '.questions-link/test/question/.Rprofile' },
-    { navPage: 'question', filename: 'questions/test/question/.course-link' },
-  ])('rejects symlink $filename in $navPage', async ({ navPage, filename }) => {
-    await withServer(createApp(navPage), async ({ url }) => {
-      await assertErrorResponse(await fetch(downloadUrl(url, filename)), 500);
     });
   });
 });

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
@@ -1,0 +1,218 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import * as path from 'node:path';
+
+import express, { type ErrorRequestHandler } from 'express';
+import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+
+import { withServer } from '@prairielearn/express-test-utils';
+
+import router from './instructorFileDownload.js';
+
+const contexts = [
+  { navPage: 'course_admin', directory: '' },
+  { navPage: 'instance_admin', directory: 'courseInstances/Fa18' },
+  { navPage: 'assessment', directory: 'courseInstances/Fa18/assessments/HW1' },
+  { navPage: 'question', directory: 'questions/test/question' },
+] as const;
+
+const contents = 'options(repos = c(CRAN = "https://cran.rstudio.com"))\n';
+let temporaryPath: string;
+let coursePath: string;
+
+function createApp(navPage: string, hasViewPermission = true) {
+  const app = express();
+  app.use((_req, res, next) => {
+    res.locals.course = { id: '1', path: coursePath };
+    res.locals.course_instance = { id: '1', short_name: 'Fa18' };
+    res.locals.assessment = { id: '1', tid: 'HW1' };
+    res.locals.question = { id: '1', qid: 'test/question' };
+    res.locals.navPage = navPage;
+    res.locals.urlPrefix = '/pl/course/1';
+    res.locals.authz_data = {
+      has_course_permission_view: hasViewPermission,
+      has_course_permission_edit: false,
+    };
+    next();
+  });
+  app.use('/file_download', router);
+  app.use(((err, _req, res, _next) => {
+    const httpError = err as Error & { status?: number };
+    res.status(httpError.status ?? 500).send('<h1>Error processing request</h1>');
+  }) satisfies ErrorRequestHandler);
+  return app;
+}
+
+function downloadUrl(url: string, filename: string) {
+  // Encode slashes as well so fetch does not normalize traversal attempts before sending them.
+  return `${url}/file_download/${encodeURIComponent(filename)}`;
+}
+
+async function assertErrorResponse(response: Response, status: number) {
+  assert.equal(response.status, status);
+  assert.isNull(response.headers.get('Content-Disposition'));
+  assert.isNull(response.headers.get('Content-Range'));
+  assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8');
+  assert.equal(await response.text(), '<h1>Error processing request</h1>');
+}
+
+describe('Instructor file downloads', () => {
+  beforeAll(async () => {
+    temporaryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'instructor-file-download-'));
+    coursePath = path.join(temporaryPath, 'course');
+    for (const { directory } of contexts) {
+      const root = path.join(coursePath, directory);
+      await fs.mkdir(path.join(root, '.config'), { recursive: true });
+      await fs.mkdir(path.join(root, '.git'), { recursive: true });
+      await fs.writeFile(path.join(root, '.Rprofile'), contents);
+      await fs.writeFile(path.join(root, 'submission.R'), contents);
+      await fs.writeFile(path.join(root, '.config', 'profile.R'), contents);
+      await fs.writeFile(path.join(root, '.git', 'config'), 'repository internals');
+    }
+    await fs.writeFile(path.join(temporaryPath, 'outside.R'), 'outside course');
+    await fs.mkdir(path.join(coursePath, 'questions/test/question-sibling'), { recursive: true });
+    await fs.writeFile(
+      path.join(coursePath, 'questions/test/question-sibling/.Rprofile'),
+      contents,
+    );
+    await fs.symlink('.Rprofile', path.join(coursePath, '.profile-link'));
+    await fs.symlink('.git', path.join(coursePath, '.repository-link'));
+    await fs.symlink('../outside.R', path.join(coursePath, '.outside-link'));
+    await fs.symlink(
+      '../../../.Rprofile',
+      path.join(coursePath, 'questions/test/question/.course-link'),
+    );
+    await fs.symlink('questions', path.join(coursePath, '.questions-link'));
+  });
+
+  afterAll(async () => {
+    await fs.rm(temporaryPath, { recursive: true, force: true });
+  });
+
+  describe.each(contexts)('$navPage', ({ navPage, directory }) => {
+    it.each(['.Rprofile', 'submission.R', '.config/profile.R'])(
+      'downloads the actual contents of %s for a course viewer',
+      async (filename) => {
+        await withServer(createApp(navPage), async ({ url }) => {
+          const response = await fetch(
+            `${downloadUrl(url, path.join(directory, filename))}?attachment=${encodeURIComponent(path.basename(filename))}`,
+          );
+          assert.equal(response.status, 200);
+          assert.equal(
+            response.headers.get('Content-Disposition'),
+            `attachment; filename="${path.basename(filename)}"`,
+          );
+          assert.equal(await response.text(), contents);
+        });
+      },
+    );
+
+    it.each(['.Rprofile', 'submission.R'])(
+      'requires course view permission for %s',
+      async (filename) => {
+        await withServer(createApp(navPage, false), async ({ url }) => {
+          await assertErrorResponse(
+            await fetch(
+              `${downloadUrl(url, path.join(directory, filename))}?attachment=profile.R&type=application/pdf`,
+            ),
+            403,
+          );
+        });
+      },
+    );
+
+    it('rejects repository internals', async () => {
+      await withServer(createApp(navPage), async ({ url }) => {
+        const response = await fetch(downloadUrl(url, path.join(directory, '.git/config')));
+        await assertErrorResponse(response, navPage === 'course_admin' ? 500 : 404);
+      });
+    });
+  });
+
+  it('supports inline previews and successful partial downloads', async () => {
+    await withServer(createApp('question'), async ({ url }) => {
+      const fileUrl = downloadUrl(url, 'questions/test/question/.Rprofile');
+      const preview = await fetch(`${fileUrl}?type=text/plain`);
+      assert.equal(preview.status, 200);
+      assert.isNull(preview.headers.get('Content-Disposition'));
+      assert.equal(preview.headers.get('Content-Type'), 'text/plain; charset=utf-8');
+      assert.equal(await preview.text(), contents);
+
+      const partial = await fetch(`${fileUrl}?attachment=.Rprofile`, {
+        headers: { Range: 'bytes=0-6' },
+      });
+      assert.equal(partial.status, 206);
+      assert.equal(
+        partial.headers.get('Content-Range'),
+        `bytes 0-6/${Buffer.byteLength(contents)}`,
+      );
+      assert.equal(await partial.text(), contents.slice(0, 7));
+    });
+  });
+
+  it.each(['missing.R', '.missing', '.config', 'submission.R/child'])(
+    'renders a normal error response for %s',
+    async (filename) => {
+      await withServer(createApp('question'), async ({ url }) => {
+        await assertErrorResponse(
+          await fetch(
+            `${downloadUrl(url, `questions/test/question/${filename}`)}?attachment=error.pdf&type=application/pdf`,
+          ),
+          404,
+        );
+      });
+    },
+  );
+
+  it('clears download headers when sendFile rejects an unsatisfiable range', async () => {
+    await withServer(createApp('question'), async ({ url }) => {
+      await assertErrorResponse(
+        await fetch(
+          `${downloadUrl(url, 'questions/test/question/.Rprofile')}?attachment=error.pdf&type=application/pdf`,
+          {
+            headers: { Range: 'bytes=10000-' },
+          },
+        ),
+        416,
+      );
+    });
+  });
+
+  it.each([
+    { navPage: 'course_admin', filename: '../outside.R' },
+    { navPage: 'course_admin', filename: 'questions/test/question/.Rprofile' },
+    { navPage: 'course_admin', filename: 'courseInstances/Fa18/.Rprofile' },
+    { navPage: 'instance_admin', filename: 'courseInstances/Fa18/assessments/HW1/.Rprofile' },
+    { navPage: 'instance_admin', filename: '.Rprofile' },
+    { navPage: 'assessment', filename: 'courseInstances/Fa18/.Rprofile' },
+    { navPage: 'question', filename: 'questions/test/question-sibling/.Rprofile' },
+    { navPage: 'question', filename: 'questions/test/question/../../../.Rprofile' },
+    { navPage: 'question', filename: 'questions/test/question/../../../../outside.R' },
+  ])('rejects $filename in $navPage', async ({ navPage, filename }) => {
+    await withServer(createApp(navPage), async ({ url }) => {
+      await assertErrorResponse(
+        await fetch(`${downloadUrl(url, filename)}?attachment=.Rprofile`),
+        500,
+      );
+    });
+  });
+
+  it('allows symlinks within the same file browser context', async () => {
+    await withServer(createApp('course_admin'), async ({ url }) => {
+      const response = await fetch(downloadUrl(url, '.profile-link'));
+      assert.equal(response.status, 200);
+      assert.equal(await response.text(), contents);
+    });
+  });
+
+  it.each([
+    { navPage: 'course_admin', filename: '.repository-link/config' },
+    { navPage: 'course_admin', filename: '.outside-link' },
+    { navPage: 'course_admin', filename: '.questions-link/test/question/.Rprofile' },
+    { navPage: 'question', filename: 'questions/test/question/.course-link' },
+  ])('rejects symlink $filename in $navPage', async ({ navPage, filename }) => {
+    await withServer(createApp(navPage), async ({ url }) => {
+      await assertErrorResponse(await fetch(downloadUrl(url, filename)), 500);
+    });
+  });
+});

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
@@ -1,9 +1,10 @@
+import { renameSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import * as path from 'node:path';
 
 import express, { type ErrorRequestHandler } from 'express';
-import { afterAll, assert, beforeAll, describe, it } from 'vitest';
+import { afterAll, assert, beforeAll, describe, it, vi } from 'vitest';
 
 import { withServer } from '@prairielearn/express-test-utils';
 
@@ -124,6 +125,47 @@ describe('Instructor file downloads', () => {
         await fetch(`${downloadUrl(url, '.Rprofile')}?attachment=profile.R`),
         403,
       );
+    });
+  });
+
+  it.each(['../outside.R', '.config/.git/config'])(
+    'keeps serving the validated file when its path is replaced with a symlink to %s',
+    async (target) => {
+      const filename = path.join(coursePath, `race-${path.basename(target)}`);
+      const replacement = `${filename}.replacement`;
+      await fs.writeFile(filename, contents);
+      await fs.symlink(target, replacement);
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- Bound to the response below.
+      const originalSendFile = express.response.sendFile;
+      using sendFile = vi.spyOn(express.response, 'sendFile').mockImplementation(function (
+        this: express.Response,
+        ...args
+      ) {
+        renameSync(replacement, filename);
+        return originalSendFile.apply(this, args);
+      });
+
+      await withServer(createApp(), async ({ url }) => {
+        const response = await fetch(downloadUrl(url, path.basename(filename)));
+        assert.equal(response.status, 200);
+        assert.equal(await response.text(), contents);
+        assert.equal(sendFile.mock.calls.length, 1);
+      });
+    },
+  );
+
+  it('rejects a symlink substituted between validation and opening', async () => {
+    const filename = path.join(coursePath, 'opening-race.R');
+    await fs.writeFile(filename, contents);
+    const originalOpen = fs.open;
+    using open = vi.spyOn(fs, 'open').mockImplementationOnce(async (...args) => {
+      await fs.rename(path.join(coursePath, '.outside-link'), filename);
+      return originalOpen(...args);
+    });
+
+    await withServer(createApp(), async ({ url }) => {
+      await assertErrorResponse(await fetch(downloadUrl(url, 'opening-race.R')), 404);
+      assert.equal(open.mock.calls.length, 1);
     });
   });
 

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.test.ts
@@ -6,7 +6,10 @@ import * as path from 'node:path';
 import express, { type ErrorRequestHandler } from 'express';
 import { afterAll, assert, beforeAll, describe, it, vi } from 'vitest';
 
+import { AugmentedError } from '@prairielearn/error';
 import { withServer } from '@prairielearn/express-test-utils';
+
+import cors from '../../middlewares/cors.js';
 
 import router from './instructorFileDownload.js';
 
@@ -34,7 +37,9 @@ function createApp(navPage = 'course_admin', hasViewPermission = true) {
   });
   app.use('/file_download', router);
   app.use(((err, _req, res, _next) => {
-    res.status((err as Error & { status?: number }).status ?? 500).send('<h1>Error</h1>');
+    res
+      .status((err as Error & { status?: number }).status ?? 500)
+      .send(err instanceof AugmentedError ? err.info : '<h1>Error</h1>');
   }) satisfies ErrorRequestHandler);
   return app;
 }
@@ -48,6 +53,8 @@ async function assertErrorResponse(response: Response, status: number) {
   assert.equal(response.status, status);
   assert.isNull(response.headers.get('Content-Disposition'));
   assert.isNull(response.headers.get('Content-Range'));
+  assert.isNull(response.headers.get('Accept-Ranges'));
+  assert.isNull(response.headers.get('Last-Modified'));
   assert.equal(response.headers.get('Content-Type'), 'text/html; charset=utf-8');
   assert.equal(await response.text(), '<h1>Error</h1>');
 }
@@ -98,23 +105,23 @@ describe('Instructor file downloads', () => {
   });
 
   it.each([
-    ['course_admin', '../outside.R', 500],
-    ['course_admin', 'questions/test/question/.Rprofile', 500],
-    ['course_admin', 'questionSources/test/question/.Rprofile', 404],
-    ['instance_admin', 'courseInstances/Fa18/assessments/HW1/.Rprofile', 500],
-    ['question', 'questions/test/question/../../../.Rprofile', 500],
-    ['question', 'questions/test/question/.course-link', 404],
-    ['course_admin', '.config/.git/config', 404],
-    ['course_admin', '.repository-link/config', 404],
-    ['course_admin', '.outside-link', 404],
-    ['course_admin', '.missing', 404],
-    ['course_admin', '.config', 404],
-    ['course_admin', 'submission.R/child', 404],
-  ] as const)('rejects %s: %s', async (navPage, filename, status) => {
+    ['course_admin', '../outside.R'],
+    ['course_admin', 'questions/test/question/.Rprofile'],
+    ['course_admin', 'questionSources/test/question/.Rprofile'],
+    ['instance_admin', 'courseInstances/Fa18/assessments/HW1/.Rprofile'],
+    ['question', 'questions/test/question/../../../.Rprofile'],
+    ['question', 'questions/test/question/.course-link'],
+    ['course_admin', '.config/.git/config'],
+    ['course_admin', '.repository-link/config'],
+    ['course_admin', '.outside-link'],
+    ['course_admin', '.missing'],
+    ['course_admin', '.config'],
+    ['course_admin', 'submission.R/child'],
+  ])('rejects %s: %s', async (navPage, filename) => {
     await withServer(createApp(navPage), async ({ url }) => {
       await assertErrorResponse(
         await fetch(`${downloadUrl(url, filename)}?attachment=error.pdf&type=application/pdf`),
-        status,
+        404,
       );
     });
   });
@@ -169,29 +176,38 @@ describe('Instructor file downloads', () => {
     });
   });
 
-  it('supports previews and ranges, and clears download headers on range errors', async () => {
-    await withServer(createApp(), async ({ url }) => {
-      const fileUrl = downloadUrl(url, '.Rprofile');
-      const preview = await fetch(`${fileUrl}?type=text/plain`);
-      assert.equal(preview.status, 200);
-      assert.isNull(preview.headers.get('Content-Disposition'));
-      assert.equal(preview.headers.get('Content-Type'), 'text/plain; charset=utf-8');
-      assert.equal(await preview.text(), contents);
+  it.each([false, true])(
+    'supports previews and ranges, and clears download headers on range errors (CORS: %s)',
+    async (withCors) => {
+      const app = express();
+      if (withCors) app.use(cors);
+      app.use(createApp());
+      await withServer(app, async ({ url }) => {
+        const fileUrl = downloadUrl(url, '.Rprofile');
+        const preview = await fetch(`${fileUrl}?type=text/plain`);
+        assert.equal(preview.status, 200);
+        assert.isNull(preview.headers.get('Content-Disposition'));
+        assert.equal(preview.headers.get('Content-Type'), 'text/plain; charset=utf-8');
+        assert.equal(await preview.text(), contents);
 
-      const partial = await fetch(fileUrl, { headers: { Range: 'bytes=0-6' } });
-      assert.equal(partial.status, 206);
-      assert.equal(
-        partial.headers.get('Content-Range'),
-        `bytes 0-6/${Buffer.byteLength(contents)}`,
-      );
-      assert.equal(await partial.text(), contents.slice(0, 7));
+        const partial = await fetch(fileUrl, { headers: { Range: 'bytes=0-6' } });
+        assert.equal(partial.status, 206);
+        assert.equal(
+          partial.headers.get('Content-Range'),
+          `bytes 0-6/${Buffer.byteLength(contents)}`,
+        );
+        assert.equal(await partial.text(), contents.slice(0, 7));
 
-      await assertErrorResponse(
-        await fetch(`${fileUrl}?attachment=error.pdf&type=application/pdf`, {
+        const rangeError = await fetch(`${fileUrl}?attachment=error.pdf&type=application/pdf`, {
           headers: { Range: 'bytes=10000-' },
-        }),
-        416,
-      );
-    });
-  });
+        });
+        await assertErrorResponse(rangeError, 416);
+        assert.notEqual(rangeError.headers.get('ETag'), preview.headers.get('ETag'));
+        assert.equal(
+          rangeError.headers.get('Cache-Control'),
+          withCors ? preview.headers.get('Cache-Control') : null,
+        );
+      });
+    },
+  );
 });

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
@@ -1,7 +1,12 @@
+import { realpath } from 'node:fs/promises';
+import * as path from 'node:path';
+
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { HttpStatusError } from '@prairielearn/error';
+
+import { getPaths } from '../../lib/instructorFiles.js';
 
 const router = Router();
 
@@ -11,9 +16,55 @@ router.get(
     if (!res.locals.authz_data.has_course_permission_view) {
       throw new HttpStatusError(403, 'Access denied (must be course viewer)');
     }
-    if (req.query.type) res.type(req.query.type.toString());
-    if (req.query.attachment) res.attachment(req.query.attachment.toString());
-    res.sendFile(req.params[0], { root: res.locals.course.path });
+    const paths = getPaths(req.params[0], res.locals);
+    try {
+      // Check resolved paths too so symlinks cannot bypass the file browser's boundaries.
+      const [coursePath, workingPath] = await Promise.all([
+        realpath(paths.coursePath),
+        realpath(paths.workingPath),
+      ]);
+      const resolvedPaths = getPaths(path.relative(coursePath, workingPath), {
+        ...res.locals,
+        course: { ...res.locals.course, path: coursePath },
+      });
+      // The file browser hides .git directories, including nested repositories.
+      if (
+        [paths.workingPathRelativeToCourse, resolvedPaths.workingPathRelativeToCourse].some((p) =>
+          p.split(path.sep).includes('.git'),
+        )
+      ) {
+        throw new HttpStatusError(404, 'Not Found');
+      }
+
+      if (req.query.type) res.type(req.query.type.toString());
+      if (req.query.attachment) res.attachment(req.query.attachment.toString());
+      await new Promise<void>((resolve, reject) => {
+        res.sendFile(
+          path.relative(resolvedPaths.rootPath, resolvedPaths.workingPath) || '.',
+          { root: resolvedPaths.rootPath, dotfiles: 'allow' },
+          (err?: Error) => (err ? reject(err) : resolve()),
+        );
+      });
+    } catch (err) {
+      if (res.headersSent || res.destroyed) {
+        res.destroy();
+        return;
+      }
+
+      // Let the error page render as HTML instead of being treated as a download.
+      res.removeHeader('Content-Disposition');
+      res.removeHeader('Content-Type');
+      res.removeHeader('Content-Length');
+      res.removeHeader('Content-Range');
+      if (
+        err instanceof Error &&
+        'code' in err &&
+        (err.code === 'ENOENT' || err.code === 'ENOTDIR' || err.code === 'EISDIR')
+      ) {
+        throw new HttpStatusError(404, 'Not Found');
+      }
+      throw err;
+    }
   }),
 );
 

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
@@ -5,6 +5,7 @@ import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
 import { HttpStatusError } from '@prairielearn/error';
+import { contains } from '@prairielearn/path-utils';
 
 import { getPaths } from '../../lib/instructorFiles.js';
 
@@ -18,18 +19,28 @@ router.get(
     }
     const paths = getPaths(req.params[0], res.locals);
     try {
-      // Check resolved paths too so symlinks cannot bypass the file browser's boundaries.
-      const [coursePath, workingPath] = await Promise.all([
+      // Resolve the boundaries too: a context can itself live beneath a symlink.
+      const [coursePath, rootPath, workingPath, invalidRootPaths] = await Promise.all([
         realpath(paths.coursePath),
+        realpath(paths.rootPath),
         realpath(paths.workingPath),
+        Promise.all(
+          paths.invalidRootPaths.map(async (invalidRootPath) => {
+            try {
+              return await realpath(invalidRootPath);
+            } catch (err) {
+              if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return null;
+              throw err;
+            }
+          }),
+        ),
       ]);
-      const resolvedPaths = getPaths(path.relative(coursePath, workingPath), {
-        ...res.locals,
-        course: { ...res.locals.course, path: coursePath },
-      });
-      // The file browser hides .git directories, including nested repositories.
       if (
-        [paths.workingPathRelativeToCourse, resolvedPaths.workingPathRelativeToCourse].some((p) =>
+        !contains(coursePath, workingPath) ||
+        !contains(rootPath, workingPath) ||
+        invalidRootPaths.some((p) => p !== null && contains(p, workingPath)) ||
+        // The file browser hides .git directories, including nested repositories.
+        [paths.workingPathRelativeToCourse, path.relative(coursePath, workingPath)].some((p) =>
           p.split(path.sep).includes('.git'),
         )
       ) {
@@ -40,8 +51,8 @@ router.get(
       if (req.query.attachment) res.attachment(req.query.attachment.toString());
       await new Promise<void>((resolve, reject) => {
         res.sendFile(
-          path.relative(resolvedPaths.rootPath, resolvedPaths.workingPath) || '.',
-          { root: resolvedPaths.rootPath, dotfiles: 'allow' },
+          path.relative(rootPath, workingPath) || '.',
+          { root: rootPath, dotfiles: 'allow' },
           (err?: Error) => (err ? reject(err) : resolve()),
         );
       });

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
@@ -1,4 +1,5 @@
-import { realpath } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import { Router } from 'express';
@@ -21,13 +22,13 @@ router.get(
     try {
       // Resolve the boundaries too: a context can itself live beneath a symlink.
       const [coursePath, rootPath, workingPath, invalidRootPaths] = await Promise.all([
-        realpath(paths.coursePath),
-        realpath(paths.rootPath),
-        realpath(paths.workingPath),
+        fs.realpath(paths.coursePath),
+        fs.realpath(paths.rootPath),
+        fs.realpath(paths.workingPath),
         Promise.all(
           paths.invalidRootPaths.map(async (invalidRootPath) => {
             try {
-              return await realpath(invalidRootPath);
+              return await fs.realpath(invalidRootPath);
             } catch (err) {
               if (err instanceof Error && 'code' in err && err.code === 'ENOENT') return null;
               throw err;
@@ -35,26 +36,42 @@ router.get(
           }),
         ),
       ]);
-      if (
-        !contains(coursePath, workingPath) ||
-        !contains(rootPath, workingPath) ||
-        invalidRootPaths.some((p) => p !== null && contains(p, workingPath)) ||
-        // The file browser hides .git directories, including nested repositories.
-        [paths.workingPathRelativeToCourse, path.relative(coursePath, workingPath)].some((p) =>
-          p.split(path.sep).includes('.git'),
-        )
-      ) {
+
+      function validatePath(filePath: string) {
+        if (
+          !contains(coursePath, filePath) ||
+          !contains(rootPath, filePath) ||
+          invalidRootPaths.some((p) => p !== null && contains(p, filePath)) ||
+          // The file browser hides .git directories, including nested repositories.
+          [paths.workingPathRelativeToCourse, path.relative(coursePath, filePath)].some((p) =>
+            p.split(path.sep).includes('.git'),
+          )
+        ) {
+          throw new HttpStatusError(404, 'Not Found');
+        }
+      }
+      validatePath(workingPath);
+
+      // Refuse a symlink substituted after realpath, and avoid blocking on special files.
+      await using file = await fs.open(
+        workingPath,
+        constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+      );
+      const descriptorPath = `${process.platform === 'linux' ? '/proc/self/fd' : '/dev/fd'}/${file.fd}`;
+      if (process.platform === 'linux') {
+        // O_NOFOLLOW only protects the final component; a parent could have been replaced too.
+        validatePath(await fs.realpath(descriptorPath));
+      }
+      if (!(await file.stat()).isFile()) {
         throw new HttpStatusError(404, 'Not Found');
       }
 
+      res.type(path.extname(workingPath) || 'application/octet-stream');
       if (req.query.type) res.type(req.query.type.toString());
       if (req.query.attachment) res.attachment(req.query.attachment.toString());
       await new Promise<void>((resolve, reject) => {
-        res.sendFile(
-          path.relative(rootPath, workingPath) || '.',
-          { root: rootPath, dotfiles: 'allow' },
-          (err?: Error) => (err ? reject(err) : resolve()),
-        );
+        // Serve the retained inode so a rename cannot redirect Express's stat/open operations.
+        res.sendFile(descriptorPath, (err?: Error) => (err ? reject(err) : resolve()));
       });
     } catch (err) {
       if (res.headersSent || res.destroyed) {
@@ -70,7 +87,10 @@ router.get(
       if (
         err instanceof Error &&
         'code' in err &&
-        (err.code === 'ENOENT' || err.code === 'ENOTDIR' || err.code === 'EISDIR')
+        (err.code === 'ENOENT' ||
+          err.code === 'ENOTDIR' ||
+          err.code === 'EISDIR' ||
+          err.code === 'ELOOP')
       ) {
         throw new HttpStatusError(404, 'Not Found');
       }

--- a/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
+++ b/apps/prairielearn/src/pages/instructorFileDownload/instructorFileDownload.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 
-import { HttpStatusError } from '@prairielearn/error';
+import { AugmentedError, HttpStatusError } from '@prairielearn/error';
 import { contains } from '@prairielearn/path-utils';
 
 import { getPaths } from '../../lib/instructorFiles.js';
@@ -18,8 +18,9 @@ router.get(
     if (!res.locals.authz_data.has_course_permission_view) {
       throw new HttpStatusError(403, 'Access denied (must be course viewer)');
     }
-    const paths = getPaths(req.params[0], res.locals);
+    const originalCacheControl = res.getHeader('Cache-Control');
     try {
+      const paths = getPaths(req.params[0], res.locals);
       // Resolve the boundaries too: a context can itself live beneath a symlink.
       const [coursePath, rootPath, workingPath, invalidRootPaths] = await Promise.all([
         fs.realpath(paths.coursePath),
@@ -79,18 +80,27 @@ router.get(
         return;
       }
 
-      // Let the error page render as HTML instead of being treated as a download.
+      // Remove file headers while preserving upstream cache restrictions for the error page.
       res.removeHeader('Content-Disposition');
       res.removeHeader('Content-Type');
       res.removeHeader('Content-Length');
       res.removeHeader('Content-Range');
+      res.removeHeader('Accept-Ranges');
+      res.removeHeader('ETag');
+      res.removeHeader('Last-Modified');
+      if (originalCacheControl === undefined) {
+        res.removeHeader('Cache-Control');
+      } else {
+        res.setHeader('Cache-Control', originalCacheControl);
+      }
       if (
-        err instanceof Error &&
-        'code' in err &&
-        (err.code === 'ENOENT' ||
-          err.code === 'ENOTDIR' ||
-          err.code === 'EISDIR' ||
-          err.code === 'ELOOP')
+        err instanceof AugmentedError ||
+        (err instanceof Error &&
+          'code' in err &&
+          (err.code === 'ENOENT' ||
+            err.code === 'ENOTDIR' ||
+            err.code === 'EISDIR' ||
+            err.code === 'ELOOP'))
       ) {
         throw new HttpStatusError(404, 'Not Found');
       }


### PR DESCRIPTION
# Description

Downloading a dotfile such as `.Rprofile` from the instructor file browser currently returns a 404 instead of the file. When the request includes an attachment filename, the error response retains download headers and browsers can report an invalid response instead of displaying the error page.

Allow dotfile downloads after applying the file browser's context-specific path restrictions to both the requested path and its resolved symlink target. Support symlinked context roots and bind each download to a retained file descriptor so pathname replacement cannot redirect the response. Keep `.git` paths inaccessible and retain the course Viewer permission requirement.

Return plain 404 responses for invalid paths without exposing filesystem details. Clear file-transfer and cache metadata on errors while preserving cache restrictions supplied by upstream middleware.

- [x] I have disclosed the level of AI assistance used: Codex implemented the change and regression tests.

# Testing

- Added 25 HTTP regression cases covering dotfiles and ordinary files, symlinked roots, context boundaries and traversal, repository internals, Viewer permissions, previews, ranges, and error responses.
- Reproduced symlink replacement leaks before fixing them. Tests cover replacement before opening and before serving, and verify that errors omit file metadata while retaining upstream cache restrictions.
