### PR TITLE
Include submitted code and text files in AI grading

### DIFF
--- a/apps/prairielearn/elements/pl-file-editor/pl-file-editor.py
+++ b/apps/prairielearn/elements/pl-file-editor/pl-file-editor.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+import html as stdlib_html
 import os
 
 import chevron
@@ -65,6 +66,19 @@ def prepare(element_html: str, data: pl.QuestionData) -> None:
 
 
 def render(element_html: str, data: pl.QuestionData) -> str:
+    if data["ai_grading"] and data["panel"] == "submission":
+        element = lxml.html.fragment_fromstring(element_html)
+        file_name = pl.get_string_attrib(element, "file-name", "")
+        if any(
+            file["name"] == file_name
+            for file in data["submitted_answers"].get("_files", [])
+        ):
+            return (
+                f'<div data-ai-grading-file-name="{stdlib_html.escape(file_name, quote=True)}">'
+                f"{stdlib_html.escape(file_name)}</div>"
+            )
+        return ""
+
     if data["panel"] != "question":
         return ""
 

--- a/apps/prairielearn/elements/pl-file-editor/pl_file_editor_test.py
+++ b/apps/prairielearn/elements/pl-file-editor/pl_file_editor_test.py
@@ -1,0 +1,60 @@
+import base64
+import importlib
+
+import pytest
+
+file_editor = importlib.import_module("pl-file-editor")
+
+
+@pytest.mark.parametrize("code", [b"print('hello')", b""])
+def test_render_ai_submission_file_marker(code: bytes) -> None:
+    output = file_editor.render(
+        '<pl-file-editor file-name="src/a&amp;b.py"></pl-file-editor>',
+        {
+            "panel": "submission",
+            "ai_grading": True,
+            "submitted_answers": {
+                "_files": [
+                    {
+                        "name": "src/a&b.py",
+                        "contents": base64.b64encode(code).decode(),
+                    },
+                    {"name": "other.txt", "contents": ""},
+                ]
+            },
+        },
+    )
+    assert output == (
+        '<div data-ai-grading-file-name="src/a&amp;b.py">src/a&amp;b.py</div>'
+    )
+
+
+@pytest.mark.parametrize("submitted_answers", [{}, {"_files": []}])
+def test_render_ai_submission_without_file(
+    submitted_answers: dict[str, list[dict[str, str]]],
+) -> None:
+    assert (
+        file_editor.render(
+            '<pl-file-editor file-name="answer.py"></pl-file-editor>',
+            {
+                "panel": "submission",
+                "ai_grading": True,
+                "submitted_answers": submitted_answers,
+            },
+        )
+        == ""
+    )
+
+
+@pytest.mark.parametrize(
+    ("ai_grading", "panel"),
+    [(False, "submission"), (False, "answer"), (True, "answer")],
+)
+def test_render_other_panels_are_empty(ai_grading: bool, panel: str) -> None:
+    assert (
+        file_editor.render(
+            '<pl-file-editor file-name="answer.py"></pl-file-editor>',
+            {"panel": panel, "ai_grading": ai_grading},
+        )
+        == ""
+    )

--- a/apps/prairielearn/elements/pl-file-preview/pl-file-preview.py
+++ b/apps/prairielearn/elements/pl-file-preview/pl-file-preview.py
@@ -16,8 +16,8 @@ def render(element_html: str, data: pl.QuestionData) -> str:
         return ""
 
     if data["ai_grading"]:
-        # In theory, we may want to support AI grading of arbitrary file uploads,
-        # but for now, we'll just avoid rendering anything at all.
+        # AI grading reads submitted files directly, including files without an
+        # input-element marker (such as workspace files).
         return ""
 
     # Fetch any submitted files

--- a/apps/prairielearn/elements/pl-file-upload/pl_file_upload_test.py
+++ b/apps/prairielearn/elements/pl-file-upload/pl_file_upload_test.py
@@ -188,18 +188,19 @@ def test_get_answer_name_parts() -> None:
     assert len(outputs) == 4
 
 
