### PR TITLE
Fix clearing AI grading results without prior manual grading

### DIFF
--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading-util.sql
@@ -170,12 +170,10 @@ WITH
       feedback = mrsnagj.feedback
     FROM
       deleted_grading_jobs AS dgj
-      LEFT JOIN most_recent_submission_manual_grading_jobs AS mrsmgj ON TRUE
-      LEFT JOIN most_recent_submission_non_ai_grading_jobs AS mrsnagj ON TRUE
+      LEFT JOIN most_recent_submission_manual_grading_jobs AS mrsmgj ON (mrsmgj.submission_id = dgj.submission_id)
+      LEFT JOIN most_recent_submission_non_ai_grading_jobs AS mrsnagj ON (mrsnagj.submission_id = dgj.submission_id)
     WHERE
       s.id = dgj.submission_id
-      AND mrsmgj.submission_id = s.id
-      AND mrsnagj.submission_id = s.id
   ),
   most_recent_instance_question_manual_grading_jobs AS (
     SELECT DISTINCT

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.test.sql
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.test.sql
@@ -33,3 +33,105 @@ DELETE FROM job_sequences
 WHERE
   assessment_question_id = $assessment_question_id
   AND type = 'ai_grading';
+
+-- BLOCK insert_submission_with_ai_grading
+WITH
+  new_assessment_instance AS (
+    INSERT INTO
+      assessment_instances (assessment_id, user_id, number, max_points)
+    SELECT
+      aq.assessment_id,
+      $authn_user_id,
+      1,
+      aq.max_points
+    FROM
+      assessment_questions AS aq
+    WHERE
+      aq.id = $assessment_question_id
+    RETURNING
+      id
+  ),
+  new_instance_question AS (
+    INSERT INTO
+      instance_questions (
+        assessment_instance_id,
+        assessment_question_id,
+        is_ai_graded
+      )
+    SELECT
+      id,
+      $assessment_question_id,
+      TRUE
+    FROM
+      new_assessment_instance
+    RETURNING
+      id
+  ),
+  new_variant AS (
+    INSERT INTO
+      variants (
+        instance_question_id,
+        question_id,
+        course_id,
+        user_id,
+        authn_user_id,
+        variant_seed
+      )
+    SELECT
+      iq.id,
+      q.id,
+      q.course_id,
+      $authn_user_id,
+      $authn_user_id,
+      '1'
+    FROM
+      new_instance_question AS iq
+      JOIN assessment_questions AS aq ON (aq.id = $assessment_question_id)
+      JOIN questions AS q ON (q.id = aq.question_id)
+    RETURNING
+      id
+  ),
+  new_submission AS (
+    INSERT INTO
+      submissions (variant_id, is_ai_graded, feedback)
+    SELECT
+      id,
+      TRUE,
+      '{"manual": "AI feedback"}'::jsonb
+    FROM
+      new_variant
+    RETURNING
+      id
+  ),
+  prior_grading_job AS (
+    INSERT INTO
+      grading_jobs (
+        submission_id,
+        grading_method,
+        feedback,
+        manual_points
+      )
+    SELECT
+      id,
+      $grading_method::enum_grading_method,
+      '{"manual": "Previous feedback"}'::jsonb,
+      2
+    FROM
+      new_submission
+    WHERE
+      $grading_method::enum_grading_method IS NOT NULL
+  ),
+  ai_grading_job AS (
+    INSERT INTO
+      grading_jobs (submission_id, grading_method, feedback)
+    SELECT
+      id,
+      'AI',
+      '{"manual": "AI feedback"}'::jsonb
+    FROM
+      new_submission
+  )
+SELECT
+  id
+FROM
+  new_submission;

--- a/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.test.ts
+++ b/apps/prairielearn/src/ee/lib/ai-grading/ai-grading.test.ts
@@ -10,9 +10,12 @@ import { selectAssessmentByTid } from '../../../models/assessment.js';
 import { selectCourseInstanceByShortName } from '../../../models/course-instances.js';
 import { selectCourseByShortName } from '../../../models/course.js';
 import { selectQuestionByQid } from '../../../models/question.js';
+import { selectSubmissionById } from '../../../models/submission.js';
 import * as helperCourse from '../../../tests/helperCourse.js';
 import * as helperDb from '../../../tests/helperDb.js';
 import { getOrCreateUser } from '../../../tests/utils/auth.js';
+
+import { deleteAiGradingJobs } from './ai-grading-util.js';
 
 const sql = loadSqlEquiv(import.meta.url);
 
@@ -36,7 +39,7 @@ async function selectStatus(job_sequence_id: string): Promise<string> {
   return await queryScalar(sql.select_status, { job_sequence_id }, EnumJobStatusSchema);
 }
 
-describe('stopJobSequence (AI grading scope)', () => {
+describe('AI grading', () => {
   let assessment_question_id: string;
   let authn_user_id: string;
 
@@ -75,6 +78,32 @@ describe('stopJobSequence (AI grading scope)', () => {
     // invariant can be exercised without cross-test bleed.
     await execute(sql.delete_test_ai_grading_sequences, { assessment_question_id });
   });
+
+  it.each([null, 'Internal', 'Manual'] as const)(
+    'deletes AI grading results with prior grading method %s',
+    async (grading_method) => {
+      await helperDb.runInTransactionAndRollback(async () => {
+        const submission_id = await queryScalar(
+          sql.insert_submission_with_ai_grading,
+          { assessment_question_id, authn_user_id, grading_method },
+          IdSchema,
+        );
+
+        const iqs = await deleteAiGradingJobs({
+          assessment_question_ids: [assessment_question_id],
+          authn_user_id,
+        });
+
+        assert.lengthOf(iqs, 1);
+        const submission = await selectSubmissionById({ submission_id });
+        assert.isFalse(submission.is_ai_graded);
+        assert.deepEqual(
+          submission.feedback,
+          grading_method ? { manual: 'Previous feedback' } : null,
+        );
+      });
+    },
+  );
 
   it('atomically transitions Running → Stopping and returns true once', async () => {
     const job_sequence_id = await insertAiGradingJobSequence({


### PR DESCRIPTION
# Description

Deleting AI grading results can leave a submission marked as AI-graded with its old feedback when it has no prior manual grading job.

The submission update uses left joins for previous grading jobs, but conditions in the WHERE clause exclude submissions where those jobs are missing. Move those conditions into the joins so the update also clears submissions without prior grading history.

- [ ] I have disclosed the level of AI assistance used.

AI assistance: Codex drafted the SQL change and regression tests. I manually reviewed the changes before submitting this PR.

# Testing

Added database regression tests that call `deleteAiGradingJobs` for submissions with no prior grading, prior internal grading, and prior manual grading. They check that the AI flag is cleared and feedback is either cleared or restored.

The first two cases fail against the original query and pass with this change. All seven tests in the AI-grading test file pass.
