### PR TITLE
Fix Staff permission popover overflow

### DIFF
--- a/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
+++ b/apps/prairielearn/src/pages/instructorCourseAdminStaff/StaffTable.tsx
@@ -19,6 +19,7 @@ import {
   type MultiSelectFilterValue,
   NuqsAdapter,
   OverlayTrigger,
+  type OverlayTriggerProps,
   TanstackTableCard,
   type TanstackTableCoreInstance,
   type TanstackTableHeader,
@@ -85,6 +86,22 @@ const INSTANCE_ROLE_DESCRIPTIONS: Record<InstanceRole, string> = {
     'Can see all assessments, questions, and issues. Can view student data but cannot make changes.',
   'Student Data Editor':
     'Can see all assessments, questions, and issues. Can view and edit student data, including grading.',
+};
+
+const PERMISSION_POPOVER_CONFIG: OverlayTriggerProps['popperConfig'] = {
+  modifiers: [
+    {
+      name: 'resize',
+      enabled: true,
+      phase: 'write',
+      // Role descriptions and error messages can change the popover's size while it's open.
+      effect: ({ state, instance }) => {
+        const observer = new ResizeObserver(() => void instance.update());
+        observer.observe(state.elements.popper);
+        return () => observer.disconnect();
+      },
+    },
+  ],
 };
 
 function SelectAllCheckbox({ table }: { table: TanstackTableCoreInstance<CourseUsersRow> }) {
@@ -191,7 +208,8 @@ function CoursePermissionCell({
     <OverlayTrigger
       show={show}
       trigger="click"
-      placement="right"
+      placement="auto"
+      popperConfig={PERMISSION_POPOVER_CONFIG}
       popover={{
         props: {
           id: `course-permission-popover-${courseUser.user.id}`,
@@ -296,7 +314,8 @@ function CourseInstanceAccessCell({
     <OverlayTrigger
       show={show}
       trigger="click"
-      placement="bottom"
+      placement="auto"
+      popperConfig={PERMISSION_POPOVER_CONFIG}
       popover={{
         props: {
           id: `ci-permission-popover-${courseUser.user.id}-${courseInstance.id}`,


### PR DESCRIPTION
# Description

Keep Staff permission popovers within the viewport by using automatic placement and a Popper resize modifier that repositions them when role descriptions or error messages change their size.

- [x] I have disclosed the level of AI assistance used: majority of implementation.

# Testing

Reproduced the original issue in Firefox by opening a semester permission popover at the bottom of the staff list, where its action buttons extended below the viewport.
Verified with Playwright in Firefox and Chromium at 1340×768 and 1000×600 that both permission popovers remain fully visible while switching between short and long role descriptions, and confirmed that permission changes save and reopen correctly in Firefox.