-def test_render_ai_grading_submission_with_matching_files() -> None:
+@pytest.mark.parametrize("extension", ["pdf", "py", "cpp", "java", "txt"])
+def test_render_ai_grading_submission_with_matching_files(extension: str) -> None:
     output = file_upload.render(
-        '<pl-file-upload file-patterns="*.pdf" optional-file-names="notes.png"></pl-file-upload>',
+        f'<pl-file-upload file-patterns="*.{extension}" optional-file-names="notes.png"></pl-file-upload>',
         {
             "panel": "submission",
             "ai_grading": True,
             "format_errors": {},
             "submitted_answers": {
                 "_files": [
-                    {"name": "solution.pdf", "contents": "pdfdata"},
+                    {"name": f"solution.{extension}", "contents": "filedata"},
                     {"name": "notes.png", "contents": "imagedata"},
-                    {"name": "ignored.txt", "contents": "textdata"},
+                    {"name": "ignored.other", "contents": "textdata"},
                 ]
             },
         },
@@ -207,7 +208,7 @@ def test_render_ai_grading_submission_with_matching_files() -> None:
 
     assert output == (
         '<div data-ai-grading-file-name="notes.png">notes.png</div>\n'
-        '<div data-ai-grading-file-name="solution.pdf">solution.pdf</div>'
+        f'<div data-ai-grading-file-name="solution.{extension}">solution.{extension}</div>'
     )
 
 

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-file-providers.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-file-providers.test.ts
@@ -1,0 +1,84 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { generateText } from 'ai';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAiGradingOpenAI } from './ai-grading-openai-provider.js';
+import { generateSubmissionContent } from './ai-grading-util.js';
+
+const code = 'def square(x):\n    return x * x  # café\n';
+const text = `Submitted file: answer.py\n\n${code}`;
+
+describe('submitted code provider requests', () => {
+  it.each([
+    {
+      name: 'OpenAI',
+      model: (fetch: typeof globalThis.fetch) =>
+        createAiGradingOpenAI({ apiKey: 'test-key', fetch })('gpt-5.6-terra'),
+      response: {
+        id: 'resp_test',
+        created_at: 0,
+        model: 'gpt-5.6-terra',
+        output: [
+          {
+            id: 'msg_test',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'Correct', annotations: [] }],
+          },
+        ],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+      expectedBody: { input: [{ role: 'user', content: [{ type: 'input_text', text }] }] },
+    },
+    {
+      name: 'Anthropic',
+      model: (fetch: typeof globalThis.fetch) =>
+        createAnthropic({ apiKey: 'test-key', fetch })('claude-sonnet-5'),
+      response: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-sonnet-5',
+        content: [{ type: 'text', text: 'Correct' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+      expectedBody: { messages: [{ role: 'user', content: [{ type: 'text', text }] }] },
+    },
+    {
+      name: 'Google',
+      model: (fetch: typeof globalThis.fetch) =>
+        createGoogleGenerativeAI({ apiKey: 'test-key', fetch })('gemini-3.8-flash'),
+      response: {
+        candidates: [
+          { content: { role: 'model', parts: [{ text: 'Correct' }] }, finishReason: 'STOP' },
+        ],
+        usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+      },
+      expectedBody: { contents: [{ role: 'user', parts: [{ text }] }] },
+    },
+  ])('sends decoded code as native text to $name', async ({ model, response, expectedBody }) => {
+    const fetchFunction = vi.fn<typeof fetch>(async () => Response.json(response));
+    const result = await generateText({
+      model: model(fetchFunction),
+      messages: [
+        {
+          role: 'user',
+          content: generateSubmissionContent({
+            submission_text: '',
+            submitted_answer: {
+              _files: [{ name: 'answer.py', contents: Buffer.from(code).toString('base64') }],
+            },
+          }),
+        },
+      ],
+    });
+
+    expect(result.text).toBe('Correct');
+    expect(fetchFunction).toHaveBeenCalledOnce();
+    expect(JSON.parse(fetchFunction.mock.calls[0][1]?.body as string)).toMatchObject(expectedBody);
+  });
+});

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.test.ts
@@ -9,6 +9,7 @@ import { sanitizeObject } from '@prairielearn/sanitize';
 import { type RubricItem } from '../../../lib/db-types.js';
 
 import {
+  containsSubmissionAttachment,
   correctImagesOrientation,
   extractAiGradingExplanationFromCompletion,
   extractSubmissionImages,
@@ -253,6 +254,7 @@ describe('parseSubmission', () => {
     expect(result).toEqual([
       { type: 'text', text: '<p>Text</p>' },
       { type: 'file', fileName: 'missing.jpg', fileData: null },
+      { type: 'file', fileName: 'other.jpg', fileData: 'otherdata' },
     ]);
   });
 
@@ -276,6 +278,149 @@ describe('parseSubmission', () => {
 });
 
 describe('generateSubmissionContent', () => {
+  it.each([
+    'solution.py',
+    'solution.cpp',
+    'Solution.java',
+    'notes.txt',
+    'Makefile',
+    'answer.custom',
+  ])('sends %s as decoded text with its filename', (name) => {
+    const text = '\tα = "<div>& café</div>"\r\n\n    return α\n';
+    expect(
+      generateSubmissionContent({
+        submission_text: `<div data-ai-grading-file-name="${name}">${name}</div>`,
+        submitted_answer: { _files: [{ name, contents: Buffer.from(text).toString('base64') }] },
+      }),
+    ).toEqual([{ type: 'text', text: `Submitted file: ${name}\n\n${text}` }]);
+  });
+
+  it.each([
+    Buffer.from('\ufeffprint("hello")\n', 'utf8'),
+    Buffer.from('\ufeffprint("hello")\n', 'utf16le'),
+    Buffer.from('\ufeffprint("hello")\n', 'utf16le').swap16(),
+  ])('decodes Unicode text with a byte-order mark', (bytes) => {
+    expect(
+      generateSubmissionContent({
+        submission_text: '',
+        submitted_answer: { _files: [{ name: 'answer.py', contents: bytes.toString('base64') }] },
+      }),
+    ).toEqual([{ type: 'text', text: 'Submitted file: answer.py\n\nprint("hello")\n' }]);
+  });
+
+  it('includes empty files without calling them missing', () => {
+    expect(
+      generateSubmissionContent({
+        submission_text: '',
+        submitted_answer: { _files: [{ name: 'empty.txt', contents: '' }] },
+      }),
+    ).toEqual([{ type: 'text', text: 'Submitted file: empty.txt\n\n' }]);
+  });
+
+  it('includes stored workspace files without submission HTML and without truncation', () => {
+    const text = '# comment\n'.repeat(2000) + 'result = 42\n';
+    expect(
+      generateSubmissionContent({
+        submission_text: '',
+        submitted_answer: {
+          _files: [{ name: 'src/answer.py', contents: Buffer.from(text).toString('base64') }],
+        },
+      }),
+    ).toEqual([{ type: 'text', text: `Submitted file: src/answer.py\n\n${text}` }]);
+  });
+
+  it('preserves mixed submission order and appends unmarked files only once', () => {
+    const result = generateSubmissionContent({
+      submission_text: [
+        '<p>Before</p>',
+        '<div data-ai-grading-file-name="answer.cpp">answer.cpp</div>',
+        '<p>Between</p>',
+        '<div data-file-upload-file-name="work.pdf">work.pdf</div>',
+        '<div data-image-capture-uuid="capture" data-file-name="photo.png">photo.png</div>',
+        '<div data-ai-grading-file-name="photo.png">photo.png</div>',
+        '<div data-ai-grading-file-name="answer.cpp">answer.cpp</div>',
+        '<p>After</p>',
+      ].join(''),
+      submitted_answer: {
+        _files: [
+          { name: 'notes.txt', contents: Buffer.from('notes').toString('base64') },
+          { name: 'photo.png', contents: 'imagedata' },
+          { name: 'answer.cpp', contents: Buffer.from('int main() {}').toString('base64') },
+          { name: 'work.pdf', contents: 'pdfdata' },
+          { name: 'notes.txt', contents: Buffer.from('notes').toString('base64') },
+          { name: 'src/helper.py', contents: Buffer.from('pass').toString('base64') },
+        ],
+      },
+    });
+    expect(result).toEqual([
+      { type: 'text', text: '<p>Before</p>' },
+      { type: 'text', text: 'Submitted file: answer.cpp\n\nint main() {}' },
+      { type: 'text', text: '<p>Between</p>' },
+      { type: 'text', text: 'Submitted file: work.pdf' },
+      { type: 'file', filename: 'work.pdf', data: 'pdfdata', mediaType: 'application/pdf' },
+      { type: 'text', text: 'Submitted file: photo.png' },
+      {
+        type: 'file',
+        filename: 'photo.png',
+        data: 'imagedata',
+        mediaType: 'image/png',
+        providerOptions: { openai: { imageDetail: 'auto' } },
+      },
+      { type: 'text', text: '<p>After</p>' },
+      { type: 'text', text: 'Submitted file: notes.txt\n\nnotes' },
+      { type: 'text', text: 'Submitted file: src/helper.py\n\npass' },
+    ]);
+  });
+
+  it.each([
+    Buffer.from([0xc3, 0x28]),
+    Buffer.from([0xff]),
+    Buffer.from([0xff, 0xfe, 0x61]),
+    Buffer.from([0xff, 0xfe, 0x00, 0xd8]),
+  ])('rejects invalid text encodings', (bytes) => {
+    expect(() =>
+      generateSubmissionContent({
+        submission_text: '',
+        submitted_answer: { _files: [{ name: 'answer.py', contents: bytes.toString('base64') }] },
+      }),
+    ).toThrow('AI grading could not read "answer.py" as text');
+  });
+
+  it.each([
+    Buffer.from('PK\u0003\u0004'),
+    Buffer.from('hello\u0000world'),
+    Buffer.from('text without BOM', 'utf16le'),
+    Buffer.from([0xff, 0xfe, 0, 0, 0x61, 0, 0, 0]),
+  ])('rejects binary data even when it can be decoded', (bytes) => {
+    expect(() =>
+      generateSubmissionContent({
+        submission_text: '',
+        submitted_answer: { _files: [{ name: 'answer.txt', contents: bytes.toString('base64') }] },
+      }),
+    ).toThrow('AI grading cannot read binary file "answer.txt"');
+  });
+
+  it('rejects invalid base64 instead of silently losing bytes', () => {
+    expect(() =>
+      generateSubmissionContent({
+        submission_text: '',
+        submitted_answer: { _files: [{ name: 'answer.txt', contents: 'aGVsbG8=!' }] },
+      }),
+    ).toThrow('Submitted file "answer.txt" has invalid base64 data');
+  });
+
+  it('recognizes unmarked attachments for grading explanations', () => {
+    expect(
+      containsSubmissionAttachment({
+        submission_text: '',
+        submitted_answer: { _files: [{ name: 'answer.txt', contents: '' }] },
+      }),
+    ).toBe(true);
+    expect(containsSubmissionAttachment({ submission_text: '', submitted_answer: null })).toBe(
+      false,
+    );
+  });
+
   it('generates named PDF file parts', () => {
     const result = generateSubmissionContent({
       submission_text: '<div data-ai-grading-file-name="solution.pdf">solution.pdf</div>',
@@ -300,21 +445,28 @@ describe('generateSubmissionContent', () => {
       generateSubmissionContent({
         submission_text: '<div data-ai-grading-file-name="solution.zip">solution.zip</div>',
         submitted_answer: {
-          _files: [{ name: 'solution.zip', contents: 'zipdata' }],
+          _files: [
+            { name: 'solution.zip', contents: Buffer.from('PK\u0003\u0004').toString('base64') },
+          ],
         },
       }),
-    ).toThrow('AI grading only supports PDF, JPEG, PNG, and WebP files');
+    ).toThrow('AI grading cannot read binary file "solution.zip"');
   });
 
   it('includes uploaded images in orientation correction', () => {
     const result = extractSubmissionImages({
       submission_text: '<div data-ai-grading-file-name="solution.png">solution.png</div>',
       submitted_answer: {
-        _files: [{ name: 'solution.png', contents: 'imagedata' }],
+        _files: [
+          { name: 'solution.png', contents: 'imagedata' },
+          { name: 'workspace.jpg', contents: 'workspacedata' },
+          { name: 'answer.py', contents: Buffer.from('pass').toString('base64') },
+          { name: 'work.pdf', contents: 'pdfdata' },
+        ],
       },
     });
 
-    expect(result).toEqual({ 'solution.png': 'imagedata' });
+    expect(result).toEqual({ 'solution.png': 'imagedata', 'workspace.jpg': 'workspacedata' });
   });
 });
 

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+
 import {
   type GenerateTextResult,
   type LanguageModel,
@@ -72,7 +74,7 @@ const SubmissionVariantSchema = z.object({
 type UserContentParts = Exclude<UserContent, string>;
 
 // Keep this to media types supported as inline file parts by every AI-grading provider.
-const SUPPORTED_AI_GRADING_FILE_MEDIA_TYPES = new Set([
+const AI_GRADING_BINARY_FILE_MEDIA_TYPES = new Set([
   'application/pdf',
   'image/jpeg',
   'image/png',
@@ -232,8 +234,17 @@ function getAiGradingFileName($: cheerio.CheerioAPI, el: AnyNode): string | unde
   return options?.submitted_file_name;
 }
 
-export function containsSubmissionAttachment(submission_text: string): boolean {
-  return cheerio.load(submission_text)(AI_GRADING_FILE_SELECTOR).length > 0;
+export function containsSubmissionAttachment({
+  submission_text,
+  submitted_answer,
+}: {
+  submission_text: string;
+  submitted_answer: Record<string, any> | null;
+}): boolean {
+  return (
+    (submitted_answer?._files?.length ?? 0) > 0 ||
+    cheerio.load(submission_text)(AI_GRADING_FILE_SELECTOR).length > 0
+  );
 }
 
 function containsSubmissionImage(submission_text: string): boolean {
@@ -248,13 +259,47 @@ function containsSubmissionImage(submission_text: string): boolean {
   return false;
 }
 
-function getAiGradingFileMediaType(fileName: string): string {
+function getAiGradingFileMediaType(fileName: string): string | null {
   const mediaType = mime.getType(fileName);
-  if (mediaType && SUPPORTED_AI_GRADING_FILE_MEDIA_TYPES.has(mediaType)) {
+  if (mediaType && AI_GRADING_BINARY_FILE_MEDIA_TYPES.has(mediaType)) {
     return mediaType;
   }
 
-  throw new Error(`AI grading only supports PDF, JPEG, PNG, and WebP files; found "${fileName}".`);
+  return null;
+}
+
+function decodeAiGradingTextFile(fileName: string, fileData: string): string {
+  const bytes = Buffer.from(fileData, 'base64');
+  if (bytes.toString('base64') !== fileData) {
+    throw new Error(`Submitted file "${fileName}" has invalid base64 data.`);
+  }
+
+  // File extensions cannot reliably distinguish source code from binary files.
+  // Decode strictly so invalid bytes are never silently replaced in the student's work.
+  const encoding =
+    bytes[0] === 0xff && bytes[1] === 0xfe
+      ? 'utf-16le'
+      : bytes[0] === 0xfe && bytes[1] === 0xff
+        ? 'utf-16be'
+        : 'utf-8';
+  let text: string;
+  try {
+    text = new TextDecoder(encoding, { fatal: true }).decode(bytes);
+  } catch (cause) {
+    throw new Error(
+      `AI grading could not read "${fileName}" as text. Use UTF-8 or UTF-16 with a byte-order mark, or submit a PDF, JPEG, PNG, or WebP file.`,
+      { cause },
+    );
+  }
+
+  // Binary files can contain valid Unicode but still include non-text control characters.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u0008\u000e-\u001f\u007f-\u009f]/u.test(text)) {
+    throw new Error(
+      `AI grading cannot read binary file "${fileName}". Submit its contents as text, PDF, JPEG, PNG, or WebP instead.`,
+    );
+  }
+  return text;
 }
 
 /**
@@ -281,7 +326,7 @@ export function generateSubmissionContent({
       case 'text':
         return [segment];
       case 'file': {
-        if (!segment.fileData) {
+        if (segment.fileData === null) {
           return [
             {
               type: 'text',
@@ -291,6 +336,14 @@ export function generateSubmissionContent({
         }
 
         const mediaType = getAiGradingFileMediaType(segment.fileName);
+        if (!mediaType) {
+          return [
+            {
+              type: 'text',
+              text: `Submitted file: ${segment.fileName}\n\n${decodeAiGradingTextFile(segment.fileName, segment.fileData)}`,
+            },
+          ];
+        }
         return [
           {
             type: 'text',
@@ -344,7 +397,8 @@ type SubmissionHTMLSegment =
  * preserves the full HTML structure for text segments, ensuring the prompt matches what the
  * instructor sees on the AI grading preview page. Attachments are identified by an internal marker
  * emitted by supported elements and returned as separate segments. Legacy markers emitted by
- * `pl-image-capture` and `pl-file-upload` are also recognized.
+ * `pl-image-capture` and `pl-file-upload` are also recognized. Files without a marker
+ * (for example, workspace files) are appended in their stored order.
  */
 export function parseSubmission({
   submission_text,
@@ -355,13 +409,6 @@ export function parseSubmission({
 }): SubmissionHTMLSegment[] {
   const $ = cheerio.load(submission_text);
   const attachmentElements = $(AI_GRADING_FILE_SELECTOR);
-
-  // If there are no attachments, return the full HTML as a single text segment.
-  if (attachmentElements.length === 0) {
-    const text = $('body').html()?.trim();
-    if (!text) return [];
-    return [{ type: 'text', text }];
-  }
 
   // Extract attachment data and replace each element with a unique marker so we can split the
   // HTML into alternating text/attachment segments.
@@ -419,11 +466,19 @@ export function parseSubmission({
     }
   }
 
+  // Some submission paths do not render file markers. Include their files too,
+  // while preserving the positions of marked files and avoiding duplicates.
+  for (const file of submitted_answer?._files ?? []) {
+    if (includedFileNames.has(file.name)) continue;
+    includedFileNames.add(file.name);
+    segments.push({ type: 'file', fileName: file.name, fileData: file.contents });
+  }
+
   return segments;
 }
 
 /**
- * Returns all images referenced by AI-grading file markers in the rendered submission.
+ * Returns all supported images in the submission, including files without markers.
  * Returns a mapping from an image's filename to its base64-encoded contents.
  */
 export function extractSubmissionImages({
@@ -442,7 +497,7 @@ export function extractSubmissionImages({
     (acc, segment) => {
       if (segment.type === 'text' || !segment.fileData) return acc;
 
-      if (getAiGradingFileMediaType(segment.fileName).startsWith('image/')) {
+      if (getAiGradingFileMediaType(segment.fileName)?.startsWith('image/')) {
         acc[segment.fileName] = segment.fileData;
       }
       return acc;
@@ -925,9 +980,11 @@ export async function correctImagesOrientation({
   > = {};
 
   for (const [filename, image] of Object.entries(submittedImages)) {
+    const mediaType = getAiGradingFileMediaType(filename);
+    assert(mediaType);
     const { correctedImage, degreesRotated, response } = await correctImageOrientation({
       image,
-      mediaType: getAiGradingFileMediaType(filename),
+      mediaType,
       model,
     });
 

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.ts
@@ -624,7 +624,10 @@ export async function aiGrade({
           })
         : {};
       const hasImage = Object.keys(submittedImages).length > 0;
-      const hasAttachment = containsSubmissionAttachment(submission_text);
+      const hasAttachment = containsSubmissionAttachment({
+        submission_text,
+        submitted_answer: submission.submitted_answer,
+      });
 
       const { rubric, rubric_items } = await selectCompleteRubric(assessment_question.id);
 

--- a/docs/aiGrading/index.md
+++ b/docs/aiGrading/index.md
@@ -8,7 +8,8 @@ AI grading uses large language models to grade manual questions in PrairieLearn.
 
 AI grading works on manually graded questions that use these elements:
 
-- [`pl-file-upload`](../elements/pl-file-upload.md) for PDF, JPEG, PNG, and WebP files
+- [`pl-file-upload`](../elements/pl-file-upload.md) for text and source-code files, PDFs, and supported images
+- [`pl-file-editor`](../elements/pl-file-editor.md) for source-code files
 - [`pl-image-capture`](../elements/pl-image-capture.md)
 - [`pl-rich-text-editor`](../elements/pl-rich-text-editor.md)
 - [`pl-string-input`](../elements/pl-string-input.md)
@@ -19,10 +20,20 @@ Common use cases include:
 - Mathematical proofs and derivations
 - Diagrams and handwritten work
 - PDF documents produced with external tools
-- Code explanations and written reasoning
+- Source code, code explanations, and written reasoning
 - Short-answer justifications
 
 Questions can combine these elements. For example, when a question contains both `pl-file-upload` and `pl-image-capture`, every distinct submitted file is sent to the model once.
+
+AI grading also includes files saved in the submission from [workspaces](../workspaces/index.md). Only files collected for grading are included; the AI grader does not read the live workspace. Files do not need a `pl-file-preview` element to be included.
+
+### Submitted file formats
+
+- **Text and source code:** Files such as `.py`, `.cpp`, `.java`, `.txt`, `.csv`, and `.json` are decoded and sent as text with their filenames. Any filename or extension is accepted if the contents are readable text. Indentation, line breaks, and Unicode are preserved. Supported encodings are UTF-8 (with or without a byte-order mark) and UTF-16 (with a byte-order mark).
+- **PDFs and images:** PDF, JPEG, PNG, and WebP files are sent as attachments so the model can interpret their visual content.
+- **Other binary formats or encodings:** Files such as ZIP archives, compiled programs, and binary Office documents are not decoded as text. An unreadable file causes AI grading of that submission to fail with an error identifying the file, rather than producing a grade with missing content. Convert these files to a supported format or use manual grading.
+
+Text files are passed as source text, without executing code or rendering HTML, Markdown, or SVG. File contents count toward the model's input limits; they are not truncated by PrairieLearn.
 
 ## Prerequisites
 

--- a/docs/elements/pl-file-editor.md
+++ b/docs/elements/pl-file-editor.md
@@ -56,6 +56,10 @@ Alternatively, instructors may define a custom mode, which can be an alternative
 
 This element supports additional preview options through [element extensions](../elementExtensions.md). To provide this functionality, the extension must assign, to `window.PLFileEditor.prototype.preview.PREVIEW_TYPE` (where `PREVIEW_TYPE` is the value of the `preview` attribute), a function that converts a string representing the editor's content into suitable HTML content.
 
+## AI grading
+
+Submitted code is included in [AI grading](../aiGrading/index.md) as text labeled with its filename, preserving indentation and Unicode. A `pl-file-preview` element is not required. Questions can combine the editor with file uploads and image capture; each distinct submitted file is sent once.
+
 ## Example implementations
 
 - [element/fileEditor]

--- a/docs/elements/pl-file-upload.md
+++ b/docs/elements/pl-file-upload.md
@@ -72,7 +72,7 @@ Required files (`file-names` or `file-patterns`) and optional files (`optional-f
 
 The `pl-file-upload` element and the contents of the uploaded file(s) are only displayed by default in the question panel. If the contents are expected to be listed in the submission panel, they should be explicitly added using other elements such as [`pl-file-preview`](pl-file-preview.md) or [`pl-xss-safe`](pl-xss-safe.md).
 
-AI grading supports PDF, JPEG, PNG, and WebP files submitted with `pl-file-upload`. Other file types can still be used with manual or external grading, but cannot be graded with AI grading. Questions can combine `pl-file-upload` with other supported elements such as [`pl-image-capture`](pl-image-capture.md); each distinct submitted file is sent to the model once. Learn more in the [AI grading docs](../aiGrading/index.md).
+AI grading supports text and source-code files (including `.py`, `.cpp`, `.java`, and `.txt`) as well as PDF, JPEG, PNG, and WebP files submitted with `pl-file-upload`. Text is decoded from UTF-8 or UTF-16 with a byte-order mark and sent with its filename. Other binary formats cause an explicit AI grading error; they can still be used with manual or external grading. Questions can combine `pl-file-upload` with other supported elements such as [`pl-file-editor`](pl-file-editor.md) and [`pl-image-capture`](pl-image-capture.md); each distinct submitted file is sent to the model once. See [supported file formats](../aiGrading/index.md#submitted-file-formats) for encoding details and limitations.
 
 ## Example implementations
 


### PR DESCRIPTION
# Description

AI grading currently rejects source-code uploads and can omit saved files when no attachment marker is rendered. This prevents instructors from applying an AI rubric to submitted code, including after external test-based grading.

Decode text and source-code files into filename-labeled text message parts, preserving whitespace and Unicode. Accept readable text regardless of extension, using UTF-8 or UTF-16 with a byte-order mark. Include every saved submission file: preserve marked files' positions, append unmarked files in stored order, and deduplicate by filename. File editors now emit AI submission markers; workspace files are read from the saved submission, without requiring a file-preview element.

PDF, JPEG, PNG, and WebP attachments retain their existing processing, including image rotation and OpenAI high-detail PDFs. Other binary formats, malformed base64, and unsupported text encodings produce a filename-specific error instead of silently discarding content or replacing invalid bytes. ZIP archives, compiled programs, and binary Office documents still require conversion or manual grading. Contents are not truncated, so model input limits still apply.

The original allowlist covered inline file formats shared by the grading providers. Expanding it alone is insufficient: the installed OpenAI AI SDK adapter rejects non-PDF document parts by default, while Anthropic accepts PDF and plain-text documents but not arbitrary source-code MIME types. Decoded text parts work across all three providers. Current API references: [OpenAI file inputs](https://developers.openai.com/api/docs/guides/file-inputs), [Anthropic files](https://platform.claude.com/docs/en/build-with-claude/files#working-with-other-file-formats), and [Google document types](https://ai.google.dev/gemini-api/docs/document-processing#document-types).

- [x] I have disclosed the level of AI assistance used: Codex wrote the majority of the implementation, tests, and documentation.

# Testing

- Mocked HTTP requests through the actual OpenAI, Anthropic, and Google SDK adapters verify that source code arrives as native text. Existing coverage verifies PDF high detail and image handling; no live model requests or student grading were performed.
- Regression coverage includes code/text extensions and extensionless files; file-editor/upload markers; saved workspace files without HTML; mixed attachments and duplicates; Unicode, whitespace, BOMs, empty and large files; malformed base64, invalid Unicode, and binary control bytes. The focused suites pass 72 TypeScript and 66 Python tests.
- Updated AI grading and element documentation builds successfully in strict mode.
